### PR TITLE
PP-1948 Enable feature flag for async capture by default

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -54,7 +54,7 @@ executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
-asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-false}
+asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-true}
 
 captureProcessConfig:
   schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -66,7 +66,7 @@ executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
-asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-false}
+asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-true}
 
 captureProcessConfig:
   schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -65,7 +65,7 @@ executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
-asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-false}
+asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-true}
 
 captureProcessConfig:
   schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -55,7 +55,7 @@ executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
-asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-false}
+asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-true}
 
 captureProcessConfig:
   schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -39,7 +39,7 @@ executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
-asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-false}
+asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-true}
 
 captureProcessConfig:
   schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -36,7 +36,7 @@ executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
-asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-false}
+asynchronousCapture: ${ASYNCHRONOUS_CAPTURE:-true}
 
 captureProcessConfig:
   schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Enable asynchronous capture by default. Unless `ASYNCHRONOUS_CAPTURE` is specifically set to `false` the new async mean of capturing is now going to be enabled.

