### PR TITLE
PP-2626 Authorisation refactoring. Transactions.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/CardTypesResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/CardTypesResource.java
@@ -28,7 +28,6 @@ public class CardTypesResource {
     @GET
     @Path(CARD_TYPES_API_PATH)
     @Produces(APPLICATION_JSON)
-    @Transactional
     public Response getCardTypes() {
         return successResponseWithEntity(ImmutableMap.of(CARD_TYPES_FIELD_NAME, cardTypeDao.findAll()));
     }

--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -44,36 +44,38 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
     }
 
     @Transactional
-    public GatewayResponse<BaseAuthoriseResponse> postOperation(ChargeEntity chargeEntity,
+    public GatewayResponse<BaseAuthoriseResponse> postOperation(String chargeId,
                                                                 Auth3dsDetails auth3DsDetails,
                                                                 GatewayResponse<BaseAuthoriseResponse> operationResponse) {
-        ChargeEntity reloadedCharge = chargeDao.merge(chargeEntity);
+        return chargeDao.findByExternalId(chargeId).map(chargeEntity -> {
 
-        ChargeStatus status = operationResponse.getBaseResponse()
-                .map(BaseAuthoriseResponse::authoriseStatus)
-                .map(BaseAuthoriseResponse.AuthoriseStatus::getMappedChargeStatus)
-                .orElse(ChargeStatus.AUTHORISATION_ERROR);
+            ChargeStatus status = operationResponse.getBaseResponse()
+                    .map(BaseAuthoriseResponse::authoriseStatus)
+                    .map(BaseAuthoriseResponse.AuthoriseStatus::getMappedChargeStatus)
+                    .orElse(ChargeStatus.AUTHORISATION_ERROR);
 
-        String transactionId = operationResponse.getBaseResponse()
-                .map(BaseAuthoriseResponse::getTransactionId).orElse("");
+            String transactionId = operationResponse.getBaseResponse()
+                    .map(BaseAuthoriseResponse::getTransactionId).orElse("");
 
-        logger.info("AuthCardDetails authorisation response received - charge_external_id={}, operation_type={}, transaction_id={}, status={}",
-                chargeEntity.getExternalId(), OperationType.AUTHORISATION_3DS.getValue(), transactionId, status);
+            logger.info("AuthCardDetails authorisation response received - charge_external_id={}, operation_type={}, transaction_id={}, status={}",
+                    chargeEntity.getExternalId(), OperationType.AUTHORISATION_3DS.getValue(), transactionId, status);
 
-        GatewayAccountEntity account = chargeEntity.getGatewayAccount();
+            GatewayAccountEntity account = chargeEntity.getGatewayAccount();
 
-        metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.authorise-3ds.result.%s", account.getGatewayName(), account.getType(), account.getId(), status.toString())).inc();
+            metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.authorise-3ds.result.%s", account.getGatewayName(), account.getType(), account.getId(), status.toString())).inc();
 
-        reloadedCharge.setStatus(status);
+            chargeEntity.setStatus(status);
 
-        if (StringUtils.isBlank(transactionId)) {
-            logger.warn("Auth3DSDetails authorisation response received with no transaction id. -  charge_external_id={}", reloadedCharge.getExternalId());
-        } else {
-            reloadedCharge.setGatewayTransactionId(transactionId);
-        }
+            if (StringUtils.isBlank(transactionId)) {
+                logger.warn("Auth3DSDetails authorisation response received with no transaction id. -  charge_external_id={}", chargeId);
+            } else {
+                chargeEntity.setGatewayTransactionId(transactionId);
+            }
 
-        chargeDao.mergeAndNotifyStatusHasChanged(reloadedCharge, Optional.empty());
-        return operationResponse;
+            chargeDao.mergeAndNotifyStatusHasChanged(chargeEntity, Optional.empty());
+            return operationResponse;
+
+        }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -5,6 +5,7 @@ import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.domain.Auth3dsDetails;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -36,9 +37,10 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
     }
 
     @Transactional
-    public ChargeEntity preOperation(ChargeEntity chargeEntity, Auth3dsDetails auth3DsDetails) {
-        chargeEntity = preOperation(chargeEntity, OperationType.AUTHORISATION_3DS, getLegalStates(), AUTHORISATION_3DS_READY);
-        return chargeEntity;
+    public ChargeEntity preOperation(String chargeId, Auth3dsDetails auth3DsDetails) {
+        return chargeDao.findByExternalId(chargeId)
+                .map(chargeEntity -> preOperation(chargeEntity, OperationType.AUTHORISATION_3DS, getLegalStates(), AUTHORISATION_3DS_READY))
+                .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
 
     @Transactional

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -6,14 +6,9 @@ import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.GatewayError;
-import uk.gov.pay.connector.model.domain.AddressEntity;
-import uk.gov.pay.connector.model.domain.AuthCardDetails;
-import uk.gov.pay.connector.model.domain.CardDetailsEntity;
-import uk.gov.pay.connector.model.domain.CardTypeEntity;
-import uk.gov.pay.connector.model.domain.ChargeEntity;
-import uk.gov.pay.connector.model.domain.ChargeStatus;
-import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.*;
 import uk.gov.pay.connector.model.gateway.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
 
@@ -22,11 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_ERROR;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_READY;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
 import static uk.gov.pay.connector.model.domain.NumbersInStringsSanitizer.sanitize;
 
 public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetails> {
@@ -47,22 +38,29 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
     }
 
     @Transactional
-    public ChargeEntity preOperation(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+    public ChargeEntity preOperation(String chargeId, AuthCardDetails authCardDetails) {
 
-        String cardBrand = authCardDetails.getCardBrand();
-        ChargeEntity reloadedCharge = chargeDao.merge(chargeEntity);
+        return chargeDao.findByExternalId(chargeId).map(chargeEntity -> {
 
-        if (!reloadedCharge.getGatewayAccount().isRequires3ds() && cardBrandRequires3ds(cardBrand)) {
-            reloadedCharge.setStatus(ChargeStatus.AUTHORISATION_ABORTED);
-            logger.error("AuthCardDetails authorisation failed pre operation. Card brand requires 3ds but Gateway account has 3ds disabled - charge_external_id={}, operation_type={}, card_brand={}",
-                    chargeEntity.getExternalId(), OperationType.AUTHORISATION.getValue(), cardBrand);
-            chargeEntity = chargeDao.mergeAndNotifyStatusHasChanged(reloadedCharge, Optional.empty());
-        } else {
-            chargeEntity = preOperation(chargeEntity, OperationType.AUTHORISATION, getLegalStates(), AUTHORISATION_READY);
-            getPaymentProviderFor(chargeEntity).generateTransactionId().ifPresent(chargeEntity::setGatewayTransactionId);
-        }
+            String cardBrand = authCardDetails.getCardBrand();
 
-        return chargeEntity;
+            if (!chargeEntity.getGatewayAccount().isRequires3ds() && cardBrandRequires3ds(cardBrand)) {
+
+                chargeEntity.setStatus(ChargeStatus.AUTHORISATION_ABORTED);
+
+                logger.error("AuthCardDetails authorisation failed pre operation. Card brand requires 3ds but Gateway account has 3ds disabled - charge_external_id={}, operation_type={}, card_brand={}",
+                        chargeEntity.getExternalId(), OperationType.AUTHORISATION.getValue(), cardBrand);
+
+                chargeDao.notifyStatusHasChanged(chargeEntity, Optional.empty());
+
+            } else {
+                chargeEntity = preOperation(chargeEntity, OperationType.AUTHORISATION, getLegalStates(), AUTHORISATION_READY);
+                getPaymentProviderFor(chargeEntity).generateTransactionId().ifPresent(chargeEntity::setGatewayTransactionId);
+            }
+
+            return chargeEntity;
+
+        }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
 
     private boolean cardBrandRequires3ds(String cardBrand) {
@@ -86,14 +84,15 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
     @Transactional
     public GatewayResponse<BaseAuthoriseResponse> postOperation(ChargeEntity chargeEntity, AuthCardDetails authCardDetails, GatewayResponse<BaseAuthoriseResponse> operationResponse) {
+
         ChargeEntity reloadedCharge = chargeDao.merge(chargeEntity);
 
         ChargeStatus status = operationResponse.getBaseResponse()
-                            .map(BaseAuthoriseResponse::authoriseStatus)
-                            .map(BaseAuthoriseResponse.AuthoriseStatus::getMappedChargeStatus)
-                            .orElseGet(() -> operationResponse.getGatewayError()
-                                    .map(gatewayError -> mapError(gatewayError))
-                                    .orElse(ChargeStatus.AUTHORISATION_ERROR));
+                .map(BaseAuthoriseResponse::authoriseStatus)
+                .map(BaseAuthoriseResponse.AuthoriseStatus::getMappedChargeStatus)
+                .orElseGet(() -> operationResponse.getGatewayError()
+                        .map(gatewayError -> mapError(gatewayError))
+                        .orElse(ChargeStatus.AUTHORISATION_ERROR));
 
         String transactionId = operationResponse.getBaseResponse()
                 .map(BaseAuthoriseResponse::getTransactionId).orElse("");
@@ -117,7 +116,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
         }
 
         appendCardDetails(reloadedCharge, authCardDetails);
-        chargeDao.mergeAndNotifyStatusHasChanged(reloadedCharge, Optional.empty());
+        chargeDao.notifyStatusHasChanged(reloadedCharge, Optional.empty());
         return operationResponse;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
@@ -47,6 +47,8 @@ public class CardCaptureService extends CardService implements TransactionalGate
     @Transactional
     @Override
     public ChargeEntity preOperation(ChargeEntity chargeEntity) {
+        //TODO PP-2626 As part of refactoring work. Merging operation is not done inside preOperation anymore. This will be (if possible) removed.
+        chargeDao.merge(chargeEntity);
         return preOperation(chargeEntity, CardService.OperationType.CAPTURE, legalStatuses, ChargeStatus.CAPTURE_READY);
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
@@ -47,9 +47,10 @@ public class CardCaptureService extends CardService implements TransactionalGate
     @Transactional
     @Override
     public ChargeEntity preOperation(ChargeEntity chargeEntity) {
-        //TODO PP-2626 As part of refactoring work. Merging operation is not done inside preOperation anymore. This will be (if possible) removed.
-        chargeDao.merge(chargeEntity);
-        return preOperation(chargeEntity, CardService.OperationType.CAPTURE, legalStatuses, ChargeStatus.CAPTURE_READY);
+        //TODO PP-2626 As part of refactoring work. Merging operation is not done inside preOperation anymore.
+        //TODO PP-2626 This will be (if possible) removed.
+        ChargeEntity reloadedCharge = chargeDao.merge(chargeEntity);
+        return preOperation(reloadedCharge, CardService.OperationType.CAPTURE, legalStatuses, ChargeStatus.CAPTURE_READY);
     }
 
     @Transactional
@@ -97,7 +98,7 @@ public class CardCaptureService extends CardService implements TransactionalGate
                 chargeEntity.getExternalId(), OperationType.CAPTURE.getValue(), transactionId, nextStatus);
 
         reloadedCharge.setStatus(nextStatus);
-        //update the charge with the new transaction id from gateway, if present.
+
         if (isBlank(transactionId)) {
             logger.warn("Card capture response received with no transaction id. - charge_external_id={}", reloadedCharge.getExternalId());
         }

--- a/src/main/java/uk/gov/pay/connector/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotificationService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service;
 
+import com.google.inject.persist.Transactional;
 import fj.data.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +35,7 @@ public class NotificationService {
         this.dnsUtils = dnsUtils;
     }
 
+    @Transactional
     public boolean handleNotificationFor(String ipAddress, PaymentGatewayName paymentGatewayName, String payload) {
         PaymentProvider paymentProvider = paymentProviders.byName(paymentGatewayName);
         Handler handler = new Handler(paymentProvider);

--- a/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
@@ -40,6 +40,7 @@ import static uk.gov.pay.connector.service.CardExecutorService.ExecutionStatus.I
 
 @RunWith(MockitoJUnitRunner.class)
 public class Card3dsResponseAuthServiceTest extends CardServiceTest {
+
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);

--- a/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.model.domain.*;
 import static org.mockito.Mockito.mock;
 
 public abstract class CardServiceTest {
+
     protected final PaymentProvider mockedPaymentProvider = mock(PaymentProvider.class);
     protected PaymentProviders mockedProviders = mock(PaymentProviders.class);
     protected MetricRegistry mockMetricRegistry;

--- a/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
+++ b/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
@@ -40,12 +40,17 @@ public class AuthUtils {
     }
 
     public static Address addressFor(String line1, String city, String postcode, String country) {
+        return addressFor(line1, line1, city, postcode, null, country);
+    }
+
+    public static Address addressFor(String line1, String line2, String city, String postcode, String county, String country) {
         Address address = Address.anAddress();
         address.setLine1(line1);
-        address.setLine2(line1);
+        address.setLine2(line2);
         address.setCity(city);
         address.setPostcode(postcode);
         address.setCountry(country);
+        address.setCounty(county);
         return address;
     }
 


### PR DESCRIPTION
## WHAT
Authorisation transactions refactoring
- Transaction operations should be defined having the minimum steps necessary while leaving the database in a consistent state

- A typical Authorisation request:
    1. Transaction. PreOperation -> Read charge and update its status to AUTHORISATION_READY (from ENTERING_CARD_DETAILS).

    2. No Transactional. Gateway operation

    3. Transaction.PostOperation -> Read data from Operation (Gateway response) and update charge accordingly + Change status event.

- What has been done:

    1. PreOperation (transactional annotated method) accepting external charge id rather than entity since reads must be within the transaction. Retrieving data must be part of the transaction in order to guarantee consistency.

    2. Still with doubts on OptimisticLockException catching for Authorisation PreOperation. A clearer message will be added in order to analyse when this occurs.

    3. Amended other operations as we go along (PreOperation for capture will execute the merge before to keep backward compatibility).

    4. PostOperation. Removed`merge` to read the entity as done in the PreOperation.

    5. Avoid `merge` charge when creating events, committing the transaction should take care of the necessary queries to update the data according to the entity updates made.
