### PR TITLE
PP-2117 Pinned down version of commons-collections dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,11 @@
             <artifactId>jackson-core</artifactId>
             <version>2.8.7</version>
         </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
         <!-- testing -->
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

Pinned down version 3.2.2 of `commons-collections` transient dependency to prevent Maven to pull any of the previous versions which may contain vulnerabilities as reported previously by `Snyk`:

- https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-7501


