### PR TITLE
PP-2245 Updated Worldpay status mapper to ignore certain types of notifications

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayStatusMapper.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayStatusMapper.java
@@ -11,12 +11,15 @@ public class WorldpayStatusMapper {
     private static final StatusMapper<String> STATUS_MAPPER =
             StatusMapper
                     .<String>builder()
+                    .ignore("SENT_FOR_AUTHORISATION")
                     .ignore("AUTHORISED")
                     .ignore("CANCELLED")
+                    .ignore("EXPIRED")
                     .map("CAPTURED", CAPTURED)
                     .ignore("REFUSED")
                     .ignore("REFUSED_BY_BANK")
-                    .ignore("SENT_FOR_AUTHORISATION")
+                    .ignore("SETTLED_BY_MERCHANT")
+                    .ignore("SENT_FOR_REFUND")
                     .map("REFUNDED", REFUNDED)
                     .map("REFUNDED_BY_MERCHANT", REFUNDED)
                     .map("REFUND_FAILED", REFUND_ERROR)


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

- Updated Worldpay status mapper to ignore the following notifications which we receive
   (from looking in the logs) but we don't need to handle specifically:
      - `EXPIRED`
      - `SETTLED_BY_MERCHANT`
      - `SENT_FOR_REFUND`

