### PR TITLE
PP-1924 fix test clean up

### DIFF
--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -337,7 +337,7 @@ public class DatabaseTestHelper {
     public void deleteAllCardTypes() {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("DELETE FROM card_types")
+                        .createStatement("DELETE FROM accepted_card_types; DELETE FROM card_types;")
                         .execute()
         );
     }


### PR DESCRIPTION
For unknown reasons (presumably different test order but not sure) unit
tests started failing on Jenkins. The error was a foreign key constraint violation
on card_types and accepted_card_types during the `deleteAllCardTypes` utility
method, so have modified to clear accepted_card_types before card_types.

