### PR TITLE
PP-2825 Remove email from cards table

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
@@ -23,9 +23,6 @@ public class CardEntity extends AbstractEntity {
     @Embedded
     private AddressEntity billingAddress;
 
-    @Column(name = "email")
-    private String email;
-
     @Column(name = "charge_id")
     private Long chargeId;
 
@@ -87,7 +84,6 @@ public class CardEntity extends AbstractEntity {
             return false;
         if (cardBrand != null ? !cardBrand.equals(that.cardBrand) : that.cardBrand != null)
             return false;
-        if (email != null ? !email.equals(that.email) : that.email != null) return false;
         if (chargeId != null ? !chargeId.equals(that.chargeId) : that.chargeId != null)
             return false;
         return billingAddress != null ? billingAddress.equals(that.billingAddress) : that.billingAddress == null;
@@ -100,17 +96,8 @@ public class CardEntity extends AbstractEntity {
         result = 31 * result + (expiryDate != null ? expiryDate.hashCode() : 0);
         result = 31 * result + (cardBrand != null ? cardBrand.hashCode() : 0);
         result = 31 * result + (billingAddress != null ? billingAddress.hashCode() : 0);
-        result = 31 * result + (email != null ? email.hashCode() : 0);
         result = 31 * result + (chargeId != null ? chargeId.hashCode() : 0);
         return result;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
     }
 
     public static CardEntity from(CardDetailsEntity cardDetailsEntity, String email, Long chargeId) {
@@ -120,7 +107,6 @@ public class CardEntity extends AbstractEntity {
         entity.setCardHolderName(cardDetailsEntity.getCardHolderName());
         entity.setExpiryDate(cardDetailsEntity.getExpiryDate());
         entity.setLastDigitsCardNumber(cardDetailsEntity.getLastDigitsCardNumber());
-        entity.setEmail(email);
         entity.setChargeId(chargeId);
 
         return entity;

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -776,4 +776,8 @@
                         tableName="cards"/>
     </changeSet>
 
+    <changeSet id="make email coumn in cards nullable" author="">
+        <dropNotNullConstraint tableName="cards" columnName="email"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
We are going to create a users table which will hold emails so we no
longer want to persist it in the cards table.

- Made the email column on cards table nullable as we are no longer
going to set it. Will drop this column in a latter release.
- Removed email from CardEntity so we no longer set it when we create a
row in cards.

with @alexbishop1

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


