### PR TITLE
PP-1501 Allow updating of ePDQ gateway account credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/GatewayAccountResource.java
@@ -70,6 +70,7 @@ public class GatewayAccountResource {
         providerCredentialFields = newHashMap();
         providerCredentialFields.put("worldpay", conf.getWorldpayConfig().getCredentials());
         providerCredentialFields.put("smartpay", conf.getSmartpayConfig().getCredentials());
+        providerCredentialFields.put("epdq", conf.getEpdqConfig().getCredentials());
     }
 
     @GET

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -56,6 +56,8 @@ epdq:
   urls:
     test: ${GDS_CONNECTOR_EPDQ_TEST_URL}
     live: ${GDS_CONNECTOR_EPDQ_LIVE_URL}
+  credentials: ['username','password','psp_id','sha_in_passphrase']
+
   # The Jersey Client timeouts are set to the same values as for Worldpay initially until we gather more metrics
   # to be in a position to tweak more appropriately.
   jerseyClientOverrides:

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -34,7 +34,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
             return new GatewayAccountPayload()
                     .withUsername("a-username")
                     .withPassword("a-password")
-                    .withMerchantId("a-mercahnt-id")
+                    .withMerchantId("a-merchant-id")
                     .withServiceName("a-service-name");
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -3,15 +3,18 @@ package uk.gov.pay.connector.it.resources;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.response.ValidatableResponse;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static javax.ws.rs.core.Response.Status.*;
-import static org.hamcrest.Matchers.*;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.LIVE;
 import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.resources.ApiPaths.GATEWAY_ACCOUNTS_API_PATH;
@@ -236,7 +239,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
     }
 
     @Test
-    public void createAccountShouldFailIfPaymentProviderIsNotSandboxOfWorldpay() throws Exception {
+    public void createAccountShouldFailIfPaymentProviderIsNotRecognised() throws Exception {
         String testProvider = "random";
         String payload = toJson(ImmutableMap.of("payment_provider", testProvider));
 
@@ -275,6 +278,11 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
     @Test
     public void createAGatewayAccountForSmartpay() throws Exception {
         createAGatewayAccountFor("smartpay");
+    }
+
+    @Test
+    public void createAGatewayAccountForEpdq() throws Exception {
+        createAGatewayAccountFor("epdq");
     }
 
     @Test


### PR DESCRIPTION
Make it so that connector can process requests to update ePDQ gateway account credentials (e.g. from selfservice).

Username, password, PSP ID and SHA-IN passphrase mandatory.