### PR TITLE
PP 109 citizen user provides card details

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,14 @@ Content-Type: application/json
     "status": "CREATED"
     "links": [
         {
-            "href": "http://connector.service/v1/api/charges/1",
             "rel": "self",
-            "method": "GET"
+            "method": "GET",
+            "href": "http://connector.service/v1/api/charges/1"
+        },
+        {
+            "rel": "cardAuth",
+            "method": "POST",
+            "href": "http://connector.service/v1/frontend/charges/1/cards"
         }
     ],
 }

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ The Pay Connector in Java (Dropwizard)
 
 ## Integration tests
 
-To run the integration tests, the `DOCKER_HOST` and `DOCKER_CERT_PATH` environment variables must be set up correctly. On OS X, with boot2docker, this can be done like this:
+To run the integration tests, the `DOCKER_HOST` and `DOCKER_CERT_PATH` environment variables must be set up correctly. On OS X the environment can be set up with:
 
 ```
     eval $(boot2docker shellinit)
+    eval $(docker-machine env <virtual-machine-name>)
+
 ```
 
 The command to run the integration tests is:
@@ -101,11 +103,6 @@ Content-Type: application/json
             "rel": "self",
             "method": "GET",
             "href": "http://connector.service/v1/api/charges/1"
-        },
-        {
-            "rel": "cardAuth",
-            "method": "POST",
-            "href": "http://connector.service/v1/frontend/charges/1/cards"
         }
     ],
 }
@@ -147,14 +144,14 @@ Content-Type: application/json
 #### Response example
 
 ```
-200 OK
+201 Created
 Content-Type: application/json
-Location: http://connector.service/v1/frontend/charges/1
+Location: http://connector.service/v1/api/charges/1
 
 {
     "charge_id": "1",
     "links": [{
-        "href": "http://connector.service/v1/frontend/charges/1",
+        "href": "http://connector.service/v1/api/charges/1",
         "rel" : "self",
         "method" : "GET"
         }
@@ -191,12 +188,15 @@ Content-Type: application/json
     "amount": 5000,
     "status": "CREATED",
     "links": [{
-        "href": "http://connector.service/v1/frontend/charges/1",
-        "rel" : "self",
-        "method" : "GET"
-        }
-      ]
-
+                "href": "http://connector.service/v1/frontend/charges/1",
+                "rel" : "self",
+                "method" : "GET"
+            },
+            {
+                "rel": "cardAuth",
+                "method": "POST",
+                "href": "http://connector.service/v1/frontend/charges/1/cards"
+            }],
 }
 ```
 

