### PR TITLE
Extract the right COMMIT tag even for a pull request.

### DIFF
--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
-COMMIT=$(git rev-parse HEAD)
+if [ "x${ghprbActualCommit}" = "x" ]; then
+    COMMIT=$(git rev-parse HEAD)
+else
+    COMMIT=$ghprbActualCommit
+fi
+
 IMAGE="govukpay/connector:$COMMIT"
 mvn clean package && docker build -t $IMAGE . && docker push $IMAGE
+


### PR DESCRIPTION
When pulling a PR, jenkins will see the PR merged into master as the latest commit
and we really want the tag of the commit before the merge.
