### PR TITLE
PP-2342 Correct GDS_CONNECTOR_EPDQ_LIVE_URL description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 | `GDS_CONNECTOR_WORLDPAY_LIVE_URL` | - | Pointing to the LIVE gateway URL of Worldpay payment provider. |
 | `GDS_CONNECTOR_SMARTPAY_TEST_URL` | - | Pointing to the TEST gateway URL of Smartpay payment provider. |
 | `GDS_CONNECTOR_SMARTPAY_LIVE_URL` | - | Pointing to the LIVE gateway URL of Smartpay payment provider. |
-| `GDS_CONNECTOR_EPDQ_TEST_URL` | - | Pointing to the TEST gateway URL of Epdq payment provider. |
-| `GDS_CONNECTOR_EPDQ_LIVE_URL` | - | Pointing to the TEST gateway URL of Epdq payment provider. |
+| `GDS_CONNECTOR_EPDQ_TEST_URL` | - | Pointing to the TEST gateway URL of ePDQ payment provider. |
+| `GDS_CONNECTOR_EPDQ_LIVE_URL` | - | Pointing to the LIVE gateway URL of ePDQ payment provider. |
 | `ASYNCHRONOUS_CAPTURE` | true | whether to handle capture asynchronously. When asynchronous capture is enabled, capture requests are deferred and operated in batch by a background task  |
 
 ### Background captures


### PR DESCRIPTION
Change description of `GDS_CONNECTOR_EPDQ_LIVE_URL` from “Pointing to the TEST gateway URL of Epdq payment provider” to “Pointing to the LIVE gateway URL of ePDQ payment provider”

Also use the correct case for ePDQ everywhere