### PR TITLE
PP-2744 Make email column in cards table be varchar(254)

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -745,4 +745,10 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="update email column in cards table to 254 chars" author="">
+        <modifyDataType columnName="email"
+                        newDataType="varchar(254)"
+                        tableName="cards"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Amusingly, we repeated the same mistake made when the `email` column was first added to the `charges` table by making it a `varchar(50)`, which is too short.

with @georgeracu
with @chrisgrimble