### PR TITLE
PP-2825 Remove email from cards table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -780,4 +780,7 @@
         <dropNotNullConstraint tableName="cards" columnName="email"/>
     </changeSet>
 
+    <changeSet id="drop email from cards table" author="">
+        <dropColumn tableName="cards" columnName="email"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
The email is not written at the same time as the other card data and we
are thinking of moving it to transactions. For now remove it from cards
table and just leave it on charges. Have already stopped the email
column being used.

- Dropped email from the cards table.


