### PR TITLE
PP-2392 adopt service name when account creation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/GatewayAccountResource.java
@@ -158,6 +158,9 @@ public class GatewayAccountResource {
         GatewayAccountEntity entity = new GatewayAccountEntity(provider, newHashMap(), type);
         logger.info("Setting the new account to accept all card types by default", provider, accountType);
         entity.setCardTypes(cardTypeDao.findAll());
+        if (node.has(SERVICE_NAME_FIELD_NAME)) {
+            entity.setServiceName(node.get(SERVICE_NAME_FIELD_NAME).textValue());
+        }
         if (node.has(DESCRIPTION_FIELD_NAME)) {
             entity.setDescription(node.get(DESCRIPTION_FIELD_NAME).textValue());
         }
@@ -173,6 +176,7 @@ public class GatewayAccountResource {
         account.put("gateway_account_id", String.valueOf(entity.getId()));
         account.put(PROVIDER_ACCOUNT_TYPE, entity.getType());
         account.put(DESCRIPTION_FIELD_NAME, entity.getDescription());
+        account.put(SERVICE_NAME_FIELD_NAME, entity.getServiceName());
         account.put(ANALYTICS_ID_FIELD_NAME, entity.getAnalyticsId());
 
         addSelfLink(newLocation, account);

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -202,15 +202,15 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
     }
 
     @Test
-    public void createGatewayAccountWithDescriptionAndAnalyticsId() {
-        String payload = toJson(ImmutableMap.of("description", "desc", "analytics_id", "analytics-id"));
+    public void createGatewayAccountWithNameDescriptionAndAnalyticsId() {
+        String payload = toJson(ImmutableMap.of("service_name","my service name","description", "desc", "analytics_id", "analytics-id"));
         ValidatableResponse response = givenSetup()
                 .body(payload)
                 .post(ACCOUNTS_API_URL)
                 .then()
                 .statusCode(201);
 
-        assertCorrectCreateResponse(response, TEST, "desc", "analytics-id");
+        assertCorrectCreateResponse(response, TEST, "desc", "analytics-id", "my service name");
         assertGettingAccountReturnsProviderName(response, "sandbox", TEST);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -63,7 +63,7 @@ public class GatewayAccountResourceTestBase {
                 .statusCode(201)
                 .contentType(JSON);
 
-        assertCorrectCreateResponse(response, GatewayAccountEntity.Type.TEST, description, analyticsId);
+        assertCorrectCreateResponse(response, GatewayAccountEntity.Type.TEST, description, analyticsId, null);
         assertGettingAccountReturnsProviderName(response, testProvider, GatewayAccountEntity.Type.TEST);
         assertGatewayAccountCredentialsAreEmptyInDB(response);
         assertGatewayAccountCredentialsAreEmptyInDB(response);
@@ -86,9 +86,9 @@ public class GatewayAccountResourceTestBase {
     }
 
     void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountEntity.Type type) {
-        assertCorrectCreateResponse(response, type, null, null);
+        assertCorrectCreateResponse(response, type, null, null, null);
     }
-    void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountEntity.Type type, String description, String analyticsId) {
+    void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountEntity.Type type, String description, String analyticsId, String name) {
         String accountId = response.extract().path("gateway_account_id");
         String urlSlug = "api/accounts/" + accountId;
 
@@ -96,6 +96,7 @@ public class GatewayAccountResourceTestBase {
                 .body("gateway_account_id", containsString(accountId))
                 .body("type", is(type.toString()))
                 .body("description", is(description))
+                .body("service_name", is(name))
                 .body("analytics_id", is(analyticsId))
                 .body("links[0].href", containsString(urlSlug))
                 .body("links[0].rel", is("self"))


### PR DESCRIPTION
Service name is used in both payment pages and confirmation email. Therefore it is required to capture at creation time.

Not mandating it, as the existing integrations must work
