### PR TITLE
PP-2777 Create transaction table, fix exception when changing status

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.service.PaymentGatewayName;
@@ -21,6 +23,7 @@ import static uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions.d
 @SequenceGenerator(name = "charges_charge_id_seq", sequenceName = "charges_charge_id_seq", allocationSize = 1)
 @Access(AccessType.FIELD)
 public class ChargeEntity extends AbstractEntity {
+    private final static Logger logger = LoggerFactory.getLogger(ChargeEntity.class);
 
     @Column(name = "external_id")
     private String externalId;
@@ -152,6 +155,11 @@ public class ChargeEntity extends AbstractEntity {
     public void setStatus(ChargeStatus targetStatus) throws InvalidStateTransitionException {
         if (defaultTransitions().isValidTransition(fromString(this.status), targetStatus)) {
             this.status = targetStatus.getValue();
+            logger.info(String.format("Changing charge status for externalId [%s] [%s]->[%s]",
+                    externalId,
+                    this.status,
+                    targetStatus.getValue())
+            );
         } else {
             throw new InvalidStateTransitionException(this.status, targetStatus.getValue());
         }

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
@@ -50,7 +50,12 @@ public class CardCaptureProcess {
 
             chargesToCapture.forEach((charge) -> {
                 if (shouldRetry(charge)) {
-                    captureService.doCapture(charge.getExternalId());
+                    try {
+                        captureService.doCapture(charge.getExternalId());
+                    } catch (Exception e) {
+                        logger.error("Exception when running capture for [" + charge.getExternalId() + "]", e);
+                        throw e;
+                    }
                 } else {
                     captureService.markChargeAsCaptureError(charge.getExternalId());
                 }

--- a/src/main/java/uk/gov/pay/connector/service/StatusUpdater.java
+++ b/src/main/java/uk/gov/pay/connector/service/StatusUpdater.java
@@ -1,13 +1,17 @@
 package uk.gov.pay.connector.service;
 
 import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 
 import javax.inject.Inject;
 
 @Transactional
 public class StatusUpdater {
+    private static final Logger logger = LoggerFactory.getLogger(StatusUpdater.class);
 
     private final PaymentRequestDao paymentRequestDao;
 
@@ -19,7 +23,21 @@ public class StatusUpdater {
     public  void updateChargeTransactionStatus(String externalId, ChargeStatus newChargeStatus) {
         paymentRequestDao.findByExternalId(externalId).ifPresent(paymentRequestEntity -> {
             if (paymentRequestEntity.hasChargeTransaction()) {
-                paymentRequestEntity.getChargeTransaction().setStatus(newChargeStatus);
+                ChargeTransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
+                chargeTransaction.setStatus(newChargeStatus);
+                logger.info(String.format("Changing transaction status for externalId [%s] transactionId [%s] [%s]->[%s]",
+                        externalId,
+                        chargeTransaction.getId(),
+                        chargeTransaction.getStatus().getValue(),
+                        newChargeStatus.getValue())
+                );
+            } else {
+                logger.info(
+                        String.format("Not updating transaction status for externalId [%s] to [%s] charge transaction not found",
+                                externalId,
+                                newChargeStatus.getValue()
+                        )
+                );
             }
         });
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
@@ -70,20 +70,6 @@ public class PaymentRequestDaoITest extends DaoITestBase {
         assertThat(byExternalId.get().getChargeTransaction().getStatus(), is(ChargeStatus.ENTERING_CARD_DETAILS));
     }
 
-    @Test(expected = InvalidStateTransitionException.class)
-    public void shouldThrowException_whenUpdatingToInvalidState() throws Exception {
-        ChargeStatus initialStatus = ChargeStatus.CREATED;
-        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
-                .withGatewayAccountEntity(gatewayAccount)
-                .withTransactions(aChargeTransactionEntity().withStatus(initialStatus).build())
-                .build();
-
-        paymentRequestDao.persist(paymentRequestEntity);
-
-        statusUpdater.updateChargeTransactionStatus(paymentRequestEntity.getExternalId(),
-                 ChargeStatus.AUTHORISATION_READY);
-    }
-
     @Test
     public void shouldPersistMultipleTransactions() throws Exception {
         PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()


### PR DESCRIPTION
Were getting exceptions with invalid state transitions on transactions.
As we are dual writing the state to charges and transactions and the
change to charges was successful, only log an warning if the transition
on transactions is invalid. We think these were due to some instances
being upgraded before others so transaction status were being updated
on some instances but not others. If your requests came into a
number of instances your transaction status may not get updated.

- Change throwing an exception when doing an invalid transition between
states on transactions to logging a warning.
- Add logging whenever we try and change a transaction status.
- Improve logging when we throw an exception in the CardCaptureProcess
so we knoe the external id of the charge causing the exception.
- Removed test from PaymentRequestDaoITest that checked changing
between invalid states threw an exception. This should probably should
have been moved to TransactionEntityTest as the code had moved to
TransactionEntity, but now is being removed from there.