### PR TITLE
PP-2398 Fix refunds events history

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/connector/model/TransactionEvent.java
@@ -77,10 +77,6 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
                 null);
     }
 
-    static public State newState(String status, boolean finished, String code, String message) {
-        return new State(status, finished, code, message);
-    }
-
     public enum Type {
         PAYMENT,
         REFUND
@@ -165,15 +161,17 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
         TransactionEvent that = (TransactionEvent) o;
 
         if (type != that.type) return false;
+        if (extRefundReference != null ? !extRefundReference.equals(that.extRefundReference) : that.extRefundReference != null) return false;
         if (extChargeId != null ? !extChargeId.equals(that.extChargeId) : that.extChargeId != null) return false;
         if (state != null ? !state.equals(that.state) : that.state != null) return false;
         return !(amount != null ? !amount.equals(that.amount) : that.amount != null);
-
     }
+
 
     @Override
     public int hashCode() {
         int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + (extRefundReference != null ? extRefundReference.hashCode() : 0);
         result = 31 * result + (extChargeId != null ? extChargeId.hashCode() : 0);
         result = 31 * result + (state != null ? state.hashCode() : 0);
         result = 31 * result + (amount != null ? amount.hashCode() : 0);

--- a/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.model;
+
+import org.junit.Test;
+import uk.gov.pay.connector.model.api.ExternalChargeState;
+
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.model.TransactionEvent.Type;
+import static uk.gov.pay.connector.model.TransactionEvent.extractState;
+import static uk.gov.pay.connector.model.api.ExternalRefundStatus.EXTERNAL_SUBMITTED;
+
+public class TransactionEventTest {
+
+    @Test
+    public void equals_shouldReturnTrue_whenSameInstance() {
+
+        TransactionEvent event = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED), 100L, ZonedDateTime.now());
+
+        assertThat(event.equals(event), is(true));
+    }
+
+    @Test
+    public void equals_shouldReturnTrue_whenFieldsAreTheSame() {
+
+        TransactionEvent event1 = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED), 100L, ZonedDateTime.now());
+        TransactionEvent event2 = new TransactionEvent(Type.PAYMENT, "charge", extractState(ExternalChargeState.EXTERNAL_CREATED), 100L, ZonedDateTime.now());
+
+        assertThat(event1.equals(event2), is(true));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenFieldsRefundReferenceIsDifferent() {
+
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+
+        assertThat(event1.equals(event2), is(false));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenFirstObjectRefundReferenceIsNull() {
+
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+
+        assertThat(event1.equals(event2), is(false));
+    }
+
+    @Test
+    public void equals_shouldReturnFalse_whenSecondObjectRefundReferenceIsNull() {
+
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+
+        assertThat(event1.equals(event2), is(false));
+    }
+}


### PR DESCRIPTION
## WHAT
- Refunds with different refund references and same amount and state were being missing in the transaction events list. This was due to the fact that references for these refunds weren't being compared in `equals` method for transaction events.


