### PR TITLE
PP-2022 upgrading to notify client v3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Important configurations.
 | `SECURE_WORLDPAY_NOTIFICATION_DOMAIN` | `worldpay.com` | incoming requests will have a reverse DNS lookup done on their domain. They must resolve to a domain with this suffix (see `DnsUtils.ipMatchesDomain()`) |
 | `NOTIFY_EMAIL_ENABLED` | false | Whether confirmation emails will be sent using GOV.UK Notify |
 | `NOTIFY_PAYMENT_RECEIPT_EMAIL_TEMPLATE_ID` | - | ID of the email template specified in the GOV.UK Notify to be used for sending emails. An email template can accept personalisation (placeholder values which are passed in by the code). |
-| `NOTIFY_SERVICE_ID` | - | Service ID for the account created at GOV.UK Notify |
-| `NOTIFY_SECRET` | - | Secret for the account created at GOV.UK Notify |
+| `NOTIFY_API_KEY` | - | API Key for the account created at GOV.UK Notify |
 | `NOTIFY_BASE_URL` | `https://api.notifications.service.gov.uk` | Base URL of GOV.UK Notify API to be used|
 | `GDS_CONNECTOR_WORLDPAY_TEST_URL` | - | Pointing to the TEST gateway URL of Worldpay payment provider. |
 | `GDS_CONNECTOR_WORLDPAY_LIVE_URL` | - | Pointing to the LIVE gateway URL of Worldpay payment provider. |

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>uk.gov.service.notify</groupId>
             <artifactId>notifications-java-client</artifactId>
-            <version>2.0.0-RELEASE</version>
+            <version>3.1.2-RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -11,7 +11,6 @@ import uk.gov.pay.connector.model.builder.EntityBuilder;
 import uk.gov.pay.connector.service.CardExecutorService;
 import uk.gov.pay.connector.service.NotifyClientProvider;
 import uk.gov.pay.connector.service.PaymentProviders;
-import uk.gov.pay.connector.service.UserNotificationService;
 import uk.gov.pay.connector.util.HashUtil;
 
 import java.util.Properties;

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.model.builder.EntityBuilder;
 import uk.gov.pay.connector.service.CardExecutorService;
 import uk.gov.pay.connector.service.NotifyClientProvider;
 import uk.gov.pay.connector.service.PaymentProviders;
+import uk.gov.pay.connector.service.UserNotificationService;
 import uk.gov.pay.connector.util.HashUtil;
 
 import java.util.Properties;

