### PR TITLE
PP-2538 Added missing index on refunds.created_date

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -609,4 +609,12 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="createIndex refunds.created_date" author="">
+        <createIndex indexName="idx_refunds_created_date"
+                     tableName="refunds"
+                     unique="false">
+            <column name="created_date" />
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
_A brief description of the pull request:_


Underlying query used to produce the transaction list and the csv report orders records by `refunds.created_date`, hence an index is beneficial for performances.
