### PR TITLE
PP-2759 Create table card_3ds

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/Card3dsDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/Card3dsDao.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.dao;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.model.domain.Card3dsEntity;
+
+import javax.persistence.EntityManager;
+
+@Transactional
+public class Card3dsDao extends JpaDao<Card3dsEntity> {
+
+    @Inject
+    public Card3dsDao(Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
@@ -1,0 +1,91 @@
+package uk.gov.pay.connector.model.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "card_3ds")
+public class Card3dsEntity extends AbstractEntity {
+
+    @Column(name = "pa_request")
+    private String paRequest;
+
+    @Column(name = "issuer_url")
+    private String issuerUrl;
+
+    @Column(name = "worldpay_machine_cookie")
+    private String worldpayMachineCookie;
+
+    @Column(name = "charge_id")
+    private Long chargeId;
+
+    public Card3dsEntity() {
+    }
+
+    public String getPaRequest() {
+        return paRequest;
+    }
+
+    public void setPaRequest(String paRequest) {
+        this.paRequest = paRequest;
+    }
+
+    public String getIssuerUrl() {
+        return issuerUrl;
+    }
+
+    public void setIssuerUrl(String issuerUrl) {
+        this.issuerUrl = issuerUrl;
+    }
+
+    public String getWorldpayMachineCookie() {
+        return worldpayMachineCookie;
+    }
+
+    public void setWorldpayMachineCookie(String worldpayMachineCookie) {
+        this.worldpayMachineCookie = worldpayMachineCookie;
+    }
+
+    public Long getChargeId() {
+        return chargeId;
+    }
+
+    public void setChargeId(Long chargeId) {
+        this.chargeId = chargeId;
+    }
+
+    public static Card3dsEntity from(ChargeEntity chargeEntity) {
+
+        Card3dsEntity entity = new Card3dsEntity();
+        entity.setChargeId(chargeEntity.getId());
+        entity.setIssuerUrl(chargeEntity.get3dsDetails().getIssuerUrl());
+        entity.setPaRequest(chargeEntity.get3dsDetails().getPaRequest());
+        entity.setWorldpayMachineCookie(chargeEntity.getProviderSessionId());
+
+        return entity;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Card3dsEntity that = (Card3dsEntity) o;
+
+        if (!paRequest.equals(that.paRequest)) return false;
+        if (!issuerUrl.equals(that.issuerUrl)) return false;
+        if (worldpayMachineCookie != null ? !worldpayMachineCookie.equals(that.worldpayMachineCookie) : that.worldpayMachineCookie != null)
+            return false;
+        return chargeId.equals(that.chargeId);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = paRequest.hashCode();
+        result = 31 * result + issuerUrl.hashCode();
+        result = 31 * result + (worldpayMachineCookie != null ? worldpayMachineCookie.hashCode() : 0);
+        result = 31 * result + chargeId.hashCode();
+        return result;
+    }
+}

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -745,6 +745,31 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="create table card_3ds" author="">
+        <createTable tableName="card_3ds">
+            <column name="id" type="bigserial" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="charge_id" type="bigserial">
+                <constraints foreignKeyName="fk__card_3ds_charges"
+                             referencedTableName="charges"
+                             referencedColumnNames="id" nullable="false"/>
+            </column>
+            <column name="pa_request" type="text">
+                <constraints nullable="false"/>
+            </column>
+            <column name="issuer_url" type="text">
+                <constraints nullable="false"/>
+            </column>
+            <column name="worldpay_machine_cookie" type="text">
+                <constraints nullable="true"/>
+            </column>
+            <column name="version" type="bigint" defaultValue="0">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
     <changeSet id="update email column in cards table to 254 chars" author="">
         <modifyDataType columnName="email"
                         newDataType="varchar(254)"

--- a/src/test/java/uk/gov/pay/connector/it/dao/Card3dsDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/Card3dsDaoITest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.it.dao;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.connector.dao.Card3dsDao;
+import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.model.domain.Card3dsEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+
+import java.util.HashMap;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+
+public class Card3dsDaoITest extends DaoITestBase {private DatabaseFixtures.TestAccount defaultTestAccount;
+    private Card3dsDao card3dsDao;
+    private ChargeDao chargeDao;
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+
+    @Before
+    public void setUp() throws Exception {
+        card3dsDao = env.getInstance(Card3dsDao.class);
+        chargeDao = env.getInstance(ChargeDao.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldCreateACardEntity() throws Exception {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withPaRequest("Test pa request")
+                .withIssuerUrl("http://example.com")
+                .build();
+
+        chargeDao.persist(chargeEntity);
+
+        Card3dsEntity card3dsEntity = Card3dsEntity.from(chargeEntity);
+
+        card3dsDao.persist(card3dsEntity);
+
+        assertThat(card3dsEntity.getId(), is(notNullValue()));
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/GuicedTestEnvironment.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GuicedTestEnvironment.java
@@ -44,6 +44,7 @@ public class GuicedTestEnvironment {
             bind(GatewayAccountDao.class).in(Singleton.class);
             bind(PaymentRequestDao.class).in(Singleton.class);
             bind(CardDao.class).in(Singleton.class);
+            bind(Card3dsDao.class).in(Singleton.class);
         }
     }
 }


### PR DESCRIPTION
- Updated migration script
- Added new entity `Card3dsEntity`
- Added new Dao `Card3dsDao`
- Added creation of `Card3dsEntity` when the auth response has necessary
fields;
- Added tests and updated existing to test new code;

with @alexbishop1
with @chrisgrimble

## WHAT
Create a new table `card_3ds` and populate it at the same time when populating records
 in table `charges`.
The table will be backfilled at a later stage.


