### PR TITLE
PP-2755 - Added userExternalId as 'submitted_by' in transactions events response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/connector/model/TransactionEvent.java
@@ -171,6 +171,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
         if (extRefundReference != null ? !extRefundReference.equals(that.extRefundReference) : that.extRefundReference != null) return false;
         if (extChargeId != null ? !extChargeId.equals(that.extChargeId) : that.extChargeId != null) return false;
         if (state != null ? !state.equals(that.state) : that.state != null) return false;
+        if (userExternalId != null ? !userExternalId.equals(that.userExternalId) : that.userExternalId != null) return false;
         return !(amount != null ? !amount.equals(that.amount) : that.amount != null);
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/connector/model/TransactionEvent.java
@@ -85,6 +85,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     private final Type type;
     private String extChargeId;
     private String extRefundReference;
+    private String userExternalId;
     private State state;
     private Long amount;
     private ZonedDateTime updated;
@@ -97,13 +98,14 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
         this.updated = updated;
     }
 
-    public TransactionEvent(Type type, String extChargeId, String extRefundReference, State state, Long amount, ZonedDateTime updated) {
+    public TransactionEvent(Type type, String extChargeId, String extRefundReference, State state, Long amount, ZonedDateTime updated, String userExternalId) {
         this.type = type;
         this.extRefundReference = extRefundReference;
         this.extChargeId = extChargeId;
         this.state = state;
         this.amount = amount;
         this.updated = updated;
+        this.userExternalId = userExternalId;
     }
 
     @JsonProperty("type")
@@ -114,6 +116,11 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     @JsonProperty("refund_reference")
     public String getRefundId() {
         return extRefundReference;
+    }
+
+    @JsonProperty("submitted_by")
+    public String getUserExternalId() {
+        return userExternalId;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/pay/connector/resources/ChargeEventsResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargeEventsResource.java
@@ -83,7 +83,8 @@ public class ChargeEventsResource {
                         event.getReference(),
                         extractState(event.getStatus().toExternal()),
                         event.getAmount(),
-                        event.getHistoryStartDate()
+                        event.getHistoryStartDate(),
+                        event.getUserExternalId()
                 ))
                 .collect(toList());
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -90,6 +90,7 @@ public class DatabaseFixtures {
         private Long chargeId;
         private long amount;
         private ZonedDateTime createdDate;
+        private String userExternalId;
 
         TestRefundHistory(TestRefund testRefund) {
             this.id = testRefund.getId();
@@ -97,20 +98,36 @@ public class DatabaseFixtures {
             this.externalId = testRefund.getExternalRefundId();
             this.amount = testRefund.getAmount();
             this.createdDate = testRefund.getCreatedDate();
+            this.userExternalId = testRefund.getSubmittedByUserExternalId();
         }
 
         public TestRefundHistory insert(RefundStatus status, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate) {
-            databaseTestHelper.addRefundHistory(id, externalId, "", amount, status.toString(), chargeId, createdDate, historyStartDate, historyEndDate);
+            databaseTestHelper.addRefundHistory(id, externalId, "", amount, status.toString(), chargeId, createdDate, historyStartDate, historyEndDate, null);
             return this;
         }
 
         public TestRefundHistory insert(RefundStatus status, String reference, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate) {
-            databaseTestHelper.addRefundHistory(id, externalId, reference, amount, status.toString(), chargeId, createdDate, historyStartDate, historyEndDate);
+            databaseTestHelper.addRefundHistory(id, externalId, reference, amount, status.toString(), chargeId, createdDate, historyStartDate, historyEndDate, null);
             return this;
         }
 
         public TestRefundHistory insert(RefundStatus status, String reference, ZonedDateTime historyStartDate) {
-            databaseTestHelper.addRefundHistory(id, externalId, reference, amount, status.toString(), chargeId, createdDate, historyStartDate);
+            databaseTestHelper.addRefundHistory(id, externalId, reference, amount, status.toString(), chargeId, createdDate, historyStartDate, null);
+            return this;
+        }
+
+        public TestRefundHistory insert(RefundStatus status, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByExternalId) {
+            databaseTestHelper.addRefundHistory(id, externalId, "", amount, status.toString(), chargeId, createdDate, historyStartDate, historyEndDate, submittedByExternalId);
+            return this;
+        }
+
+        public TestRefundHistory insert(RefundStatus status, String reference, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByExternalId) {
+            databaseTestHelper.addRefundHistory(id, externalId, reference, amount, status.toString(), chargeId, createdDate, historyStartDate, historyEndDate, submittedByExternalId);
+            return this;
+        }
+
+        public TestRefundHistory insert(RefundStatus status, String reference, ZonedDateTime historyStartDate, String submittedByExternalId) {
+            databaseTestHelper.addRefundHistory(id, externalId, reference, amount, status.toString(), chargeId, createdDate, historyStartDate, submittedByExternalId);
             return this;
         }
     }
@@ -479,7 +496,7 @@ public class DatabaseFixtures {
         RefundStatus status = CREATED;
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
         TestCharge testCharge;
-        String submittedBy;
+        String submittedByUserExternalId;
 
         public TestRefund withTestCharge(TestCharge charge) {
             this.testCharge = charge;
@@ -502,7 +519,7 @@ public class DatabaseFixtures {
         }
 
         public TestRefund withSubmittedBy(String submittedBy) {
-            this.submittedBy = submittedBy;
+            this.submittedByUserExternalId = submittedBy;
             return this;
         }
 
@@ -514,7 +531,7 @@ public class DatabaseFixtures {
         public TestRefund insert() {
             if (testCharge == null)
                 throw new IllegalStateException("Test charge must be provided.");
-            databaseTestHelper.addRefund(id, externalRefundId, reference, amount, status.toString(), testCharge.getChargeId(), createdDate);
+            databaseTestHelper.addRefund(id, externalRefundId, reference, amount, status.toString(), testCharge.getChargeId(), createdDate, submittedByUserExternalId);
             return this;
         }
 
@@ -545,6 +562,10 @@ public class DatabaseFixtures {
 
         public TestCharge getTestCharge() {
             return testCharge;
+        }
+
+        public String getSubmittedByUserExternalId() {
+            return submittedByUserExternalId;
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -479,6 +479,7 @@ public class DatabaseFixtures {
         RefundStatus status = CREATED;
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
         TestCharge testCharge;
+        String submittedBy;
 
         public TestRefund withTestCharge(TestCharge charge) {
             this.testCharge = charge;
@@ -497,6 +498,11 @@ public class DatabaseFixtures {
 
         public TestRefund withReference(String reference) {
             this.reference = reference;
+            return this;
+        }
+
+        public TestRefund withSubmittedBy(String submittedBy) {
+            this.submittedBy = submittedBy;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceITest.java
@@ -23,6 +23,7 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
 
 public class ChargeEventsResourceITest {
 
+    public static final String SUBMITTED_BY = "r378y387y8weriyi";
     private DatabaseTestHelper databaseTestHelper;
 
     @Rule
@@ -104,7 +105,7 @@ public class ChargeEventsResourceITest {
                 .withReference(testReferenceRefund1)
                 .withType(RefundStatus.REFUNDED)
                 .withCreatedDate(refundTest1RefundedDate)
-                .withSubmittedBy("ABC123")
+                .withSubmittedBy(SUBMITTED_BY)
                 .insert();
 
         ZonedDateTime refundTest2RefundedDate = createdDate.plusSeconds(12);
@@ -117,9 +118,9 @@ public class ChargeEventsResourceITest {
 
         ZonedDateTime historyRefund1SubmittedStartDate = createdDate.plusSeconds(8);
         createTestRefundHistory(refundedTestRefund1)
-                .insert(RefundStatus.CREATED, createdDate.plusSeconds(7), historyRefund1SubmittedStartDate)
-                .insert(RefundStatus.REFUND_SUBMITTED, testReferenceRefund1, historyRefund1SubmittedStartDate, refundTest1RefundedDate)
-                .insert(RefundStatus.REFUNDED, testReferenceRefund1, refundTest1RefundedDate);
+                .insert(RefundStatus.CREATED, createdDate.plusSeconds(7), historyRefund1SubmittedStartDate, SUBMITTED_BY)
+                .insert(RefundStatus.REFUND_SUBMITTED, testReferenceRefund1, historyRefund1SubmittedStartDate, refundTest1RefundedDate, SUBMITTED_BY)
+                .insert(RefundStatus.REFUNDED, testReferenceRefund1, refundTest1RefundedDate, SUBMITTED_BY);
 
         ZonedDateTime historyRefund2SubmittedStartDate = createdDate.plusSeconds(11);
         createTestRefundHistory(refundedTestRefund2)
@@ -134,8 +135,8 @@ public class ChargeEventsResourceITest {
                 .body("events[0]", new TransactionEventMatcher("PAYMENT", withState("created", "false"), "100", createdTestChargeEvent.getUpdated()))
                 .body("events[1]", new TransactionEventMatcher("PAYMENT", withState("started", "false"), "100", enteringCardDetailsTestChargeEvent.getUpdated()))
                 .body("events[2]", new TransactionEventMatcher("PAYMENT", withState("success", "true"), "100", captureApprovedTestChargeEvent.getUpdated()))
-                .body("events[3]", new TransactionEventMatcher("REFUND", withState("submitted", "false"), "10", historyRefund1SubmittedStartDate, testReferenceRefund1, null))
-                .body("events[4]", new TransactionEventMatcher("REFUND", withState("success", "true"), "10", refundTest1RefundedDate, testReferenceRefund1, null))
+                .body("events[3]", new TransactionEventMatcher("REFUND", withState("submitted", "false"), "10", historyRefund1SubmittedStartDate, testReferenceRefund1, SUBMITTED_BY))
+                .body("events[4]", new TransactionEventMatcher("REFUND", withState("success", "true"), "10", refundTest1RefundedDate, testReferenceRefund1, SUBMITTED_BY))
                 .body("events[5]", new TransactionEventMatcher("REFUND", withState("submitted", "false"), "90", historyRefund2SubmittedStartDate, testReferenceRefund2, null))
                 .body("events[6]", new TransactionEventMatcher("REFUND", withState("success", "true"), "90", refundTest2RefundedDate, testReferenceRefund2, null));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceITest.java
@@ -104,6 +104,7 @@ public class ChargeEventsResourceITest {
                 .withReference(testReferenceRefund1)
                 .withType(RefundStatus.REFUNDED)
                 .withCreatedDate(refundTest1RefundedDate)
+                .withSubmittedBy("ABC123")
                 .insert();
 
         ZonedDateTime refundTest2RefundedDate = createdDate.plusSeconds(12);
@@ -133,10 +134,10 @@ public class ChargeEventsResourceITest {
                 .body("events[0]", new TransactionEventMatcher("PAYMENT", withState("created", "false"), "100", createdTestChargeEvent.getUpdated()))
                 .body("events[1]", new TransactionEventMatcher("PAYMENT", withState("started", "false"), "100", enteringCardDetailsTestChargeEvent.getUpdated()))
                 .body("events[2]", new TransactionEventMatcher("PAYMENT", withState("success", "true"), "100", captureApprovedTestChargeEvent.getUpdated()))
-                .body("events[3]", new TransactionEventMatcher("REFUND", withState("submitted", "false"), "10", historyRefund1SubmittedStartDate, testReferenceRefund1))
-                .body("events[4]", new TransactionEventMatcher("REFUND", withState("success", "true"), "10", refundTest1RefundedDate, testReferenceRefund1))
-                .body("events[5]", new TransactionEventMatcher("REFUND", withState("submitted", "false"), "90", historyRefund2SubmittedStartDate, testReferenceRefund2))
-                .body("events[6]", new TransactionEventMatcher("REFUND", withState("success", "true"), "90", refundTest2RefundedDate, testReferenceRefund2));
+                .body("events[3]", new TransactionEventMatcher("REFUND", withState("submitted", "false"), "10", historyRefund1SubmittedStartDate, testReferenceRefund1, null))
+                .body("events[4]", new TransactionEventMatcher("REFUND", withState("success", "true"), "10", refundTest1RefundedDate, testReferenceRefund1, null))
+                .body("events[5]", new TransactionEventMatcher("REFUND", withState("submitted", "false"), "90", historyRefund2SubmittedStartDate, testReferenceRefund2, null))
+                .body("events[6]", new TransactionEventMatcher("REFUND", withState("success", "true"), "90", refundTest2RefundedDate, testReferenceRefund2, null));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
+++ b/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
@@ -45,18 +45,20 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
     private State state;
     private String amount;
     private String updated;
-    private final String refundReference;
+    private String refundReference;
+    private String submittedBy;
 
-    public TransactionEventMatcher(String type, State state, String amount, ZonedDateTime updated, String refundReference) {
+    public TransactionEventMatcher(String type, State state, String amount, ZonedDateTime updated, String refundReference, String submittedBy) {
         this.type = type;
         this.state = state;
         this.amount = amount;
         this.updated = DateTimeUtils.toUTCDateTimeString(updated);
         this.refundReference = refundReference;
+        this.submittedBy = submittedBy;
     }
 
     public TransactionEventMatcher(String type, State state, String amount, ZonedDateTime updated) {
-        this(type, state, amount, updated, null);
+        this(type, state, amount, updated, null, null);
     }
 
     static public State withState(String status, String finished) {
@@ -71,6 +73,7 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
     public void describeTo(Description description) {
         description.appendText("{amount=").appendValue(amount).appendText(", ");
         description.appendText("refund_reference=").appendValue(refundReference).appendText(", ");
+        description.appendText("submitted_by=").appendValue(submittedBy).appendText(", ");
         description.appendText("state={");
         description.appendText("finished=").appendValue(state.getFinished()).appendText(", ");
         description.appendText("status=").appendValue(state.getStatus()).appendText(", ");

--- a/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
+++ b/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
@@ -46,7 +46,7 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
     private String amount;
     private String updated;
     private String refundReference;
-    private String submittedBy;
+    private String refundSubmittedBy;
 
     public TransactionEventMatcher(String type, State state, String amount, ZonedDateTime updated, String refundReference, String submittedBy) {
         this.type = type;
@@ -54,7 +54,7 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
         this.amount = amount;
         this.updated = DateTimeUtils.toUTCDateTimeString(updated);
         this.refundReference = refundReference;
-        this.submittedBy = submittedBy;
+        this.refundSubmittedBy = submittedBy;
     }
 
     public TransactionEventMatcher(String type, State state, String amount, ZonedDateTime updated) {
@@ -73,7 +73,7 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
     public void describeTo(Description description) {
         description.appendText("{amount=").appendValue(amount).appendText(", ");
         description.appendText("refund_reference=").appendValue(refundReference).appendText(", ");
-        description.appendText("submitted_by=").appendValue(submittedBy).appendText(", ");
+        description.appendText("submitted_by=").appendValue(refundSubmittedBy).appendText(", ");
         description.appendText("state={");
         description.appendText("finished=").appendValue(state.getFinished()).appendText(", ");
         description.appendText("status=").appendValue(state.getStatus()).appendText(", ");
@@ -100,6 +100,7 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
                 ObjectUtils.equals(record.get("refund_reference"), refundReference) &&
                 ObjectUtils.equals(record.get("type"), type) &&
                 ObjectUtils.equals(record.get("amount"), Integer.valueOf(amount)) &&
-                ObjectUtils.equals(record.get("updated"), updated);
+                ObjectUtils.equals(record.get("updated"), updated) &&
+                ObjectUtils.equals(record.get("submitted_by"), refundSubmittedBy);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
@@ -33,8 +33,8 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenFieldsRefundReferenceIsDifferent() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
 
         assertThat(event1.equals(event2), is(false));
     }
@@ -42,8 +42,8 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenFirstObjectRefundReferenceIsNull() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
 
         assertThat(event1.equals(event2), is(false));
     }
@@ -51,8 +51,8 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenSecondObjectRefundReferenceIsNull() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now());
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
 
         assertThat(event1.equals(event2), is(false));
     }

--- a/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
@@ -13,6 +13,8 @@ import static uk.gov.pay.connector.model.api.ExternalRefundStatus.EXTERNAL_SUBMI
 
 public class TransactionEventTest {
 
+    public static final String USER_EXTERNAL_ID = "r378y387y8weriyi";
+
     @Test
     public void equals_shouldReturnTrue_whenSameInstance() {
 
@@ -33,8 +35,8 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenFieldsRefundReferenceIsDifferent() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(), USER_EXTERNAL_ID);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
 
         assertThat(event1.equals(event2), is(false));
     }
@@ -42,8 +44,8 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenFirstObjectRefundReferenceIsNull() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
 
         assertThat(event1.equals(event2), is(false));
     }
@@ -51,9 +53,10 @@ public class TransactionEventTest {
     @Test
     public void equals_shouldReturnFalse_whenSecondObjectRefundReferenceIsNull() {
 
-        TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
-        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),null);
+        TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
+        TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
 
         assertThat(event1.equals(event2), is(false));
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -137,10 +137,27 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void addRefundHistory(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate) {
+    public void addRefund(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate, String submittedByUserExternalId) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO refunds_history(id, external_id, reference, amount, status, charge_id, created_date, history_start_date, history_end_date) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date, :history_start_date, :history_end_date)")
+                        .createStatement("INSERT INTO refunds(id, external_id, reference, amount, status, charge_id, created_date, user_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date, :user_external_id)")
+                        .bind("id", id)
+                        .bind("external_id", externalId)
+                        .bind("reference", reference)
+                        .bind("amount", amount)
+                        .bind("status", status)
+                        .bind("charge_id", chargeId)
+                        .bind("created_date", Timestamp.from(createdDate.toInstant()))
+                        .bind("user_external_id", submittedByUserExternalId)
+                        .bind("version", 1)
+                        .execute()
+        );
+    }
+
+    public void addRefundHistory(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByUserExternalId) {
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("INSERT INTO refunds_history(id, external_id, reference, amount, status, charge_id, created_date, history_start_date, history_end_date, user_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date, :history_start_date, :history_end_date, :user_external_id)")
                         .bind("id", id)
                         .bind("external_id", externalId)
                         .bind("reference", reference)
@@ -150,15 +167,16 @@ public class DatabaseTestHelper {
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
                         .bind("history_start_date", Timestamp.from(historyStartDate.toInstant()))
                         .bind("history_end_date", Timestamp.from(historyEndDate.toInstant()))
+                        .bind("user_external_id", submittedByUserExternalId)
                         .bind("version", 1)
                         .execute()
         );
     }
 
-    public void addRefundHistory(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate, ZonedDateTime historyStartDate) {
+    public void addRefundHistory(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate, ZonedDateTime historyStartDate, String submittedByUserExternalId) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO refunds_history(id, external_id, reference, amount, status, charge_id, created_date, history_start_date) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date, :history_start_date)")
+                        .createStatement("INSERT INTO refunds_history(id, external_id, reference, amount, status, charge_id, created_date, history_start_date, user_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date, :history_start_date, :user_external_id)")
                         .bind("id", id)
                         .bind("external_id", externalId)
                         .bind("reference", reference)
@@ -167,6 +185,7 @@ public class DatabaseTestHelper {
                         .bind("charge_id", chargeId)
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
                         .bind("history_start_date", Timestamp.from(historyStartDate.toInstant()))
+                        .bind("user_external_id", submittedByUserExternalId)
                         .bind("version", 1)
                         .execute()
         );


### PR DESCRIPTION
- added 'submitted_by' key in transactions event response so that we can show who submitted a refund in selfservice

