### PR TITLE
PP-2279 Block CVC in cardholder when processing auth requests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -285,6 +285,48 @@ public class AuthCardDetailsValidatorTest {
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
+    @Test
+    public void validationFailsIfCardHolderContainsThreeDigitsPossiblySurroundedByWhitespace() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder(" \t 321 ");
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationFailsIfCardHolderContainsFourDigitsPossiblySurroundedByWhitespace() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder(" 1234 \t");
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationSucceedsIfCardHolderContainsThreeDigitsSurroundedByNonWhitespace() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder("Mr. 333");
+        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationSucceedsIfCardHolderContainsFourDigitsSurroundedByNonWhitespace() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder("1234 Jr.");
+        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationSucceedsIfCardHolderContainsTwoDigits() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder("22");
+        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationSucceedsIfCardHolderContainsFiveDigits() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder("12345");
+        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
     private AuthCardDetails buildAuthCardDetailsFor(String cardNo, String cvc, String expiry, String cardBrand) {
         return buildAuthCardDetailsFor(cardNo, cvc, expiry, cardBrand, goodAddress());
     }


### PR DESCRIPTION
Make connector reject requests to /v1/frontend/charges/_chargeId_/cards if the cardholder name consists of exactly three or four characters (possibly surrounded by whitespace)

Compile other validation regular expressions just once and remove some duplication

* By “CVC”, we mean “CVC/CVV2/CSC/CID/security code/those three digits on the back/except if it’s AmEx when it’s four digits on the front”

with @SandorArpa
with @juanjoqmelian