### PR TITLE
PP-1825 Upgrade local tests to Postgres 9.6.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
         }
       }
       steps {
-        sh 'docker pull govukpay/postgres:9.4.4'
+        sh 'docker pull govukpay/postgres:9.6.5'
         sh 'mvn clean package'
       }
     }
@@ -38,7 +38,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        sh 'docker pull govukpay/postgres:9.4.4'
+        sh 'docker pull govukpay/postgres:9.6.5'
         sh 'mvn -Dmaven.test.skip=true clean package'
       }
     }

--- a/src/test/java/uk/gov/pay/connector/util/PostgresContainer.java
+++ b/src/test/java/uk/gov/pay/connector/util/PostgresContainer.java
@@ -31,7 +31,7 @@ public class PostgresContainer {
     public static final String DB_PASSWORD = "mysecretpassword";
     public static final String DB_USERNAME = "postgres";
     public static final int DB_TIMEOUT_SEC = 15;
-    public static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.4.4";
+    public static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.6.5";
     public static final String INTERNAL_PORT = "5432";
 
     public PostgresContainer(DockerClient docker, String host) throws DockerException, InterruptedException, IOException, ClassNotFoundException {


### PR DESCRIPTION
I've been moaning about these tests running 9.4.4 atop a container
with security issues on and off since February 2016 (see
https://payments-platform.atlassian.net/browse/PAYICE-108)

On top of that, real environments have been running postgresql 9.6.x
since March 2017 so this is doubly annoying.
(https://github.com/alphagov/pay-infra/commit/1ae9e2a08bb4789728d49b192d513ecede81c713)
