### PR TITLE
Refactor card authorise service test for clarity

### DIFF
--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -130,7 +130,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Test
     public void shouldRespondAuthorisationSuccess() throws Exception {
         AuthCardDetails authCardDetails = AuthUtils.aValidAuthorisationDetails();
-
         providerWillAuthorise();
 
         GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
@@ -142,7 +141,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Test(expected = ConflictRuntimeException.class)
     public void shouldRespondAuthorisationFailedWhen3dsRequiredConflictingConfigurationOfCardTypeWithGatewayAccount() throws Exception {
-
         AuthCardDetails authCardDetails = AuthUtils.aValidAuthorisationDetails();
 
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity();
@@ -209,12 +207,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Test
     public void shouldRetainGeneratedTransactionIdIfAuthorisationAborted() throws Exception {
         String generatedTransactionId = "generated-transaction-id";
-
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(generatedTransactionId));
-
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
-
         when(mockedPaymentProvider.authorise(any())).thenThrow(RuntimeException.class);
 
         try {
@@ -350,26 +345,24 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Test(expected = OperationAlreadyInProgressRuntimeException.class)
     public void shouldThrowAnOperationAlreadyInProgressRuntimeExceptionWhenStatusIsAuthorisationReady() {
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.AUTHORISATION_READY);
-
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         when(mockedChargeDao.merge(any())).thenReturn(charge);
-
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 
         cardAuthorisationService.doAuthorise(charge.getExternalId(), AuthUtils.aValidAuthorisationDetails());
+
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
     @Test(expected = IllegalStateRuntimeException.class)
     public void shouldThrowAnIllegalStateRuntimeExceptionWhenInvalidStatus() throws Exception {
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.CREATED);
-
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         when(mockedChargeDao.merge(any())).thenReturn(charge);
-
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 
         cardAuthorisationService.doAuthorise(charge.getExternalId(), AuthUtils.aValidAuthorisationDetails());
+
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
@@ -377,10 +370,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     public void shouldThrowAConflictRuntimeException() throws Exception {
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         when(mockedChargeDao.merge(any())).thenThrow(new OptimisticLockException());
-
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 
         cardAuthorisationService.doAuthorise(charge.getExternalId(), AuthUtils.aValidAuthorisationDetails());
+
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 


### PR DESCRIPTION
Interested in feedback on this

this is partly a [comprehension refactoring](https://martinfowler.com/articles/workflowsOfRefactoring/#comprehension), but also an attempt to make
the tests more readable/easy to understand by moving towards a more consistent
given/when/then pattern for each test.

In my opinion, this structure makes it easier to understand a unit test by clearly separating out these elements:

1. setting up a stable and repeatable context within which the subject of the
   test will be exercised. This could involve setting up stubs or other test
   doubles, injecting these doubles or otherwise constructing objects which
   comprise the fixed and repeatable environment of the test (aka 'given')
2. explicitly invoking the subject of the test to trigger the tested behaviour (aka 'when')
3. inspecting return values and/or side effects of probing the test subject
   typically by making assertions or verifying mock interactions (aka 'then')

I have deliberately refactored helper methods which contained a combination of 'given' and 'when'.

For example the `authorisationResponse` method both configured the mock payment
provider to return a particular response ('given') and invoked the
`doAuthorise` method of `cardAuthorisationService` ('when'). I've now separated
all of these helper methods so that they only do mock setup (ie. purely
'given') and do not invoke the test subject.

Every test now contains an explicit invocation of the test subject `cardAuthorisationService.doAuthorise()`.

I've also renamed and refactored some of the fixture/mock setup methods.
Instead of `mockXXX` I've followed a pattern of naming `providerWillX`.

## Feedback requested

Do you think the tests are more readable this way?

What do you think of the given/when/then pattern?