### PR TITLE
PP-2769 Back fill 3D Secure data from charges table to cards_3ds table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -976,4 +976,25 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="backfill card_3ds table" author="">
+        <sql>
+            INSERT INTO card_3ds (
+                pa_request,
+                issuer_url,
+                worldpay_machine_cookie,
+                charge_id
+            )
+            SELECT
+                ch.pa_request_3ds,
+                ch.issuer_url_3ds,
+                ch.provider_session_id,
+                ch.id
+            FROM charges ch
+            LEFT JOIN card_3ds c ON c.charge_id = ch.id
+            WHERE c.charge_id IS NULL
+                AND ch.pa_request_3ds IS NOT NULL
+                AND ch.issuer_url_3ds IS NOT NULL;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Back fill the data into the cards_3ds table that was created a number
of weeks ago. This was reverted once before going totest, staging or
prod as the load it caused was too high for the database and resulted
in service outage. Database servers have now been upgraded and so
adding this back in.