### PR TITLE
PP-2270 Sanitize Charge details values

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/AddressEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/AddressEntity.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.model.domain;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 
+import static uk.gov.pay.connector.model.domain.NumbersInStringsSanitizer.*;
+
 @Embeddable
 public class AddressEntity {
 
@@ -24,12 +26,12 @@ public class AddressEntity {
     }
 
     public AddressEntity(Address address) {
-        this.line1 = address.getLine1();
-        this.line2 = address.getLine2();
-        this.postcode = address.getPostcode();
-        this.city = address.getCity();
-        this.county = address.getCounty();
-        this.country = address.getCountry();
+        this.line1 = sanitize(address.getLine1());
+        this.line2 = sanitize(address.getLine2());
+        this.postcode = sanitize(address.getPostcode());
+        this.city = sanitize(address.getCity());
+        this.county = sanitize(address.getCounty());
+        this.country = sanitize(address.getCountry());
     }
 
     public Address toAddress(){

--- a/src/main/java/uk/gov/pay/connector/model/domain/NumbersInStringsSanitizer.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/NumbersInStringsSanitizer.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.model.domain;
+
+import com.google.common.base.CharMatcher;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class NumbersInStringsSanitizer {
+
+    private static final int MAXIMUM_NUMBER_OF_NUMBERS_IN_STRING_ALLOWED = 10;
+    private static final CharMatcher CHAR_MATCHER_NUMBERS_RANGE = CharMatcher.inRange('0', '9');
+    private static final String CHARACTER_PER_NUMBER_REPLACEMENT = "*";
+
+    public static String sanitize(String value) {
+        String result = value;
+        if (isNotBlank(value)) {
+            String numberOfDigits = CHAR_MATCHER_NUMBERS_RANGE.retainFrom(value);
+            if (numberOfDigits.length() > MAXIMUM_NUMBER_OF_NUMBERS_IN_STRING_ALLOWED) {
+                result = CHAR_MATCHER_NUMBERS_RANGE.replaceFrom(value, CHARACTER_PER_NUMBER_REPLACEMENT);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.NumbersInStringsSanitizer.*;
 
 public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetails> {
 
@@ -87,9 +88,9 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
     private void appendCardDetails(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
         CardDetailsEntity detailsEntity = new CardDetailsEntity();
-        detailsEntity.setCardBrand(authCardDetails.getCardBrand());
+        detailsEntity.setCardBrand(sanitize(authCardDetails.getCardBrand()));
         detailsEntity.setBillingAddress(new AddressEntity(authCardDetails.getAddress()));
-        detailsEntity.setCardHolderName(authCardDetails.getCardHolder());
+        detailsEntity.setCardHolderName(sanitize(authCardDetails.getCardHolder()));
         detailsEntity.setExpiryDate(authCardDetails.getEndDate());
         detailsEntity.setLastDigitsCardNumber(StringUtils.right(authCardDetails.getCardNo(), 4));
         chargeEntity.setCardDetails(detailsEntity);

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -27,6 +27,7 @@ import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.pay.connector.model.ChargeResponse.ChargeResponseBuilder;
 import static uk.gov.pay.connector.model.ChargeResponse.aChargeResponse;
+import static uk.gov.pay.connector.model.domain.NumbersInStringsSanitizer.*;
 import static uk.gov.pay.connector.resources.ApiPaths.CHARGE_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUNDS_API_PATH;
 
@@ -92,7 +93,7 @@ public class ChargeService {
     public ChargeEntity updateCharge(ChargeEntity chargeEntity, PatchRequestBuilder.PatchRequest chargePatchRequest) {
         switch (chargePatchRequest.getPath()) {
             case ChargesApiResource.EMAIL_KEY:
-                chargeEntity.setEmail(chargePatchRequest.getValue());
+                chargeEntity.setEmail(sanitize(chargePatchRequest.getValue()));
         }
 
         chargeDao.merge(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -139,6 +139,10 @@ public class ChargingITestBase extends ChargingITestCommon{
         return buildJsonAuthorisationDetailsFor("Mr. Payment", cardNumber, cvc, expiryDate, cardBrand, "The Money Pool", null, "London", null, "DO11 4RS", "GB");
     }
 
+    protected String buildDetailedJsonAuthorisationDetailsFor(String cardNumber, String cvc, String expiryDate, String cardBrand, String cardHolderName, String addressLine1, String addressLine2, String city, String county, String postcode, String country) {
+        return buildJsonAuthorisationDetailsFor(cardHolderName, cardNumber, cvc, expiryDate, cardBrand, addressLine1, addressLine2, city, county, postcode, country);
+    }
+
     protected ValidatableResponse getCharge(String chargeId) {
         return connectorRestApi
                 .withChargeId(chargeId)

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
@@ -102,5 +102,4 @@ public class ChargeDaoCardDetailsITest extends DaoITestBase {
         assertThat(cardDetailsSaved, hasEntry("address_county", cardDetailsEntity.getBillingAddress().getCounty()));
         assertThat(cardDetailsSaved, hasEntry("address_country", cardDetailsEntity.getBillingAddress().getCountry()));
     }
-
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthoriseResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthoriseResourceITest.java
@@ -68,6 +68,63 @@ public class CardAuthoriseResourceITest extends ChargingITestBase {
     }
 
     @Test
+    public void sanitizeCardDetails_shouldStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingMoreThan10Numbers() throws Exception {
+
+        String sanitizedValue = "r-**-**-*  Ju&^****-**";
+        String valueWithMoreThan10CharactersAsNumbers = "r-12-34-5  Ju&^6501-76";
+        String cardHolderName = valueWithMoreThan10CharactersAsNumbers;
+        String addressLine1 = valueWithMoreThan10CharactersAsNumbers;
+        String addressLine2 = valueWithMoreThan10CharactersAsNumbers;
+        String city = valueWithMoreThan10CharactersAsNumbers;
+        String county = valueWithMoreThan10CharactersAsNumbers;
+        String postcode = valueWithMoreThan10CharactersAsNumbers;
+        String country = valueWithMoreThan10CharactersAsNumbers;
+        String cardBrand = valueWithMoreThan10CharactersAsNumbers;
+
+        String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor("4444333322221111", "123", "11/30", cardBrand, cardHolderName, addressLine1, addressLine2, city, county, postcode, country));
+
+        Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge-"));
+        Map<String, Object> chargeCardDetails = app.getDatabaseTestHelper().getChargeCardDetailsByChargeId(chargeId);
+        assertThat(chargeCardDetails, hasEntry("last_digits_card_number", "1111"));
+        assertThat(chargeCardDetails, hasEntry("address_county", sanitizedValue));
+        assertThat(chargeCardDetails, hasEntry("address_line1", sanitizedValue));
+        assertThat(chargeCardDetails, hasEntry("address_line2", sanitizedValue));
+        assertThat(chargeCardDetails, hasEntry("address_country", sanitizedValue));
+        assertThat(chargeCardDetails, hasEntry("address_city", sanitizedValue));
+        assertThat(chargeCardDetails, hasEntry("card_brand", sanitizedValue));
+        assertThat(chargeCardDetails, hasEntry("address_postcode", sanitizedValue));
+        assertThat(chargeCardDetails, hasEntry("cardholder_name", sanitizedValue));
+    }
+
+    @Test
+    public void sanitizeCardDetails_shouldNotStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingRight10Numbers() throws Exception {
+
+        String valueWith10CharactersAsNumbers = "r-12-34-5  Ju&^6501-7m";
+        String cardHolderName = valueWith10CharactersAsNumbers;
+        String addressLine1 = valueWith10CharactersAsNumbers;
+        String addressLine2 = valueWith10CharactersAsNumbers;
+        String city = valueWith10CharactersAsNumbers;
+        String county = valueWith10CharactersAsNumbers;
+        String postcode = valueWith10CharactersAsNumbers;
+        String country = valueWith10CharactersAsNumbers;
+        String cardBrand = valueWith10CharactersAsNumbers;
+
+        String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor("4444333322221111", "123", "11/30", cardBrand, cardHolderName, addressLine1, addressLine2, city, county, postcode, country));
+
+        Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge-"));
+        Map<String, Object> chargeCardDetails = app.getDatabaseTestHelper().getChargeCardDetailsByChargeId(chargeId);
+        assertThat(chargeCardDetails, hasEntry("last_digits_card_number", "1111"));
+        assertThat(chargeCardDetails, hasEntry("address_county", valueWith10CharactersAsNumbers));
+        assertThat(chargeCardDetails, hasEntry("address_line1", valueWith10CharactersAsNumbers));
+        assertThat(chargeCardDetails, hasEntry("address_line2", valueWith10CharactersAsNumbers));
+        assertThat(chargeCardDetails, hasEntry("address_country", valueWith10CharactersAsNumbers));
+        assertThat(chargeCardDetails, hasEntry("address_city", valueWith10CharactersAsNumbers));
+        assertThat(chargeCardDetails, hasEntry("card_brand", valueWith10CharactersAsNumbers));
+        assertThat(chargeCardDetails, hasEntry("address_postcode", valueWith10CharactersAsNumbers));
+        assertThat(chargeCardDetails, hasEntry("cardholder_name", valueWith10CharactersAsNumbers));
+    }
+
+    @Test
     public void shouldNotAuthoriseCard_ForSpecificCardNumber1() throws Exception {
         String cardDetailsToReject = buildJsonAuthorisationDetailsFor("4000000000000002", "visa");
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -68,7 +68,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     private static final long AMOUNT = 6234L;
 
     private String returnUrl = "http://service.url/success-page/";
-    private String email = randomAlphanumeric(242) + "@example.com";
+    private String email = randomAlphabetic(242) + "@example.com";
 
     private RestAssuredClient createChargeApi = new RestAssuredClient(app, accountId);
     private RestAssuredClient getChargeApi = new RestAssuredClient(app, accountId);
@@ -181,9 +181,9 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
 
         getCharge(chargeId)
-            .body("settlement_summary.capture_submit_time", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
-            .body("settlement_summary.capture_submit_time", isWithin(10, SECONDS))
-            .body("settlement_summary.captured_date", equalTo(expectedDayOfCapture))
+                .body("settlement_summary.capture_submit_time", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("settlement_summary.capture_submit_time", isWithin(10, SECONDS))
+                .body("settlement_summary.captured_date", equalTo(expectedDayOfCapture))
         ;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -25,6 +25,7 @@ import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status;
 import static javax.ws.rs.core.Response.Status.*;
+import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
@@ -43,7 +44,7 @@ public class ChargesFrontendResourceITest {
     private String accountId = "72332423443245";
     private String description = "Test description";
     private String returnUrl = "http://whatever.com";
-    private String email = randomAlphanumeric(242) + "@example.com";
+    private String email = randomAlphabetic(242) + "@example.com";
     private String serviceName = "a cool service";
     private String analyticsId = "test-123";
     private String type = "test";
@@ -287,7 +288,7 @@ public class ChargesFrontendResourceITest {
     @Test
     public void patchValidEmailOnChargeWithReplaceOp_shouldReturnOk() {
         String chargeId = postToCreateACharge(expectedAmount);
-        String email = randomAlphanumeric(242) + "@example.com";
+        String email = randomAlphabetic(242) + "@example.com";
 
         String patchBody = createPatch("replace", "email", email);
 
@@ -298,6 +299,24 @@ public class ChargesFrontendResourceITest {
         response.statusCode(OK.getStatusCode())
                 .contentType(JSON)
                 .body("email", is(email));
+    }
+
+    @Test
+    public void sanitize_patchValidEmailOnChargeWithReplaceOp_shouldReturnOk_withSanitizedData() {
+
+        String chargeId = postToCreateACharge(expectedAmount);
+        String email = "r-12-34-5  Ju&^6501-76@example.com";
+        String sanitizedEmail = "r-**-**-*  Ju&^****-**@example.com";
+
+        String patchBody = createPatch("replace", "email", email);
+
+        ValidatableResponse response = connectorRestApi
+                .withChargeId(chargeId)
+                .patchCharge(patchBody);
+
+        response.statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("email", is(sanitizedEmail));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/NumbersInStringsSanitizerTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/NumbersInStringsSanitizerTest.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.model.domain;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+
+public class NumbersInStringsSanitizerTest {
+
+    @Test
+    public void sanitize_shouldSanitizeNumbersAsStarsInStringWith11Numbers() {
+
+        String sanitizedValue = NumbersInStringsSanitizer.sanitize("01234567892");
+
+        assertThat(sanitizedValue, is("***********"));
+    }
+
+    @Test
+    public void sanitize_shouldNotSanitizeNumbersAsStarsInStringWith10Numbers() {
+
+        String sanitizedValue = NumbersInStringsSanitizer.sanitize("2345678912");
+
+        assertThat(sanitizedValue, is("2345678912"));
+    }
+
+    @Test
+    public void sanitize_shouldNotSanitizeABlankString() {
+
+        String sanitizedValue = NumbersInStringsSanitizer.sanitize("  ");
+
+        assertThat(sanitizedValue, is("  "));
+    }
+
+    @Test
+    public void sanitize_shouldNotSanitizeANullValue() {
+
+        String sanitizedValue = NumbersInStringsSanitizer.sanitize(null);
+
+        assertThat(sanitizedValue, is(nullValue()));
+    }
+
+    @Test
+    public void sanitize_shouldSanitizeStringWithDigitsInRandomPositions() {
+
+        String sanitizedValue = NumbersInStringsSanitizer.sanitize("&%)9(&%^&*988   hjdjkd$%12  **2221opsdja9q8987^&*88&6^f99s*%^");
+
+        assertThat(sanitizedValue, is("&%)*(&%^&****   hjdjkd$%**  ******opsdja*q****^&***&*^f**s*%^"));
+    }
+}


### PR DESCRIPTION
## WHAT
 - Mitigate possible mistakes in fields as values might accidentally contain other information that the user intended to send.

- Basic sanitization of relevant data. Add Sanitizer where Strings containing more than 10 character digits are obfuscated to `*` characters.


