### PR TITLE
PP-2768 Revert backfill for cards

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -776,47 +776,4 @@
                         tableName="cards"/>
     </changeSet>
 
-    <changeSet id="createIndex cards.charge_id" author="">
-        <createIndex indexName="idx_cards_charge_id"
-                     tableName="cards"
-                     unique="true">
-            <column name="charge_id" type="bigserial"/>
-        </createIndex>
-    </changeSet>
-
-    <changeSet id="backfill cards with data from charges" author="">
-        <sql>
-            INSERT INTO cards (
-                cardholder_name,
-                email,
-                card_brand,
-                last_digits_card_number,
-                expiry_date,
-                address_line1,
-                address_line2,
-                address_postcode,
-                address_city,
-                address_county,
-                address_country,
-                charge_id
-            )
-            SELECT
-                ch.cardholder_name,
-                ch.email,
-                ch.card_brand,
-                ch.last_digits_card_number,
-                ch.expiry_date,
-                ch.address_line1,
-                ch.address_line2,
-                ch.address_postcode,
-                ch.address_city,
-                ch.address_county,
-                ch.address_country,
-                ch.id
-            FROM charges ch
-            LEFT JOIN cards c ON c.charge_id = ch.id
-            WHERE c.charge_id IS NULL;
-        </sql>
-    </changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
- Removed adding index and backfilling table cards
- Currently there are NULL values in the table charges
and this values need to be inserted into the table cards therefore
the current migration script fails

with @chrisgrimble

## WHAT
This is a rollback of the previous commit due to `NULL` columns in table `charges`. This was preventing `connector` to start because the database migrations were failing.

Removed migration script to backfill the table `cards` due to errors of `NULL` values in 
not nullable columns.
Edit: added logs and fixed formatting

`2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: [2017-10-24 15:33:09.696] [main] #033[1;31mERROR#033[0;39m #033[36mliquibase#033[0;39m [requestID=] - migrations.xml: migrations.xml::backfill cards with data from charges::: Change Set migrations.xml::backfill cards with data from charges:: failed.  Error: org.postgresql.util.PSQLException: ERROR: null value in column "card_brand" violates not-null constraint
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]:   Detail: Failing row contains (9311, 1, null, null, null, null, null, null, null, null, null, null, null, 0).
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: liquibase.exception.DatabaseException: org.postgresql.util.PSQLException: ERROR: null value in column "card_brand" violates not-null constraint
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]:   Detail: Failing row contains (9311, 1, null, null, null, null, null, null, null, null, null, null, null, 0).
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:316)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:55)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:122)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.database.AbstractJdbcDatabase.execute(AbstractJdbcDatabase.java:1227)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.database.AbstractJdbcDatabase.executeStatements(AbstractJdbcDatabase.java:1210)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.changelog.ChangeSet.execute(ChangeSet.java:550)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:43)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:73)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.Liquibase.update(Liquibase.java:200)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.Liquibase.update(Liquibase.java:181)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.Liquibase.update(Liquibase.java:174)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.migrations.DbMigrateCommand.run(DbMigrateCommand.java:68)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.migrations.DbCommand.run(DbCommand.java:52)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.migrations.AbstractLiquibaseCommand.run(AbstractLiquibaseCommand.java:64)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:85)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.cli.Cli.run(Cli.java:75)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.Application.run(Application.java:79)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at uk.gov.pay.connector.app.ConnectorApp.main(ConnectorApp.java:133)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: Caused by: org.postgresql.util.PSQLException: ERROR: null value in column "card_brand" violates not-null constraint
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]:   Detail: Failing row contains (9311, 1, null, null, null, null, null, null, null, null, null, null, null, 0).
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2270)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1998)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:255)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:570)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:406)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:398)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:314)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011... 17 common frames omitted
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: [2017-10-24 15:33:09.711] [main] #033[34mINFO #033[0;39m #033[36mliquibase#033[0;39m [requestID=] - migrations.xml::backfill cards with data from charges::: Successfully released change log lock
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: Exception in thread "main" liquibase.exception.MigrationFailedException: Migration failed for change set migrations.xml::backfill cards with data from charges:::
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]:      Reason: liquibase.exception.DatabaseException: org.postgresql.util.PSQLException: ERROR: null value in column "card_brand" violates not-null constraint
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]:   Detail: Failing row contains (9311, 1, null, null, null, null, null, null, null, null, null, null, null, 0).
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.changelog.ChangeSet.execute(ChangeSet.java:586)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:43)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:73)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.Liquibase.update(Liquibase.java:200)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.Liquibase.update(Liquibase.java:181)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.Liquibase.update(Liquibase.java:174)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.migrations.DbMigrateCommand.run(DbMigrateCommand.java:68)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.migrations.DbCommand.run(DbCommand.java:52)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.migrations.AbstractLiquibaseCommand.run(AbstractLiquibaseCommand.java:64)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.cli.ConfiguredCommand.run(ConfiguredCommand.java:85)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.cli.Cli.run(Cli.java:75)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at io.dropwizard.Application.run(Application.java:79)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at uk.gov.pay.connector.app.ConnectorApp.main(ConnectorApp.java:133)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: Caused by: liquibase.exception.DatabaseException: org.postgresql.util.PSQLException: ERROR: null value in column "card_brand" violates not-null constraint
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]:   Detail: Failing row contains (9311, 1, null, null, null, null, null, null, null, null, null, null, null, 0).
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:316)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:55)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:122)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.database.AbstractJdbcDatabase.execute(AbstractJdbcDatabase.java:1227)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.database.AbstractJdbcDatabase.executeStatements(AbstractJdbcDatabase.java:1210)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.changelog.ChangeSet.execute(ChangeSet.java:550)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011... 12 more
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: Caused by: org.postgresql.util.PSQLException: ERROR: null value in column "card_brand" violates not-null constraint
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]:   Detail: Failing row contains (9311, 1, null, null, null, null, null, null, null, null, null, null, null, 0).
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2270)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:1998)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:255)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:570)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.jdbc2.AbstractJdbc2Statement.executeWithFlags(AbstractJdbc2Statement.java:406)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at org.postgresql.jdbc2.AbstractJdbc2Statement.execute(AbstractJdbc2Statement.java:398)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:314)
2017-10-24T15:33:09+00:00 ip6-localhost pay-connector[3989]: #011... 17 more
`

