### PR TITLE
PP-2769 Backfill card_3ds

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -882,4 +882,40 @@
             WHERE p.external_id IS NULL;
         </sql>
     </changeSet>
+
+    <changeSet id="change card_3ds.charge_id to bigint" author="">
+        <modifyDataType tableName="card_3ds"
+                        columnName="charge_id"
+                        newDataType="bigint"/>
+    </changeSet>
+
+    <changeSet id="create unique index card_3ds.charge_id" author="">
+        <createIndex tableName="card_3ds"
+                     indexName="idx_card_3ds_charge_id"
+                     unique="true">
+            <column name="charge_id" type="bigint"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="backfill card_3ds table" author="">
+        <sql>
+            INSERT INTO card_3ds (
+                pa_request,
+                issuer_url,
+                worldpay_machine_cookie,
+                charge_id
+            )
+            SELECT
+                ch.pa_request_3ds,
+                ch.issuer_url_3ds,
+                ch.provider_session_id,
+                ch.id
+            FROM charges ch
+            LEFT JOIN card_3ds c ON c.charge_id = ch.id
+            WHERE c.charge_id IS NULL
+            AND ch.pa_request_3ds IS NOT NULL
+            AND ch.issuer_url_3ds IS NOT NULL;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
- Changed column type to bigint on card_3ds_.charge_id
- Added index on card_3ds.charge_id
- Added SQL script to backfill table card_3ds with historic
data from table charges

@with chrisgrimble

## WHAT
Backfill table `card_3ds` with historic data from table `charges`.
At this moment, table `card_3ds` receives new data every time when `charges` table gets 
updated fields `pa_request_3ds`, `issuer_url_3ds` and `provider_session_id`. 
The current migration is required to have these two tables in sync for historic data that is 
in `charges` and not in `card_3ds`.

In the same changeset there is a data type change for `charge_id` from `bigserial` to `bigint` 
because postgresql will allocate sequences to `bigserial` and we don't need that as this 
column is a foreign key from `charge.id`.



