### PR TITLE
PP-2626 Transactions refactoring. Clean up

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeEventDao.java
@@ -2,10 +2,14 @@ package uk.gov.pay.connector.dao;
 
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import java.time.ZonedDateTime;
+import java.util.Optional;
 
 @Transactional
 public class ChargeEventDao extends JpaDao<ChargeEventEntity> {
@@ -13,5 +17,9 @@ public class ChargeEventDao extends JpaDao<ChargeEventEntity> {
     @Inject
     public ChargeEventDao(final Provider<EntityManager> entityManager) {
         super(entityManager);
+    }
+
+    public void persistChargeEventOf(ChargeEntity chargeEntity, Optional<ZonedDateTime> gatewayEventDate) {
+        this.persist(ChargeEventEntity.from(chargeEntity, ChargeStatus.fromString(chargeEntity.getStatus()), ZonedDateTime.now(), gatewayEventDate));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -5,6 +5,7 @@ import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.domain.Auth3dsDetails;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
@@ -22,13 +23,13 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_3DS_R
 
 public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3dsDetails> {
 
-
     @Inject
     public Card3dsResponseAuthService(ChargeDao chargeDao,
+                                      ChargeEventDao chargeEventDao,
                                       PaymentProviders providers,
                                       CardExecutorService cardExecutorService,
                                       Environment environment) {
-        super(chargeDao, providers, cardExecutorService, environment);
+        super(chargeDao, chargeEventDao, providers, cardExecutorService, environment);
     }
 
     public GatewayResponse<BaseAuthoriseResponse> operation(ChargeEntity chargeEntity, Auth3dsDetails auth3DsDetails) {
@@ -74,7 +75,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
                 chargeEntity.setGatewayTransactionId(transactionId);
             }
 
-            chargeDao.notifyStatusHasChanged(chargeEntity, Optional.empty());
+            chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
             return operationResponse;
 
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));

--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -74,7 +74,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
                 chargeEntity.setGatewayTransactionId(transactionId);
             }
 
-            chargeDao.mergeAndNotifyStatusHasChanged(chargeEntity, Optional.empty());
+            chargeDao.notifyStatusHasChanged(chargeEntity, Optional.empty());
             return operationResponse;
 
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.service;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.exception.OperationAlreadyInProgressRuntimeException;
@@ -21,8 +22,8 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
 
     private final CardExecutorService cardExecutorService;
 
-    public CardAuthoriseBaseService(ChargeDao chargeDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment) {
-        super(chargeDao, providers, environment);
+    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment) {
+        super(chargeDao, chargeEventDao, providers, environment);
         this.cardExecutorService = cardExecutorService;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/CardService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardService.java
@@ -5,6 +5,7 @@ import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.exception.ChargeExpiredRuntimeException;
 import uk.gov.pay.connector.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.exception.OperationAlreadyInProgressRuntimeException;
@@ -19,6 +20,7 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.fromString;
 
 public abstract class CardService<T extends BaseResponse> {
     protected final ChargeDao chargeDao;
+    protected final ChargeEventDao  chargeEventDao;
     private final PaymentProviders providers;
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected MetricRegistry metricRegistry;
@@ -40,8 +42,9 @@ public abstract class CardService<T extends BaseResponse> {
         }
     }
 
-    protected CardService(ChargeDao chargeDao, PaymentProviders providers, Environment environment) {
+    protected CardService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, Environment environment) {
         this.chargeDao = chargeDao;
+        this.chargeEventDao = chargeEventDao;
         this.providers = providers;
         this.metricRegistry = environment.metrics();
     }

--- a/src/main/java/uk/gov/pay/connector/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeExpiryService.java
@@ -142,7 +142,8 @@ public class ChargeExpiryService {
             logger.info("Charge status to update - charge_external_id={}, status={}, to_status={}",
                     chargeEntity.getExternalId(), chargeEntity.getStatus(), status);
             chargeEntity.setStatus(status);
-            return chargeDao.mergeAndNotifyStatusHasChanged(chargeEntity, Optional.empty());
+            chargeDao.notifyStatusHasChanged(chargeEntity, Optional.empty());
+            return chargeEntity;
         };
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeExpiryService.java
@@ -7,6 +7,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
@@ -41,14 +43,17 @@ public class ChargeExpiryService {
             AUTHORISATION_SUCCESS);
 
     private final ChargeDao chargeDao;
+    private final ChargeEventDao chargeEventDao;
     private final PaymentProviders providers;
-    private Provider<TransactionFlow> transactionFlowProvider;
+    private final Provider<TransactionFlow> transactionFlowProvider;
 
     @Inject
     public ChargeExpiryService(ChargeDao chargeDao,
+                               ChargeEventDao chargeEventDao,
                                PaymentProviders providers,
                                Provider<TransactionFlow> transactionFlowProvider) {
         this.chargeDao = chargeDao;
+        this.chargeEventDao = chargeEventDao;
         this.providers = providers;
         this.transactionFlowProvider = transactionFlowProvider;
     }
@@ -69,7 +74,7 @@ public class ChargeExpiryService {
     private int expireChargesWithCancellationNotRequired(List<ChargeEntity> nonAuthSuccessCharges) {
         List<ChargeEntity> processedEntities = nonAuthSuccessCharges
                 .stream().map(chargeEntity -> transactionFlowProvider.get()
-                        .executeNext(changeStatusTo(chargeDao, chargeEntity.getExternalId(), EXPIRED, Optional.empty()))
+                        .executeNext(changeStatusTo(chargeDao, chargeEventDao, chargeEntity.getExternalId(), EXPIRED, Optional.empty()))
                         .complete()
                         .get(ChargeEntity.class))
                 .collect(Collectors.toList());
@@ -85,7 +90,7 @@ public class ChargeExpiryService {
 
         gatewayAuthorizedCharges.forEach(chargeEntity -> {
             ChargeEntity processedEntity = transactionFlowProvider.get()
-                    .executeNext(prepareForTerminate(chargeDao, chargeEntity.getExternalId(), EXPIRE_FLOW))
+                    .executeNext(prepareForTerminate(chargeDao, chargeEventDao, chargeEntity.getExternalId(), EXPIRE_FLOW))
                     .executeNext(doGatewayCancel(providers))
                     .executeNext(finishExpireCancel())
                     .complete().get(ChargeEntity.class);
@@ -117,33 +122,34 @@ public class ChargeExpiryService {
     }
 
     private ChargeStatus determineTerminalState(ChargeEntity chargeEntity, GatewayResponse<BaseCancelResponse> cancelResponse, StatusFlow statusFlow) {
+        if (!cancelResponse.isSuccessful()) {
+            logUnsuccessfulResponseReasons(chargeEntity, cancelResponse);
+        }
 
-      if (!cancelResponse.isSuccessful()) {
-        logUnsuccessfulResponseReasons(chargeEntity, cancelResponse);
-      }
-
-      return cancelResponse.getBaseResponse().map(response -> {
-          switch (response.cancelStatus()) {
-              case CANCELLED:
-                  return statusFlow.getSuccessTerminalState();
-              case SUBMITTED:
-                  return statusFlow.getSubmittedState();
-              default:
-                  return statusFlow.getFailureTerminalState();
-          }
-      }).orElse(statusFlow.getFailureTerminalState());
+        return cancelResponse.getBaseResponse().map(response -> {
+            switch (response.cancelStatus()) {
+                case CANCELLED:
+                    return statusFlow.getSuccessTerminalState();
+                case SUBMITTED:
+                    return statusFlow.getSubmittedState();
+                default:
+                    return statusFlow.getFailureTerminalState();
+            }
+        }).orElse(statusFlow.getFailureTerminalState());
     }
 
     private TransactionalOperation<TransactionContext, ChargeEntity> finishExpireCancel() {
         return context -> {
-            ChargeEntity chargeEntity = context.get(ChargeEntity.class);
-            GatewayResponse gatewayResponse = context.get(GatewayResponse.class);
-            ChargeStatus status = determineTerminalState(chargeEntity, gatewayResponse, EXPIRE_FLOW);
-            logger.info("Charge status to update - charge_external_id={}, status={}, to_status={}",
-                    chargeEntity.getExternalId(), chargeEntity.getStatus(), status);
-            chargeEntity.setStatus(status);
-            chargeDao.notifyStatusHasChanged(chargeEntity, Optional.empty());
-            return chargeEntity;
+            String externalId = context.get(ChargeEntity.class).getExternalId();
+            return chargeDao.findByExternalId(externalId).map(chargeEntity -> {
+                GatewayResponse gatewayResponse = context.get(GatewayResponse.class);
+                ChargeStatus status = determineTerminalState(chargeEntity, gatewayResponse, EXPIRE_FLOW);
+                logger.info("Charge status to update - charge_external_id={}, status={}, to_status={}",
+                        chargeEntity.getExternalId(), chargeEntity.getStatus(), status);
+                chargeEntity.setStatus(status);
+                chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+                return chargeEntity;
+            }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
         };
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotificationService.java
@@ -202,7 +202,7 @@ public class NotificationService {
                     gatewayAccount.getGatewayName(),
                     gatewayAccount.getType());
 
-            chargeDao.mergeAndNotifyStatusHasChanged(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
+            chargeDao.notifyStatusHasChanged(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
         }
 
         private <T> void updateRefundStatus(EvaluatedRefundStatusNotification<T> notification) {

--- a/src/main/java/uk/gov/pay/connector/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotificationService.java
@@ -5,6 +5,7 @@ import fj.data.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.dao.RefundDao;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.model.*;
@@ -23,13 +24,15 @@ public class NotificationService {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final ChargeDao chargeDao;
+    private final ChargeEventDao chargeEventDao;
     private final RefundDao refundDao;
     private final PaymentProviders paymentProviders;
     private final DnsUtils dnsUtils;
 
     @Inject
-    public NotificationService(ChargeDao chargeDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils) {
+    public NotificationService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils) {
         this.chargeDao = chargeDao;
+        this.chargeEventDao = chargeEventDao;
         this.refundDao = refundDao;
         this.paymentProviders = paymentProviders;
         this.dnsUtils = dnsUtils;
@@ -202,7 +205,7 @@ public class NotificationService {
                     gatewayAccount.getGatewayName(),
                     gatewayAccount.getType());
 
-            chargeDao.notifyStatusHasChanged(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
+            chargeEventDao.persistChargeEventOf(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
         }
 
         private <T> void updateRefundStatus(EvaluatedRefundStatusNotification<T> notification) {

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoITest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.connector.dao;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.it.dao.DaoITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+
+public class ChargeEventDaoITest extends DaoITestBase {
+
+    private ChargeDao chargeDao;
+    private ChargeEventDao chargeEventDao;
+    private DatabaseFixtures.TestCardDetails defaultTestCardDetails;
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+    @Before
+    public void setUp() throws Exception {
+        chargeDao = env.getInstance(ChargeDao.class);
+        chargeEventDao = env.getInstance(ChargeEventDao.class);
+        defaultTestCardDetails = new DatabaseFixtures(databaseTestHelper).validTestCardDetails();
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+
+    @Test
+    public void persistChargeEventOfChargeEntity_succeeds() throws Exception {
+
+        Long chargeId = 56735L;
+        String externalChargeId = "charge456";
+
+        String transactionId = "345654";
+        String transactionId2 = "345655";
+        String transactionId3 = "345656";
+
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withTransactionId(transactionId)
+                .insert();
+
+        Optional<ChargeEntity> charge = chargeDao.findById(chargeId);
+        ChargeEntity entity = charge.get();
+        entity.setStatus(ENTERING_CARD_DETAILS);
+
+        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+
+        //move status to AUTHORISED
+        entity.setStatus(AUTHORISATION_READY);
+        entity.setStatus(AUTHORISATION_SUCCESS);
+        entity.setGatewayTransactionId(transactionId2);
+
+        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+
+        entity.setStatus(CAPTURE_READY);
+        entity.setGatewayTransactionId(transactionId3);
+
+        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+
+        List<ChargeEventEntity> events = chargeDao.findById(chargeId).get().getEvents();
+
+        assertThat(events, hasSize(3));
+        assertThat(events, shouldIncludeStatus(ENTERING_CARD_DETAILS));
+        assertThat(events, shouldIncludeStatus(AUTHORISATION_SUCCESS));
+        assertThat(events, shouldIncludeStatus(CAPTURE_READY));
+        assertDateMatch(events.get(0).getUpdated());
+    }
+
+    private void assertDateMatch(ZonedDateTime createdDateTime) {
+        assertThat(createdDateTime, within(1, ChronoUnit.MINUTES, ZonedDateTime.now()));
+    }
+
+    private Matcher<? super List<ChargeEventEntity>> shouldIncludeStatus(ChargeStatus... expectedStatuses) {
+        return new TypeSafeMatcher<List<ChargeEventEntity>>() {
+            @Override
+            protected boolean matchesSafely(List<ChargeEventEntity> chargeEvents) {
+                List<ChargeStatus> actualStatuses = chargeEvents.stream()
+                        .map(ChargeEventEntity::getStatus)
+                        .collect(toList());
+                return actualStatuses.containsAll(asList(expectedStatuses));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(String.format("does not contain [%s]", expectedStatuses));
+            }
+        };
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
@@ -59,7 +59,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedChargeDao, mockedProviders, mockExecutorService, mockEnvironment);
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedChargeDao, mockedChargeEventDao, mockedProviders, mockExecutorService, mockEnvironment);
     }
 
     public void setupMockExecutorServiceMock() {

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -190,12 +190,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withStatus(ENTERING_CARD_DETAILS)
                 .build();
-        ChargeEntity reloadedCharge = spy(charge);
 
         when(mockedCardTypeDao.findByBrand(authCardDetails.getCardBrand())).thenReturn(newArrayList(cardTypeEntity));
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        when(mockedChargeDao.merge(charge)).thenReturn(reloadedCharge);
-        when(mockedChargeDao.mergeAndNotifyStatusHasChanged(reloadedCharge, Optional.empty())).thenReturn(reloadedCharge);
 
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 
@@ -204,6 +201,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
             fail("Expected test to fail with ConflictRuntimeException due to configuration conflicting in 3ds requirements");
         } catch (ConflictRuntimeException e) {
             assertThat(charge.getStatus(), is(AUTHORISATION_ABORTED.toString()));
+            verify(mockedChargeDao).notifyStatusHasChanged(charge, Optional.empty());
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureServiceTest.java
@@ -362,7 +362,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
     public void markChargeAsCaptureApproved_shouldSetChargeStatusToCaptureApprovedAndWriteChargeEvent() {
         ChargeEntity chargeEntity = spy(createNewChargeWith("worldpay", 1L, AUTHORISATION_SUCCESS, "gatewayTxId"));
         when(mockedChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
-        when(mockedChargeDao.mergeAndNotifyStatusHasChanged(chargeEntity, Optional.empty())).thenReturn(chargeEntity);
+        doNothing().when(mockedChargeDao).notifyStatusHasChanged(chargeEntity, Optional.empty());
 
         ChargeEntity result = cardCaptureService.markChargeAsCaptureApproved(chargeEntity.getExternalId());
 

--- a/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.service;
 import com.codahale.metrics.MetricRegistry;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.model.domain.*;
 
 import static org.mockito.Mockito.mock;
@@ -13,6 +14,7 @@ public abstract class CardServiceTest {
     protected PaymentProviders mockedProviders = mock(PaymentProviders.class);
     protected MetricRegistry mockMetricRegistry;
     protected ChargeDao mockedChargeDao = mock(ChargeDao.class);
+    protected ChargeEventDao mockedChargeEventDao = mock(ChargeEventDao.class);
     protected CardTypeDao mockedCardTypeDao = mock(CardTypeDao.class);
 
     protected ChargeEntity createNewChargeWith(Long chargeId, ChargeStatus status) {

--- a/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
@@ -75,8 +75,7 @@ public class ChargeExpiryServiceTest {
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
         ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
         ArgumentCaptor<CancelGatewayRequest> cancelCaptor = ArgumentCaptor.forClass(CancelGatewayRequest.class);
-        when(mockChargeDao.mergeAndNotifyStatusHasChanged(captor.capture(), any()))
-                .thenAnswer(invocationOnMock -> invocationOnMock.getArguments()[0]);
+        doNothing().when(mockChargeDao).notifyStatusHasChanged(captor.capture(), any());
 
         chargeExpiryService.expire(singletonList(chargeEntity));
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.model.CancelGatewayRequest;
 import uk.gov.pay.connector.model.GatewayError;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
@@ -41,6 +42,9 @@ public class ChargeExpiryServiceTest {
     private ChargeDao mockChargeDao;
 
     @Mock
+    private ChargeEventDao mockChargeEventDao;
+
+    @Mock
     private PaymentProviders mockPaymentProviders;
 
     @Mock
@@ -51,7 +55,7 @@ public class ChargeExpiryServiceTest {
 
     @Before
     public void setup() {
-        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockPaymentProviders, TransactionFlow::new);
+        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, TransactionFlow::new);
     }
 
     @Test
@@ -75,7 +79,7 @@ public class ChargeExpiryServiceTest {
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
         ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
         ArgumentCaptor<CancelGatewayRequest> cancelCaptor = ArgumentCaptor.forClass(CancelGatewayRequest.class);
-        doNothing().when(mockChargeDao).notifyStatusHasChanged(captor.capture(), any());
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture(), any());
 
         chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -107,7 +111,7 @@ public class ChargeExpiryServiceTest {
                     ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
 
                     when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
-                    doNothing().when(mockChargeDao).notifyStatusHasChanged(captor.capture(), any());
+                    doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture(), any());
 
                     chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -137,7 +141,7 @@ public class ChargeExpiryServiceTest {
         when(mockPaymentProviders.byName(PaymentGatewayName.WORLDPAY)).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
         ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
-        doNothing().when(mockChargeDao).notifyStatusHasChanged(captor.capture(), any());
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture(), any());
 
         chargeExpiryService.expire(singletonList(chargeEntity));
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -5,15 +5,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.LinksConfig;
-import uk.gov.pay.connector.dao.CardTypeDao;
-import uk.gov.pay.connector.dao.ChargeDao;
-import uk.gov.pay.connector.dao.GatewayAccountDao;
-import uk.gov.pay.connector.dao.TokenDao;
+import uk.gov.pay.connector.dao.*;
 import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -30,7 +26,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
@@ -42,7 +37,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -66,6 +60,8 @@ public class ChargeServiceTest {
     private TokenDao mockedTokenDao;
     @Mock
     private ChargeDao mockedChargeDao;
+    @Mock
+    private ChargeEventDao mockedChargeEventDao;
     @Mock
     private GatewayAccountDao mockedGatewayAccountDao;
     @Mock
@@ -105,7 +101,7 @@ public class ChargeServiceTest {
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
 
-        service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders);
+        service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao, mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders);
     }
 
     @Test
@@ -166,6 +162,7 @@ public class ChargeServiceTest {
         }});
 
         assertThat(response, is(expectedChargeResponse.build()));
+        verify(mockedChargeEventDao).persistChargeEventOf(createdChargeEntity,Optional.empty());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -294,25 +294,6 @@ public class ChargeServiceTest {
         assertThat(chargeForAccount.isPresent(), is(false));
     }
 
-    @Test
-    public void shouldUpdateChargeStatusForAllChargesWithTheGivenStatus() {
-        ChargeEntity chargeEntity1 = mock(ChargeEntity.class);
-        ChargeEntity chargeEntity2 = mock(ChargeEntity.class);
-
-        service.updateStatus(asList(chargeEntity1, chargeEntity2), ChargeStatus.ENTERING_CARD_DETAILS, Optional.empty());
-
-        InOrder inOrder = inOrder(chargeEntity1, chargeEntity2, mockedChargeDao);
-
-        inOrder.verify(chargeEntity1).setStatus(ChargeStatus.ENTERING_CARD_DETAILS);
-        inOrder.verify(mockedChargeDao).mergeAndNotifyStatusHasChanged(chargeEntity1, Optional.empty());
-
-        inOrder.verify(chargeEntity2).setStatus(ChargeStatus.ENTERING_CARD_DETAILS);
-        inOrder.verify(mockedChargeDao).mergeAndNotifyStatusHasChanged(chargeEntity2, Optional.empty());
-    }
-
-    /**
-     * TODO To create a matcher rather than using main src to build our assertions
-     */
     @Deprecated
     private ChargeResponseBuilder chargeResponseBuilderOf(ChargeEntity chargeEntity) throws URISyntaxException {
         ChargeResponse.RefundSummary refunds = new ChargeResponse.RefundSummary();

--- a/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
@@ -305,7 +305,7 @@ public class NotificationServiceTest {
         verify(mockedChargeEntity).setStatus(CAPTURED);
 
         ArgumentCaptor<Optional> generatedTimeCaptor = ArgumentCaptor.forClass(Optional.class);
-        verify(mockedChargeDao).mergeAndNotifyStatusHasChanged(argThat(obj -> mockedChargeEntity.equals(obj)), generatedTimeCaptor.capture());
+        verify(mockedChargeDao).notifyStatusHasChanged(argThat(obj -> mockedChargeEntity.equals(obj)), generatedTimeCaptor.capture());
 
         assertTrue(ChronoUnit.SECONDS.between((ZonedDateTime) generatedTimeCaptor.getValue().get(), ZonedDateTime.now()) < 10);
 

--- a/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.dao.RefundDao;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.model.Notification;
@@ -60,6 +61,9 @@ public class NotificationServiceTest {
     private ChargeDao mockedChargeDao;
 
     @Mock
+    private ChargeEventDao mockedChargeEventDao;
+
+    @Mock
     private RefundDao mockedRefundDao;
 
     @Mock
@@ -81,7 +85,7 @@ public class NotificationServiceTest {
 
         when(mockedPaymentProvider.verifyNotification(any(Notification.class), any(GatewayAccountEntity.class))).thenReturn(true);
 
-        notificationService = new NotificationService(mockedChargeDao, mockedRefundDao, mockedPaymentProviders, mockDnsUtils);
+        notificationService = new NotificationService(mockedChargeDao, mockedChargeEventDao, mockedRefundDao, mockedPaymentProviders, mockDnsUtils);
     }
 
     private Notifications<Pair<String, Boolean>> createNotificationFor(String transactionId, String reference, Pair<String, Boolean> status) {
@@ -305,7 +309,7 @@ public class NotificationServiceTest {
         verify(mockedChargeEntity).setStatus(CAPTURED);
 
         ArgumentCaptor<Optional> generatedTimeCaptor = ArgumentCaptor.forClass(Optional.class);
-        verify(mockedChargeDao).notifyStatusHasChanged(argThat(obj -> mockedChargeEntity.equals(obj)), generatedTimeCaptor.capture());
+        verify(mockedChargeEventDao).persistChargeEventOf(argThat(obj -> mockedChargeEntity.equals(obj)), generatedTimeCaptor.capture());
 
         assertTrue(ChronoUnit.SECONDS.between((ZonedDateTime) generatedTimeCaptor.getValue().get(), ZonedDateTime.now()) < 10);
 


### PR DESCRIPTION
## WHAT

- Use _ChargeEventDao_ instead of _ChargeDao_ to persist events of a charge.
- Removed unused Transactional method update statuses
- Merge after https://github.com/alphagov/pay-connector/pull/452

