### PR TITLE
PP-1897 Fixed a bug in the metric to track the size of the queue of c…

### DIFF
--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -47,8 +48,8 @@ public class CardCaptureProcessTest {
         CaptureProcessConfig mockCaptureConfiguration = mock(CaptureProcessConfig.class);
 
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        Meter mockMeter = mock(Meter.class);
-        when(mockMetricRegistry.meter(anyString())).thenReturn(mockMeter);
+        Counter mockCounter = mock(Counter.class);
+        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockCaptureConfiguration.getBatchSize()).thenReturn(10);
         when(mockCaptureConfiguration.getRetryFailuresEveryAsJavaDuration()).thenReturn(Duration.ofMinutes(60));


### PR DESCRIPTION
## WHAT

A Meter was used for tracking the size of the queue, but a Meter is to measure the rate of events over time.
We rather need to just log the size of the queue overtime, which is just an integer.
Among the Metrics available in Dropwizard, probably the Gauge is the more appropriate,
but that is not very efficient as that would need to calculate the size of the queue (which changes
very slowly) at regular interval. A CachedGauge is then a better option, but that complicates
things a bit and we still don't have control on when the metric collection is triggered.
That's why I have decided to use a Counter, which still makes sense, but we need to use it
a bit cleverly, as it just provide methods to increment or decrement the counter. Ideally,
to consider in the futre, is to create a new Metric (probably inheriting from Counter) which
would allow us to set a value directly with a set method.

For more information, you can see Dropwizard Metrics guide.

