### PR TITLE
PP-2536 Added missing index on charges.gateway_account_id

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -601,4 +601,12 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="createIndex charges.gateway_account_id" author="">
+        <createIndex indexName="idx_charges_gateway_account_id"
+                     tableName="charges"
+                     unique="false">
+            <column name="gateway_account_id" type="bigserial"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_

There is a FK constraint on the `charges.gateway_account_id` referencing the PK of `gateway_account` table. An index on `charges.gateway_account_id` will improve performance on joins between those to tables/columns.



