### PR TITLE
PP-111: Citizen user sees summary of their service and charge before payment steps

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -60,7 +60,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         ChargeDao chargeDao = new ChargeDao(jdbi);
         GatewayAccountDao gatewayAccountDao = new GatewayAccountDao(jdbi);
 
-        environment.jersey().register(new ChargesApiResource(chargeDao, gatewayAccountDao));
+        environment.jersey().register(new ChargesApiResource(chargeDao, gatewayAccountDao, conf.getLinks()));
         environment.jersey().register(new ChargesFrontendResource(chargeDao));
         environment.jersey().register(new CardDetailsResource(chargeDao));
         environment.jersey().register(new ChargeCaptureResource(chargeDao));

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -13,8 +13,16 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     private DataSourceFactory dataSourceFactory = new DataSourceFactory();
 
+    @Valid
+    @NotNull
+    private LinksConfig links = new LinksConfig();
+
     @JsonProperty("database")
     public DataSourceFactory getDataSourceFactory() {
         return dataSourceFactory;
+    }
+
+    public LinksConfig getLinks() {
+        return links;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/LinksConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/LinksConfig.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.app;
+
+import io.dropwizard.Configuration;
+
+public class LinksConfig extends Configuration {
+    private String cardDetailsUrl;
+
+    public String getCardDetailsUrl() {
+        return cardDetailsUrl;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/api/Link.java
+++ b/src/main/java/uk/gov/pay/connector/model/api/Link.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.model.api;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class Link {
+
+    private String href;
+    private final String rel;
+    private final String method;
+
+    public static Link aLink(String href, String rel, String method) {
+        return new Link(href, rel, method);
+    }
+
+    private Link(String href, String rel, String method) {
+        this.href = href;
+        this.rel = rel;
+        this.method = method;
+    }
+
+    public Map<String, String> toMap() {
+        return ImmutableMap.of(
+                "href", href,
+                "rel", rel,
+                "method", method
+        );
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -15,6 +15,9 @@ logging:
         target: stdout
         logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
+links:
+  cardDetailsUrl: ${CARD_DETAILS_URL}
+
 database:
   driverClass: org.postgresql.Driver
   user: ${DB_USER}

--- a/src/test/java/uk/gov/pay/connector/it/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/ChargesApiResourceITest.java
@@ -14,12 +14,15 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.model.ChargeStatus.AUTHORIZATION_SUCCESS;
+import static uk.gov.pay.connector.util.LinksAssert.assertNextUrlLink;
 import static uk.gov.pay.connector.util.LinksAssert.assertSelfLink;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class ChargesApiResourceITest {
 
     public static final String CHARGES_API_PATH = "/v1/api/charges/";
+    public static final String FRONTEND_CARD_DETAILS_URL = "/charge/";
+
     @Rule
     public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
 
@@ -45,6 +48,7 @@ public class ChargesApiResourceITest {
 
         response.header("Location", is(documentLocation));
         assertSelfLink(response, documentLocation);
+        assertNextUrlLink(response, cardDetailsLocationFor(chargeId));
 
         ValidatableResponse getChargeResponse = getChargeResponseFor(chargeId)
                 .statusCode(200)
@@ -54,7 +58,6 @@ public class ChargesApiResourceITest {
                 .body("status", is("CREATED"));
 
         assertSelfLink(getChargeResponse, documentLocation);
-
     }
 
     @Test
@@ -117,4 +120,7 @@ public class ChargesApiResourceITest {
         return "http://localhost:" + app.getLocalPort() + CHARGES_API_PATH + chargeId;
     }
 
+    private String cardDetailsLocationFor(String chargeId) {
+        return "http://Frontend" + FRONTEND_CARD_DETAILS_URL + chargeId;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/util/LinksAssert.java
+++ b/src/test/java/uk/gov/pay/connector/util/LinksAssert.java
@@ -11,6 +11,10 @@ public class LinksAssert {
         assertLink(response, "self", GET, selfHref);
     }
 
+    public static void assertNextUrlLink(ValidatableResponse response, String selfHref) {
+        assertLink(response, "next_url", GET, selfHref);
+    }
+
     public static void assertCardAuthLink(ValidatableResponse response, String href) {
         assertLink(response, "cardAuth", POST, href);
     }

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -15,6 +15,9 @@ logging:
         target: stdout
         logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
+links:
+  cardDetailsUrl: http://Frontend/charge/{chargeId}
+
 database:
   driverClass: org.postgresql.Driver
   user: postgres

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -15,11 +15,15 @@ logging:
         target: stdout
         logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
 
+links:
+    cardDetailsUrl: http://Frontend/charge/{chargeId}
+
 database:
   driverClass: org.postgresql.Driver
   user: postgres
   password: mysecretpassword
   url:
+
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s
 
@@ -43,3 +47,4 @@ database:
 
   # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
   minIdleTime: 1 minute
+


### PR DESCRIPTION
Upon successful charge creation, connector provides a link specific to the chargeId to the card capture view in Frontend. PublicApi will use this in order to redirect the caller to the relevant link
see https://payments-platform.atlassian.net/browse/PP-111
