### PR TITLE
PP-2714 Create payment_requests table

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/PaymentRequestDao.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.dao;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+
+import javax.persistence.EntityManager;
+
+@Transactional
+public class PaymentRequestDao extends JpaDao<PaymentRequestEntity> {
+
+    @Inject
+    public PaymentRequestDao(final Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
@@ -1,0 +1,106 @@
+package uk.gov.pay.connector.model.domain;
+
+import javax.persistence.*;
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "payment_requests")
+@Access(AccessType.FIELD)
+public class PaymentRequestEntity extends AbstractEntity {
+
+    @Column(name = "amount")
+    private Long amount;
+
+    @Column(name = "return_url")
+    private String returnUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "gateway_account_id", updatable = false)
+    private GatewayAccountEntity gatewayAccount;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "reference")
+    private String reference;
+
+    @Column(name = "created_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime createdDate;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    public PaymentRequestEntity() {
+        // enjoy it JPA
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public void setReturnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
+    }
+
+    public GatewayAccountEntity getGatewayAccount() {
+        return gatewayAccount;
+    }
+
+    public void setGatewayAccount(GatewayAccountEntity gatewayAccount) {
+        this.gatewayAccount = gatewayAccount;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    public static PaymentRequestEntity from(ChargeEntity chargeEntity) {
+        PaymentRequestEntity paymentEntity = new PaymentRequestEntity();
+        paymentEntity.setAmount(chargeEntity.getAmount());
+        paymentEntity.setCreatedDate(chargeEntity.getCreatedDate());
+        paymentEntity.setDescription(chargeEntity.getDescription());
+        paymentEntity.setExternalId(chargeEntity.getExternalId());
+        paymentEntity.setGatewayAccount(chargeEntity.getGatewayAccount());
+        paymentEntity.setReference(chargeEntity.getReference());
+        paymentEntity.setReturnUrl(chargeEntity.getReturnUrl());
+
+        return paymentEntity;
+    }
+}

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -656,4 +656,39 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="build payment_requests table" author="">
+        <createTable tableName="payment_requests">
+            <column name="id" type="bigserial" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="amount" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="gateway_account_id" type="bigserial">
+                <constraints foreignKeyName="fk__payment_requests_gateway_accounts"
+                             referencedTableName="gateway_accounts"
+                             referencedColumnNames="id" nullable="false"/>
+            </column>
+            <column name="return_url" type="text">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="varchar(255)" defaultValue="">
+                <constraints nullable="false" unique="false"/>
+            </column>
+            <column name="reference" type="varchar(255)" defaultValue="">
+                <constraints nullable="false" unique="false"/>
+            </column>
+            <column name="created_date" type="timestamp without timezone"
+                    defaultValueComputed="(now() at time zone 'utc')">
+                <constraints nullable="false"/>
+            </column>
+            <column name="external_id" type="char(26)">
+                <constraints nullable="true" unique="true"/>
+            </column>
+            <column name="version" type="bigint" defaultValue="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/connector/it/dao/GuicedTestEnvironment.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GuicedTestEnvironment.java
@@ -6,10 +6,7 @@ import com.google.inject.Injector;
 import com.google.inject.Singleton;
 import com.google.inject.persist.PersistService;
 import com.google.inject.persist.jpa.JpaPersistModule;
-import uk.gov.pay.connector.dao.ChargeDao;
-import uk.gov.pay.connector.dao.ChargeEventDao;
-import uk.gov.pay.connector.dao.GatewayAccountDao;
-import uk.gov.pay.connector.dao.TokenDao;
+import uk.gov.pay.connector.dao.*;
 
 public class GuicedTestEnvironment {
 
@@ -45,6 +42,7 @@ public class GuicedTestEnvironment {
             bind(ChargeEventDao.class).in(Singleton.class);
             bind(TokenDao.class).in(Singleton.class);
             bind(GatewayAccountDao.class).in(Singleton.class);
+            bind(PaymentRequestDao.class).in(Singleton.class);
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
@@ -1,0 +1,54 @@
+package uk.gov.pay.connector.it.dao;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+
+import java.util.HashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture.aValidPaymentRequestEntity;
+
+public class PaymentRequestDaoITest extends DaoITestBase {
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+    private PaymentRequestDao paymentRequestDao;
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+
+    @Before
+    public void setUp() throws Exception {
+        paymentRequestDao = env.getInstance(PaymentRequestDao.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldCreateAPaymentRequest() throws Exception {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        assertThat(paymentRequestEntity.getId(), is(notNullValue()));
+        // Ensure always max precision is being millis
+        assertThat(paymentRequestEntity.getCreatedDate().getNano() % 1000000, is(0));
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.defaultGatewayAccountEntity;
+
+public class PaymentRequestEntityFixture {
+
+    private String externalId = RandomIdGenerator.newId();
+    private Long amount = 500L;
+    private String returnUrl = "http://return.com";
+    private String description = "This is a description";
+    private String reference = "This is a reference";
+    private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
+    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+
+    public static PaymentRequestEntityFixture aValidPaymentRequestEntity() {
+        return new PaymentRequestEntityFixture();
+    }
+
+    public PaymentRequestEntity build() {
+        PaymentRequestEntity entity = new PaymentRequestEntity();
+        entity.setReturnUrl(this.returnUrl);
+        entity.setReference(this.reference);
+        entity.setGatewayAccount(this.gatewayAccountEntity);
+        entity.setExternalId(this.externalId);
+        entity.setDescription(this.description);
+        entity.setCreatedDate(this.createdDate);
+        entity.setAmount(this.amount);
+
+        return entity;
+    }
+
+    public PaymentRequestEntityFixture withGatewayAccountEntity(GatewayAccountEntity gatewayAccount) {
+        this.gatewayAccountEntity = gatewayAccount;
+        return this;
+    }
+}


### PR DESCRIPTION
- Created PaymentRequestEntity;
- Created PaymentRequestDao;
- Created test for Dao;
- Created PaymentRequestEntityFixture;
- Changed ChargeService#create to write to payment_requests table after writing into charges, inside the same transaction;
- Added test for the new insert for the ChargeService;
- Added migration for the new table;

with @alexbishop1 

_WHAT_
The purpose of this change is to enable database refactoring for the table `charges`. This table will be split into 3 other tables, and the first one is `payment_charges`.
Initially the `create` charge operation into the `ChargeService` will start writing into both tables `charges` and `payment_requests` but will keep reading only from the `charges`. The `id` column in `payment_charges` will be the same as in `charges` because later on the missing data from the `payment_charges` will be backfilled.

Edit: added context on what this change is and enables for future work.
