### PR TITLE
PP-2626 Add extra logging in caught OptimisticLockExceptions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/exception/ConflictRuntimeException.java
+++ b/src/main/java/uk/gov/pay/connector/exception/ConflictRuntimeException.java
@@ -16,7 +16,7 @@ public class ConflictRuntimeException extends WebApplicationException {
         super(conflictErrorResponse(format("Operation for charge conflicting, %s", chargeId)));
     }
 
-    public ConflictRuntimeException(Exception exception) {
-        super(conflictErrorResponse(format("Operation in conflict, %s", exception.getMessage())));
+    public ConflictRuntimeException(String message, Exception exception) {
+        super(conflictErrorResponse(format("Operation in conflict, %s, %s", message, exception.getMessage())));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.service;
 
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
@@ -20,6 +22,8 @@ import static uk.gov.pay.connector.service.CardExecutorService.ExecutionStatus;
 
 public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> extends CardService<BaseAuthoriseResponse> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(CardAuthoriseBaseService.class);
+
     private final CardExecutorService cardExecutorService;
 
     public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment) {
@@ -37,6 +41,7 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
                     throw new ConflictRuntimeException(chargeId, "configuration mismatch");
                 }
             } catch (OptimisticLockException e) {
+                LOG.info("OptimisticLockException in doAuthorise for charge external_id=" + chargeId);
                 throw new ConflictRuntimeException(chargeId);
             }
              GatewayResponse<BaseAuthoriseResponse> operationResponse = operation(charge, gatewayAuthRequest);

--- a/src/main/java/uk/gov/pay/connector/service/TransactionalGatewayOperation.java
+++ b/src/main/java/uk/gov/pay/connector/service/TransactionalGatewayOperation.java
@@ -1,23 +1,9 @@
 package uk.gov.pay.connector.service;
 
-import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
 
-import javax.persistence.OptimisticLockException;
-
 interface TransactionalGatewayOperation<T extends BaseResponse> {
-
-    default GatewayResponse<T> executeGatewayOperationFor(String chargeId) {
-        ChargeEntity charge;
-        try {
-            charge = preOperation(chargeId);
-        } catch (OptimisticLockException e) {
-            throw new ConflictRuntimeException(chargeId);
-        }
-        GatewayResponse<T> operationResponse = operation(charge);
-        return postOperation(chargeId, operationResponse);
-    }
 
     ChargeEntity preOperation(String chargeId);
 

--- a/src/main/java/uk/gov/pay/connector/service/transaction/TransactionFlow.java
+++ b/src/main/java/uk/gov/pay/connector/service/transaction/TransactionFlow.java
@@ -74,7 +74,7 @@ public class TransactionFlow {
             execute(op);
             return this;
         } catch (OptimisticLockException e) {
-            throw new ConflictRuntimeException(e);
+            throw new ConflictRuntimeException("OptimisticLockException in TransactionFlow - PreTransactional operation", e);
         }
     }
 


### PR DESCRIPTION
## WHAT

- For those ones that are caught and charge `external_id` is available, Log `INFO` with the exception with `external_id` of the charge affected.

- For _TransactionFlow_ instances the exception thrown is modified to add some extra information (`ConflictRuntimeException`).


