### PR TITLE
PP-1775 Extracted scheduling parameters out of `CaptureProcessScheduler` into the config file

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
@@ -4,9 +4,25 @@ import io.dropwizard.Configuration;
 import io.dropwizard.util.Duration;
 
 public class CaptureProcessConfig extends Configuration {
+    private long schedulerInitialDelayInSeconds;
+    private long schedulerRandomIntervalMinimumInSeconds;
+    private long schedulerRandomIntervalMaximumInSeconds;
+
     private int batchSize;
     private Duration retryFailuresEvery;
     private int maximumRetries;
+
+    public long getSchedulerInitialDelayInSeconds() {
+        return schedulerInitialDelayInSeconds;
+    }
+
+    public long getSchedulerRandomIntervalMinimumInSeconds() {
+        return schedulerRandomIntervalMinimumInSeconds;
+    }
+
+    public long getSchedulerRandomIntervalMaximumInSeconds() {
+        return schedulerRandomIntervalMaximumInSeconds;
+    }
 
     public int getBatchSize() {
         return batchSize;

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -88,7 +88,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(SchemeRewriteFilter.class));
         environment.jersey().register(injector.getInstance(Auth3dsDetailsFactory.class));
 
-        setupSchedulers(environment, injector);
+        setupSchedulers(configuration, environment, injector);
 
         setupSmartpayBasicAuth(environment, injector.getInstance(SmartpayAccountSpecificAuthenticator.class));
 
@@ -134,8 +134,8 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         System.setProperty("https.proxyPort", configuration.getClientConfiguration().getProxyConfiguration().getPort().toString());
     }
 
