### PR TITLE
Work around a race condition in with Postgres in container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /app
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 
-CMD java -jar *-allinone.jar db migrate *.yaml && java -jar *-allinone.jar server *.yaml
+CMD sleep 2 && java -jar *-allinone.jar db migrate *.yaml && java -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
Work around a race condition in with Postgres in container startup - it's not immediately available, and needs about a second to bind ports beyond what docker gives it. This is a temporary fix, we should be doing connection pooling and maybe not doing migrations like this at all, plus it's for dev only as Pg will be running on RDS in live, but sleep 1 won't break other uses
