### PR TITLE
PP-2279 Block CVC with no surrounding whitespace in cardholder

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/AuthCardDetailsValidator.java
+++ b/src/main/java/uk/gov/pay/connector/resources/AuthCardDetailsValidator.java
@@ -13,7 +13,7 @@ public class AuthCardDetailsValidator {
 
     private static final Pattern TWELVE_TO_NINETEEN_DIGITS = compile("[0-9]{12,19}");
     private static final Pattern THREE_TO_FOUR_DIGITS = compile("[0-9]{3,4}");
-    private static final Pattern THREE_TO_FOUR_DIGITS_POSSIBLY_SURROUNDED_BY_WHITESPACE = compile("\\s+[0-9]{3,4}\\s+");
+    private static final Pattern THREE_TO_FOUR_DIGITS_POSSIBLY_SURROUNDED_BY_WHITESPACE = compile("\\s*[0-9]{3,4}\\s*");
     private static final Pattern EXPIRY_DATE = compile("[0-9]{2}/[0-9]{2}");
     private static final Pattern CONTAINS_MORE_THAN_11_NOT_NECESSARILY_CONTIGUOUS_DIGITS = compile(".*([0-9].*){12,}");
 

--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -286,14 +286,28 @@ public class AuthCardDetailsValidatorTest {
     }
 
     @Test
-    public void validationFailsIfCardHolderContainsThreeDigitsPossiblySurroundedByWhitespace() {
+    public void validationFailsIfCardHolderIsThreeDigits() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder("555");
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationFailsIfCardHolderIsFourDigits() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setCardHolder("5678");
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationFailsIfCardHolderIsThreeDigitsSurroundedByWhitespace() {
         AuthCardDetails authCardDetails = aValidAuthorisationDetails();
         authCardDetails.setCardHolder(" \t 321 ");
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
-    public void validationFailsIfCardHolderContainsFourDigitsPossiblySurroundedByWhitespace() {
+    public void validationFailsIfCardHolderIsFourDigitsSurroundedByWhitespace() {
         AuthCardDetails authCardDetails = aValidAuthorisationDetails();
         authCardDetails.setCardHolder(" 1234 \t");
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
@@ -302,7 +316,7 @@ public class AuthCardDetailsValidatorTest {
     @Test
     public void validationSucceedsIfCardHolderContainsThreeDigitsSurroundedByNonWhitespace() {
         AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("Mr. 333");
+        authCardDetails.setCardHolder("Ms 333");
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 


### PR DESCRIPTION
Make connector reject requests to /v1/frontend/charges/_chargeId_/cards if the cardholder name consists of exactly three or four digits (with no surrounding whitespace)

The original regex was wrong (used \s+ instead of \s*)

with @juanjoqmelian