### PR TITLE
Improve gateway operation response logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/GatewayError.java
+++ b/src/main/java/uk/gov/pay/connector/model/GatewayError.java
@@ -1,6 +1,11 @@
 package uk.gov.pay.connector.model;
 
-import static uk.gov.pay.connector.model.ErrorType.*;
+import static uk.gov.pay.connector.model.ErrorType.GATEWAY_CONNECTION_SOCKET_ERROR;
+import static uk.gov.pay.connector.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
+import static uk.gov.pay.connector.model.ErrorType.GATEWAY_URL_DNS_ERROR;
+import static uk.gov.pay.connector.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.model.ErrorType.MALFORMED_RESPONSE_RECEIVED_FROM_GATEWAY;
+import static uk.gov.pay.connector.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
 
 public class GatewayError {
     private String message;
@@ -45,9 +50,6 @@ public class GatewayError {
 
     @Override
     public String toString() {
-        return "GatewayError{" +
-                "message='" + message + '\'' +
-                ", errorType=" + errorType +
-                '}';
+        return "Gateway error: " + message;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/gateway/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/gateway/GatewayResponse.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 import static fj.data.Either.left;
 import static fj.data.Either.right;
 import static java.lang.String.format;
-import static org.apache.commons.lang3.StringUtils.trim;
 import static uk.gov.pay.connector.model.GatewayError.baseError;
 
 public class GatewayResponse<T extends BaseResponse> {
@@ -73,6 +72,11 @@ public class GatewayResponse<T extends BaseResponse> {
         );
     }
 
+    @Override
+    public String toString() {
+        return response.either(GatewayError::toString, T::toString);
+    }
+
     static public <T extends BaseResponse> GatewayResponse<T> with(GatewayError gatewayError) {
         logger.error(format("Error received from gateway: %s", gatewayError));
         return new GatewayResponse<>(gatewayError);
@@ -114,10 +118,7 @@ public class GatewayResponse<T extends BaseResponse> {
             Optional<String> errorMessage = getErrorMessage(response);
 
             if (errorCode.isPresent() || errorMessage.isPresent()) {
-                StringBuilder sb = new StringBuilder();
-                errorCode.ifPresent(e -> sb.append(format("[%s] ", e)));
-                errorMessage.ifPresent(sb::append);
-                return new GatewayResponse<>(baseError(trim(sb.toString())));
+                return new GatewayResponse<>(baseError(response.toString()));
             }
 
             return new GatewayResponse<>(response, sessionIdentifier);

--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -57,8 +57,10 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
             String transactionId = operationResponse.getBaseResponse()
                     .map(BaseAuthoriseResponse::getTransactionId).orElse("");
 
-            logger.info("AuthCardDetails authorisation response received - charge_external_id={}, operation_type={}, transaction_id={}, status={}",
-                    chargeEntity.getExternalId(), OperationType.AUTHORISATION_3DS.getValue(), transactionId, status);
+            logger.info("3DS response authorisation for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+                    chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
+                    chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
+                    operationResponse, chargeEntity.getStatus(), status);
 
             GatewayAccountEntity account = chargeEntity.getGatewayAccount();
 

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -8,7 +8,13 @@ import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.GatewayError;
-import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.AddressEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetails;
+import uk.gov.pay.connector.model.domain.CardDetailsEntity;
+import uk.gov.pay.connector.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 import uk.gov.pay.connector.model.gateway.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
 
@@ -17,7 +23,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.model.domain.NumbersInStringsSanitizer.sanitize;
 
 public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetails> {
@@ -99,8 +109,11 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
             operationResponse.getSessionIdentifier().ifPresent(chargeEntity::setProviderSessionId);
 
-            logger.info("AuthCardDetails authorisation response received - charge_external_id={}, operation_type={}, transaction_id={}, status={}",
-                    chargeEntity.getExternalId(), OperationType.AUTHORISATION.getValue(), transactionId, status);
+            logger.info("Authorisation for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+                    chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(),
+                    StringUtils.isNotBlank(transactionId) ? transactionId : "missing transaction ID",
+                    chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
+                    operationResponse, chargeEntity.getStatus(), status);
 
             GatewayAccountEntity account = chargeEntity.getGatewayAccount();
 

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
@@ -18,7 +18,12 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 
 public class CardCaptureService extends CardService implements TransactionalGatewayOperation<BaseCaptureResponse> {
 
@@ -92,8 +97,10 @@ public class CardCaptureService extends CardService implements TransactionalGate
                     String transactionId = operationResponse.getBaseResponse()
                             .map(BaseCaptureResponse::getTransactionId).orElse("");
 
-                    logger.info("Card capture response received - charge_external_id={}, operation_type={}, transaction_id={}, status={}",
-                            chargeEntity.getExternalId(), OperationType.CAPTURE.getValue(), transactionId, nextStatus);
+                    logger.info("Capture for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+                            chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
+                            chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
+                            operationResponse, chargeEntity.getStatus(), nextStatus);
 
                     chargeEntity.setStatus(nextStatus);
 

--- a/src/main/java/uk/gov/pay/connector/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeCancelService.java
@@ -26,7 +26,9 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_3DS_R
 import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.model.gateway.GatewayResponse.GatewayResponseBuilder.responseBuilder;
-import static uk.gov.pay.connector.service.CancelServiceFunctions.*;
+import static uk.gov.pay.connector.service.CancelServiceFunctions.changeStatusTo;
+import static uk.gov.pay.connector.service.CancelServiceFunctions.doGatewayCancel;
+import static uk.gov.pay.connector.service.CancelServiceFunctions.prepareForTerminate;
 import static uk.gov.pay.connector.service.StatusFlow.SYSTEM_CANCELLATION_FLOW;
 import static uk.gov.pay.connector.service.StatusFlow.USER_CANCELLATION_FLOW;
 
@@ -88,11 +90,10 @@ public class ChargeCancelService {
             GatewayResponse cancelResponse = context.get(GatewayResponse.class);
             ChargeStatus status = determineTerminalState(cancelResponse, statusFlow);
 
-            logger.info("Card cancel response received - charge_external_id={}, transaction_id={}, status={}",
-                    chargeEntity.getExternalId(), chargeEntity.getGatewayTransactionId(), status);
-
-            logger.info("Charge status to update - charge_external_id={}, status={}, to_status={}",
-                    chargeEntity.getExternalId(), chargeEntity.getStatus(), status);
+            logger.info("Cancel for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+                    chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
+                    chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
+                    cancelResponse, chargeEntity.getStatus(), status);
 
             chargeEntity.setStatus(status);
             chargeDao.notifyStatusHasChanged(chargeEntity, Optional.empty());

--- a/src/main/java/uk/gov/pay/connector/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeRefundService.java
@@ -137,10 +137,11 @@ public class ChargeRefundService {
             RefundStatus status = gatewayResponse.isSuccessful() ? RefundStatus.REFUND_SUBMITTED : RefundStatus.REFUND_ERROR;
             String reference = getRefundReference(refundEntity, gatewayResponse);
 
-            logger.info("Card refund response received -  transaction_id={}, charge_id={}, charge_external_id={}, refund_id={}, refund_external_id={}, refund_reference={}, refund_status={}, refund_amount={}",
-                    chargeEntity.getGatewayTransactionId(), chargeEntity.getId(), chargeEntity.getExternalId(), refundEntity.getId(), refundEntity.getExternalId(), reference, refundEntity.getStatus(), refundEntity.getAmount());
-            logger.info("Refund status to update - status={}, to_status={} for transaction_id={}, charge_id={}, charge_external_id={}, refund_id={}, refund_external_id={}, refund_reference={}, refund_status={}, refund_amount={}",
-                    refundEntity.getStatus(), status, chargeEntity.getGatewayTransactionId(), chargeEntity.getId(), chargeEntity.getExternalId(), refundEntity.getId(), refundEntity.getExternalId(), reference, refundEntity.getStatus(), refundEntity.getAmount());
+            logger.info("Refund {} ({} {}) for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+                    refundEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), refundEntity.getReference(),
+                    chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
+                    chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
+                    gatewayResponse, refundEntity.getStatus(), status);
 
             refundEntity.setStatus(status);
             refundEntity.setReference(reference);

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.epdq;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "ncresponse")
 public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseAuthoriseResponse {
@@ -68,6 +70,24 @@ public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseA
         if (hasError())
             return super.getErrorMessage();
         return null;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "ePDQ authorisation response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("PAYID: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(status)) {
+            joiner.add("STATUS: " + status);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("NCERROR: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("NCERRORPLUS: " + getErrorMessage());
+        }
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqBaseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqBaseResponse.java
@@ -23,4 +23,8 @@ abstract public class EpdqBaseResponse implements BaseResponse {
     public String getErrorMessage() {
         return trim(errorMessage);
     }
+
+    @Override
+    public abstract String toString();
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqCancelResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqCancelResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.epdq;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.service.BaseCancelResponse;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "ncresponse")
 public class EpdqCancelResponse extends EpdqBaseResponse implements BaseCancelResponse {
@@ -50,6 +52,24 @@ public class EpdqCancelResponse extends EpdqBaseResponse implements BaseCancelRe
         if (hasError())
             return super.getErrorMessage();
         return null;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "ePDQ cancel response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("PAYID: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(status)) {
+            joiner.add("STATUS: " + status);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("NCERROR: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("NCERRORPLUS: " + getErrorMessage());
+        }
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqCaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqCaptureResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.epdq;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.service.BaseCaptureResponse;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "ncresponse")
 public class EpdqCaptureResponse extends EpdqBaseResponse implements BaseCaptureResponse {
@@ -37,6 +39,24 @@ public class EpdqCaptureResponse extends EpdqBaseResponse implements BaseCapture
         if (hasError())
             return super.getErrorMessage();
         return null;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "ePDQ capture response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("PAYID: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(status)) {
+            joiner.add("STATUS: " + status);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("NCERROR: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("NCERRORPLUS: " + getErrorMessage());
+        }
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqRefundResponse.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.connector.service.epdq;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.service.BaseRefundResponse;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -45,4 +47,26 @@ public class EpdqRefundResponse extends EpdqBaseResponse implements BaseRefundRe
         }
         return Optional.of(transactionId + "/" + payIdSub);
     }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "ePDQ refund response (", ")");
+        if (StringUtils.isNotBlank(transactionId)) {
+            joiner.add("PAYID: " + transactionId);
+        }
+        if (StringUtils.isNotBlank(payIdSub)) {
+            joiner.add("PAYIDSUB: " + payIdSub);
+        }
+        if (StringUtils.isNotBlank(status)) {
+            joiner.add("STATUS: " + status);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("NCERROR: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("NCERRORPLUS: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.smartpay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "Envelope", namespace = "http://schemas.xmlsoap.org/soap/envelope/")
 public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implements BaseAuthoriseResponse {
@@ -39,4 +41,23 @@ public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implemen
     public String get3dsIssuerUrl() {
         return null;
     }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "SmartPay authorisation response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("pspReference: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(result)) {
+            joiner.add("resultCode: " + result);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("faultcode: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("faultstring: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayBaseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayBaseResponse.java
@@ -21,5 +21,7 @@ abstract public class SmartpayBaseResponse implements BaseResponse {
         return trim(errorMessage);
     }
 
+    @Override
+    public abstract String toString();
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayCancelResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayCancelResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.smartpay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.service.BaseCancelResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "Envelope", namespace="http://schemas.xmlsoap.org/soap/envelope/")
 public class SmartpayCancelResponse extends SmartpayBaseResponse implements BaseCancelResponse {
@@ -19,6 +21,21 @@ public class SmartpayCancelResponse extends SmartpayBaseResponse implements Base
     @Override
     public CancelStatus cancelStatus() {
         return CancelStatus.CANCELLED;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "SmartPay cancel response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("pspReference: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("faultcode: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("faultstring: " + getErrorMessage());
+        }
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayCaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayCaptureResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.smartpay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.service.BaseCaptureResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "Envelope", namespace = "http://schemas.xmlsoap.org/soap/envelope/")
 public class SmartpayCaptureResponse extends SmartpayBaseResponse implements BaseCaptureResponse {
@@ -17,4 +19,23 @@ public class SmartpayCaptureResponse extends SmartpayBaseResponse implements Bas
     public String getTransactionId() {
         return captureTransactionId;
     }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "SmartPay capture response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("pspReference: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(captureResponse)) {
+            joiner.add("response: " + captureResponse);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("faultcode: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("faultstring: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayRefundResponse.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.connector.service.smartpay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.service.BaseRefundResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "Envelope", namespace = "http://schemas.xmlsoap.org/soap/envelope/")
 public class SmartpayRefundResponse extends SmartpayBaseResponse implements BaseRefundResponse {
@@ -16,4 +18,20 @@ public class SmartpayRefundResponse extends SmartpayBaseResponse implements Base
     public Optional<String> getReference() {
         return Optional.ofNullable(pspReference);
     }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "SmartPay refund response (", ")");
+        if (StringUtils.isNotBlank(pspReference)) {
+            joiner.add("pspReference: " + pspReference);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("faultcode: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("faultstring: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayBaseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayBaseResponse.java
@@ -21,4 +21,7 @@ abstract public class WorldpayBaseResponse implements BaseResponse {
         return trim(errorMessage);
     }
 
+    @Override
+    public abstract String toString();
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayCancelResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayCancelResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.worldpay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.service.BaseCancelResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "paymentService")
 public class WorldpayCancelResponse extends WorldpayBaseResponse implements BaseCancelResponse {
@@ -23,6 +25,21 @@ public class WorldpayCancelResponse extends WorldpayBaseResponse implements Base
 
     public void setTransactionId(String transactionId) {
         this.transactionId = transactionId;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Worldpay cancel response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("orderCode: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("error code: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("error: " + getErrorMessage());
+        }
+        return joiner.toString();
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayCaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayCaptureResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.worldpay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.service.BaseCaptureResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "paymentService")
 public class WorldpayCaptureResponse extends WorldpayBaseResponse implements BaseCaptureResponse {
@@ -15,4 +17,20 @@ public class WorldpayCaptureResponse extends WorldpayBaseResponse implements Bas
     public String getTransactionId() {
         return transactionId;
     }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Worldpay capture response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("orderCode: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("error code: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("error: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderStatusResponse.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.connector.service.worldpay;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 import uk.gov.pay.connector.service.BaseCancelResponse;
 import uk.gov.pay.connector.service.BaseInquiryResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
 
 import static org.apache.commons.lang3.StringUtils.trim;
 
@@ -127,4 +129,32 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
     public String get3dsIssuerUrl() {
         return issuerUrl;
     }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Worldpay authorisation response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("orderCode: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(getLastEvent())) {
+            joiner.add("lastEvent: "+ getLastEvent());
+        }
+        if (StringUtils.isNotBlank(getRefusedReturnCode())) {
+            joiner.add("ISO8583ReturnCode code: " + getRefusedReturnCode());
+        }
+        if (StringUtils.isNotBlank(getRefusedReturnCodeDescription())) {
+            joiner.add("ISO8583ReturnCode description: " + getRefusedReturnCodeDescription());
+        }
+        if (StringUtils.isNotBlank(get3dsIssuerUrl())) {
+            joiner.add("issuerURL: " + get3dsIssuerUrl());
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("error code: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("error: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayRefundResponse.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service.worldpay;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.service.BaseRefundResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 @XmlRootElement(name = "paymentService")
 public class WorldpayRefundResponse extends WorldpayBaseResponse implements BaseRefundResponse {
@@ -12,4 +14,21 @@ public class WorldpayRefundResponse extends WorldpayBaseResponse implements Base
     public Optional<String> getReference() {
         return Optional.empty();
     }
+
+    @Override
+    public String toString() {
+        if (!StringUtils.isNotBlank(getErrorCode()) && !StringUtils.isNotBlank(getErrorMessage())) {
+            return "Worldpay refund response";
+        }
+
+        StringJoiner joiner = new StringJoiner(", ", "Worldpay refund response (", ")");
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("error code: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("error: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
@@ -4,7 +4,11 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 
 public class EpdqCardResourceITest extends ChargingITestBase {
 
@@ -43,7 +47,9 @@ public class EpdqCardResourceITest extends ChargingITestBase {
     public void shouldNotAuthorise_whenTransactionIsInError() throws Exception {
         epdq.mockAuthorisationError();
 
-        String expectedErrorMessage = "[50001111] An error has occurred; please try again later. If you are the owner or the integrator of this website, please log into the  back office to see the details of the error.";
+        String expectedErrorMessage = "ePDQ authorisation response (PAYID: 0, STATUS: 0, NCERROR: 50001111, " +
+                "NCERRORPLUS: An error has occurred; please try again later. If you are the owner or the integrator " +
+                "of this website, please log into the  back office to see the details of the error.)";
         String expectedChargeStatus = AUTHORISATION_ERROR.getValue();
         shouldReturnErrorForAuthorisationDetailsWithMessage(authorisationDetails, expectedErrorMessage, expectedChargeStatus);
     }
@@ -52,7 +58,7 @@ public class EpdqCardResourceITest extends ChargingITestBase {
     public void shouldNotAuthorise_aTransactionInAnyOtherNonSupportedState() throws Exception {
         epdq.mockAuthorisationOther();
 
-        String expectedErrorMessage = "[0] !";
+        String expectedErrorMessage = "ePDQ authorisation response (PAYID: 3014644340, STATUS: 52, NCERROR: 0, NCERRORPLUS: !)";
         String expectedChargeStatus = AUTHORISATION_ERROR.getValue();
         shouldReturnErrorForAuthorisationDetailsWithMessage(authorisationDetails, expectedErrorMessage, expectedChargeStatus);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
@@ -18,16 +18,24 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUNDS_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUND_API_PATH;
 
@@ -256,7 +264,10 @@ public class EpdqRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
                 .body("message",
-                        is("[50001111] An error has occurred; please try again later. If you are the owner or the integrator of this website, please log into the  back office to see the details of the error."));
+                        is("ePDQ refund response (PAYID: 0, STATUS: 0, NCERROR: 50001111, " +
+                                "NCERRORPLUS: An error has occurred; please try again later. " +
+                                "If you are the owner or the integrator of this website, " +
+                                "please log into the  back office to see the details of the error.)"));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
@@ -18,17 +18,22 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUNDS_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUND_API_PATH;
 
@@ -233,7 +238,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
         smartpay.mockRefundError();
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
-                .body("message", is("[soap:Server] security 901 Invalid Merchant Account"));
+                .body("message", is("SmartPay refund response " +
+                        "(faultcode: soap:Server, faultstring: security 901 Invalid Merchant Account)"));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
@@ -18,12 +18,18 @@ import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
@@ -238,7 +244,7 @@ public class WorldpayRefundITest extends ChargingITestBase {
         worldpay.mockRefundError();
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
-                .body("message", is("[2] Something went wrong."));
+                .body("message", is("Worldpay refund response (error code: 2, error: Something went wrong.)"));
 
         java.util.List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/model/gateway/GatewayResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/gateway/GatewayResponseTest.java
@@ -45,49 +45,7 @@ public class GatewayResponseTest {
     }
 
     @Test
-    public void shouldHandleAGatewayResponseWithAnErrorCode() {
-        GatewayError error = new GatewayError(
-                "[errorCode]",
-                GENERIC_GATEWAY_ERROR);
-
-        BaseResponse baseResponse = createBaseResponseWith("errorCode", null);
-        GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
-        GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
-                .withResponse(baseResponse)
-                .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is(error.getMessage()));
-        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
-    }
-
-    @Test
-    public void shouldHandleAGatewayResponseWithAnErrorMessage() {
-        GatewayError error = new GatewayError(
-                "an error",
-                GENERIC_GATEWAY_ERROR);
-
-        BaseResponse baseResponse = createBaseResponseWith(null, "an error");
-        GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
-        GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
-                .withResponse(baseResponse)
-                .build();
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is(error.getMessage()));
-        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
-    }
-
-    @Test
     public void shouldHandleAGatewayResponseWithAnErrorCodeAndMessage() {
-        GatewayError error = new GatewayError(
-                "[123] oops, something went wrong",
-                GENERIC_GATEWAY_ERROR);
-
         BaseResponse baseResponse = createBaseResponseWith("123", "oops, something went wrong");
         GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
         GatewayResponse<BaseResponse> gatewayResponse = gatewayResponseBuilder
@@ -97,7 +55,8 @@ public class GatewayResponseTest {
         assertThat(gatewayResponse.isSuccessful(), is(false));
         assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is(error.getMessage()));
+        assertThat(gatewayResponse.getGatewayError().get().getMessage(),
+                is("Randompay something response (errorCode: 123, errorMessage: oops, something went wrong)"));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
     }
 
@@ -112,6 +71,11 @@ public class GatewayResponseTest {
             @Override
             public String getErrorMessage() {
                 return errorMessage;
+            }
+
+            @Override
+            public String toString() {
+                return "Randompay something response (errorCode: " + errorCode + ", errorMessage: " + errorMessage + ')';
             }
         };
     }

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -73,6 +73,7 @@ public class ChargeRefundServiceTest {
         WorldpayRefundResponse worldpayResponse = mock(WorldpayRefundResponse.class);
         when(worldpayResponse.getReference()).thenReturn(Optional.ofNullable(reference));
         when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
+        when(worldpayResponse.toString()).thenReturn("Randompay refund response (errorCode: " + errorCode + ")");
         GatewayResponseBuilder<WorldpayRefundResponse> gatewayResponseBuilder = responseBuilder();
         GatewayResponse refundResponse = gatewayResponseBuilder
                 .withResponse(worldpayResponse)
@@ -359,7 +360,8 @@ public class ChargeRefundServiceTest {
 
         assertThat(gatewayResponse.getRefundGatewayResponse().isFailed(), is(true));
         assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().get().getMessage(), is("[error-code]"));
+        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().get().getMessage(),
+                is("Randompay refund response (errorCode: error-code)"));
         assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().get().getErrorType(), is(ErrorType.GENERIC_GATEWAY_ERROR));
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, accountId);

--- a/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
@@ -384,7 +384,7 @@ public class WorldpayPaymentProviderTest {
 
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("[5] Order has already been paid", GENERIC_GATEWAY_ERROR));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Worldpay capture response (error code: 5, error: Order has already been paid)", GENERIC_GATEWAY_ERROR));
     }
 
     @Test


### PR DESCRIPTION
Recently, there have been a few occassions where I’ve had to look in the logs and found the information logged when we receive a response to a gateway operation request (authorisation, capture, cancel, refund, etc.) to be somewhat lacking.

Currently, when we receive a response to an authorisation request, we log, at INFO level, the following (with the placeholders replaced by actual values, of course, and some line breaks have been added):

```
AuthCardDetails authorisation response received - charge_external_id={},
operation_type={}, transaction_id={}, status={}
```

Note that `status` is the new status that the payment will be moved to as a result of the response. Meanwhile, `operation_type` is always “Authorisation”, so is basically redundant.

For 3D Secure authorisations, we log this at INFO:

```
AuthCardDetails authorisation response received - charge_external_id={},
operation_type={}, transaction_id={}, status={}
```

There’s a mistake here: it should be `Auth3dsDetails` rather than `AuthCardDetails`. The operation type is “3D Secure Response Authorisation” but otherwise it’s the same as regular authorisation.

Capture logs a line at INFO like this:

```
Card capture response received - charge_external_id={}, operation_type={},
transaction_id={}, status={}
```

Once again, `status` is the new status. The `operation_type` is always “Capture”.

For cancel, we split the relevant details across two lines at INFO:

```
Card cancel response received - charge_external_id={}, transaction_id={},
status={}
```

```
Charge status to update - charge_external_id={}, status={}, to_status={}
```

In both, `status` is the old status.

Refunds also get two lines at INFO:

```
Card refund response received -  transaction_id={}, charge_id={},
charge_external_id={}, refund_id={}, refund_external_id={},
refund_reference={}, refund_status={}, refund_amount={}
```

```
Refund status to update - status={}, to_status={} for transaction_id={},
charge_id={}, charge_external_id={}, refund_id={}, refund_external_id={},
refund_reference={}, refund_status={}, refund_amount={}
```

The `refund_id` is an entity database ID, which we never seem to log for anything else. Both `refund_status` and `status` are the old status of the refund, so the second line includes it twice!

What none of these log lines contain is any real indication of what was in the gateway response (or if some problem meant there wasn’t a gateway response): the best we get is the status the payment (or refund) will become. Sometimes more details about the content of the response or errors encountered in receiving it will be logged elsewhere but they are usually devoid of information about which payment they relate to. This can mean having to look at adjacent log lines or compare timestamps to fully investigate a problem.

Furthermore, there is no indication of the payment gateway or service in question.

This pull request makes the log lines look like this (with some example values):

```
Authorisation for abcdefghijklmnopqrstuvwxyz (epdq 1111111) for MOF-TLA (42) —
ePDQ authorisation response (PAYID: 1111111, STATUS: 5) ∴ AUTHORISATION READY →
AUTHORISED
```

```
3DS response authorisation for abcdefghijklmnopqrstuvwxyz (worldpay
fddebf25-960e-4fe5-aee6-ce2c8b29ed5c) for MOF-TLA (42) — Worldpay authorisation
response (orderCode: fddebf25-960e-4fe5-aee6-ce2c8b29ed5c, lastEvent:
AUTHORISED) ∴ AUTHORISATION 3DS READY → AUTHORISED
```

```
Capture for abcdefghijklmnopqrstuvwxyz (worldpay
fddebf25-960e-4fe5-aee6-ce2c8b29ed5c) for MOF-TLA (42) — Gateway error:
Worldpay capture response (error code: 1, error: Internal error) ∴ CAPTURE
READY → CAPTURE APPROVED RETRY
```

```
Cancel for abcdefghijklmnopqrstuvwxyz (smartpay 8313547924770610) for MOF-TLA
(42) — Gateway error: Gateway connection timeout error ∴ USER CANCEL READY
→ USER CANCEL ERROR
```

```
Refund zyxwvutsrqponmlkjihgfedcba (ePDQ 1111111/3) for
abcdefghijklmnopqrstuvwxyz (ePDQ 1111111) for MOF-TLA (42) — ePDQ refund
response (PAYID: 1111111, PAYIDSUB: 3, STATUS: 81) ∴ CREATED → REFUND
SUBMITTED
```

While not perfect, the intention is to fit in more information and rely on context rather than snake case labels that are neither the exact names of fields nor true structured logging.

(Note that the refund log lines no longer include the entity database IDs nor the amount, which are probably redundant.)

Each log line has three parts: the bit before the em dash, the bit between the em dash and the “∴” (“therefore” symbol) and the bit after the “∴”.

With the exception of refunds, the part before the hyphen includes the type of operation, the external ID of the charge, the payment gateway and its transaction ID (grouped together in parentheses), and the analytics ID of the service (seems a reasonable alternative to the verbose full name) with the gateway account ID in brackets (because many gateway accounts may share the same service name). With the exception of authorisation, the transaction ID is always what the charge already had, not what’s in the response (which will either be the same or not present).

For refunds, we include the operation type, the external ID of the refund, the payment gateway and refund reference (grouped together in parentheses), and the charge details as described above.

After the hyphen is simply what `toString()` returns for the `GatewayResponse`. A `GatewayResponse` is really just a wrapper around an `Either` of something that extends `BaseResponse` or a `GatewayError`. So the `toString()` of `GatewayResponse` just defers to these.

All classes that extend `BaseResponse` have had a `toString()` method added that outputs the fields we extract from the response (omitting any that are blank), using their original names (or close to them) to make cross-referencing with the gateways’ documentation etc. easier.

The `GatewayError` has had its `toString()` rewritten to be “Gateway Error: ” followed by its `message`. This message may be something along the lines of “Gateway connection timeout error” or it may come from a failed `BaseResponse`.

When constructing the `message` for a `GatewayError` from a failed `BaseResponse`, we now just `toString()` the `BaseResponse` (see above) rather than extracting the error code and message and converting to the form “[1] Internal error” (a couple of tests that tested this behaviour have been removed).

We no longer include the value of the `ErrorType` enum in the `toString()` of `GatewayError` as it usually just repeats what the message said or is simply `GENERIC_GATEWAY_ERROR`.

Finally, after the “∴” (“therefore” symbol), we display the old and new status of the charge or refund.

For now, no other log lines have been removed, even though they may now contain duplicated information (albeit at higher levels like ERROR than INFO). These may be examined at a later date.