### PR TITLE
PP-2120 Removed the logging of the entire notification payload but only relevant notification data

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/BaseNotification.java
+++ b/src/main/java/uk/gov/pay/connector/model/BaseNotification.java
@@ -40,10 +40,14 @@ public class BaseNotification<T> implements Notification {
     public String toString() {
         return new StringBuilder()
                 .append("Notification [")
-                .append("reference=" + reference)
-                .append(", transactionId=" + transactionId)
-                .append(", status=" + status)
-                .append(", gatewayEventDate=" + gatewayEventDate)
+                .append("reference=")
+                .append(reference)
+                .append(", transactionId=")
+                .append(transactionId)
+                .append(", status=")
+                .append(status)
+                .append(", gatewayEventDate=")
+                .append(gatewayEventDate)
                 .append("]")
                 .toString();
     }

--- a/src/main/java/uk/gov/pay/connector/model/BaseNotification.java
+++ b/src/main/java/uk/gov/pay/connector/model/BaseNotification.java
@@ -35,4 +35,16 @@ public class BaseNotification<T> implements Notification {
     public ZonedDateTime getGatewayEventDate() {
         return gatewayEventDate;
     }
+
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("Notification [")
+                .append("reference=" + reference)
+                .append(", transactionId=" + transactionId)
+                .append(", status=" + status)
+                .append(", gatewayEventDate=" + gatewayEventDate)
+                .append("]")
+                .toString();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/model/Notifications.java
+++ b/src/main/java/uk/gov/pay/connector/model/Notifications.java
@@ -39,6 +39,6 @@ public class Notifications<T> {
 
     @Override
     public String toString() {
-        return String.format("Notifications [notifications=[%s]]", StringUtils.join(get(), ", "));
+        return String.format("Notifications [notifications=%s]", get());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/Notifications.java
+++ b/src/main/java/uk/gov/pay/connector/model/Notifications.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.model;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.LocalDate;
 import java.time.ZonedDateTime;
@@ -36,5 +37,8 @@ public class Notifications<T> {
         return notifications;
     }
 
-
+    @Override
+    public String toString() {
+        return String.format("Notifications [notifications=[%s]]", StringUtils.join(get(), ", "));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/resources/NotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/NotificationResource.java
@@ -53,7 +53,6 @@ public class NotificationResource {
     }
 
     private Response handleNotification(String ipAddress, String name, String notification) {
-        logger.info("Received notification from provider={}, notification={}", name, notification);
         PaymentGatewayName paymentGatewayName = PaymentGatewayName.valueFrom(name);
         if (!notificationService.handleNotificationFor(ipAddress, paymentGatewayName, notification)) {
             logger.error("Rejected notification for ip '{}'", ipAddress);

--- a/src/test/java/uk/gov/pay/connector/model/NotificationsTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/NotificationsTest.java
@@ -32,4 +32,21 @@ public class NotificationsTest {
         assertThat(notifications.get().get(1).getGatewayEventDate(), is(now));
     }
 
+    @Test
+    public void shouldConvertToString() {
+        ZonedDateTime now = ZonedDateTime.now();
+
+        Notifications<String> notifications = Notifications
+                .<String>builder()
+                .addNotificationFor("transaction-id-1", "reference-1", "status-1", now)
+                .addNotificationFor("transaction-id-2", "reference-2", "status-2", now)
+                .build();
+
+        assertThat(notifications.toString(),
+                is(String.format("Notifications [notifications=" +
+                        "[Notification [reference=reference-1, transactionId=transaction-id-1, status=status-1, gatewayEventDate=%s], " +
+                        "Notification [reference=reference-2, transactionId=transaction-id-2, status=status-2, gatewayEventDate=%s]]]",
+                        now.toString(), now.toString())));
+    }
+
 }


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Removed the line that was responsible for logging all notification payloads verbatim which sometimes included personally identifiable information which was undesirable from a security point of view.
- This has been replaces in favour of logging the parsed notification transpiring in the logs only the following relevant information: `reference`, `transactionId`, `status`, `gatewayEventDate`.


