### PR TITLE
PP-2777 Create transaction table, drop transactions

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -930,4 +930,8 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet id="delete all transactions after failed rolled back" author="">
+        <delete tableName="transactions" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
We rolled back a release where some transaction status did not stay in
sync with charge status. Delete everything in transactions to clear
these out. This is safe to do as we are dual writing to charges and
transactions but only using charges at the moment. They will then get
populated later when we back fill transactions.


