### PR TITLE
PP-2733 Make connector database migrations not be run during deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ WORKDIR /app
 ADD target/*.yaml /app/
 ADD target/pay-*-allinone.jar /app/
 ADD docker-startup.sh /app/docker-startup.sh
+ADD docker-startup-with-db-migration.sh /app/docker-startup-with-db-migration.sh
 
 CMD bash ./docker-startup.sh

--- a/docker-startup-with-db-migration.sh
+++ b/docker-startup-with-db-migration.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 java -jar *-allinone.jar waitOnDependencies *.yaml && \
+  java -jar *-allinone.jar db migrate *.yaml && \
   java $JAVA_OPTS -jar *-allinone.jar server *.yaml


### PR DESCRIPTION
Disable the automatic db migration at startup. As some environments
were depending on this to create their db's at startup added a new
script that will still run the db migration at startup. Then override
the docker command in docker-compose to use this script.

- Added new docker-local-startup.sh file that still does the db
migration this is what the docker-start.sh file used to to do.
- Add the new file to the docker image that is created.
- Removed db migrate from docker-start.sh.

with @georgeracu


