### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,57 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent any
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+  }
+
+  libraries {
+    lib("pay-jenkins-library@master")
+  }
+
+  environment {
+    DOCKER_HOST = "unix:///var/run/docker.sock"
+  }
+
+  stages {
+    stage('Maven Build') {
+      steps {
+        sh 'mvn clean package'
+      }
+    }
+    stage('Docker Build') {
+      steps {
+        script {
+          buildApp{
+            app = "connector"
+          }
+        }
+      }
+    }
+    stage('Test') {
+      steps {
+        runEndToEnd("connector")
+      }
+    }
+    stage('Docker Tag') {
+      steps {
+        script {
+          dockerTag {
+            app = "connector"
+          }
+        }
+      }
+    }
+    stage('Deploy') {
+      when {
+        branch 'master'
+      }
+      steps {
+        deploy("connector", "test", null, true)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a Jenkinsfile for `pay-connector`.

Apart from the referenced project name, this is identical to the Jenkinsfile for `pay-adminusers`.

When this is merged, the following Jenkins jobs need to be disabled and deleted:
- `trigger-pay-connector-master`
- `trigger-pay-connector-pull-request`
- `build-pay-connector`
- `deploy-connector`

In addition, `pay-chef` needs to be modified to ensure the above jobs are not recreated.

Once this is merged, existing branches will need a Jenkinsfile to get the full CI experience (new branches will inherit the one from `master`, of course).