### PR TITLE
PP-2245 Abort ignored notification fast

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotificationService.java
@@ -96,6 +96,14 @@ public class NotificationService {
         private <T> boolean verify(Notification<T> notification) {
             logger.info("Verifying {} notification {}", paymentProvider.getPaymentGatewayName(), notification);
 
+            // If the notification is intended to be ignored, we abort immediately to avoid further complications.
+            // Depending on the payment provider and the type of the notification we may not always for instance have a
+            // transaction id, hence if we intend to ignore the notification it is safer to do it here.
+            if (paymentProvider.getStatusMapper().from(notification.getStatus()).getType() == InterpretedStatus.Type.IGNORED) {
+                logger.info("{} notification {} ignored", paymentProvider.getPaymentGatewayName(), notification);
+                return false;
+            }
+
             if (isBlank(notification.getTransactionId())) {
                 logger.error("{} notification {} failed verification because it has no transaction ID", paymentProvider.getPaymentGatewayName(), notification);
                 return false;

--- a/src/main/java/uk/gov/pay/connector/service/StatusMapper.java
+++ b/src/main/java/uk/gov/pay/connector/service/StatusMapper.java
@@ -80,6 +80,18 @@ public class StatusMapper<T> {
         return new Builder<>();
     }
 
+    public InterpretedStatus from(T gatewayStatus, ChargeStatus currentStatus) {
+        return from(GatewayStatusWithCurrentStatus.of(gatewayStatus, currentStatus), validStatuses);
+    }
+
+    public InterpretedStatus from(T gatewayStatus) {
+        List<StatusMap<T>> gatewayStatusesOnly = this.validStatuses
+                .stream()
+                .filter(validStatus -> validStatus.getFromStatus() instanceof GatewayStatusOnly)
+                .collect(Collectors.toList());
+        return from(GatewayStatusOnly.of(gatewayStatus), gatewayStatusesOnly);
+    }
+
     private InterpretedStatus from(StatusMapFromStatus<T> gatewayStatus, List<StatusMap<T>> wantedValidStatuses) {
 
         Optional<StatusMap<T>> statusMap = wantedValidStatuses
@@ -108,17 +120,5 @@ public class StatusMapper<T> {
         }
 
         return new UnknownStatus();
-    }
-
-    public InterpretedStatus from(T gatewayStatus, ChargeStatus currentStatus) {
-        return from(GatewayStatusWithCurrentStatus.of(gatewayStatus, currentStatus), validStatuses);
-    }
-
-    public InterpretedStatus from(T gatewayStatus) {
-        List<StatusMap<T>> gatewayStatusesOnly = this.validStatuses
-                .stream()
-                .filter(validStatus -> validStatus.getFromStatus() instanceof GatewayStatusOnly)
-                .collect(Collectors.toList());
-        return from(GatewayStatusOnly.of(gatewayStatus), gatewayStatusesOnly);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
@@ -98,23 +98,27 @@ public class NotificationServiceTest {
                 MappedChargeStatus mockedMappedChargeStatus = mock(MappedChargeStatus.class);
                 when(mockedMappedChargeStatus.getType()).thenReturn(type);
                 when(mockedMappedChargeStatus.getChargeStatus()).thenReturn((ChargeStatus) status);
+                when(mockedStatusMapper.from(any())).thenReturn(mockedMappedChargeStatus);
                 when(mockedStatusMapper.from(any(), any(ChargeStatus.class))).thenReturn(mockedMappedChargeStatus);
                 return mockedStatusMapper;
             case REFUND_STATUS:
                 MappedRefundStatus mockedMappedRefundStatus = mock(MappedRefundStatus.class);
                 when(mockedMappedRefundStatus.getType()).thenReturn(type);
                 when(mockedMappedRefundStatus.getRefundStatus()).thenReturn((RefundStatus) status);
+                when(mockedStatusMapper.from(any())).thenReturn(mockedMappedRefundStatus);
                 when(mockedStatusMapper.from(any(), any(ChargeStatus.class))).thenReturn(mockedMappedRefundStatus);
                 return mockedStatusMapper;
             case IGNORED:
                 IgnoredStatus mockedIgnoredStatus = mock(IgnoredStatus.class);
                 when(mockedIgnoredStatus.getType()).thenReturn(type);
+                when(mockedStatusMapper.from(any())).thenReturn(mockedIgnoredStatus);
                 when(mockedStatusMapper.from(any(), any(ChargeStatus.class))).thenReturn(mockedIgnoredStatus);
                 return mockedStatusMapper;
             case UNKNOWN:
             default:
                 UnknownStatus mockedUnknownStatus = mock(UnknownStatus.class);
                 when(mockedUnknownStatus.getType()).thenReturn(type);
+                when(mockedStatusMapper.from(any())).thenReturn(mockedUnknownStatus);
                 when(mockedStatusMapper.from(any(), any(ChargeStatus.class))).thenReturn(mockedUnknownStatus);
                 return mockedStatusMapper;
         }

--- a/src/test/java/uk/gov/pay/connector/service/StatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/StatusMapperTest.java
@@ -4,14 +4,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUBMITTED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCELLED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCEL_SUBMITTED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCELLED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
 import static uk.gov.pay.connector.model.domain.RefundStatus.REFUNDED;
 
 public class StatusMapperTest {
@@ -34,6 +27,13 @@ public class StatusMapperTest {
     }
 
     @Test
+    public void shouldIgnore_WhenNoCurrentStatusProvided() {
+        InterpretedStatus ignoredStatus = statusMapper.from("IGNORED_STATUS");
+
+        assertThat(ignoredStatus.getType(), is(InterpretedStatus.Type.IGNORED));
+    }
+
+    @Test
     public void shouldMapGatewayStatusOnlyToChargeStatus() {
         InterpretedStatus mappedStatus = statusMapper.from("HERE_WE_ONLY_CARE_ABOUT_THE_GATEWAY_STATUS", CAPTURE_SUBMITTED);
 
@@ -42,8 +42,24 @@ public class StatusMapperTest {
     }
 
     @Test
+    public void shouldMapGatewayStatusOnlyToChargeStatus_WhenNoCurrentStatusProvided() {
+        InterpretedStatus mappedStatus = statusMapper.from("HERE_WE_ONLY_CARE_ABOUT_THE_GATEWAY_STATUS");
+
+        assertThat(mappedStatus.getType(), is(InterpretedStatus.Type.CHARGE_STATUS));
+        assertThat(mappedStatus.getChargeStatus(), is(CAPTURED));
+    }
+
+    @Test
     public void shouldMapGatewayStatusOnlyToRefundStatus() {
         InterpretedStatus mappedStatus = statusMapper.from("AGAIN_WE_ONLY_CARE_ABOUT_THE_GATEWAY_STATUS", CAPTURED);
+
+        assertThat(mappedStatus.getType(), is(InterpretedStatus.Type.REFUND_STATUS));
+        assertThat(mappedStatus.getRefundStatus(), is(REFUNDED));
+    }
+
+    @Test
+    public void shouldMapGatewayStatusOnlyToRefundStatus_WhenNoCurrentStatusProvided() {
+        InterpretedStatus mappedStatus = statusMapper.from("AGAIN_WE_ONLY_CARE_ABOUT_THE_GATEWAY_STATUS");
 
         assertThat(mappedStatus.getType(), is(InterpretedStatus.Type.REFUND_STATUS));
         assertThat(mappedStatus.getRefundStatus(), is(REFUNDED));
@@ -60,6 +76,13 @@ public class StatusMapperTest {
     @Test
     public void shouldNotMapGatewayStatusWithCurrentStatusUnlessCurrentStatusMatches() {
         InterpretedStatus mappedStatus = statusMapper.from("HERE_WE_CARE_ABOUT_THE_GATEWAY_STATUS_AND_THE_CURRENT_STATUS", AUTHORISATION_SUBMITTED);
+
+        assertThat(mappedStatus.getType(), is(InterpretedStatus.Type.UNKNOWN));
+    }
+
+    @Test
+    public void shouldNotMapGatewayStatus_WhenNoCurrentStatusProvided() {
+        InterpretedStatus mappedStatus = statusMapper.from("HERE_WE_CARE_ABOUT_THE_GATEWAY_STATUS_AND_THE_CURRENT_STATUS");
 
         assertThat(mappedStatus.getType(), is(InterpretedStatus.Type.UNKNOWN));
     }


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Notifications of a certain type and for certain providers (i.e. prior authorisation for Worldpay) don't have a transaction id in their payload per design and hence there would be no way to reconcile with the charge that originated the transaction feedback. However since we genuinely don't care about these notifications specifically, they are generally to be ignored gracefully by Connector. This change is to identify notifications that are to be ignored at the early stage of processing during verification phase and abort gracefully and immediately with appropriate logging at INFO level.