--- a/src/main/java/uk/gov/pay/connector/resources/CardDetailsResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/CardDetailsResource.java
@@ -29,6 +29,8 @@ import static uk.gov.pay.connector.util.ResponseUtil.responseWithChargeNotFound;
 
 @Path("/")
 public class CardDetailsResource {
+    public static final String CARD_AUTH_FRONTEND_PATH = "/v1/frontend/charges/{chargeId}/cards";
+
     private final Logger logger = LoggerFactory.getLogger(CardDetailsResource.class);
     private final ChargeDao chargeDao;
 
@@ -37,7 +39,7 @@ public class CardDetailsResource {
     }
 
     @POST
-    @Path("/v1/frontend/charges/{chargeId}/cards")
+    @Path(CARD_AUTH_FRONTEND_PATH)
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     public Response addCardDetailsForCharge(@PathParam("chargeId") String chargeId, Map<String, Object> cardDetails) throws PayDBIException {

--- a/src/main/java/uk/gov/pay/connector/util/LinksBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/util/LinksBuilder.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.util;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static javax.ws.rs.HttpMethod.GET;
+
+public class LinksBuilder {
+    private final List<Link> links;
+
+    private LinksBuilder() {
+        links = new ArrayList<>();
+    }
+
+    public static LinksBuilder linksBuilder(URI selfLocation) {
+        return new LinksBuilder()
+                .addLink("self", GET, selfLocation);
+    }
+
+    public LinksBuilder addLink(String relation, String method, URI href) {
+        links.add(new Link(relation, method, href));
+        return this;
+    }
+
+    public Map<String, Object> appendLinksTo(Map<String, Object> data) {
+        List<Map<String, Object>> dataLinks = newArrayList();
+        for (Link link : links) {
+            dataLinks.add(ImmutableMap.of("rel", link.rel, "method", link.method, "href", link.href));
+        }
+        data.put("links", dataLinks);
+        return data;
+    }
+
+    private class Link {
+        private String rel;
+        private String method;
+        private URI href;
+
+        public Link(String rel, String method, URI href) {
+            this.rel = rel;
+            this.method = method;
+            this.href = href;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/CardDetailsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/CardDetailsResourceITest.java
@@ -68,7 +68,7 @@ public class CardDetailsResourceITest {
 
         assertChargeStatusIs(chargeId, "CREATED");
     }
-    
+
     @Test
     public void shouldReturnErrorAndDoNotUpdateChargeStatusIfCardDetailsAreInvalid() throws Exception {
         String chargeId = createNewCharge();

--- a/src/test/java/uk/gov/pay/connector/it/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/ChargesApiResourceITest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.model.ChargeStatus.AUTHORIZATION_SUCCESS;
+import static uk.gov.pay.connector.util.LinksAssert.assertCardAuthLink;
 import static uk.gov.pay.connector.util.LinksAssert.assertSelfLink;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
@@ -54,6 +55,9 @@ public class ChargesApiResourceITest {
                 .body("status", is("CREATED"));
 
         assertSelfLink(getChargeResponse, documentLocation);
+
+        String cardAuthUrl = expectedCardAuthUrlFor(chargeId);
+        assertCardAuthLink(getChargeResponse, cardAuthUrl);
     }
 
     @Test
@@ -114,5 +118,9 @@ public class ChargesApiResourceITest {
 
     private String expectedChargeLocationFor(String chargeId) {
         return "http://localhost:" + app.getLocalPort() + CHARGES_API_PATH + chargeId;
+    }
+
+    private String expectedCardAuthUrlFor(String chargeId) {
+        return "http://localhost:" + app.getLocalPort() + "/v1/frontend/charges/" + chargeId + "/cards";
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/LinksAssert.java
+++ b/src/test/java/uk/gov/pay/connector/util/LinksAssert.java
@@ -3,11 +3,20 @@ package uk.gov.pay.connector.util;
 import com.jayway.restassured.response.ValidatableResponse;
 
 import static javax.ws.rs.HttpMethod.GET;
+import static javax.ws.rs.HttpMethod.POST;
 import static org.hamcrest.Matchers.is;
 
 public class LinksAssert {
     public static void assertSelfLink(ValidatableResponse response, String selfHref) {
-        response.body("links.find {links -> links.rel == 'self' }.href", is(selfHref));
-        response.body("links.find {links -> links.rel == 'self' }.method", is(GET));
+        assertLink(response, "self", GET, selfHref);
+    }
+
+    public static void assertCardAuthLink(ValidatableResponse response, String href) {
+        assertLink(response, "cardAuth", POST, href);
+    }
+
+    private static void assertLink(ValidatableResponse response, String rel, String method, String href) {
+        response.body("links.find {link -> link.rel == '" + rel + "' }.href", is(href));
+        response.body("links.find {link -> link.rel == '" + rel + "' }.method", is(method));
     }
 }


### PR DESCRIPTION
`GET /v1/api/charges/{chargeId}` now contains a new link called `cardAuth`, which contains the URL for posting a card authorization:

``` json
...
    "links": [
        {
            "rel": "self",
            "method": "GET",
            "href": "http://connector.service/v1/api/charges/1"
        },
        {
            "rel": "cardAuth",
            "method": "POST",
            "href": "http://connector.service/v1/frontend/charges/1/cards"
        }
    ]
```
