### PR TITLE
PP-2035 Extended the code so that we can handle a different media type for each gateway.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,4 @@ $ java -jar target/pay-connector-0.1-SNAPSHOT-allinone.jar
 GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. We will give appropriate credit to those reporting confirmed issues. Please e-mail gds-team-pay-security@digital.cabinet-office.gov.uk with details of any issue you find, we aim to reply quickly.
 
 
+

--- a/src/main/java/uk/gov/pay/connector/service/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/service/GatewayClient.java
@@ -39,15 +39,13 @@ public class GatewayClient {
     private final Client client;
     private final Map<String, String> gatewayUrlMap;
     private final MetricRegistry metricRegistry;
-    private final MediaType mediaType;
     private final BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier;
 
-    public GatewayClient(Client client, Map<String, String> gatewayUrlMap, MediaType mediaType,
-                          BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier, MetricRegistry metricRegistry) {
+    public GatewayClient(Client client, Map<String, String> gatewayUrlMap,
+        BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier, MetricRegistry metricRegistry) {
         this.gatewayUrlMap = gatewayUrlMap;
         this.client = client;
         this.metricRegistry = metricRegistry;
-        this.mediaType = mediaType;
         this.sessionIdentifier = sessionIdentifier;
     }
 
@@ -70,7 +68,7 @@ public class GatewayClient {
                             account.getCredentials().get(CREDENTIALS_PASSWORD)));
 
             response = sessionIdentifier.apply(request, requestBuilder)
-                    .post(Entity.entity(request.getPayload(), mediaType));
+                    .post(Entity.entity(request.getPayload(), request.getMediaType()));
 
             int statusCode = response.getStatus();
             Response gatewayResponse = new Response(response);

--- a/src/main/java/uk/gov/pay/connector/service/GatewayClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/service/GatewayClientFactory.java
@@ -4,8 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.client.Invocation.Builder;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -18,12 +17,12 @@ public class GatewayClientFactory {
         this.clientFactory = clientFactory;
     }
 
-    public GatewayClient createGatewayClient(PaymentGatewayName gateway, GatewayOperation operation, Map<String, String> gatewayUrlMap,
-                                             MediaType mediaType,
-                                             BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> sessionIdentier, MetricRegistry metricRegistry) {
-
+    public GatewayClient createGatewayClient(PaymentGatewayName gateway, GatewayOperation operation,
+        Map<String, String> gatewayUrlMap, BiFunction<GatewayOrder, Builder, Builder> sessionIdentier,
+        MetricRegistry metricRegistry)
+    {
         Client client = clientFactory.createWithDropwizardClient(gateway, operation, metricRegistry);
-        return new GatewayClient(client, gatewayUrlMap, mediaType, sessionIdentier, metricRegistry);
+        return new GatewayClient(client, gatewayUrlMap, sessionIdentier, metricRegistry);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/GatewayOrder.java
+++ b/src/main/java/uk/gov/pay/connector/service/GatewayOrder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service;
 
+import javax.ws.rs.core.MediaType;
 import uk.gov.pay.connector.model.OrderRequestType;
 
 import java.util.Optional;
@@ -9,11 +10,14 @@ public class GatewayOrder {
     private OrderRequestType orderRequestType;
     private String payload;
     private String providerSessionId;
+    private MediaType mediaType;
 
-    public GatewayOrder(OrderRequestType orderRequestType, String payload, String providerSessionId) {
+    public GatewayOrder(OrderRequestType orderRequestType, String payload, String providerSessionId,
+        MediaType mediaType) {
         this.orderRequestType = orderRequestType;
         this.payload = payload;
         this.providerSessionId = providerSessionId;
+        this.mediaType = mediaType;
     }
 
     public OrderRequestType getOrderRequestType() {
@@ -26,5 +30,9 @@ public class GatewayOrder {
 
     public Optional<String> getProviderSessionId() {
         return Optional.ofNullable(providerSessionId);
+    }
+
+    MediaType getMediaType() {
+        return mediaType;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/OrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/OrderRequestBuilder.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.service;
 
 
+import javax.ws.rs.core.MediaType;
 import uk.gov.pay.connector.model.OrderRequestType;
 import uk.gov.pay.connector.model.domain.AuthCardDetails;
 import uk.gov.pay.connector.util.templates.PayloadBuilder;
@@ -77,6 +78,8 @@ abstract public class OrderRequestBuilder {
         this.orderRequestType = orderRequestType;
     }
 
+    public abstract MediaType getMediaType();
+
     public OrderRequestBuilder withTransactionId(String transactionId) {
         templateData.setTransactionId(defaultString(transactionId));
         return this;
@@ -116,6 +119,6 @@ abstract public class OrderRequestBuilder {
     public GatewayOrder build() {
         return new GatewayOrder(
                 orderRequestType,
-                payloadBuilder.buildWith(templateData), providerSessionId);
+                payloadBuilder.buildWith(templateData), providerSessionId, getMediaType());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/PaymentProviders.java
+++ b/src/main/java/uk/gov/pay/connector/service/PaymentProviders.java
@@ -11,7 +11,6 @@ import uk.gov.pay.connector.service.worldpay.WorldpayPaymentProvider;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Invocation;
-import javax.ws.rs.core.MediaType;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -50,9 +49,8 @@ public class PaymentProviders<T extends BaseResponse> {
                                                     GatewayOperation operation,
                                                     BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> sessionIdentifier) {
         return gatewayClientFactory.createGatewayClient(
-                gateway, operation, config.getGatewayConfigFor(gateway).getUrls(),
-                MediaType.APPLICATION_XML_TYPE, sessionIdentifier,
-                environment.metrics());
+                gateway, operation, config.getGatewayConfigFor(gateway).getUrls(), sessionIdentifier, environment.metrics()
+        );
     }
 
     private PaymentProvider createWorldpayProvider() {

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service.epdq;
 
+import javax.ws.rs.core.MediaType;
 import uk.gov.pay.connector.model.OrderRequestType;
 import uk.gov.pay.connector.service.OrderRequestBuilder;
 import uk.gov.pay.connector.service.epdq.EpdqSignedPayloadDefinition.EpdqSignedPayloadDefinitionFactory;
@@ -116,5 +117,10 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
     public EpdqOrderRequestBuilder withShaPassphrase(String shaPassphrase) {
         epdqTemplateData.setShaPassphrase(shaPassphrase);
         return this;
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return MediaType.APPLICATION_FORM_URLENCODED_TYPE;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayOrderRequestBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service.smartpay;
 
+import javax.ws.rs.core.MediaType;
 import uk.gov.pay.connector.model.OrderRequestType;
 import uk.gov.pay.connector.service.OrderRequestBuilder;
 import uk.gov.pay.connector.util.templates.PayloadBuilder;
@@ -49,5 +50,10 @@ public class SmartpayOrderRequestBuilder extends OrderRequestBuilder {
     public SmartpayOrderRequestBuilder withReference(String reference) {
         smartpayTemplateData.setReference(reference);
         return this;
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return MediaType.APPLICATION_XML_TYPE;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderRequestBuilder.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service.worldpay;
 
+import javax.ws.rs.core.MediaType;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import uk.gov.pay.connector.model.OrderRequestType;
@@ -159,5 +160,10 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     public WorldpayOrderRequestBuilder withPaResponse3ds(String paResponse) {
         worldpayTemplateData.setPaResponse3ds(paResponse);
         return this;
+    }
+
+    @Override
+    public MediaType getMediaType() {
+        return MediaType.APPLICATION_XML_TYPE;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
+import javax.ws.rs.core.MediaType;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -28,7 +29,6 @@ import uk.gov.pay.connector.service.epdq.EpdqPaymentProvider;
 import uk.gov.pay.connector.util.TestClientFactory;
 
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.URL;
 import java.util.EnumMap;
@@ -111,7 +111,8 @@ public class EpdqPaymentProviderTest {
 
     private PaymentProvider getEpdqPaymentProvider() throws Exception {
         Client client = TestClientFactory.createJerseyClient();
-        GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url), MediaType.APPLICATION_FORM_URLENCODED_TYPE, EpdqPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
+        GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
+            EpdqPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
         EnumMap<GatewayOperation, GatewayClient> gatewayClients = GatewayOperationClientBuilder.builder()
                 .authClient(gatewayClient)
                 .captureClient(gatewayClient)

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -29,7 +29,6 @@ import uk.gov.pay.connector.util.TestClientFactory;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import javax.ws.rs.client.Client;
-import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.URL;
 import java.util.EnumMap;
@@ -179,8 +178,8 @@ public class SmartpayPaymentProviderTest {
 
     private PaymentProvider getSmartpayPaymentProvider() throws Exception {
         Client client = TestClientFactory.createJerseyClient();
-        GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url), MediaType.APPLICATION_XML_TYPE,
-                SmartpayPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
+        GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
+            SmartpayPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
         EnumMap<GatewayOperation, GatewayClient> gatewayClients = GatewayOperationClientBuilder.builder()
                 .authClient(gatewayClient)
                 .captureClient(gatewayClient)

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -27,7 +27,6 @@ import uk.gov.pay.connector.service.worldpay.WorldpayPaymentProvider;
 import uk.gov.pay.connector.util.AuthUtils;
 
 import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.net.URL;
 import java.util.EnumMap;
@@ -240,8 +239,7 @@ public class WorldpayPaymentProviderTest {
         GatewayClient gatewayClient = new GatewayClient(
                 ClientBuilder.newClient(),
                 getWorldpayConfig().getUrls(),
-                MediaType.APPLICATION_XML_TYPE,
-                WorldpayPaymentProvider.includeSessionIdentifier(),
+            WorldpayPaymentProvider.includeSessionIdentifier(),
                 mockMetricRegistry
         );
         EnumMap<GatewayOperation, GatewayClient> gatewayClientEnumMap = GatewayOperationClientBuilder.builder()

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
@@ -8,7 +8,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.core.MediaType;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -33,7 +32,7 @@ public class GatewayClientFactoryTest {
         BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier = (GatewayOrder o, Builder b) -> mockBuilder;
 
         GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE,
-                gatewayUrlMap, MediaType.TEXT_XML_TYPE, sessionIdentifier, mockMetricRegistry);
+                gatewayUrlMap, sessionIdentifier, mockMetricRegistry);
 
         assertNotNull(gatewayClient);
         verify(mockClientFactory).createWithDropwizardClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);

--- a/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
@@ -19,7 +19,6 @@ import uk.gov.pay.connector.service.smartpay.SmartpayPaymentProvider;
 import uk.gov.pay.connector.service.worldpay.WorldpayPaymentProvider;
 
 import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.core.MediaType;
 import java.util.Map;
 import java.util.function.BiFunction;
 
@@ -115,32 +114,32 @@ public class PaymentProvidersTest {
 
     @Test
     public void shouldSetupGatewayClientForGatewayOperations() {
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, AUTHORISE, worldpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, CANCEL, worldpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, CAPTURE, worldpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, REFUND, worldpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, AUTHORISE, worldpayUrlMap,
+            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, CANCEL, worldpayUrlMap,
+            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, CAPTURE, worldpayUrlMap,
+            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, REFUND, worldpayUrlMap,
+            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
 
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, AUTHORISE, smartpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, CANCEL, smartpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, CAPTURE, smartpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, REFUND, smartpayUrlMap, MediaType.APPLICATION_XML_TYPE,
-                SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, AUTHORISE, smartpayUrlMap,
+            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, CANCEL, smartpayUrlMap,
+            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, CAPTURE, smartpayUrlMap,
+            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, REFUND, smartpayUrlMap,
+            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
 
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, AUTHORISE, epdqUrlMap, MediaType.APPLICATION_XML_TYPE,
-                EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, CANCEL, epdqUrlMap, MediaType.APPLICATION_XML_TYPE,
-                EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, CAPTURE, epdqUrlMap, MediaType.APPLICATION_XML_TYPE,
-                EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, REFUND, epdqUrlMap, MediaType.APPLICATION_XML_TYPE,
-                EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(EPDQ, AUTHORISE, epdqUrlMap,
+            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(EPDQ, CANCEL, epdqUrlMap,
+            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(EPDQ, CAPTURE, epdqUrlMap,
+            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
+        verify(gatewayClientFactory).createGatewayClient(EPDQ, REFUND, epdqUrlMap,
+            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
 
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
+import javax.ws.rs.core.MediaType;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +28,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.EnumMap;
 import java.util.Map;
@@ -88,13 +88,13 @@ public class EpdqPaymentProviderTest {
                 .thenReturn(mockClient);
 
         GatewayClient authClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.EPDQ, GatewayOperation.AUTHORISE,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
         GatewayClient cancelClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.EPDQ, GatewayOperation.CANCEL,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
         GatewayClient refundClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.EPDQ, GatewayOperation.REFUND,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
         GatewayClient captureClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.EPDQ, GatewayOperation.CAPTURE,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
 
         gatewayClients = GatewayOperationClientBuilder.builder()
                 .authClient(authClient)
@@ -272,7 +272,8 @@ public class EpdqPaymentProviderTest {
     }
 
     private void verifyPaymentProviderRequest(String requestPayload) {
-        verify(mockClientInvocationBuilder).post(Entity.entity(requestPayload, "application/xml"));
+        verify(mockClientInvocationBuilder).post(Entity.entity(requestPayload,
+            MediaType.APPLICATION_FORM_URLENCODED));
     }
 
     private String successAuthRequest() {

--- a/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
@@ -34,7 +34,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URL;
@@ -93,13 +92,13 @@ public class SmartpayPaymentProviderTest {
         mockSmartpaySuccessfulOrderSubmitResponse();
 
         GatewayClient authClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.AUTHORISE,
-                urlMap, MediaType.APPLICATION_XML_TYPE, mockSessionIdentifier, mockMetricRegistry);
+                urlMap, mockSessionIdentifier, mockMetricRegistry);
         GatewayClient cancelClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.CANCEL,
-                urlMap, MediaType.APPLICATION_XML_TYPE, mockSessionIdentifier, mockMetricRegistry);
+                urlMap, mockSessionIdentifier, mockMetricRegistry);
         GatewayClient refundClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.REFUND,
-                urlMap, MediaType.APPLICATION_XML_TYPE, mockSessionIdentifier, mockMetricRegistry);
+                urlMap, mockSessionIdentifier, mockMetricRegistry);
         GatewayClient captureClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.CAPTURE,
-                urlMap, MediaType.APPLICATION_XML_TYPE, mockSessionIdentifier, mockMetricRegistry);
+                urlMap, mockSessionIdentifier, mockMetricRegistry);
 
 
         EnumMap<GatewayOperation, GatewayClient> gatewayClients = GatewayOperationClientBuilder.builder()

--- a/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
@@ -27,7 +27,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -99,13 +98,13 @@ public class WorldpayPaymentProviderTest {
                 .thenReturn(mockClient);
 
         GatewayClient authClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
         GatewayClient cancelClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, GatewayOperation.CANCEL,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
         GatewayClient refundClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, GatewayOperation.REFUND,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
         GatewayClient captureClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, GatewayOperation.CAPTURE,
-                urlMap, MediaType.APPLICATION_XML_TYPE, includeSessionIdentifier(), mockMetricRegistry);
+                urlMap, includeSessionIdentifier(), mockMetricRegistry);
 
         gatewayClients = GatewayOperationClientBuilder.builder()
                 .authClient(authClient)


### PR DESCRIPTION
## WHAT

Extended the code so that we can handle different media types for each gateway.

This change was required because, whilst all our existing gateways (e.g. Worldpay)
requires 'application/xml' as the mediatype for requests, the new Epdq gateway
requires a different one (multipart/form-data).

On an implementation level, we removed mediatype as constructor argument for
GatewayClient (which has not got a per-gateway specific implementation), and moved
that information into the abstract method OrderRequestBuilder::getMediaType() which
has to be overridden by each per-gateway subclasses, e.g. EpdqOrderRequestBuilder.

with @alexbishop1




