### PR TITLE
PP-2330 Upgrade notify client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>uk.gov.service.notify</groupId>
             <artifactId>notifications-java-client</artifactId>
-            <version>3.1.2-RELEASE</version>
+            <version>3.1.3-RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
notifications-java-client 3.1.2-RELEASE is affected by https://snyk.io/vuln/SNYK-JAVA-ORGBITBUCKETBC-30206?utm_campaign=vuln_alert&utm_medium=email&utm_source=Vuln

This upgrades to 3.1.3-RELEASE, which fixes the vulnerability