### PR TITLE
Replace UTF-8 symbols in log lines with ASCII art

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -58,7 +58,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
             String transactionId = operationResponse.getBaseResponse()
                     .map(BaseAuthoriseResponse::getTransactionId).orElse("");
 
-            logger.info("3DS response authorisation for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+            logger.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                     chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
                     chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
                     operationResponse, chargeEntity.getStatus(), status);

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -111,7 +111,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
             operationResponse.getSessionIdentifier().ifPresent(chargeEntity::setProviderSessionId);
 
-            logger.info("Authorisation for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+            logger.info("Authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                     chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(),
                     StringUtils.isNotBlank(transactionId) ? transactionId : "missing transaction ID",
                     chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
@@ -98,7 +98,7 @@ public class CardCaptureService extends CardService implements TransactionalGate
                     String transactionId = operationResponse.getBaseResponse()
                             .map(BaseCaptureResponse::getTransactionId).orElse("");
 
-                    logger.info("Capture for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+                    logger.info("Capture for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                             chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
                             chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
                             operationResponse, chargeEntity.getStatus(), nextStatus);

--- a/src/main/java/uk/gov/pay/connector/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeCancelService.java
@@ -94,7 +94,7 @@ public class ChargeCancelService {
             GatewayResponse cancelResponse = context.get(GatewayResponse.class);
             ChargeStatus status = determineTerminalState(cancelResponse, statusFlow);
 
-            logger.info("Cancel for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+            logger.info("Cancel for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                     chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
                     chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),
                     cancelResponse, chargeEntity.getStatus(), status);

--- a/src/main/java/uk/gov/pay/connector/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeRefundService.java
@@ -137,7 +137,7 @@ public class ChargeRefundService {
             RefundStatus status = gatewayResponse.isSuccessful() ? RefundStatus.REFUND_SUBMITTED : RefundStatus.REFUND_ERROR;
             String reference = getRefundReference(refundEntity, gatewayResponse);
 
-            logger.info("Refund {} ({} {}) for {} ({} {}) for {} ({}) — {} ∴ {} → {}",
+            logger.info("Refund {} ({} {}) for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                     refundEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), refundEntity.getReference(),
                     chargeEntity.getExternalId(), chargeEntity.getPaymentGatewayName().getName(), chargeEntity.getGatewayTransactionId(),
                     chargeEntity.getGatewayAccount().getAnalyticsId(), chargeEntity.getGatewayAccount().getId(),


### PR DESCRIPTION
Tragically, Sumo Logic replaces symbols with HTML entity references

For example, it makes:

“∴ CAPTURE READY → CAPTURE SUBMITTED”

… into:

“&amp;there4; CAPTURE READY &amp;rarr; CAPTURE SUBMITTED”

… which doesn’t look so good