### PR TITLE
PP-2626 Capture refactoring. Transactions.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/TransactionalGatewayOperation.java
+++ b/src/main/java/uk/gov/pay/connector/service/TransactionalGatewayOperation.java
@@ -8,22 +8,20 @@ import javax.persistence.OptimisticLockException;
 
 interface TransactionalGatewayOperation<T extends BaseResponse> {
 
-    default GatewayResponse<T> executeGatewayOperationFor(ChargeEntity chargeEntity) {
-        ChargeEntity preOperationResponse;
+    default GatewayResponse<T> executeGatewayOperationFor(String chargeId) {
+        ChargeEntity charge;
         try {
-            preOperationResponse = preOperation(chargeEntity);
+            charge = preOperation(chargeId);
         } catch (OptimisticLockException e) {
-            throw new ConflictRuntimeException(chargeEntity.getExternalId());
+            throw new ConflictRuntimeException(chargeId);
         }
-
-        GatewayResponse<T> operationResponse = operation(preOperationResponse);
-
-        return postOperation(preOperationResponse, operationResponse);
+        GatewayResponse<T> operationResponse = operation(charge);
+        return postOperation(chargeId, operationResponse);
     }
 
-    ChargeEntity preOperation(ChargeEntity chargeEntity);
+    ChargeEntity preOperation(String chargeId);
 
     GatewayResponse<T> operation(ChargeEntity chargeEntity);
 
-    GatewayResponse<T> postOperation(ChargeEntity chargeEntity, GatewayResponse<T> operationResponse);
+    GatewayResponse<T> postOperation(String chargeId, GatewayResponse<T> operationResponse);
 }


### PR DESCRIPTION
## WHAT
- Capture. Transactions refactoring.
- PreOperation and PostOperation (transactional annotated methods) accepting external charge id rather than entity since reads must be within the transaction. Retrieving data must be part of the transaction in order to guarantee consistency.
- A transaction for an update must be opened before read the entity and close after the update (JPA using entity set method), reading the object and then executing merge can cause undesirable results (very unlikely in our case but still could happen).
- See: 
    - http://blog.xebia.com/jpa-implementation-patterns-saving-detached-entities/
    - https://stackoverflow.com/questions/18101488/does-guice-persist-provide-transaction-scoped-or-application-managed-entitymanag



