### PR TITLE
PP-2853 Upgrade base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM govukpay/openjdk:8-jre-alpine
+FROM govukpay/openjdk:8-151-jre-alpine
 
 RUN apk update
 RUN apk upgrade


### PR DESCRIPTION
We have built a new base java image.
See https://github.com/alphagov/pay-infra/pull/1064

This updates Dockerfile to use the new base.