-    private void setupSchedulers(Environment environment, Injector injector) {
-        CaptureProcessScheduler captureProcessScheduler = new CaptureProcessScheduler(environment, injector.getInstance(CardCaptureProcess.class));
+    private void setupSchedulers(ConnectorConfiguration configuration, Environment environment, Injector injector) {
+        CaptureProcessScheduler captureProcessScheduler = new CaptureProcessScheduler(configuration, environment, injector.getInstance(CardCaptureProcess.class));
         environment.lifecycle().manage(captureProcessScheduler);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/CaptureProcessScheduler.java
+++ b/src/main/java/uk/gov/pay/connector/service/CaptureProcessScheduler.java
@@ -4,6 +4,8 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.CaptureProcessConfig;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 
 import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
@@ -14,14 +16,28 @@ public class CaptureProcessScheduler implements Managed {
 
     static final String CAPTURE_PROCESS_SCHEDULER_NAME = "capture-process";
     static final int SCHEDULER_THREADS = 1;
+
     static final long INITIAL_DELAY_IN_SECONDS = 20L;
     static final long RANDOM_INTERVAL_MINIMUM_IN_SECONDS = 150L;
     static final long RANDOM_INTERVAL_MAXIMUM_IN_SECONDS = 200L;
+
+    private long initialDelayInSeconds = INITIAL_DELAY_IN_SECONDS;
+    private long randomIntervalMinimumInSeconds = RANDOM_INTERVAL_MINIMUM_IN_SECONDS;
+    private long randomIntervalMaximumInSeconds = RANDOM_INTERVAL_MAXIMUM_IN_SECONDS;
+
     private final CardCaptureProcess cardCaptureProcess;
     ScheduledExecutorService scheduledExecutorService;
 
-    public CaptureProcessScheduler(Environment environment, CardCaptureProcess cardCaptureProcess) {
+    public CaptureProcessScheduler(ConnectorConfiguration configuration, Environment environment, CardCaptureProcess cardCaptureProcess) {
         this.cardCaptureProcess = cardCaptureProcess;
+
+        if ((configuration != null) && (configuration.getCaptureProcessConfig() != null)) {
+            CaptureProcessConfig captureProcessConfig = configuration.getCaptureProcessConfig();
+            initialDelayInSeconds = captureProcessConfig.getSchedulerInitialDelayInSeconds();
+            randomIntervalMinimumInSeconds = captureProcessConfig.getSchedulerRandomIntervalMinimumInSeconds();
+            randomIntervalMaximumInSeconds = captureProcessConfig.getSchedulerRandomIntervalMaximumInSeconds();
+        }
+
         scheduledExecutorService = environment
                 .lifecycle()
                 .scheduledExecutorService(CAPTURE_PROCESS_SCHEDULER_NAME)
@@ -31,7 +47,7 @@ public class CaptureProcessScheduler implements Managed {
 
     public void start() {
         long interval = randomTimeInterval();
-        logger.info("Scheduling CardCaptureProcess to run every {} seconds (will start in {} seconds)", interval, INITIAL_DELAY_IN_SECONDS);
+        logger.info("Scheduling CardCaptureProcess to run every {} seconds (will start in {} seconds)", interval, initialDelayInSeconds);
 
         scheduledExecutorService.scheduleAtFixedRate(() -> {
             try {
@@ -39,12 +55,15 @@ public class CaptureProcessScheduler implements Managed {
             } catch (Exception e) {
                 logger.error("Unexpected error running capture operations", e);
             }
-        }, INITIAL_DELAY_IN_SECONDS, interval, TimeUnit.SECONDS);
+        }, initialDelayInSeconds, interval, TimeUnit.SECONDS);
     }
 
     private long randomTimeInterval() {
+        if (randomIntervalMaximumInSeconds == randomIntervalMinimumInSeconds) {
+            return randomIntervalMinimumInSeconds;
+        }
         Random rn = new Random();
-        return rn.longs(RANDOM_INTERVAL_MINIMUM_IN_SECONDS, RANDOM_INTERVAL_MAXIMUM_IN_SECONDS).findFirst().getAsLong();
+        return rn.longs(randomIntervalMinimumInSeconds, randomIntervalMaximumInSeconds).findFirst().getAsLong();
     }
 
     public void stop() {

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
@@ -44,10 +44,12 @@ public class CardCaptureProcess {
 
             List<ChargeEntity> chargesToCapture = chargeDao.findChargesForCapture(captureConfig.getBatchSize(), captureConfig.getRetryFailuresEveryAsJavaDuration());
 
-            logger.info("Capturing : "+ chargesToCapture.size() + " of " + queueSize + " charges");
+            if (chargesToCapture.size() > 0) {
+                logger.info("Capturing : " + chargesToCapture.size() + " of " + queueSize + " charges");
+            }
 
             chargesToCapture.forEach((charge) -> {
-                if(shouldRetry(charge)) {
+                if (shouldRetry(charge)) {
                     captureService.doCapture(charge.getExternalId());
                 } else {
                     captureService.markChargeAsCaptureError(charge);

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -54,6 +54,10 @@ executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
+  schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}
+  schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
+  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
+
   batchSize: ${CAPTURE_PROCESS_BATCH_SIZE:-10}
   retryFailuresEvery: ${CAPTURE_PROCESS_RETRY_FAILURES_EVERY:-60 minutes}
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
@@ -124,6 +124,5 @@ public class CardCaptureProcessTest {
         cardCaptureProcess.runCapture();
 
         verify(mockCardCaptureService).markChargeAsCaptureError(mockCharge1);
-
     }
 }

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -67,6 +67,9 @@ executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
+  schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}
+  schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
+  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -66,6 +66,9 @@ executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
+  schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}
+  schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
+  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -56,6 +56,9 @@ executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
+  schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}
+  schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
+  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -40,6 +40,9 @@ executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
+  schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}
+  schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
+  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -37,6 +37,9 @@ executorServiceConfig:
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:
+  schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}
+  schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
+  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Extracted scheduling parameters out of `CaptureProcessScheduler` into the config file to gain the ability to customise the scheduling time interval per environment. It became apparent that it would be useful to run the capture process more frequently in end to end tests to capture charges rapidly and avoid unnecessary delays in the tests relying on the capture process.
- Suppressed logging showing how charges being processed if no charges needs processing in the current batch. This is to avoid littering the logs with useless lines: `INFO  u.g.p.c.s.CardCaptureProcess - Capturing : 0 of 0 charges`


