### PR TITLE
PP-2733 Revert disabled automatic migrations

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 java -jar *-allinone.jar waitOnDependencies *.yaml && \
+  java -jar *-allinone.jar db migrate *.yaml && \
   java $JAVA_OPTS -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
Disbaling the automatic migration at startup cause issues with the tests
in CI and for other devs as they have not built their dbs.

- Revert change to docker-startup.sh so we are running the migration as
part of the startup again.

with @georgeracu