### PR TITLE
PP-2756 Add notifySettings to gatewayAccountEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
@@ -72,6 +72,10 @@ public class GatewayAccountEntity extends AbstractEntity {
     @Column(name = "requires_3ds")
     private boolean requires3ds;
 
+    @Column(name = "notify_settings", columnDefinition = "json")
+    @Convert(converter = JsonToMapConverter.class)
+    private Map<String, String> notifySettings;
+
     @JsonBackReference
     @OneToOne(mappedBy = "accountEntity", cascade = CascadeType.PERSIST)
     private EmailNotificationEntity emailNotification;
@@ -192,6 +196,14 @@ public class GatewayAccountEntity extends AbstractEntity {
 
     public void setType(Type type) {
         this.type = type;
+    }
+
+    public void setNotifySettings(Map<String, String> notifySettings){
+        this.notifySettings = notifySettings;
+    }
+
+    public Map<String, String> getNotifySettings() {
+        return notifySettings;
     }
 
     public Map<String, String> withoutCredentials() {

--- a/src/main/java/uk/gov/pay/connector/model/domain/JsonToMapConverter.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/JsonToMapConverter.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.model.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.postgresql.util.PGobject;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+@Converter
+public class JsonToMapConverter implements AttributeConverter<Map<String, String>, PGobject> {
+    @Override
+    public PGobject convertToDatabaseColumn(Map<String, String> keyValueMap) {
+        PGobject pGobject = new PGobject();
+        pGobject.setType("json");
+        if(null != keyValueMap && !keyValueMap.isEmpty()) {
+            try {
+                pGobject.setValue(new ObjectMapper().writeValueAsString(keyValueMap));
+            } catch (SQLException | JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return pGobject;
+    }
+
+    @Override
+    public Map<String, String> convertToEntityAttribute(PGobject pgObject) {
+        try {
+            if (pgObject != null && !isEmpty(pgObject.toString())) {
+                return new ObjectMapper().readValue(pgObject.toString(), new TypeReference<Map<String, String>>() {});
+            }
+            return null;
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/JsonToMapConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/JsonToMapConverterTest.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.connector.model.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.postgresql.util.PGobject;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class JsonToMapConverterTest {
+
+    private JsonToMapConverter jsonToMapConverter;
+    private PGobject pGobject;
+
+    @Before
+    public void setUp(){
+        jsonToMapConverter = new JsonToMapConverter();
+        pGobject = new PGobject();
+        pGobject.setType("json");
+    }
+
+    @Test
+    public void shouldReturnAMapContainingTheValuesOfAPGObject() throws Exception {
+        JsonNode payload = new ObjectMapper()
+                .valueToTree(ImmutableMap.of(
+                        "json_field_1", "json_value_1",
+                        "json_field_2", "json_value_2"));
+
+        Map<String, String> values = ImmutableMap.of("json_field_1", "json_value_1", "json_field_2", "json_value_2");
+        pGobject.setValue(new ObjectMapper().writeValueAsString(values));
+
+        Map<String, String> jsonValues = jsonToMapConverter.convertToEntityAttribute(pGobject);
+
+        assertThat(new ObjectMapper().writeValueAsString(jsonValues), is(payload.toString()));
+    }
+
+    @Test
+    public void shouldReturnNoMapWhenDBFieldIsNull() throws Exception {
+        pGobject.setValue(null);
+        Map<String, String> jsonValues = jsonToMapConverter.convertToEntityAttribute(pGobject);
+
+        assertThat(jsonValues, is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnPGObjectContainingPredifinedValues() throws Exception {
+        Map<String, String> values = ImmutableMap.of("json_field_1", "json_value_1", "json_field_2", "json_value_2");
+        pGobject = jsonToMapConverter.convertToDatabaseColumn(values);
+
+        assertThat(pGobject.getType(), is("json"));
+        assertThat(pGobject.getValue(), is(new ObjectMapper().writeValueAsString(values)));
+    }
+
+    @Test
+    public void shouldReturnNullWhenEmptyMap() throws Exception {
+        Map<String, String> values = ImmutableMap.of();
+        pGobject = jsonToMapConverter.convertToDatabaseColumn(values);
+        assertThat(pGobject.getValue(), is(nullValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -498,5 +498,15 @@ public class DatabaseTestHelper {
         );
     }
 
+    public Map<String, String> getNotifySettings(Long gatewayAccountId) {
+
+        String jsonString = jdbi.withHandle(h ->
+                h.createQuery("SELECT notify_settings from gateway_accounts WHERE id = :gatewayAccountId")
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .map(StringColumnMapper.INSTANCE)
+                        .first()
+        );
+        return new Gson().fromJson(jsonString, Map.class);
+    }
 
 }


### PR DESCRIPTION
- add a new json type field to gatewayAccountEntity to store notify API settings for custom branding
- refactor CredentialsConverter to be a generic JSON type converter 
- adding unit and integration tests for the entity and the converter