--- a/src/main/java/uk/gov/pay/connector/app/NotifyConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/NotifyConfiguration.java
@@ -4,13 +4,10 @@ import io.dropwizard.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
 public class NotifyConfiguration extends Configuration {
 
     private String emailTemplateId;
-    private String serviceId;
-    private String secret;
+    private String apiKey;
     private String notificationBaseURL;
     private boolean emailNotifyEnabled;
 
@@ -20,12 +17,8 @@ public class NotifyConfiguration extends Configuration {
         return emailTemplateId;
     }
 
-    public String getServiceId() {
-        return serviceId;
-    }
-
-    public String getSecret() {
-        return secret;
+    public String getApiKey() {
+        return apiKey;
     }
 
     public String getNotificationBaseURL() {

--- a/src/main/java/uk/gov/pay/connector/service/NotifyClientProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotifyClientProvider.java
@@ -3,24 +3,27 @@ package uk.gov.pay.connector.service;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.NotifyConfiguration;
 import uk.gov.service.notify.NotificationClient;
+
+import javax.net.ssl.SSLContext;
+
+import static uk.gov.pay.connector.util.TrustStoreLoader.getSSLContext;
 
 public class NotifyClientProvider implements Provider<NotificationClient> {
 
-    private ConnectorConfiguration configuration;
+    private NotifyConfiguration configuration;
+    private final SSLContext sslContext;
 
     @Inject
     public NotifyClientProvider(ConnectorConfiguration configuration) {
-        this.configuration = configuration;
+        this.configuration = configuration.getNotifyConfiguration();
+        this.sslContext = getSSLContext();
     }
 
     @Override
     public NotificationClient get() {
-
-        return new NotificationClient(configuration.getNotifyConfiguration().getSecret(),
-                configuration.getNotifyConfiguration().getServiceId(),
-                configuration.getNotifyConfiguration().getNotificationBaseURL()
-        );
+        return new NotificationClient(configuration.getApiKey(), configuration.getNotificationBaseURL(), null, sslContext);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/UserNotificationService.java
@@ -14,7 +14,7 @@ import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.service.notify.Notification;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
-import uk.gov.service.notify.NotificationResponse;
+import uk.gov.service.notify.SendEmailResponse;
 
 import javax.inject.Inject;
 import java.math.BigDecimal;
@@ -51,10 +51,8 @@ public class UserNotificationService {
             Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
             return executorService.submit(() -> {
                 try {
-                    NotificationResponse response = notificationClient.sendEmail(
-                            this.emailTemplateId, emailAddress, buildEmailPersonalisationFromCharge(chargeEntity)
-                    );
-                    return Optional.of(response.getNotificationId());
+                    SendEmailResponse response = notificationClient.sendEmail(emailTemplateId, emailAddress, buildEmailPersonalisationFromCharge(chargeEntity), null);
+                    return Optional.of(response.getNotificationId().toString());
                 } catch (NotificationClientException e) {
                     logger.error("Failed to send confirmation email - charge_external_id=" + chargeEntity.getExternalId(), e);
                     metricRegistry.counter("notify-operations.failures").inc();

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -160,9 +160,8 @@ jpa:
   cacheSharedDefault: false
 
 notifyConfig:
+  apiKey: ${NOTIFY_API_KEY:-api_key-pay-notify-service-id-pay-notify-secret-needs-to-be-32-chars-fsghdngfhmhfkrgsfs}
   emailTemplateId: ${NOTIFY_PAYMENT_RECEIPT_EMAIL_TEMPLATE_ID}
-  serviceId: ${NOTIFY_SERVICE_ID}
-  secret: ${NOTIFY_SECRET}
   notificationBaseURL: ${NOTIFY_BASE_URL:-https://api.notifications.service.gov.uk}
   emailNotifyEnabled: ${NOTIFY_EMAIL_ENABLED:-false}
 

--- a/src/test/java/uk/gov/pay/connector/service/UserNotificationServiceIntTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/UserNotificationServiceIntTest.java
@@ -10,8 +10,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.it.mock.NotifyEmailMock;
 import uk.gov.pay.connector.model.domain.ChargeEntity;

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -132,8 +132,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
-  serviceId: test-service-id
-  secret: 11111111-1111-1111-1111-111111111111
+  apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
 

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -131,8 +131,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
-  serviceId: test-service-id
-  secret: 11111111-1111-1111-1111-111111111111
+  apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
 

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -121,8 +121,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
-  serviceId: test-service-id
-  secret: 11111111-1111-1111-1111-111111111111
+  apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -127,8 +127,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
-  serviceId: test-service-id
-  secret: 11111111-1111-1111-1111-111111111111
+  apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -124,8 +124,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
-  serviceId: test-service-id
-  secret: 11111111-1111-1111-1111-111111111111
+  apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false
 


### PR DESCRIPTION
The upgrade needed to be done in order to consistent with adminusers and to be compatible with the latest API from notify. The primary change is that they have moved in favour of a API Key style auth mechanism over the existing serviceId + secret approach.

Currently not happy with the Asynchronous implementation in UserNotificationService.java. This uses a fixed unmanaged threadpool + uses a Future<T> style to make it asynchronous . This could be improved to a more promise style approach (see adminusers notify integration style) and using a Dropwizard managed execution service.



