### PR TITLE
PP-1776 Allow capture approved charges to be captured

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
@@ -22,7 +22,8 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
 public class CardCaptureService extends CardService implements TransactionalGatewayOperation<BaseCaptureResponse> {
 
     private static List<ChargeStatus> legalStatuses = ImmutableList.of(
-            AUTHORISATION_SUCCESS
+            AUTHORISATION_SUCCESS,
+            CAPTURE_APPROVED
     );
 
     private final UserNotificationService userNotificationService;


### PR DESCRIPTION
The `CardCaptureService` has a precondition guard on the status of charges
which are allowed to be captured. This is useful for preventing calls to the
(private) `/frontend/charges/{chargeId}/capture` endpoint from attempting to
capture a charge which should not be captured.

We overlooked this guard in the original work because the
`CardCaptureProcessTest` mocks out the `CardCaptureService`, and there is no
integrating test.
