### PR TITLE
PP-1793 Instrument gateway clients to monitor their connection pool

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -10,6 +10,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.model.builder.EntityBuilder;
 import uk.gov.pay.connector.service.CardExecutorService;
 import uk.gov.pay.connector.service.NotifyClientProvider;
+import uk.gov.pay.connector.service.PaymentProviders;
 import uk.gov.pay.connector.util.HashUtil;
 
 import java.util.Properties;
@@ -29,6 +30,7 @@ public class ConnectorModule extends AbstractModule {
         bind(Environment.class).toInstance(environment);
         bind(CardExecutorService.class).in(Singleton.class);
         bind(NotifyClientProvider.class).in(Singleton.class);
+        bind(PaymentProviders.class).in(Singleton.class);
         bind(EntityBuilder.class);
         bind(HashUtil.class);
 

--- a/src/main/java/uk/gov/pay/connector/service/GatewayClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/service/GatewayClientFactory.java
@@ -22,7 +22,7 @@ public class GatewayClientFactory {
                                              MediaType mediaType,
                                              BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> sessionIdentier, MetricRegistry metricRegistry) {
 
-        Client client = clientFactory.createWithDropwizardClient(gateway, operation);
+        Client client = clientFactory.createWithDropwizardClient(gateway, operation, metricRegistry);
         return new GatewayClient(client, gatewayUrlMap, mediaType, sessionIdentier, metricRegistry);
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
@@ -24,18 +24,18 @@ public class GatewayClientFactoryTest {
 
     @Mock
     ClientFactory mockClientFactory;
-
+    @Mock
+    MetricRegistry mockMetricRegistry;
     @Test
     public void shouldBuildGatewayClient() {
         Map<String, String> gatewayUrlMap = mock(Map.class);
         Builder mockBuilder = mock(Builder.class);
         BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier = (GatewayOrder o, Builder b) -> mockBuilder;
-        MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
 
         GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE,
                 gatewayUrlMap, MediaType.TEXT_XML_TYPE, sessionIdentifier, mockMetricRegistry);
 
         assertNotNull(gatewayClient);
-        verify(mockClientFactory).createWithDropwizardClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE);
+        verify(mockClientFactory).createWithDropwizardClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
@@ -86,7 +86,7 @@ public class SmartpayPaymentProviderTest {
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockClientFactory.createWithDropwizardClient(
-                eq(PaymentGatewayName.SMARTPAY), any(GatewayOperation.class))
+                eq(PaymentGatewayName.SMARTPAY), any(GatewayOperation.class), any(MetricRegistry.class))
         )
         .thenReturn(mockClient);
 

--- a/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
@@ -96,7 +96,7 @@ public class WorldpayPaymentProviderTest {
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockClientFactory.createWithDropwizardClient(
-                eq(PaymentGatewayName.WORLDPAY), any(GatewayOperation.class))
+                eq(PaymentGatewayName.WORLDPAY), any(GatewayOperation.class), any(MetricRegistry.class))
         )
                 .thenReturn(mockClient);
 


### PR DESCRIPTION
## WHAT
Ensure PaymentProviders is a Singleton
- We were assuming `PaymentProviders` to be a singleton, instantiated
  when connector starts up. Instead, guice was automatically
  creating a new istance every time `PaymentProviders` was requested.
  I counted 6+ instances getting created at startup. Not so single
  after all :)
- As this class is responsible for the creation of gateway clients,
  we were therefore creating unnecessary instances of clients. 
  So, we are now explicitly binding `PaymentPrivider` to the singleton class.

Instrument gateway clients
- We are creating a gateway client for each operation. Instead of
  using the default connection manager, we can use the instrumented one
  brought by dropwizard-metrics.
  See
https://github.com/dropwizard/metrics/blob/3.2-development/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpClientConnectionManager.java
- This instrumented client keeps track of 4 metrics, `available-connections`,
  `leased-connections`, `pending-connections`, `max-connections`.
  As we have a client for each operation, we will have these metrics
  per operation, too. The metrics path will look like:
  `<payment_provider>.<operation>.<metric>`. For example, for the
  worldpay auth client: `worldpay.auth.max-connections`.
- All of these new metrics are gauges.

## HOW 
_Steps to test or reproduce:_


