### PR TITLE
PP-2390 update docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apk upgrade
 
 RUN apk add bash
 
-ENV JAVA_HOME /usr/lib/jvm/java-8-*/
 ENV PORT 8080
 ENV ADMIN_PORT 8081
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM govukpay/openjdk:8-jre-alpine
 
 RUN apk update
 RUN apk upgrade


### PR DESCRIPTION
## WHAT

- Changed `Dockerfile` base image from `openjdk:8-jre-alpine` to our own `govukpay/openjdk:8-jre-alpine`.
- Removed `$JAVA_HOME` environment variable pointing to invalid path.

## WHY

- The valid path for `$JAVA_HOME` is set by upstream `Dockerfile`.
- We created our own base java image to be able to update Java to latest version (from Alpine's edge repository) and control our own security.
  Currently, the latest official `openjdk:8-jre-alpine` image contains Java version `8u131` which is exposed to a number of CVEs and the latest Java version (`8u141`) is not available in the official `openjdk:8-jre-alpine` image which is using "`main`" apk repository.
  The latest java version is only available in alpine's `edge` community apk repository: http://dl-cdn.alpinelinux.org/alpine/edge/community

More information: alphagov/pay-infra#965
