### PR TITLE
[PP-127]: update external status mapping.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/api/ExternalChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/model/api/ExternalChargeStatus.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.model.api;
 import uk.gov.pay.connector.model.ChargeStatus;
 
 import static org.apache.commons.lang3.ArrayUtils.contains;
+import static uk.gov.pay.connector.model.ChargeStatus.AUTHORIZATION_REJECTED;
 import static uk.gov.pay.connector.model.ChargeStatus.AUTHORIZATION_SUBMITTED;
 import static uk.gov.pay.connector.model.ChargeStatus.AUTHORIZATION_SUCCESS;
 import static uk.gov.pay.connector.model.ChargeStatus.CAPTURED;
@@ -14,6 +15,7 @@ public enum ExternalChargeStatus {
     EXT_CREATED("CREATED", CREATED),
     EXT_IN_PROGRESS("IN PROGRESS", AUTHORIZATION_SUBMITTED, AUTHORIZATION_SUCCESS),
     EXT_SUCCEEDED("SUCCEEDED", CAPTURED),
+    EXT_FAILED("FAILED", AUTHORIZATION_REJECTED),
     EXT_SYSTEM_CANCELLED("SYSTEM CANCELLED", SYSTEM_CANCELLED);
 
     private final String value;


### PR DESCRIPTION
the mapping for the internal status `AUTHORIZATION REJECTED` was missing, is now mapped to the external status `FAILED`.
