### PR TITLE
PP-2768 Backfill cards table from charges

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -779,7 +779,7 @@
     <changeSet id="createIndex cards.charge_id" author="">
         <createIndex indexName="idx_cards_charge_id"
                      tableName="cards"
-                     unique="false">
+                     unique="true">
             <column name="charge_id" type="bigserial"/>
         </createIndex>
     </changeSet>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -776,4 +776,47 @@
                         tableName="cards"/>
     </changeSet>
 
+    <changeSet id="createIndex cards.charge_id" author="">
+        <createIndex indexName="idx_cards_charge_id"
+                     tableName="cards"
+                     unique="false">
+            <column name="charge_id" type="bigserial"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="backfill cards with data from charges" author="">
+        <sql>
+            INSERT INTO cards (
+                cardholder_name,
+                email,
+                card_brand,
+                last_digits_card_number,
+                expiry_date,
+                address_line1,
+                address_line2,
+                address_postcode,
+                address_city,
+                address_county,
+                address_country,
+                charge_id
+            )
+            SELECT
+                ch.cardholder_name,
+                ch.email,
+                ch.card_brand,
+                ch.last_digits_card_number,
+                ch.expiry_date,
+                ch.address_line1,
+                ch.address_line2,
+                ch.address_postcode,
+                ch.address_city,
+                ch.address_county,
+                ch.address_country,
+                ch.id
+            FROM charges ch
+            LEFT JOIN cards c ON c.charge_id = ch.id
+            WHERE c.charge_id IS NULL;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
- Added index on column cards.charge_id
- Added migration to insert into cards missing records from charges

with @chrisgrimble

## WHAT
Add to the `cards` table missing rows from `charges`.

## HOW 
Use Liquibase migrations to copy data from `charges` to `cards`.


