### PR TITLE
PP-2777 Create transactions table

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/PaymentRequestDao.java
@@ -3,9 +3,11 @@ package uk.gov.pay.connector.dao;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
-
 import javax.persistence.EntityManager;
+import java.util.Optional;
+
 
 @Transactional
 public class PaymentRequestDao extends JpaDao<PaymentRequestEntity> {
@@ -13,5 +15,23 @@ public class PaymentRequestDao extends JpaDao<PaymentRequestEntity> {
     @Inject
     public PaymentRequestDao(final Provider<EntityManager> entityManager) {
         super(entityManager);
+    }
+
+    public Optional<PaymentRequestEntity> findByExternalId(String externalId) {
+        String query = "SELECT p FROM PaymentRequestEntity p " +
+                "WHERE p.externalId = :externalId";
+
+        return entityManager.get()
+                .createQuery(query, PaymentRequestEntity.class)
+                .setParameter("externalId", externalId)
+                .getResultList().stream().findFirst();
+    }
+
+    public Optional<PaymentRequestEntity> updateChargeTransactionStatus(String externalId, ChargeStatus newChargeStatus) {
+        return findByExternalId(externalId).map(paymentRequestEntity -> {
+            paymentRequestEntity.getChargeTransaction().setStatus(newChargeStatus);
+
+            return paymentRequestEntity;
+        });
     }
 }

--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jooq.impl.DSL.*;
 
+@Deprecated // This will be removed once the new refunds functionality has been completed.
 @Transactional
 public class TransactionDao {
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
-import static uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions.stateTransitionsFor;
+import static uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions.defaultTransitions;
 
 @Entity
 @Table(name = "charges")
@@ -150,7 +150,7 @@ public class ChargeEntity extends AbstractEntity {
     }
 
     public void setStatus(ChargeStatus targetStatus) throws InvalidStateTransitionException {
-        if (stateTransitionsFor(getPaymentGatewayName()).isValidTransition(fromString(this.status), targetStatus)) {
+        if (defaultTransitions().isValidTransition(fromString(this.status), targetStatus)) {
             this.status = targetStatus.getValue();
         } else {
             throw new InvalidStateTransitionException(this.status, targetStatus.getValue());

--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeStatus.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.model.domain;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -75,6 +76,10 @@ public enum ChargeStatus implements Status {
 
     public ExternalChargeState toExternal() {
         return externalStatus;
+    }
+
+    public static boolean isValid(String status) {
+        return Arrays.stream(values()).anyMatch(value -> StringUtils.equals(value.getValue(), status));
     }
 
     public static ChargeStatus fromString(String status) {

--- a/src/main/java/uk/gov/pay/connector/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PaymentGatewayStateTransitions.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.connector.model.domain;
 
-import uk.gov.pay.connector.service.PaymentGatewayName;
-
-class PaymentGatewayStateTransitions {
+public class PaymentGatewayStateTransitions {
     private static StateTransitions defaultTransitions = new DefaultStateTransitions();
 
-    static StateTransitions stateTransitionsFor(PaymentGatewayName gatewayName) {
+    public static StateTransitions defaultTransitions() {
         return defaultTransitions;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
@@ -1,7 +1,14 @@
 package uk.gov.pay.connector.model.domain;
 
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+
 import javax.persistence.*;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
 
 @Entity
 @Table(name = "payment_requests")
@@ -30,6 +37,9 @@ public class PaymentRequestEntity extends AbstractEntity {
 
     @Column(name = "external_id")
     private String externalId;
+
+    @OneToMany(mappedBy = "paymentRequest", cascade = CascadeType.ALL)
+    private List<TransactionEntity> transactions = new ArrayList<>();
 
     public PaymentRequestEntity() {
         // enjoy it JPA
@@ -91,7 +101,31 @@ public class PaymentRequestEntity extends AbstractEntity {
         this.externalId = externalId;
     }
 
-    public static PaymentRequestEntity from(ChargeEntity chargeEntity) {
+    public List<TransactionEntity> getTransactions() {
+        return Collections.unmodifiableList(transactions);
+    }
+
+    public void addTransaction(TransactionEntity transactionEntity) {
+        this.transactions.add(transactionEntity);
+        transactionEntity.setPaymentRequest(this);
+    }
+
+    public void setTransactions(List<TransactionEntity> transactions) {
+        this.transactions = transactions;
+        transactions.forEach(transactionEntity -> transactionEntity.setPaymentRequest(this));
+    }
+
+    public TransactionEntity getChargeTransaction() {
+        return transactions.stream().filter(byChargeTransactions()).findFirst().orElseThrow(
+                () -> new IllegalStateException("Payment Request has been initialised without a charge transaction")
+        );
+    }
+
+    private Predicate<TransactionEntity> byChargeTransactions() {
+        return transactionEntity -> transactionEntity.getOperation().equals(TransactionOperation.CHARGE);
+    }
+
+    public static PaymentRequestEntity from(ChargeEntity chargeEntity, TransactionEntity transactionEntity) {
         PaymentRequestEntity paymentEntity = new PaymentRequestEntity();
         paymentEntity.setAmount(chargeEntity.getAmount());
         paymentEntity.setCreatedDate(chargeEntity.getCreatedDate());
@@ -100,6 +134,7 @@ public class PaymentRequestEntity extends AbstractEntity {
         paymentEntity.setGatewayAccount(chargeEntity.getGatewayAccount());
         paymentEntity.setReference(chargeEntity.getReference());
         paymentEntity.setReturnUrl(chargeEntity.getReturnUrl());
+        paymentEntity.addTransaction(transactionEntity);
 
         return paymentEntity;
     }

--- a/src/main/java/uk/gov/pay/connector/model/domain/StateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/StateTransitions.java
@@ -7,14 +7,14 @@ import java.util.Map;
 
 import static java.util.Collections.emptyList;
 
-abstract class StateTransitions {
+public abstract class StateTransitions {
     private Map<ChargeStatus, List<ChargeStatus>> transitionTable;
 
     StateTransitions(Map<ChargeStatus, List<ChargeStatus>> transitionTable) {
         this.transitionTable = transitionTable;
     }
 
-    boolean isValidTransition(ChargeStatus state, ChargeStatus targetState) {
+    public boolean isValidTransition(ChargeStatus state, ChargeStatus targetState) {
         return transitionTable.getOrDefault(state, emptyList()).contains(targetState);
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
@@ -1,0 +1,118 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+import uk.gov.pay.connector.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.model.domain.*;
+
+import javax.persistence.*;
+
+import static uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions.defaultTransitions;
+
+@Entity
+@Table(name = "transactions")
+public class TransactionEntity extends AbstractEntity {
+
+    @Column(name = "gateway_transaction_id")
+    private String gatewayTransactionId;
+
+    @Column(name = "amount")
+    private Long amount;
+
+    @Column(name = "refund_external_id")
+    private String refundExternalId;
+
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private ChargeStatus status;
+
+    @Column(name = "user_external_id")
+    private String userExternalId;
+
+    @Column(name = "operation")
+    @Enumerated(EnumType.STRING)
+    private TransactionOperation operation;
+
+    @ManyToOne
+    @JoinColumn(name = "payment_request_id", referencedColumnName = "id", updatable = false)
+    private PaymentRequestEntity paymentRequest;
+
+    public TransactionEntity() {
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public void setGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public String getRefundExternalId() {
+        return refundExternalId;
+    }
+
+    public void setRefundExternalId(String refundExternalId) {
+        this.refundExternalId = refundExternalId;
+    }
+
+    public ChargeStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ChargeStatus status) {
+        checkValidStateTransition(status);
+        this.status = status;
+    }
+
+    @Deprecated // should be removed with ChargeEntity
+    public void setChargeStatus(String status) {
+        this.status = ChargeStatus.fromString(status);
+    }
+
+    public String getUserExternalId() {
+        return userExternalId;
+    }
+
+    public void setUserExternalId(String userExternalId) {
+        this.userExternalId = userExternalId;
+    }
+
+    public PaymentRequestEntity getPaymentRequest() {
+        return paymentRequest;
+    }
+
+    public void setPaymentRequest(PaymentRequestEntity paymentRequest) {
+        this.paymentRequest = paymentRequest;
+    }
+
+    public TransactionOperation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(TransactionOperation operation) {
+        this.operation = operation;
+    }
+
+    public static TransactionEntity from(ChargeEntity chargeEntity) {
+        TransactionEntity transactionEntity = new TransactionEntity();
+        transactionEntity.setGatewayTransactionId(chargeEntity.getGatewayTransactionId());
+        transactionEntity.setAmount(chargeEntity.getAmount());
+        transactionEntity.setStatus(ChargeStatus.fromString(chargeEntity.getStatus()));
+        transactionEntity.setOperation(TransactionOperation.CHARGE);
+
+        return transactionEntity;
+    }
+
+    private void checkValidStateTransition(ChargeStatus newChargeStatus) {
+        if (status != null && !defaultTransitions().isValidTransition(status, newChargeStatus)) {
+            throw new InvalidStateTransitionException(status.getValue(), newChargeStatus.getValue());
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionOperation.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionOperation.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+public enum TransactionOperation {
+    CHARGE,
+    REFUND
+}

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
@@ -2,13 +2,11 @@ package uk.gov.pay.connector.resources;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.collect.ImmutableList;
-import com.google.inject.persist.Transactional;
 import io.dropwizard.jersey.PATCH;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
-import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 import uk.gov.pay.connector.model.domain.*;
@@ -21,19 +19,15 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.model.FrontendChargeResponse.aFrontendChargeResponse;
 import static uk.gov.pay.connector.model.builder.PatchRequestBuilder.aPatchRequestBuilder;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.resources.ApiPaths.*;
 import static uk.gov.pay.connector.resources.ApiValidators.validateChargePatchParams;
@@ -44,18 +38,16 @@ import static uk.gov.pay.connector.util.ResponseUtil.*;
 public class ChargesFrontendResource {
 
     private static final Logger logger = LoggerFactory.getLogger(ChargesFrontendResource.class);
-    private static final List<ChargeStatus> CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS = newArrayList(CREATED, ENTERING_CARD_DETAILS);
+    private static final String NEW_STATUS = "new_status";
     private final ChargeDao chargeDao;
     private final ChargeService chargeService;
     private final CardTypeDao cardTypeDao;
-    private final ChargeEventDao chargeEventDao;
 
     @Inject
-    public ChargesFrontendResource(ChargeDao chargeDao, ChargeService chargeService, CardTypeDao cardTypeDao, ChargeEventDao chargeEventDao) {
+    public ChargesFrontendResource(ChargeDao chargeDao, ChargeService chargeService, CardTypeDao cardTypeDao) {
         this.chargeDao = chargeDao;
         this.chargeService = chargeService;
         this.cardTypeDao = cardTypeDao;
-        this.chargeEventDao = chargeEventDao;
     }
 
     @GET
@@ -102,36 +94,35 @@ public class ChargesFrontendResource {
     @Path(FRONTEND_CHARGE_STATUS_API_PATH)
     @Produces(APPLICATION_JSON)
     @JsonView(GatewayAccountEntity.Views.FrontendView.class)
-    @Transactional
     public Response updateChargeStatus(@PathParam("chargeId") String chargeId, Map newStatusMap) {
         if (invalidInput(newStatusMap)) {
-            return fieldsMissingResponse(ImmutableList.of("new_status"));
+            return fieldsMissingResponse(ImmutableList.of(NEW_STATUS));
         }
-        try {
-            return updateStatus(chargeId, ChargeStatus.fromString(newStatusMap.get("new_status").toString()), Optional.empty());
-        } catch (IllegalArgumentException e) {
-            logger.error(e.getMessage(), e);
-            return badRequestResponse(e.getMessage());
+
+        String chargeStatusString = newStatusMap.get(NEW_STATUS).toString();
+        if (!ChargeStatus.isValid(chargeStatusString)) {
+            String msg = "charge status not recognized: " + chargeStatusString;
+            logger.error(msg);
+            return badRequestResponse(msg);
         }
+
+        ChargeStatus newChargeStatus = ChargeStatus.fromString(newStatusMap.get(NEW_STATUS).toString());
+        if (!isValidStateTransition(newChargeStatus)) {
+            return getInvalidStatusResponse(chargeId, newChargeStatus);
+        }
+
+        return chargeService.updateStatus(chargeId, newChargeStatus)
+                .map(chargeEntity -> Response.noContent().build())
+                .orElseGet(() -> getInvalidStatusResponse(chargeId, newChargeStatus));
+    }
+
+    private Response getInvalidStatusResponse(String chargeId, ChargeStatus newChargeStatus) {
+        return badRequestResponse("charge with id: " + chargeId +
+                " cannot be updated to the new status: " + newChargeStatus.getValue());
     }
 
     private boolean invalidInput(Map newStatusMap) {
-        return newStatusMap == null || newStatusMap.get("new_status") == null;
-    }
-
-    private Response updateStatus(String chargeId, ChargeStatus newChargeStatus, Optional<ZonedDateTime> generatedTime) {
-        if (!isValidStateTransition(newChargeStatus)) {
-            return badRequestResponse("charge with id: " + chargeId + " cant be updated to the new state: " + newChargeStatus.getValue());
-        }
-        return chargeDao.findByExternalId(chargeId)
-                .map(chargeEntity -> {
-                    if (CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS.contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
-                        chargeEntity.setStatus(newChargeStatus);
-                        chargeEventDao.persistChargeEventOf(chargeEntity, generatedTime);
-                        return noContentResponse();
-                    }
-                    return badRequestResponse("charge with id: " + chargeId + " cant be updated to the new state: " + newChargeStatus.getValue());
-                }).get();
+        return newStatusMap == null || newStatusMap.get(NEW_STATUS) == null;
     }
 
     private boolean isValidStateTransition(ChargeStatus newChargeStatus) {

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.exception.OperationAlreadyInProgressRuntimeException;
@@ -26,8 +27,8 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
 
     private final CardExecutorService cardExecutorService;
 
-    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment) {
-        super(chargeDao, chargeEventDao, providers, environment);
+    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment, PaymentRequestDao paymentRequestDao) {
+        super(chargeDao, chargeEventDao, providers, environment, paymentRequestDao);
         this.cardExecutorService = cardExecutorService;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeCancelService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -45,17 +46,20 @@ public class ChargeCancelService {
     private final ChargeEventDao chargeEventDao;
     private final PaymentProviders providers;
     private final Provider<TransactionFlow> transactionFlowProvider;
+    private final PaymentRequestDao paymentRequestDao;
 
 
     @Inject
     public ChargeCancelService(ChargeDao chargeDao,
                                ChargeEventDao chargeEventDao,
                                PaymentProviders providers,
-                               Provider<TransactionFlow> transactionFlowProvider) {
+                               Provider<TransactionFlow> transactionFlowProvider,
+                               PaymentRequestDao paymentRequestDao) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.providers = providers;
         this.transactionFlowProvider = transactionFlowProvider;
+        this.paymentRequestDao = paymentRequestDao;
     }
 
     public Optional<GatewayResponse<BaseCancelResponse>> doSystemCancel(String chargeId, Long accountId) {
@@ -82,7 +86,7 @@ public class ChargeCancelService {
 
     private Optional<GatewayResponse<BaseCancelResponse>> cancelChargeWithGatewayCleanup(String chargeId, StatusFlow statusFlow) {
         return Optional.ofNullable(transactionFlowProvider.get()
-                .executeNext(prepareForTerminate(chargeDao, chargeEventDao, chargeId, statusFlow))
+                .executeNext(prepareForTerminate(chargeDao, chargeEventDao, chargeId, statusFlow, paymentRequestDao))
                 .executeNext(doGatewayCancel(providers))
                 .executeNext(finishCancel(chargeId, statusFlow))
                 .complete()
@@ -101,6 +105,7 @@ public class ChargeCancelService {
 
             chargeEntity.setStatus(status);
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+            paymentRequestDao.updateChargeTransactionStatus(chargeEntity.getExternalId(), status);
             return cancelResponse;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
@@ -121,7 +126,7 @@ public class ChargeCancelService {
     private GatewayResponse<BaseCancelResponse> nonGatewayCancel(String chargeId, StatusFlow statusFlow) {
         ChargeStatus completeStatus = statusFlow.getSuccessTerminalState();
         ChargeEntity processedCharge = transactionFlowProvider.get()
-                .executeNext(changeStatusTo(chargeDao, chargeEventDao, chargeId, completeStatus, Optional.empty()))
+                .executeNext(changeStatusTo(chargeDao, chargeEventDao, chargeId, completeStatus, Optional.empty(), paymentRequestDao))
                 .complete()
                 .get(ChargeEntity.class);
         GatewayResponseBuilder<BaseCancelResponse> gatewayResponseBuilder = responseBuilder();

--- a/src/main/java/uk/gov/pay/connector/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeExpiryService.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -46,16 +47,19 @@ public class ChargeExpiryService {
     private final ChargeEventDao chargeEventDao;
     private final PaymentProviders providers;
     private final Provider<TransactionFlow> transactionFlowProvider;
+    private final PaymentRequestDao paymentRequestDao;
 
     @Inject
     public ChargeExpiryService(ChargeDao chargeDao,
                                ChargeEventDao chargeEventDao,
                                PaymentProviders providers,
-                               Provider<TransactionFlow> transactionFlowProvider) {
+                               Provider<TransactionFlow> transactionFlowProvider,
+                               PaymentRequestDao paymentRequestDao) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.providers = providers;
         this.transactionFlowProvider = transactionFlowProvider;
+        this.paymentRequestDao = paymentRequestDao;
     }
 
     public Map<String, Integer> expire(List<ChargeEntity> charges) {
@@ -74,7 +78,7 @@ public class ChargeExpiryService {
     private int expireChargesWithCancellationNotRequired(List<ChargeEntity> nonAuthSuccessCharges) {
         List<ChargeEntity> processedEntities = nonAuthSuccessCharges
                 .stream().map(chargeEntity -> transactionFlowProvider.get()
-                        .executeNext(changeStatusTo(chargeDao, chargeEventDao, chargeEntity.getExternalId(), EXPIRED, Optional.empty()))
+                        .executeNext(changeStatusTo(chargeDao, chargeEventDao, chargeEntity.getExternalId(), EXPIRED, Optional.empty(), paymentRequestDao))
                         .complete()
                         .get(ChargeEntity.class))
                 .collect(Collectors.toList());
@@ -90,7 +94,7 @@ public class ChargeExpiryService {
 
         gatewayAuthorizedCharges.forEach(chargeEntity -> {
             ChargeEntity processedEntity = transactionFlowProvider.get()
-                    .executeNext(prepareForTerminate(chargeDao, chargeEventDao, chargeEntity.getExternalId(), EXPIRE_FLOW))
+                    .executeNext(prepareForTerminate(chargeDao, chargeEventDao, chargeEntity.getExternalId(), EXPIRE_FLOW, paymentRequestDao))
                     .executeNext(doGatewayCancel(providers))
                     .executeNext(finishExpireCancel())
                     .complete().get(ChargeEntity.class);
@@ -148,6 +152,7 @@ public class ChargeExpiryService {
                         chargeEntity.getExternalId(), chargeEntity.getStatus(), status);
                 chargeEntity.setStatus(status);
                 chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+                paymentRequestDao.updateChargeTransactionStatus(chargeEntity.getExternalId(), status);
                 return chargeEntity;
             }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
         };

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
 import uk.gov.pay.connector.resources.ChargesApiResource;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
@@ -18,18 +19,24 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.pay.connector.model.ChargeResponse.aChargeResponseBuilder;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.model.domain.NumbersInStringsSanitizer.sanitize;
 import static uk.gov.pay.connector.resources.ApiPaths.CHARGE_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUNDS_API_PATH;
 
 public class ChargeService {
+
+    private static final List<ChargeStatus> CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS = newArrayList(CREATED, ENTERING_CARD_DETAILS);
 
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;
@@ -41,7 +48,10 @@ public class ChargeService {
     private final PaymentRequestDao paymentRequestDao;
 
     @Inject
-    public ChargeService(TokenDao tokenDao, ChargeDao chargeDao, ChargeEventDao chargeEventDao, CardTypeDao cardTypeDao, GatewayAccountDao gatewayAccountDao, ConnectorConfiguration config, PaymentProviders providers, PaymentRequestDao paymentRequestDao) {
+    public ChargeService(TokenDao tokenDao, ChargeDao chargeDao, ChargeEventDao chargeEventDao,
+                         CardTypeDao cardTypeDao, GatewayAccountDao gatewayAccountDao,
+                         ConnectorConfiguration config, PaymentProviders providers,
+                         PaymentRequestDao paymentRequestDao) {
         this.tokenDao = tokenDao;
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
@@ -64,8 +74,11 @@ public class ChargeService {
             );
             chargeDao.persist(chargeEntity);
 
-            PaymentRequestEntity paymentRequestEntity = PaymentRequestEntity.from(chargeEntity);
+            PaymentRequestEntity paymentRequestEntity =
+                    PaymentRequestEntity.from(chargeEntity, TransactionEntity.from(chargeEntity));
             paymentRequestDao.persist(paymentRequestEntity);
+
+            //todo: create a TransactionEventEntity here in future stories
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
             return Optional.of(populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity).build());
@@ -90,6 +103,21 @@ public class ChargeService {
                     return Optional.of(chargeEntity);
                 })
                 .orElseGet(Optional::empty);
+    }
+
+    @Transactional
+    public Optional<ChargeEntity> updateStatus(String externalId, ChargeStatus newChargeStatus) {
+        return chargeDao.findByExternalId(externalId)
+                .map(chargeEntity -> {
+                    final ChargeStatus oldChargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+                    if (CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS.contains(oldChargeStatus)) {
+                        chargeEntity.setStatus(newChargeStatus);
+                        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+                        paymentRequestDao.updateChargeTransactionStatus(externalId, newChargeStatus);
+                        return Optional.of(chargeEntity);
+                    }
+                    return Optional.<ChargeEntity>empty();
+                }).orElse(Optional.empty());
     }
 
     public <T extends AbstractChargeResponseBuilder<T, R>, R> AbstractChargeResponseBuilder<T, R> populateResponseBuilderWith(AbstractChargeResponseBuilder<T, R> responseBuilder, UriInfo uriInfo, ChargeEntity chargeEntity) {

--- a/src/main/java/uk/gov/pay/connector/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotificationService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.dao.RefundDao;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.model.*;
@@ -28,14 +29,16 @@ public class NotificationService {
     private final RefundDao refundDao;
     private final PaymentProviders paymentProviders;
     private final DnsUtils dnsUtils;
+    private final PaymentRequestDao paymentRequestDao;
 
     @Inject
-    public NotificationService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils) {
+    public NotificationService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils, PaymentRequestDao paymentRequestDao) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.refundDao = refundDao;
         this.paymentProviders = paymentProviders;
         this.dnsUtils = dnsUtils;
+        this.paymentRequestDao = paymentRequestDao;
     }
 
     @Transactional
@@ -206,6 +209,7 @@ public class NotificationService {
                     gatewayAccount.getType());
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
+            paymentRequestDao.updateChargeTransactionStatus(chargeEntity.getExternalId(), newStatus);
         }
 
         private <T> void updateRefundStatus(EvaluatedRefundStatusNotification<T> notification) {

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -918,4 +918,38 @@
         </sql>
     </changeSet>
 
+    <changeSet id="create table transactions" author="">
+        <createTable tableName="transactions">
+            <column name="id" type="bigserial" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="payment_request_id" type="bigint">
+                <constraints foreignKeyName="fk__payment_requests_id"
+                             referencedTableName="payment_requests"
+                             referencedColumnNames="id" nullable="false"/>
+            </column>
+            <column name="gateway_transaction_id" type="text">
+                <constraints nullable="true"/>
+            </column>
+            <column name="amount" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="refund_external_id" type="char(26)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="status" type="text">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_external_id" type="varchar(32)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="version" type="bigint" defaultValue="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="operation" type="text">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
@@ -1,35 +1,101 @@
 package uk.gov.pay.connector.it.dao;
 
+import org.hamcrest.core.IsNull;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
-import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
-import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.model.domain.*;
 
 import java.util.HashMap;
+import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture.aValidPaymentRequestEntity;
+import static uk.gov.pay.connector.model.domain.TransactionEntityBuilder.aTransactionEntity;
 
 public class PaymentRequestDaoITest extends DaoITestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private PaymentRequestDao paymentRequestDao;
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
+    private GatewayAccountEntity gatewayAccount;
 
 
     @Before
     public void setUp() throws Exception {
         paymentRequestDao = env.getInstance(PaymentRequestDao.class);
         insertTestAccount();
+
+        gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
     }
 
     @Test
     public void shouldCreateAPaymentRequest() throws Exception {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        assertThat(paymentRequestEntity.getId(), is(notNullValue()));
+        // Ensure always max precision is being millis
+        assertThat(paymentRequestEntity.getCreatedDate().getNano() % 1000000, is(0));
+        paymentRequestEntity.getTransactions().forEach(
+                transactionEntity -> assertThat(transactionEntity.getId(), is(notNullValue()))
+        );
+    }
+
+    @Test
+    public void shouldUpdateTransactionStatus() throws Exception {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        paymentRequestDao.updateChargeTransactionStatus(paymentRequestEntity.getExternalId(),
+                ChargeStatus.ENTERING_CARD_DETAILS);
+        final Optional<PaymentRequestEntity> byExternalId =
+                paymentRequestDao.findByExternalId(paymentRequestEntity.getExternalId());
+
+        assertThat(byExternalId.get().getTransactions().get(0).getStatus(), is(ChargeStatus.ENTERING_CARD_DETAILS));
+    }
+
+    @Test(expected = InvalidStateTransitionException.class)
+    public void shouldThrowException_whenUpdatingToInvalidState() throws Exception {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        paymentRequestDao.updateChargeTransactionStatus(paymentRequestEntity.getExternalId(),
+                 ChargeStatus.AUTHORISATION_READY);
+    }
+
+    @Test
+    public void shouldPersistMultipleTransactions() throws Exception {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withTransactions(asList(aTransactionEntity().build(), aTransactionEntity().build())).build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+        paymentRequestEntity.getTransactions().forEach(
+                transactionEntity -> assertThat(transactionEntity.getId(), is(notNullValue()))
+        );
+    }
+
+    @Test
+    public void shouldPersistATransaction() throws Exception {
         GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
                 defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
         gatewayAccount.setId(defaultTestAccount.getAccountId());
@@ -40,9 +106,7 @@ public class PaymentRequestDaoITest extends DaoITestBase {
 
         paymentRequestDao.persist(paymentRequestEntity);
 
-        assertThat(paymentRequestEntity.getId(), is(notNullValue()));
-        // Ensure always max precision is being millis
-        assertThat(paymentRequestEntity.getCreatedDate().getNano() % 1000000, is(0));
+        assertThat(paymentRequestEntity.getChargeTransaction().getId(), is(IsNull.notNullValue()));
     }
 
     private void insertTestAccount() {

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.connector.model.domain;
 
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 
+import static java.util.Arrays.asList;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.defaultGatewayAccountEntity;
 
 public class PaymentRequestEntityFixture {
@@ -16,6 +19,7 @@ public class PaymentRequestEntityFixture {
     private String reference = "This is a reference";
     private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+    private List<TransactionEntity> transactions = asList(TransactionEntityBuilder.aTransactionEntity().build());
 
     public static PaymentRequestEntityFixture aValidPaymentRequestEntity() {
         return new PaymentRequestEntityFixture();
@@ -30,12 +34,18 @@ public class PaymentRequestEntityFixture {
         entity.setDescription(this.description);
         entity.setCreatedDate(this.createdDate);
         entity.setAmount(this.amount);
+        entity.setTransactions(transactions);
 
         return entity;
     }
 
     public PaymentRequestEntityFixture withGatewayAccountEntity(GatewayAccountEntity gatewayAccount) {
         this.gatewayAccountEntity = gatewayAccount;
+        return this;
+    }
+
+    public PaymentRequestEntityFixture withTransactions(List<TransactionEntity> transactions) {
+        this.transactions = transactions;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.model.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+
+import static org.hamcrest.core.Is.is;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.model.domain.transaction.TransactionOperation.CHARGE;
+
+public class PaymentRequestEntityTest {
+
+    private TransactionEntity expectedChargeTransaction;
+    private PaymentRequestEntity paymentRequestEntity;
+
+    @Before
+    public void setUp() throws Exception {
+        expectedChargeTransaction = new TransactionEntity();
+        expectedChargeTransaction.setOperation(CHARGE);
+
+        paymentRequestEntity = new PaymentRequestEntity();
+        paymentRequestEntity.addTransaction(expectedChargeTransaction);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionWhenNoChargeTransactionsWhichIsAnInvalidState() throws Exception {
+        new PaymentRequestEntity().getChargeTransaction();
+    }
+
+    @Test
+    public void shouldReturnChargeTransactionWhenThereIsOnlyAChargeTransaction() throws Exception {
+        TransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
+        assertThat(chargeTransaction, is(expectedChargeTransaction));
+    }
+
+    @Test
+    public void shouldReturnChargeTransactionWhenThereIsManyTransactions() throws Exception {
+        TransactionEntity refundTransaction = new TransactionEntity();
+        refundTransaction.setOperation(TransactionOperation.REFUND);
+        paymentRequestEntity.addTransaction(refundTransaction);
+
+        TransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
+        assertThat(chargeTransaction, is(expectedChargeTransaction));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/TransactionEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/TransactionEntityBuilder.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+
+public final class TransactionEntityBuilder {
+    private String gatewayTransactionId = "someGatewayTransactionId";
+    private Long amount = 1234L;
+    private String refundExternalId = "someRefundExternalId";
+    private ChargeStatus status = ChargeStatus.CREATED;
+    private String userExternalId = "someUserExternalId";
+    private TransactionOperation operation = TransactionOperation.CHARGE;
+
+    private TransactionEntityBuilder() {
+    }
+
+    public static TransactionEntityBuilder aTransactionEntity() {
+        return new TransactionEntityBuilder();
+    }
+
+    public TransactionEntityBuilder withGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+        return this;
+    }
+
+    public TransactionEntityBuilder withAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public TransactionEntityBuilder withRefundExternalId(String refundExternalId) {
+        this.refundExternalId = refundExternalId;
+        return this;
+    }
+
+    public TransactionEntityBuilder withStatus(ChargeStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public TransactionEntityBuilder withUserExternalId(String userExternalId) {
+        this.userExternalId = userExternalId;
+        return this;
+    }
+
+    public TransactionEntityBuilder withOperation(TransactionOperation operation) {
+        this.operation = operation;
+        return this;
+    }
+
+    public TransactionEntity build() {
+        TransactionEntity transactionEntity = new TransactionEntity();
+        transactionEntity.setGatewayTransactionId(gatewayTransactionId);
+        transactionEntity.setAmount(amount);
+        transactionEntity.setRefundExternalId(refundExternalId);
+        transactionEntity.setStatus(status);
+        transactionEntity.setUserExternalId(userExternalId);
+        transactionEntity.setOperation(operation);
+        return transactionEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.model.domain.*;
 
 import static org.mockito.Mockito.mock;
@@ -16,6 +17,7 @@ public abstract class CardServiceTest {
     protected ChargeDao mockedChargeDao = mock(ChargeDao.class);
     protected ChargeEventDao mockedChargeEventDao = mock(ChargeEventDao.class);
     protected CardTypeDao mockedCardTypeDao = mock(CardTypeDao.class);
+    protected PaymentRequestDao mockPaymentRequestDao = mock(PaymentRequestDao.class);
 
     protected ChargeEntity createNewChargeWith(Long chargeId, ChargeStatus status) {
         ChargeEntity entity = ChargeEntityFixture

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -14,6 +14,8 @@ import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.UriInfo;
@@ -111,7 +113,9 @@ public class ChargeServiceTest {
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
 
-        service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao, mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedPaymentRequestDao);
+        service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
+                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
+                mockedPaymentRequestDao);
     }
 
     @Test
@@ -318,6 +322,47 @@ public class ChargeServiceTest {
         Optional<ChargeResponse> chargeForAccount = service.findChargeForAccount(externalChargeId, accountId, mockedUriInfo);
 
         assertThat(chargeForAccount.isPresent(), is(false));
+    }
+
+    @Test
+    public void whenCreatingCharge_shouldCreateTransactionEntity() throws Exception {
+        service.create(CHARGE_REQUEST, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+
+        ArgumentCaptor<PaymentRequestEntity> argumentCaptor = forClass(PaymentRequestEntity.class);
+        verify(mockedPaymentRequestDao).persist(argumentCaptor.capture());
+
+        PaymentRequestEntity paymentRequestEntity = argumentCaptor.getValue();
+        assertThat(paymentRequestEntity.getTransactions().size(), is(1));
+        TransactionEntity transactionEntity = paymentRequestEntity.getTransactions().get(0);
+        assertThat(transactionEntity.getAmount(), is(100L));
+        assertThat(transactionEntity.getStatus(), is(ChargeStatus.CREATED));
+        assertThat(transactionEntity.getOperation(), is(TransactionOperation.CHARGE));
+        assertThat(transactionEntity.getRefundExternalId(), is(nullValue()));
+        assertThat(transactionEntity.getUserExternalId(), is(nullValue()));
+        assertThat(transactionEntity.getGatewayTransactionId(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldUpdateTransactionStatus_whenUpdatingChargeStatus()  throws Exception {
+
+        service.create(CHARGE_REQUEST, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+
+        ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
+
+        when(mockedChargeDao.findByExternalId(anyString()))
+                .thenReturn(Optional.of(createdChargeEntity));
+
+        final PaymentRequestEntity paymentRequestEntity = PaymentRequestEntity.from(createdChargeEntity, TransactionEntity.from(createdChargeEntity));
+        when(mockedPaymentRequestDao.findByExternalId(anyString()))
+                .thenReturn(Optional.of(paymentRequestEntity));
+
+        service.updateStatus(createdChargeEntity.getExternalId(), ChargeStatus.ENTERING_CARD_DETAILS);
+
+        verify(mockedPaymentRequestDao)
+                .updateChargeTransactionStatus(paymentRequestEntity.getExternalId(), ChargeStatus.ENTERING_CARD_DETAILS);
     }
 
     @Deprecated

--- a/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.dao.RefundDao;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.model.Notification;
@@ -75,6 +76,9 @@ public class NotificationServiceTest {
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ChargeEntity mockedChargeEntity;
 
+    @Mock
+    private PaymentRequestDao mockedPaymentRequestDao;
+
     @Before
     public void setUp() {
         when(mockedPaymentProvider.getPaymentGatewayName()).thenReturn(SANDBOX.getName());
@@ -85,7 +89,7 @@ public class NotificationServiceTest {
 
         when(mockedPaymentProvider.verifyNotification(any(Notification.class), any(GatewayAccountEntity.class))).thenReturn(true);
 
-        notificationService = new NotificationService(mockedChargeDao, mockedChargeEventDao, mockedRefundDao, mockedPaymentProviders, mockDnsUtils);
+        notificationService = new NotificationService(mockedChargeDao, mockedChargeEventDao, mockedRefundDao, mockedPaymentProviders, mockDnsUtils, mockedPaymentRequestDao);
     }
 
     private Notifications<Pair<String, Boolean>> createNotificationFor(String transactionId, String reference, Pair<String, Boolean> status) {
@@ -312,7 +316,7 @@ public class NotificationServiceTest {
         verify(mockedChargeEventDao).persistChargeEventOf(argThat(obj -> mockedChargeEntity.equals(obj)), generatedTimeCaptor.capture());
 
         assertTrue(ChronoUnit.SECONDS.between((ZonedDateTime) generatedTimeCaptor.getValue().get(), ZonedDateTime.now()) < 10);
-
+        verify(mockedPaymentRequestDao).updateChargeTransactionStatus(mockedChargeEntity.getExternalId(), ChargeStatus.CAPTURED);
         verifyNoMoreInteractions(ignoreStubs(mockedChargeDao));
     }
 


### PR DESCRIPTION
- Added liquibase changeset to create the transactions table
- Mapped Transactions table to Transactions entity which links to the
PaymentRequestEntity.
- Made TransactionEntity reference PaymentRequestEntity. This creates a
bidirectional relationship which means the transaction can be inserted
with a single sql statement. Otherwise JPA will try to insert the
Transaction with a null in the payment_request_id column, then create
another statement to update the the payment_request_id.
- Moved chargeStatusUpdate to ChargeService from ChargeFrontendResource.
- Update Transactions when change status.
- Setting gatewayTransactionId on the chargeTransaction in the same
places as it is set on the charge.

with @georgeracu


