### PR TITLE
PP-2398 Add migrations script for refunds history

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -617,4 +617,27 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="build refunds_history table" author="">
+        <createTable tableName="refunds_history">
+            <column name="id" type="bigserial"/>
+            <column name="external_id" type="char(26)" />
+            <column name="amount" type="bigint" />
+            <column name="status" type="varchar(25)" />
+            <column name="charge_id" type="bigserial" />
+            <column name="created_date" type="timestamp without timezone" />
+            <column name="version" type="bigint" defaultValue="0" />
+            <column name="reference" type="text"/>
+            <column name="history_start_date" type="timestamp without timezone" />
+            <column name="history_end_date" type="timestamp without timezone" />
+        </createTable>
+    </changeSet>
+
+    <changeSet id="createIndex refunds_history.charge_id" author="">
+        <createIndex indexName="idx_refunds_history_charge_id"
+                     tableName="refunds_history"
+                     unique="false">
+            <column name="charge_id" type="bigserial"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
- Add migrations scripts for refunds history (preparation for next PR). This is needed so we can make end to end tests backward compatible. 
