### PR TITLE
PP-2627 Change the maximum number of capture retries from 24 to 48

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following variables control the background process:
 |---------|---------|---------|
 | `CAPTURE_PROCESS_BATCH_SIZE` | `10` | limits the batch window size processed at each polling attempt. If connector is not managing to clear the queue of captures, increase this value. |
 | `CAPTURE_PROCESS_RETRY_FAILURES_EVERY` | `60 minutes` | a failed capture attempt will be returned to the queue, and will not be retried until this time has passed |
-| `CAPTURE_PROCESS_MAXIMUM_RETRIES` | `24` | connector keeps track of the number of times capture has been attempted for each charge. If a charge fails this number of times or more it will be marked as a permanent failure. An error log message will be written as well. This should *never* happen and if it does it should be investigated. |
+| `CAPTURE_PROCESS_MAXIMUM_RETRIES` | `48` | connector keeps track of the number of times capture has been attempted for each charge. If a charge fails this number of times or more it will be marked as a permanent failure. An error log message will be written as well. This should *never* happen and if it does it should be investigated. |
 
 ## Integration tests
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -81,7 +81,7 @@ captureProcessConfig:
 
   batchSize: ${CAPTURE_PROCESS_BATCH_SIZE:-10}
   retryFailuresEvery: ${CAPTURE_PROCESS_RETRY_FAILURES_EVERY:-60 minutes}
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}

--- a/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationTest.java
+++ b/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationTest.java
@@ -27,7 +27,7 @@ public class ConnectorConfigurationTest {
         CaptureProcessConfig captureProcessConfig = RULE.getConfiguration().getCaptureProcessConfig();
         assertThat(captureProcessConfig.getRetryFailuresEvery(), is(Duration.minutes(60)));
         assertThat(captureProcessConfig.getRetryFailuresEveryAsJavaDuration(), is(java.time.Duration.ofMinutes(60)));
-        assertThat(captureProcessConfig.getMaximumRetries(), is(24));
+        assertThat(captureProcessConfig.getMaximumRetries(), is(48));
         assertThat(captureProcessConfig.getBatchSize(), is(10));
     }
 

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -86,7 +86,7 @@ captureProcessConfig:
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -85,7 +85,7 @@ captureProcessConfig:
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -75,7 +75,7 @@ captureProcessConfig:
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -59,7 +59,7 @@ captureProcessConfig:
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -56,7 +56,7 @@ captureProcessConfig:
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
   retryFailuresEvery: 60 minutes
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-24}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}


### PR DESCRIPTION
If there is a connection timeout when sending a capture request to a payment gateway, it’s possible for us to end up in a situation where the payment gateway has processed the capture request but we think it has not. In this case, we will retry every hour. We’ll stop if we get a successful response to one of our requests or receive a notification telling us the payment has been captured. If neither of these two things happen, after about 24 hours we’ll give up and change the payment status to `CAPTURE ERROR`.

In a situation like the above (the payment gateway has processed the capture request but we think it has not), Worldpay will respond to our capture retry with a successful response because they treat capture requests as an idempotent operation. ePDQ, however, appears to not work in the same way and will respond with an error. This means that the only way we’ll break out of the retry cycle is if we receive a capture notification.

Usually, ePDQ processes captures overnight. This means that we should receive a capture notification during our 24 hour retry window. However, if a payment happens very late in the day, it won’t get captured until the day after, which means the notification could be received after we’ve given up retrying. By this point, the payment status will be `CAPTURE ERROR` so we will ignore the notification (we do not allow transitions from `CAPTURE ERROR` to `CAPTURED`).

Changing the maximum number of retries from 24 to 48 means we should still be retrying when we receive the ePDQ capture notification.