### PR TITLE
PP-2636 Address Deserialization of Untrusted Data vulnerability (CVE-2017-7525)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.7</version>
+            <version>2.8.10</version>
         </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
@@ -290,6 +290,12 @@
             <groupId>black.door</groupId>
             <artifactId>hate</artifactId>
             <version>v1r4t0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.carlosbecker</groupId>


### PR DESCRIPTION
## WHAT

In addition to upgrading `com.fasterxml.jackson.core:jackson-databind` to version 2.8.10, we also need to exclude version 2.7.5 from a transient dependency (black.door:hate@v1r4t0). It is not strictly needed as per se but Snyk is reporting false alarms and we need to suppress those.

## HOW
Snippet of `pom.xml`

```
<dependency>
  <groupId>black.door</groupId>
    <artifactId>hate</artifactId>
    <version>v1r4t0</version>
    <exclusions>
      <exclusion>
        <groupId>com.fasterxml.jackson.core</groupId>
        <artifactId>jackson-databind</artifactId>
      </exclusion>
    </exclusions>
</dependency>
```



