### PR TITLE
PP-2626 Capture approval and error

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
@@ -52,7 +52,7 @@ public class CardCaptureProcess {
                 if (shouldRetry(charge)) {
                     captureService.doCapture(charge.getExternalId());
                 } else {
-                    captureService.markChargeAsCaptureError(charge);
+                    captureService.markChargeAsCaptureError(charge.getExternalId());
                 }
             });
         } catch (Exception e) {

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.service;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
@@ -112,10 +111,12 @@ public class CardCaptureProcessTest {
 
     @Test
     public void shouldMarkCaptureAsErrorWhenChargeRetriesExceeded() {
+
+        String chargeId = "my-charge-1";
         ChargeEntity mockCharge1 = mock(ChargeEntity.class);
 
         when(mockChargeDao.findChargesForCapture(10, Duration.ofMinutes(60))).thenReturn(singletonList(mockCharge1));
-        when(mockCharge1.getExternalId()).thenReturn("my-charge-1");
+        when(mockCharge1.getExternalId()).thenReturn(chargeId);
         when(mockCharge1.getId()).thenReturn(1L);
 
 
@@ -123,6 +124,6 @@ public class CardCaptureProcessTest {
 
         cardCaptureProcess.runCapture();
 
-        verify(mockCardCaptureService).markChargeAsCaptureError(mockCharge1);
+        verify(mockCardCaptureService).markChargeAsCaptureError(chargeId);
     }
 }


### PR DESCRIPTION
## WHAT
- Perform read operations within the transactional methods. More info: https://stackoverflow.com/questions/18101488/does-guice-persist-provide-transaction-scoped-or-application-managed-entitymanag

- Ignore charge not found in mark charge as error. Ids are coming from a previous retrieved list.


