### PR TITLE
PP-2117 Upgrade commons-collections to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,12 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>1.6</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mindrot</groupId>


### PR DESCRIPTION
## WHAT
In addition to pinning `commons-collections` to version _3.2.2_, we also need to explicitly exclude version _3.2.1_ from transient dependency of `commons-validator`.
It is not strictly needed as per se but Snyk is reporting false alarms and we need to suppress those.


## HOW 
pom snippets:

```
<dependency>
  <groupId>commons-validator</groupId>
  <artifactId>commons-validator</artifactId>
  <version>1.6</version>
  <exclusions>
    <exclusion>
      <groupId>commons-collections</groupId>
      <artifactId>commons-collections</artifactId>
    </exclusion>
 </exclusions>
</dependency>
```
