### PR TITLE
PP-2017 remove jstl dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>3.3.5</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>jstl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
This was pulled by liquibase, although they themselves doesn't need it