### PR TITLE
PP-2777 create table transaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/PaymentRequestDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/PaymentRequestDao.java
@@ -3,9 +3,11 @@ package uk.gov.pay.connector.dao;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
-
 import javax.persistence.EntityManager;
+import java.util.Optional;
+
 
 @Transactional
 public class PaymentRequestDao extends JpaDao<PaymentRequestEntity> {
@@ -13,5 +15,15 @@ public class PaymentRequestDao extends JpaDao<PaymentRequestEntity> {
     @Inject
     public PaymentRequestDao(final Provider<EntityManager> entityManager) {
         super(entityManager);
+    }
+
+    public Optional<PaymentRequestEntity> findByExternalId(String externalId) {
+        String query = "SELECT p FROM PaymentRequestEntity p " +
+                "WHERE p.externalId = :externalId";
+
+        return entityManager.get()
+                .createQuery(query, PaymentRequestEntity.class)
+                .setParameter("externalId", externalId)
+                .getResultList().stream().findFirst();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jooq.impl.DSL.*;
 
+@Deprecated // This will be removed once the new refunds functionality has been completed.
 @Transactional
 public class TransactionDao {
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
-import static uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions.stateTransitionsFor;
+import static uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions.defaultTransitions;
 
 @Entity
 @Table(name = "charges")
@@ -150,7 +150,7 @@ public class ChargeEntity extends AbstractEntity {
     }
 
     public void setStatus(ChargeStatus targetStatus) throws InvalidStateTransitionException {
-        if (stateTransitionsFor(getPaymentGatewayName()).isValidTransition(fromString(this.status), targetStatus)) {
+        if (defaultTransitions().isValidTransition(fromString(this.status), targetStatus)) {
             this.status = targetStatus.getValue();
         } else {
             throw new InvalidStateTransitionException(this.status, targetStatus.getValue());

--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeStatus.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.model.domain;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PaymentGatewayStateTransitions.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.connector.model.domain;
 
-import uk.gov.pay.connector.service.PaymentGatewayName;
-
-class PaymentGatewayStateTransitions {
+public class PaymentGatewayStateTransitions {
     private static StateTransitions defaultTransitions = new DefaultStateTransitions();
 
-    static StateTransitions stateTransitionsFor(PaymentGatewayName gatewayName) {
+    public static StateTransitions defaultTransitions() {
         return defaultTransitions;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
@@ -122,6 +122,11 @@ public class PaymentRequestEntity extends AbstractEntity {
         );
     }
 
+    //Remove this once transactions table has been backfilled and we will no longer need to set this.
+    public boolean hasChargeTransaction() {
+        return transactions.stream().anyMatch(byChargeTransactions());
+    }
+
     private Predicate<TransactionEntity> byChargeTransactions() {
         return transactionEntity -> transactionEntity.getOperation().equals(TransactionOperation.CHARGE);
     }

--- a/src/main/java/uk/gov/pay/connector/model/domain/StateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/StateTransitions.java
@@ -7,14 +7,14 @@ import java.util.Map;
 
 import static java.util.Collections.emptyList;
 
-abstract class StateTransitions {
+public abstract class StateTransitions {
     private Map<ChargeStatus, List<ChargeStatus>> transitionTable;
 
     StateTransitions(Map<ChargeStatus, List<ChargeStatus>> transitionTable) {
         this.transitionTable = transitionTable;
     }
 
-    boolean isValidTransition(ChargeStatus state, ChargeStatus targetState) {
+    public boolean isValidTransition(ChargeStatus state, ChargeStatus targetState) {
         return transitionTable.getOrDefault(state, emptyList()).contains(targetState);
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+import uk.gov.pay.connector.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.model.domain.*;
+
+import javax.persistence.*;
+
+import static uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions.defaultTransitions;
+
+@Entity
+@DiscriminatorValue(value = "CHARGE")
+public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus> {
+
+    @Column(name = "gateway_transaction_id")
+    private String gatewayTransactionId;
+
+    public ChargeTransactionEntity() {
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public void setGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+    }
+
+    public void setStatus(ChargeStatus status) {
+        if (this.status != null && !defaultTransitions().isValidTransition(this.status, status)) {
+            throw new InvalidStateTransitionException(this.status.getValue(), status.getValue());
+        }
+        this.status = status;
+    }
+
+    public static ChargeTransactionEntity from(ChargeEntity chargeEntity) {
+        ChargeTransactionEntity transactionEntity = new ChargeTransactionEntity();
+        transactionEntity.setGatewayTransactionId(chargeEntity.getGatewayTransactionId());
+        transactionEntity.setAmount(chargeEntity.getAmount());
+        transactionEntity.setStatus(ChargeStatus.fromString(chargeEntity.getStatus()));
+        transactionEntity.setOperation(TransactionOperation.CHARGE);
+
+        return transactionEntity;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+import uk.gov.pay.connector.model.domain.AbstractEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.Status;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "transactions")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "operation")
+public abstract class TransactionEntity<E extends Status> extends AbstractEntity {
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    protected E status;
+    @Column(name = "amount")
+    private Long amount;
+    @Column(name = "operation")
+    @Enumerated(EnumType.STRING)
+    private TransactionOperation operation;
+    @ManyToOne
+    @JoinColumn(name = "payment_request_id", referencedColumnName = "id", updatable = false)
+    private PaymentRequestEntity paymentRequest;
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
+    public PaymentRequestEntity getPaymentRequest() {
+        return paymentRequest;
+    }
+
+    public void setPaymentRequest(PaymentRequestEntity paymentRequest) {
+        this.paymentRequest = paymentRequest;
+    }
+
+    public TransactionOperation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(TransactionOperation operation) {
+        this.operation = operation;
+    }
+
+    public E getStatus() {
+        return status;
+    }
+
+    public abstract void setStatus(E status);
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionOperation.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionOperation.java
@@ -1,0 +1,6 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+public enum TransactionOperation {
+    CHARGE,
+    REFUND
+}

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
@@ -2,13 +2,11 @@ package uk.gov.pay.connector.resources;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.google.common.collect.ImmutableList;
-import com.google.inject.persist.Transactional;
 import io.dropwizard.jersey.PATCH;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
-import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 import uk.gov.pay.connector.model.domain.*;
@@ -21,19 +19,15 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.model.FrontendChargeResponse.aFrontendChargeResponse;
 import static uk.gov.pay.connector.model.builder.PatchRequestBuilder.aPatchRequestBuilder;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.resources.ApiPaths.*;
 import static uk.gov.pay.connector.resources.ApiValidators.validateChargePatchParams;
@@ -44,18 +38,16 @@ import static uk.gov.pay.connector.util.ResponseUtil.*;
 public class ChargesFrontendResource {
 
     private static final Logger logger = LoggerFactory.getLogger(ChargesFrontendResource.class);
-    private static final List<ChargeStatus> CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS = newArrayList(CREATED, ENTERING_CARD_DETAILS);
+    private static final String NEW_STATUS = "new_status";
     private final ChargeDao chargeDao;
     private final ChargeService chargeService;
     private final CardTypeDao cardTypeDao;
-    private final ChargeEventDao chargeEventDao;
 
     @Inject
-    public ChargesFrontendResource(ChargeDao chargeDao, ChargeService chargeService, CardTypeDao cardTypeDao, ChargeEventDao chargeEventDao) {
+    public ChargesFrontendResource(ChargeDao chargeDao, ChargeService chargeService, CardTypeDao cardTypeDao) {
         this.chargeDao = chargeDao;
         this.chargeService = chargeService;
         this.cardTypeDao = cardTypeDao;
-        this.chargeEventDao = chargeEventDao;
     }
 
     @GET
@@ -102,36 +94,35 @@ public class ChargesFrontendResource {
     @Path(FRONTEND_CHARGE_STATUS_API_PATH)
     @Produces(APPLICATION_JSON)
     @JsonView(GatewayAccountEntity.Views.FrontendView.class)
-    @Transactional
     public Response updateChargeStatus(@PathParam("chargeId") String chargeId, Map newStatusMap) {
         if (invalidInput(newStatusMap)) {
-            return fieldsMissingResponse(ImmutableList.of("new_status"));
+            return fieldsMissingResponse(ImmutableList.of(NEW_STATUS));
         }
+
+        ChargeStatus newChargeStatus;
         try {
-            return updateStatus(chargeId, ChargeStatus.fromString(newStatusMap.get("new_status").toString()), Optional.empty());
+            newChargeStatus = ChargeStatus.fromString(newStatusMap.get(NEW_STATUS).toString());
         } catch (IllegalArgumentException e) {
             logger.error(e.getMessage(), e);
             return badRequestResponse(e.getMessage());
         }
+
+        if (!isValidStateTransition(newChargeStatus)) {
+            return getInvalidStatusResponse(chargeId, newChargeStatus);
+        }
+
+        return chargeService.updateFromInitialStatus(chargeId, newChargeStatus)
+                .map(chargeEntity -> Response.noContent().build())
+                .orElseGet(() -> getInvalidStatusResponse(chargeId, newChargeStatus));
+    }
+
+    private Response getInvalidStatusResponse(String chargeId, ChargeStatus newChargeStatus) {
+        return badRequestResponse("charge with id: " + chargeId +
+                " cannot be updated to the new status: " + newChargeStatus.getValue());
     }
 
     private boolean invalidInput(Map newStatusMap) {
-        return newStatusMap == null || newStatusMap.get("new_status") == null;
-    }
-
-    private Response updateStatus(String chargeId, ChargeStatus newChargeStatus, Optional<ZonedDateTime> generatedTime) {
-        if (!isValidStateTransition(newChargeStatus)) {
-            return badRequestResponse("charge with id: " + chargeId + " cant be updated to the new state: " + newChargeStatus.getValue());
-        }
-        return chargeDao.findByExternalId(chargeId)
-                .map(chargeEntity -> {
-                    if (CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS.contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
-                        chargeEntity.setStatus(newChargeStatus);
-                        chargeEventDao.persistChargeEventOf(chargeEntity, generatedTime);
-                        return noContentResponse();
-                    }
-                    return badRequestResponse("charge with id: " + chargeId + " cant be updated to the new state: " + newChargeStatus.getValue());
-                }).get();
+        return newStatusMap == null || newStatusMap.get(NEW_STATUS) == null;
     }
 
     private boolean isValidStateTransition(ChargeStatus newChargeStatus) {

--- a/src/main/java/uk/gov/pay/connector/service/CancelServiceFunctions.java
+++ b/src/main/java/uk/gov/pay/connector/service/CancelServiceFunctions.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.exception.IllegalStateRuntimeException;
@@ -34,13 +35,14 @@ class CancelServiceFunctions {
 
     private static final Logger logger = LoggerFactory.getLogger(CancelServiceFunctions.class);
 
-    static TransactionalOperation<TransactionContext, ChargeEntity> changeStatusTo(ChargeDao chargeDao, ChargeEventDao chargeEventDao, String chargeId, ChargeStatus targetStatus, Optional<ZonedDateTime> generationTime) {
+    static TransactionalOperation<TransactionContext, ChargeEntity> changeStatusTo(ChargeDao chargeDao, ChargeEventDao chargeEventDao, String chargeId, ChargeStatus targetStatus, Optional<ZonedDateTime> generationTime, StatusUpdater statusUpdater) {
         return context -> chargeDao.findByExternalId(chargeId)
                 .map(chargeEntity -> {
                     logger.info("Charge status to update - charge_external_id={}, status={}, to_status={}",
                             chargeEntity.getExternalId(), chargeEntity.getStatus(), targetStatus);
                     chargeEntity.setStatus(targetStatus);
                     chargeEventDao.persistChargeEventOf(chargeEntity, generationTime);
+                    statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), targetStatus);
                     return chargeEntity;
                 })
                 .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
@@ -49,10 +51,12 @@ class CancelServiceFunctions {
     static PreTransactionalOperation<TransactionContext, ChargeEntity> prepareForTerminate(ChargeDao chargeDao,
                                                                                            ChargeEventDao chargeEventDao,
                                                                                            String chargeId,
-                                                                                           StatusFlow statusFlow) {
+                                                                                           StatusFlow statusFlow,
+                                                                                           StatusUpdater statusUpdater) {
         return context -> chargeDao.findByExternalId(chargeId).map(chargeEntity -> {
+            ChargeStatus newStatus = statusFlow.getLockState();
             if (!chargeEntity.hasStatus(statusFlow.getTerminatableStatuses())) {
-                if (chargeEntity.hasStatus(statusFlow.getLockState())) {
+                if (chargeEntity.hasStatus(newStatus)) {
                     throw new OperationAlreadyInProgressRuntimeException(statusFlow.getName(), chargeId);
                 } else if (chargeEntity.hasStatus(ChargeStatus.AUTHORISATION_READY, AUTHORISATION_3DS_READY)) {
                     throw new ConflictRuntimeException(chargeEntity.getExternalId());
@@ -63,7 +67,8 @@ class CancelServiceFunctions {
 
                 throw new IllegalStateRuntimeException(chargeId);
             }
-            chargeEntity.setStatus(statusFlow.getLockState());
+            chargeEntity.setStatus(newStatus);
+            statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), newStatus);
             GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
 
             logger.info("Card cancel request sent - charge_external_id={}, charge_status={}, account_id={}, transaction_id={}, amount={}, operation_type={}, provider={}, provider_type={}, locking_status={}",
@@ -75,9 +80,10 @@ class CancelServiceFunctions {
                     OperationType.CANCELLATION.getValue(),
                     gatewayAccount.getGatewayName(),
                     gatewayAccount.getType(),
-                    statusFlow.getLockState());
+                    newStatus);
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+
             return chargeEntity;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
@@ -6,16 +6,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.model.domain.AuthorisationDetails;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
 
 import javax.persistence.OptimisticLockException;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static uk.gov.pay.connector.service.CardExecutorService.ExecutionStatus;
@@ -26,8 +29,8 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
 
     private final CardExecutorService cardExecutorService;
 
-    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment) {
-        super(chargeDao, chargeEventDao, providers, environment);
+    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment, StatusUpdater statusUpdater) {
+        super(chargeDao, chargeEventDao, providers, environment, statusUpdater);
         this.cardExecutorService = cardExecutorService;
     }
 
@@ -58,6 +61,15 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
             default:
                 throw new GenericGatewayRuntimeException("Exception occurred while doing authorisation");
         }
+    }
+
+    protected void setGatewayTransactionId(ChargeEntity chargeEntity, String transactionId, Optional<PaymentRequestEntity> paymentRequestEntity) {
+        chargeEntity.setGatewayTransactionId(transactionId);
+        paymentRequestEntity.ifPresent(paymentRequest -> {
+            if (paymentRequest.hasChargeTransaction()) {
+                paymentRequest.getChargeTransaction().setGatewayTransactionId(transactionId);
+            }
+        });
     }
 
     protected abstract ChargeEntity preOperation(String chargeId, T gatewayAuthRequest);

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureService.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.exception.IllegalStateRuntimeException;
@@ -43,8 +44,8 @@ public class CardCaptureService extends CardService implements TransactionalGate
 
 
     @Inject
-    public CardCaptureService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, UserNotificationService userNotificationService, Environment environment) {
-        super(chargeDao, chargeEventDao, providers, environment);
+    public CardCaptureService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, UserNotificationService userNotificationService, Environment environment, PaymentRequestDao paymentRequestDao, StatusUpdater statusUpdater) {
+        super(chargeDao, chargeEventDao, providers, environment, statusUpdater);
         this.userNotificationService = userNotificationService;
     }
 
@@ -80,6 +81,7 @@ public class CardCaptureService extends CardService implements TransactionalGate
             logger.info("CAPTURE_APPROVED for charge [charge_external_id={}]", externalId);
             charge.setStatus(CAPTURE_APPROVED);
             chargeEventDao.persistChargeEventOf(charge, Optional.empty());
+            statusUpdater.updateChargeTransactionStatus(charge.getExternalId(), CAPTURE_APPROVED);
             return charge;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
     }
@@ -91,6 +93,7 @@ public class CardCaptureService extends CardService implements TransactionalGate
         chargeDao.findByExternalId(chargeId).ifPresent(chargeEntity -> {
             chargeEntity.setStatus(CAPTURE_ERROR);
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+            statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), CAPTURE_ERROR);
         });
     }
 
@@ -127,6 +130,7 @@ public class CardCaptureService extends CardService implements TransactionalGate
                     metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.capture.result.%s", account.getGatewayName(), account.getType(), account.getId(), nextStatus.toString())).inc();
 
                     chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+                    statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), nextStatus);
 
                     if (operationResponse.isSuccessful()) {
                         userNotificationService.notifyPaymentSuccessEmail(chargeEntity);
@@ -136,6 +140,7 @@ public class CardCaptureService extends CardService implements TransactionalGate
                     if (chargeEntity.getPaymentGatewayName() == PaymentGatewayName.SANDBOX) {
                         chargeEntity.setStatus(CAPTURED);
                         chargeEventDao.persistChargeEventOf(chargeEntity, Optional.of(ZonedDateTime.now()));
+                        statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), CAPTURED);
                     }
 
                     return operationResponse;

--- a/src/main/java/uk/gov/pay/connector/service/CardService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ChargeExpiredRuntimeException;
 import uk.gov.pay.connector.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.exception.OperationAlreadyInProgressRuntimeException;
@@ -24,6 +25,7 @@ public abstract class CardService<T extends BaseResponse> {
     private final PaymentProviders providers;
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected MetricRegistry metricRegistry;
+    protected final StatusUpdater statusUpdater;
 
     public enum OperationType {
         CAPTURE("Capture"),
@@ -42,11 +44,12 @@ public abstract class CardService<T extends BaseResponse> {
         }
     }
 
-    protected CardService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, Environment environment) {
+    protected CardService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, Environment environment, StatusUpdater statusUpdater) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.providers = providers;
         this.metricRegistry = environment.metrics();
+        this.statusUpdater = statusUpdater;
     }
 
     public ChargeEntity preOperation(ChargeEntity chargeEntity, OperationType operationType, List<ChargeStatus> legalStatuses, ChargeStatus lockingStatus) {
@@ -77,6 +80,7 @@ public abstract class CardService<T extends BaseResponse> {
         }
 
         chargeEntity.setStatus(lockingStatus);
+        statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), lockingStatus);
         return chargeEntity;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 import uk.gov.pay.connector.resources.ChargesApiResource;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
@@ -18,18 +19,24 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static uk.gov.pay.connector.model.ChargeResponse.aChargeResponseBuilder;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.model.domain.NumbersInStringsSanitizer.sanitize;
 import static uk.gov.pay.connector.resources.ApiPaths.CHARGE_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUNDS_API_PATH;
 
 public class ChargeService {
+
+    private static final List<ChargeStatus> CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS = newArrayList(CREATED, ENTERING_CARD_DETAILS);
 
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;
@@ -39,9 +46,14 @@ public class ChargeService {
     private final LinksConfig linksConfig;
     private final PaymentProviders providers;
     private final PaymentRequestDao paymentRequestDao;
+    private final StatusUpdater statusUpdater;
 
     @Inject
-    public ChargeService(TokenDao tokenDao, ChargeDao chargeDao, ChargeEventDao chargeEventDao, CardTypeDao cardTypeDao, GatewayAccountDao gatewayAccountDao, ConnectorConfiguration config, PaymentProviders providers, PaymentRequestDao paymentRequestDao) {
+    public ChargeService(TokenDao tokenDao, ChargeDao chargeDao, ChargeEventDao chargeEventDao,
+                         CardTypeDao cardTypeDao, GatewayAccountDao gatewayAccountDao,
+                         ConnectorConfiguration config, PaymentProviders providers,
+                         PaymentRequestDao paymentRequestDao,
+                         StatusUpdater statusUpdater) {
         this.tokenDao = tokenDao;
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
@@ -50,6 +62,7 @@ public class ChargeService {
         this.linksConfig = config.getLinks();
         this.providers = providers;
         this.paymentRequestDao = paymentRequestDao;
+        this.statusUpdater = statusUpdater;
     }
 
     @Transactional
@@ -64,8 +77,11 @@ public class ChargeService {
             );
             chargeDao.persist(chargeEntity);
 
-            PaymentRequestEntity paymentRequestEntity = PaymentRequestEntity.from(chargeEntity);
+            PaymentRequestEntity paymentRequestEntity =
+                    PaymentRequestEntity.from(chargeEntity, ChargeTransactionEntity.from(chargeEntity));
             paymentRequestDao.persist(paymentRequestEntity);
+
+            //todo: create a TransactionEventEntity here in future stories
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
             return Optional.of(populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity).build());
@@ -90,6 +106,21 @@ public class ChargeService {
                     return Optional.of(chargeEntity);
                 })
                 .orElseGet(Optional::empty);
+    }
+
+    @Transactional
+    public Optional<ChargeEntity> updateFromInitialStatus(String externalId, ChargeStatus newChargeStatus) {
+        return chargeDao.findByExternalId(externalId)
+                .map(chargeEntity -> {
+                    final ChargeStatus oldChargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+                    if (CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS.contains(oldChargeStatus)) {
+                        chargeEntity.setStatus(newChargeStatus);
+                        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+                        statusUpdater.updateChargeTransactionStatus(externalId, newChargeStatus);
+                        return Optional.of(chargeEntity);
+                    }
+                    return Optional.<ChargeEntity>empty();
+                }).orElse(Optional.empty());
     }
 
     public <T extends AbstractChargeResponseBuilder<T, R>, R> AbstractChargeResponseBuilder<T, R> populateResponseBuilderWith(AbstractChargeResponseBuilder<T, R> responseBuilder, UriInfo uriInfo, ChargeEntity chargeEntity) {

--- a/src/main/java/uk/gov/pay/connector/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotificationService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.dao.RefundDao;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.model.*;
@@ -28,14 +29,16 @@ public class NotificationService {
     private final RefundDao refundDao;
     private final PaymentProviders paymentProviders;
     private final DnsUtils dnsUtils;
+    private final StatusUpdater statusUpdater;
 
     @Inject
-    public NotificationService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils) {
+    public NotificationService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils, StatusUpdater statusUpdater) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.refundDao = refundDao;
         this.paymentProviders = paymentProviders;
         this.dnsUtils = dnsUtils;
+        this.statusUpdater = statusUpdater;
     }
 
     @Transactional
@@ -206,6 +209,7 @@ public class NotificationService {
                     gatewayAccount.getType());
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
+            statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), newStatus);
         }
 
         private <T> void updateRefundStatus(EvaluatedRefundStatusNotification<T> notification) {

--- a/src/main/java/uk/gov/pay/connector/service/StatusUpdater.java
+++ b/src/main/java/uk/gov/pay/connector/service/StatusUpdater.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.connector.service;
+
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+
+import javax.inject.Inject;
+
+@Transactional
+public class StatusUpdater {
+
+    private final PaymentRequestDao paymentRequestDao;
+
+    @Inject
+    public StatusUpdater(PaymentRequestDao paymentRequestDao) {
+        this.paymentRequestDao = paymentRequestDao;
+    }
+
+    public  void updateChargeTransactionStatus(String externalId, ChargeStatus newChargeStatus) {
+        paymentRequestDao.findByExternalId(externalId).ifPresent(paymentRequestEntity -> {
+            if (paymentRequestEntity.hasChargeTransaction()) {
+                paymentRequestEntity.getChargeTransaction().setStatus(newChargeStatus);
+            }
+        });
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
@@ -1,35 +1,103 @@
 package uk.gov.pay.connector.it.dao;
 
+import org.hamcrest.core.IsNull;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
-import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
-import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.service.StatusUpdater;
 
 import java.util.HashMap;
-
+import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture.aValidPaymentRequestEntity;
+import static uk.gov.pay.connector.model.domain.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
 
 public class PaymentRequestDaoITest extends DaoITestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private PaymentRequestDao paymentRequestDao;
+    private StatusUpdater statusUpdater;
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
+    private GatewayAccountEntity gatewayAccount;
 
 
     @Before
     public void setUp() throws Exception {
         paymentRequestDao = env.getInstance(PaymentRequestDao.class);
+        statusUpdater = env.getInstance(StatusUpdater.class);
         insertTestAccount();
+
+        gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
     }
 
     @Test
     public void shouldCreateAPaymentRequest() throws Exception {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        assertThat(paymentRequestEntity.getId(), is(notNullValue()));
+        // Ensure always max precision is being millis
+        assertThat(paymentRequestEntity.getCreatedDate().getNano() % 1000000, is(0));
+        paymentRequestEntity.getTransactions().forEach(
+                transactionEntity -> assertThat(transactionEntity.getId(), is(notNullValue()))
+        );
+    }
+
+    @Test
+    public void shouldUpdateTransactionStatus() throws Exception {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        statusUpdater.updateChargeTransactionStatus(paymentRequestEntity.getExternalId(), ChargeStatus.ENTERING_CARD_DETAILS);
+        final Optional<PaymentRequestEntity> byExternalId =
+                paymentRequestDao.findByExternalId(paymentRequestEntity.getExternalId());
+
+        assertThat(byExternalId.get().getChargeTransaction().getStatus(), is(ChargeStatus.ENTERING_CARD_DETAILS));
+    }
+
+    @Test(expected = InvalidStateTransitionException.class)
+    public void shouldThrowException_whenUpdatingToInvalidState() throws Exception {
+        ChargeStatus initialStatus = ChargeStatus.CREATED;
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withTransactions(aChargeTransactionEntity().withStatus(initialStatus).build())
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        statusUpdater.updateChargeTransactionStatus(paymentRequestEntity.getExternalId(),
+                 ChargeStatus.AUTHORISATION_READY);
+    }
+
+    @Test
+    public void shouldPersistMultipleTransactions() throws Exception {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withTransactions(aChargeTransactionEntity().build(), aChargeTransactionEntity().build()).build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+        paymentRequestEntity.getTransactions().forEach(
+                transactionEntity -> assertThat(transactionEntity.getId(), is(notNullValue()))
+        );
+    }
+
+    @Test
+    public void shouldPersistATransaction() throws Exception {
         GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
                 defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
         gatewayAccount.setId(defaultTestAccount.getAccountId());
@@ -40,9 +108,7 @@ public class PaymentRequestDaoITest extends DaoITestBase {
 
         paymentRequestDao.persist(paymentRequestEntity);
 
-        assertThat(paymentRequestEntity.getId(), is(notNullValue()));
-        // Ensure always max precision is being millis
-        assertThat(paymentRequestEntity.getCreatedDate().getNano() % 1000000, is(0));
+        assertThat(paymentRequestEntity.getChargeTransaction().getId(), is(notNullValue()));
     }
 
     private void insertTestAccount() {

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeTransactionEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeTransactionEntityBuilder.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+
+public final class ChargeTransactionEntityBuilder {
+    private String gatewayTransactionId = "someGatewayTransactionId";
+    private Long amount = 1234L;
+    private ChargeStatus status = ChargeStatus.CREATED;
+    private TransactionOperation operation = TransactionOperation.CHARGE;
+
+    private ChargeTransactionEntityBuilder() {
+    }
+
+    public static ChargeTransactionEntityBuilder aChargeTransactionEntity() {
+        return new ChargeTransactionEntityBuilder();
+    }
+
+    public ChargeTransactionEntityBuilder withGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+        return this;
+    }
+
+    public ChargeTransactionEntityBuilder withAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public ChargeTransactionEntityBuilder withStatus(ChargeStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public ChargeTransactionEntityBuilder withOperation(TransactionOperation operation) {
+        this.operation = operation;
+        return this;
+    }
+
+    public ChargeTransactionEntity build() {
+        ChargeTransactionEntity transactionEntity = new ChargeTransactionEntity();
+        transactionEntity.setGatewayTransactionId(gatewayTransactionId);
+        transactionEntity.setAmount(amount);
+        transactionEntity.setStatus(status);
+        transactionEntity.setOperation(operation);
+        return transactionEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
@@ -1,10 +1,14 @@
 package uk.gov.pay.connector.model.domain;
 
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
 
+import static java.util.Arrays.asList;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.defaultGatewayAccountEntity;
 
 public class PaymentRequestEntityFixture {
@@ -16,6 +20,7 @@ public class PaymentRequestEntityFixture {
     private String reference = "This is a reference";
     private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+    private List<TransactionEntity> transactions = asList(ChargeTransactionEntityBuilder.aChargeTransactionEntity().build());
 
     public static PaymentRequestEntityFixture aValidPaymentRequestEntity() {
         return new PaymentRequestEntityFixture();
@@ -30,12 +35,18 @@ public class PaymentRequestEntityFixture {
         entity.setDescription(this.description);
         entity.setCreatedDate(this.createdDate);
         entity.setAmount(this.amount);
+        entity.setTransactions(transactions);
 
         return entity;
     }
 
     public PaymentRequestEntityFixture withGatewayAccountEntity(GatewayAccountEntity gatewayAccount) {
         this.gatewayAccountEntity = gatewayAccount;
+        return this;
+    }
+
+    public PaymentRequestEntityFixture withTransactions(TransactionEntity... transactions) {
+        this.transactions = Arrays.asList(transactions);
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.model.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+
+import static org.hamcrest.core.Is.is;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.model.domain.transaction.TransactionOperation.CHARGE;
+
+public class PaymentRequestEntityTest {
+
+    private ChargeTransactionEntity expectedChargeTransaction;
+    private PaymentRequestEntity paymentRequestEntity;
+
+    @Before
+    public void setUp() throws Exception {
+        expectedChargeTransaction = new ChargeTransactionEntity();
+        expectedChargeTransaction.setOperation(CHARGE);
+
+        paymentRequestEntity = new PaymentRequestEntity();
+        paymentRequestEntity.addTransaction(expectedChargeTransaction);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionWhenNoChargeTransactionsWhichIsAnInvalidState() throws Exception {
+        new PaymentRequestEntity().getChargeTransaction();
+    }
+
+    @Test
+    public void shouldReturnChargeTransactionWhenThereIsOnlyAChargeTransaction() throws Exception {
+        ChargeTransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
+        assertThat(chargeTransaction, is(expectedChargeTransaction));
+    }
+
+    @Test
+    public void shouldReturnChargeTransactionWhenThereIsManyTransactions() throws Exception {
+        ChargeTransactionEntity refundTransaction = new ChargeTransactionEntity();
+        refundTransaction.setOperation(TransactionOperation.REFUND);
+        paymentRequestEntity.addTransaction(refundTransaction);
+
+        ChargeTransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
+        assertThat(chargeTransaction, is(expectedChargeTransaction));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
@@ -11,13 +11,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.exception.*;
-import uk.gov.pay.connector.model.domain.Auth3dsDetails;
-import uk.gov.pay.connector.model.domain.ChargeEntity;
-import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.*;
 import uk.gov.pay.connector.model.gateway.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
 import uk.gov.pay.connector.model.gateway.GatewayResponse.GatewayResponseBuilder;
@@ -50,6 +47,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
     private Card3dsResponseAuthService card3dsResponseAuthService;
     private CardExecutorService mockExecutorService = mock(CardExecutorService.class);
+    private PaymentRequestEntity aValidPaymentRequestEntity;
 
     @Before
     public void setUpCardAuthorisationService() {
@@ -59,7 +57,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedChargeDao, mockedChargeEventDao, mockedProviders, mockExecutorService, mockEnvironment);
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedChargeDao, mockedChargeEventDao, mockedProviders, mockExecutorService, mockEnvironment, mockPaymentRequestDao, mockStatusUpdater);
+        aValidPaymentRequestEntity = PaymentRequestEntityFixture.aValidPaymentRequestEntity().build();
     }
 
     public void setupMockExecutorServiceMock() {
@@ -92,14 +91,20 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
+        when(mockPaymentRequestDao.findByExternalId(charge.getExternalId()))
+                .thenReturn(Optional.of(aValidPaymentRequestEntity));
+
 
         GatewayResponse response = card3dsResponseAuthService.doAuthorise(charge.getExternalId(), auth3dsDetails);
 
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
+        assertThat(aValidPaymentRequestEntity.getChargeTransaction().getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
         assertTrue(argumentCaptor.getValue().getTransactionId().isPresent());
         assertThat(argumentCaptor.getValue().getTransactionId().get(), is(GENERATED_TRANSACTION_ID));
+
+        verify(mockStatusUpdater).updateChargeTransactionStatus(charge.getExternalId(), AUTHORISATION_SUCCESS);
     }
 
     @Test
@@ -135,17 +140,22 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
+        when(mockPaymentRequestDao.findByExternalId(charge.getExternalId()))
+                .thenReturn(Optional.of(aValidPaymentRequestEntity));
 
         card3dsResponseAuthService.doAuthorise(charge.getExternalId(), auth3dsDetails);
 
         assertTrue(argumentCaptor.getValue().getProviderSessionId().isPresent());
         assertThat(argumentCaptor.getValue().getProviderSessionId().get(), is(providerSessionId));
+        verify(mockStatusUpdater).updateChargeTransactionStatus(charge.getExternalId(), AUTHORISATION_SUCCESS);
     }
 
     @Test
     public void shouldRespondAuthorisationRejected() throws Exception {
         ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
+        when(mockPaymentRequestDao.findByExternalId(charge.getExternalId()))
+                .thenReturn(Optional.of(aValidPaymentRequestEntity));
 
         GatewayResponse response = anAuthorisationRejectedResponse(charge, charge.getGatewayTransactionId(), argumentCaptor);
 
@@ -153,8 +163,10 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
+        assertThat(aValidPaymentRequestEntity.getChargeTransaction().getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
         assertTrue(argumentCaptor.getValue().getTransactionId().isPresent());
         assertThat(argumentCaptor.getValue().getTransactionId().get(), is(GENERATED_TRANSACTION_ID));
+        verify(mockStatusUpdater).updateChargeTransactionStatus(charge.getExternalId(), AUTHORISATION_REJECTED);
     }
 
     @Test
@@ -162,13 +174,18 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
 
+        when(mockPaymentRequestDao.findByExternalId(charge.getExternalId()))
+                .thenReturn(Optional.of(aValidPaymentRequestEntity));
+
         GatewayResponse response = anAuthorisationCancelledResponse(charge, charge.getGatewayTransactionId(), argumentCaptor);
 
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
+        assertThat(aValidPaymentRequestEntity.getChargeTransaction().getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
         assertTrue(argumentCaptor.getValue().getTransactionId().isPresent());
         assertThat(argumentCaptor.getValue().getTransactionId().get(), is(GENERATED_TRANSACTION_ID));
+        verify(mockStatusUpdater).updateChargeTransactionStatus(charge.getExternalId(), AUTHORISATION_CANCELLED);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.dao.Card3dsDao;
@@ -18,6 +19,7 @@ import uk.gov.pay.connector.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.model.GatewayError;
 import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
 import uk.gov.pay.connector.model.gateway.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse.AuthoriseStatus;
@@ -73,6 +75,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     private Card3dsDao mockCard3dsDao;
 
     private CardAuthoriseService cardAuthorisationService;
+    private PaymentRequestEntity paymentRequest;
 
     @Before
     public void setUpCardAuthorisationService() {
@@ -81,12 +84,15 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         cardAuthorisationService = new CardAuthoriseService(mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockCardDao, mockedProviders, mockExecutorService,
-                auth3dsDetailsFactory, mockEnvironment, mockCard3dsDao);
+                auth3dsDetailsFactory, mockEnvironment, mockCard3dsDao, mockPaymentRequestDao, mockStatusUpdater);
     }
 
     @Before
     public void configureChargeDaoMock() {
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
+        paymentRequest = PaymentRequestEntity.from(charge, ChargeTransactionEntity.from(charge));
+        when(mockPaymentRequestDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(paymentRequest));
+        when(mockPaymentRequestDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(paymentRequest));
     }
 
     public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
@@ -129,6 +135,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
+        assertThat(paymentRequest.getChargeTransaction().getGatewayTransactionId(), is(TRANSACTION_ID));
+
+        InOrder inOrder = inOrder(mockStatusUpdater);
+        inOrder.verify(mockStatusUpdater).updateChargeTransactionStatus(charge.getExternalId(), AUTHORISATION_READY);
+        inOrder.verify(mockStatusUpdater).updateChargeTransactionStatus(charge.getExternalId(), AUTHORISATION_SUCCESS);
     }
 
     @Test
@@ -150,6 +161,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.get3dsDetails(), is(nullValue()));
+        assertThat(paymentRequest.getChargeTransaction().getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
     }
 
@@ -212,6 +224,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
             fail("Won’t get this far");
         } catch (RuntimeException e) {
             assertThat(charge.getGatewayTransactionId(), is(generatedTransactionId));
+            assertThat(paymentRequest.getChargeTransaction().getGatewayTransactionId(), is(generatedTransactionId));
         }
     }
 
@@ -258,6 +271,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        assertThat(paymentRequest.getChargeTransaction().getGatewayTransactionId(), is(TRANSACTION_ID));
     }
 
     @Test
@@ -272,6 +286,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        assertThat(paymentRequest.getChargeTransaction().getGatewayTransactionId(), is(TRANSACTION_ID));
     }
 
     @Test
@@ -284,6 +299,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.isFailed(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(nullValue()));
+        assertThat(paymentRequest.getChargeTransaction().getGatewayTransactionId(), is(nullValue()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.model.domain.*;
 
 import static org.mockito.Mockito.mock;
@@ -16,6 +17,8 @@ public abstract class CardServiceTest {
     protected ChargeDao mockedChargeDao = mock(ChargeDao.class);
     protected ChargeEventDao mockedChargeEventDao = mock(ChargeEventDao.class);
     protected CardTypeDao mockedCardTypeDao = mock(CardTypeDao.class);
+    protected PaymentRequestDao mockPaymentRequestDao = mock(PaymentRequestDao.class);
+    protected StatusUpdater mockStatusUpdater = mock(StatusUpdater.class);
 
     protected ChargeEntity createNewChargeWith(Long chargeId, ChargeStatus status) {
         ChargeEntity entity = ChargeEntityFixture

--- a/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
@@ -53,9 +53,12 @@ public class ChargeExpiryServiceTest {
     @Mock
     private WorldpayCancelResponse mockWorldpayCancelResponse;
 
+    @Mock
+    private StatusUpdater mockStatusUpdater;
+
     @Before
     public void setup() {
-        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, TransactionFlow::new);
+        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, TransactionFlow::new, mockStatusUpdater);
     }
 
     @Test
@@ -86,6 +89,7 @@ public class ChargeExpiryServiceTest {
         verify(mockPaymentProvider).cancel(cancelCaptor.capture());
         assertThat(cancelCaptor.getValue().getTransactionId(), is(chargeEntity.getGatewayTransactionId()));
         assertThat(chargeEntity.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
+        verify(mockStatusUpdater).updateChargeTransactionStatus(chargeEntity.getExternalId(), ChargeStatus.EXPIRED);
     }
 
     @Test
@@ -117,6 +121,7 @@ public class ChargeExpiryServiceTest {
 
                     verify(mockPaymentProvider, never()).cancel(any());
                     assertThat(chargeEntity.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
+                    verify(mockStatusUpdater).updateChargeTransactionStatus(chargeEntity.getExternalId(), ChargeStatus.EXPIRED);
                 });
     }
 
@@ -146,5 +151,6 @@ public class ChargeExpiryServiceTest {
         chargeExpiryService.expire(singletonList(chargeEntity));
 
         assertThat(chargeEntity.getStatus(), is(ChargeStatus.EXPIRE_CANCEL_FAILED.getValue()));
+        verify(mockStatusUpdater).updateChargeTransactionStatus(chargeEntity.getExternalId(), ChargeStatus.EXPIRE_CANCEL_FAILED);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -14,6 +14,9 @@ import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.UriInfo;
@@ -81,6 +84,8 @@ public class ChargeServiceTest {
     private PaymentProvider mockedPaymentProvider;
     @Mock
     private PaymentRequestDao mockedPaymentRequestDao;
+    @Mock
+    private StatusUpdater mockedStatusUpdater;
 
     private ChargeService service;
 
@@ -111,7 +116,9 @@ public class ChargeServiceTest {
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
 
-        service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao, mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedPaymentRequestDao);
+        service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
+                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
+                mockedPaymentRequestDao, mockedStatusUpdater);
     }
 
     @Test
@@ -318,6 +325,43 @@ public class ChargeServiceTest {
         Optional<ChargeResponse> chargeForAccount = service.findChargeForAccount(externalChargeId, accountId, mockedUriInfo);
 
         assertThat(chargeForAccount.isPresent(), is(false));
+    }
+
+    @Test
+    public void whenCreatingCharge_shouldCreateTransactionEntity() throws Exception {
+        service.create(CHARGE_REQUEST, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+
+        ArgumentCaptor<PaymentRequestEntity> argumentCaptor = forClass(PaymentRequestEntity.class);
+        verify(mockedPaymentRequestDao).persist(argumentCaptor.capture());
+
+        PaymentRequestEntity paymentRequestEntity = argumentCaptor.getValue();
+        assertThat(paymentRequestEntity.getTransactions().size(), is(1));
+        TransactionEntity transactionEntity = paymentRequestEntity.getTransactions().get(0);
+        assertThat(transactionEntity.getAmount(), is(100L));
+        assertThat(transactionEntity.getStatus(), is(ChargeStatus.CREATED));
+        assertThat(transactionEntity.getOperation(), is(TransactionOperation.CHARGE));
+    }
+
+    @Test
+    public void shouldUpdateTransactionStatus_whenUpdatingChargeStatusFromInitialStatus()  throws Exception {
+        service.create(CHARGE_REQUEST, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+
+        ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
+
+        when(mockedChargeDao.findByExternalId(createdChargeEntity.getExternalId()))
+                .thenReturn(Optional.of(createdChargeEntity));
+
+        final PaymentRequestEntity paymentRequestEntity = PaymentRequestEntity.from(createdChargeEntity, ChargeTransactionEntity.from(createdChargeEntity));
+        when(mockedPaymentRequestDao.findByExternalId(createdChargeEntity.getExternalId()))
+                .thenReturn(Optional.of(paymentRequestEntity));
+
+        service.updateFromInitialStatus(createdChargeEntity.getExternalId(), ChargeStatus.ENTERING_CARD_DETAILS);
+
+        verify(mockedStatusUpdater)
+                .updateChargeTransactionStatus(paymentRequestEntity.getExternalId(), ChargeStatus.ENTERING_CARD_DETAILS);
     }
 
     @Deprecated

--- a/src/test/java/uk/gov/pay/connector/service/StatusUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/StatusUpdaterTest.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture;
+
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StatusUpdaterTest {
+    private static final String SOME_EXTERNAL_ID = "someExternalId";
+    @Mock
+    private PaymentRequestDao mockPaymentRequestDao;
+
+    @Test
+    public void updatesChangeTransactionStatus() throws Exception {
+        PaymentRequestEntity paymentRequest = PaymentRequestEntityFixture.aValidPaymentRequestEntity()
+                .withTransactions(aChargeTransactionEntity().withStatus(ChargeStatus.CREATED).build())
+                .build();
+        when(mockPaymentRequestDao.findByExternalId(SOME_EXTERNAL_ID)).thenReturn(Optional.of(paymentRequest));
+
+        ChargeStatus newChargeStatus = ENTERING_CARD_DETAILS;
+        new StatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, newChargeStatus);
+
+        assertThat(paymentRequest.getChargeTransaction().getStatus(), is(newChargeStatus));
+    }
+
+    @Test
+    public void doesNotUpdatesChangeTransactionStatusIfChargeTransactionDoesNotExist() throws Exception {
+        PaymentRequestEntity paymentRequest = mock(PaymentRequestEntity.class);
+        when(mockPaymentRequestDao.findByExternalId(SOME_EXTERNAL_ID)).thenReturn(Optional.of(paymentRequest));
+        when(paymentRequest.hasChargeTransaction()).thenReturn(false);
+
+        new StatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, ENTERING_CARD_DETAILS);
+
+        verify(paymentRequest).hasChargeTransaction();
+        verifyNoMoreInteractions(paymentRequest);
+    }
+}


### PR DESCRIPTION
Start writing and updating the Transaction table as well as the Charges 
table.

Check that a PaymentRequest has a charge transaction before 
modifying it. This is needed until we back fill the transactions table with
anything from charges. Once that has been done this commit can be
reverted. Have done it this way as it is a relatively small change which
will be easy to revert. Thought about creating a new ChargeTransaction
when you call getChargeTransaction if it did not exist. However this
required a ChargeEntity to be passed to getChargeTransaction() and the
changes were becoming considerable. Want this to be easy to remove once
the transactions table has been back filled.

- Mapped Transactions table to Transactions entity which links to the
PaymentRequestEntity.
- Made TransactionEntity reference PaymentRequestEntity. This creates a
bidirectional relationship which means the transaction can be inserted
with a single sql statement. Otherwise JPA will try to insert the
Transaction with a null in the payment_request_id column, then create
another statement to update the the payment_request_id.
- Moved chargeStatusUpdate to ChargeService from ChargeFrontendResource.
- Update Transactions when change status.
- Setting gatewayTransactionId on the chargeTransaction in the same
places as it is set on the charge.
- Add a hasChargeTransaction() to PaymentRequestEntity.
- Check hasChargeTransaction() before making a change to the charge
transaction.


