### PR TITLE
Pp 1789 correlation id improved logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/filters/LoggingFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/LoggingFilter.java
@@ -32,15 +32,15 @@ public class LoggingFilter implements Filter {
         String requestMethod = ((HttpServletRequest) servletRequest).getMethod();
         String requestId = StringUtils.defaultString(((HttpServletRequest) servletRequest).getHeader(HEADER_REQUEST_ID));
 
-
         MDC.put(HEADER_REQUEST_ID, requestId);
-        logger.info(format("[%s] - %s to %s began", requestId, requestMethod, requestURL));
+
+        logger.info(format("%s to %s began", requestMethod, requestURL));
         try {
             filterChain.doFilter(servletRequest, servletResponse);
         } catch (Throwable throwable) {
             logger.error("Exception - connector request - " + requestURL + " - exception - " + throwable.getMessage(), throwable);
         } finally {
-            logger.info(format("[%s] - %s to %s ended - total time %dms", requestId, requestMethod, requestURL,
+            logger.info(format("%s to %s ended - total time %dms", requestMethod, requestURL,
                     stopwatch.elapsed(TimeUnit.MILLISECONDS)));
             stopwatch.stop();
         }

--- a/src/main/java/uk/gov/pay/connector/filters/RestClientLoggingFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/RestClientLoggingFilter.java
@@ -25,12 +25,13 @@ public class RestClientLoggingFilter implements ClientRequestFilter, ClientRespo
     @Override
     public void filter(ClientRequestContext requestContext) throws IOException {
         timer.set(Stopwatch.createStarted());
+
         Optional<String> requestIdMaybe = Optional.ofNullable(MDC.get(HEADER_REQUEST_ID));
         requestId.set(requestIdMaybe.orElse(""));
 
         requestContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
-        logger.info(format("[%s] - %s to %s began",
-                requestId.get(),
+
+        logger.info(format("%s to %s began",
                 requestContext.getMethod(),
                 requestContext.getUri()));
 
@@ -39,9 +40,10 @@ public class RestClientLoggingFilter implements ClientRequestFilter, ClientRespo
     @Override
     public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
         long elapsed = timer.get().elapsed(TimeUnit.MILLISECONDS);
+
         responseContext.getHeaders().add(HEADER_REQUEST_ID, requestId.get());
-        logger.info(format("[%s] - %s to %s ended - total time %dms",
-                requestId.get(),
+
+        logger.info(format("%s to %s ended - total time %dms",
                 requestContext.getMethod(),
                 requestContext.getUri(),
                 elapsed));

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 links:
   frontendUrl: ${FRONTEND_URL}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -1,10 +1,10 @@
 server:
   applicationConnectors:
     - type: http
-      port: ${PORT}
+      port: ${PORT:-0}
   adminConnectors:
     - type: http
-      port: ${ADMIN_PORT}
+      port: ${ADMIN_PORT:-0}
 
 logging:
     level: INFO
@@ -78,9 +78,9 @@ jerseyClient:
   userAgent: connector
   gzipEnabledForRequests: false
   proxy:
-      host: ${HTTP_PROXY_HOST}
-      port: ${HTTP_PROXY_PORT}
-      scheme : ${HTTP_PROXY_SCHEME}
+      host: ${HTTP_PROXY_HOST:-0}
+      port: ${HTTP_PROXY_PORT:-0}
+      scheme : ${HTTP_PROXY_SCHEME:-https}
       nonProxyHosts:
         - localhost
 

--- a/src/test/java/uk/gov/pay/connector/it/logging/GeneralLoggingTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/logging/GeneralLoggingTest.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.it.logging;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import ch.qos.logback.classic.Logger;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.ResourceHelpers;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
+
+public class GeneralLoggingTest {
+
+  DropwizardTestSupport<ConnectorConfiguration> app;
+
+  @Test
+  public void shouldLogRequestIdForAnyLoggingInvocation() throws Exception {
+
+    app = new DropwizardTestSupport<>(ConnectorApp.class,
+        ResourceHelpers.resourceFilePath("config/test-config.yaml"));
+    app.before();
+
+    String requestId = UUID.randomUUID().toString();
+
+    Logger logger = (Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
+
+    MDC.put(HEADER_REQUEST_ID, requestId);
+
+    // reassigning standard out so that we can grab the log message and test against it
+    ByteArrayOutputStream pipeOut = new ByteArrayOutputStream();
+    PrintStream old_out = System.out;
+    System.setOut(new PrintStream(pipeOut));
+
+    logger.info("This is a test logging invocation");
+    logger.detachAndStopAllAppenders(); // this should force an appender flush
+
+    // restoring standard out to the previous state
+    System.setOut(old_out);
+
+    String output = new String(pipeOut.toByteArray());
+
+    assertThat(output, containsString(requestId));
+  }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/logging/GeneralLoggingTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/logging/GeneralLoggingTest.java
@@ -25,7 +25,7 @@ public class GeneralLoggingTest {
   public void shouldLogRequestIdForAnyLoggingInvocation() throws Exception {
 
     app = new DropwizardTestSupport<>(ConnectorApp.class,
-        ResourceHelpers.resourceFilePath("config/test-config.yaml"));
+        ResourceHelpers.resourceFilePath("config/config.yaml"));
     app.before();
 
     String requestId = UUID.randomUUID().toString();

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %nß"
 
 worldpay:
   urls:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 worldpay:
   urls:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 worldpay:
   urls:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 links:
   frontendUrl: http://Frontend/

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -13,7 +13,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%thread] %highlight(%-5level) %cyan(%logger{15}) - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 links:
   frontendUrl: http://Frontend/


### PR DESCRIPTION
## WHAT
This PR aims at improving logging for connector by solving 2 problems:

1. not all the logging entries had a requestId
2. even when the requestId was included in the log line, it was not clearly marked as the request id

We solved issue 1) by moving the inclusion of the requestId from the LoggingFilter to the logging configuration (in config/config.yaml) - this makes sure that every time Logger::info() (or the other levels) are called in the code, they are affected by the new format in the configuration. In fact, in the previous implementation the requestId was included only when the LoggingFilter::filter method was invoked.

We solved issue 2) by adding the string `requestID=` just before the request id.

We had to introduce default values in the config.yaml because we are using this configuration for the new tests.


