### PR TITLE
PP-2756 add PATCH request validator for GatewayAccountResource

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -9,10 +9,12 @@ import com.google.inject.persist.jpa.JpaPersistModule;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.model.builder.EntityBuilder;
+import uk.gov.pay.connector.resources.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.service.CardExecutorService;
 import uk.gov.pay.connector.service.PaymentProviders;
 import uk.gov.pay.connector.service.notify.NotifyClientFactoryProvider;
 import uk.gov.pay.connector.util.HashUtil;
+import uk.gov.pay.connector.validations.RequestValidator;
 
 import java.util.Properties;
 
@@ -33,6 +35,8 @@ public class ConnectorModule extends AbstractModule {
         bind(PaymentProviders.class).in(Singleton.class);
         bind(EntityBuilder.class);
         bind(HashUtil.class);
+        bind(RequestValidator.class);
+        bind(GatewayAccountRequestValidator.class).in(Singleton.class);
 
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(NotifyClientFactoryProvider.class));

--- a/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccount.java
@@ -11,6 +11,11 @@ public class GatewayAccount {
     public static final String CREDENTIALS_PASSWORD = "password";
     public static final String CREDENTIALS_SHA_IN_PASSPHRASE = "sha_in_passphrase";
     public static final String CREDENTIALS_SHA_OUT_PASSPHRASE = "sha_out_passphrase";
+    public static final String FIELD_OPERATION = "op";
+    public static final String FIELD_OPERATION_PATH = "path";
+    public static final String FIELD_VALUES = "value";
+    public static final String FIELD_NOTIFY_API_TOKEN = "api_token";
+    public static final String FIELD_NOTIFY_TEMPLATE_ID = "template_id";
 
     private Long id;
     private String gatewayName;

--- a/src/main/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidator.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.connector.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.Inject;
+import uk.gov.pay.connector.util.Errors;
+import uk.gov.pay.connector.validations.RequestValidator;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_API_TOKEN;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_TEMPLATE_ID;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION_PATH;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_VALUES;
+
+
+public class GatewayAccountRequestValidator {
+
+    private final RequestValidator requestValidator;
+    private static final Map<String, List<String>> VALID_ATTRIBUTE_UPDATE_OPERATIONS = new HashMap<String, List<String>>() {{
+        put(FIELD_OPERATION, asList("replace", "remove"));
+    }};
+    private static final String FIELD_NOTIFY_SETTINGS = "notify_settings";
+
+    @Inject
+    public GatewayAccountRequestValidator(RequestValidator requestValidator){
+        this.requestValidator = requestValidator;
+    }
+
+    public Optional<Errors> validatePatchRequest(JsonNode payload){
+        Optional<List<String>> pathCheck = requestValidator.checkIfExistsOrEmpty(payload,
+                FIELD_OPERATION, FIELD_OPERATION_PATH);
+        if(pathCheck.isPresent()){
+            return pathCheck.map(Errors::from);
+        }
+        if(!payload.findValue(FIELD_OPERATION_PATH).asText().equals(FIELD_NOTIFY_SETTINGS)) {
+            return Optional.of(Errors.from(format("Operation [%s] not supported for path [%s]",
+                    FIELD_OPERATION,
+                    payload.findValue(FIELD_OPERATION_PATH).asText())));
+        }
+        return validateNotifySettingsRequest(payload).map(Errors::from);
+
+    }
+
+    private Optional<List<String>> validateNotifySettingsRequest(JsonNode payload){
+        String op = payload.get(FIELD_OPERATION).asText();
+        if (!VALID_ATTRIBUTE_UPDATE_OPERATIONS.get(FIELD_OPERATION).contains(op)) {
+            return Optional.of(asList(format("Operation [%s] is not valid for path [%s]", op, FIELD_OPERATION)));
+        }
+        if(op.equals("remove")) {
+            return Optional.empty();
+        }
+        JsonNode valueNode = payload.get(FIELD_VALUES);
+        if(null == valueNode) {
+            return Optional.of(asList(format("Field [%s] is required", FIELD_VALUES)));
+        }
+        return requestValidator.checkIfExistsOrEmpty(valueNode, FIELD_NOTIFY_API_TOKEN, FIELD_NOTIFY_TEMPLATE_ID);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/Errors.java
+++ b/src/main/java/uk/gov/pay/connector/util/Errors.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.util;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Arrays.asList;
+
+public class Errors {
+
+    private List<String> errors = newArrayList();
+
+    private Errors(@JsonProperty("errors") List<String> errors) {
+        this.errors = errors;
+    }
+
+    public static Errors from(String error) {
+        return new Errors(asList(error));
+    }
+
+    public static Errors from(List<String> errorList) {
+        return new Errors(errorList);
+    }
+
+    @JsonGetter
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/validations/RequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/validations/RequestValidator.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.connector.validations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.math.NumberUtils.isDigits;
+
+public class RequestValidator {
+
+    public Optional<List<String>> checkIsNumeric(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, isNotNumeric(), fieldNames, "Field [%s] must be a number");
+    }
+
+    public Optional<List<String>> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
+        return applyCheck(payload, notExistOrEmpty(), fieldNames, "Field [%s] is required");
+    }
+
+    public Optional<List<String>> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {
+        return applyCheck(payload, exceedsMaxLength(maxLength), fieldNames, "Field [%s] must have a maximum length of " + maxLength + " characters");
+    }
+
+    private Function<JsonNode, Boolean> exceedsMaxLength(int maxLength) {
+        return jsonNode -> jsonNode.asText().length() > maxLength;
+    }
+
+    public Optional<List<String>> applyCheck(JsonNode payload, Function<JsonNode, Boolean> check, String[] fieldNames, String errorMessage) {
+        List<String> errors = newArrayList();
+        for (String fieldName : fieldNames) {
+            if (check.apply(payload.get(fieldName))) {
+                errors.add(format(errorMessage, fieldName));
+            }
+        }
+        return errors.size() > 0 ? Optional.of(errors) : Optional.empty();
+    }
+
+    public Function<JsonNode, Boolean> notExistOrEmpty() {
+        return (jsonElement) -> {
+            if (jsonElement instanceof NullNode) {
+                return isNullValue().apply(jsonElement);
+            } else if (jsonElement instanceof ArrayNode) {
+                return notExistOrEmptyArray().apply(jsonElement);
+            } else {
+                return notExistOrBlankText().apply(jsonElement);
+            }
+        };
+    }
+
+    public Function<JsonNode, Boolean> notExistOrEmptyArray() {
+        return jsonElement -> (
+                jsonElement == null ||
+                        ((jsonElement instanceof ArrayNode) && (jsonElement.size() == 0))
+        );
+    }
+
+    private static Function<JsonNode, Boolean> notExistOrBlankText() {
+        return jsonElement -> (
+                jsonElement == null ||
+                        isBlank(jsonElement.asText())
+        );
+    }
+
+    private static Function<JsonNode, Boolean> isNullValue() {
+        return jsonElement -> (
+                jsonElement == null || jsonElement instanceof NullNode
+        );
+    }
+
+    public static Function<JsonNode, Boolean> isNotNumeric() {
+        return jsonNode -> !isDigits(jsonNode.asText());
+    }
+
+    public static Function<JsonNode, Boolean> isNotBoolean() {
+        return jsonNode -> !ImmutableList.of("true", "false").contains(jsonNode.asText().toLowerCase());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidatorTest.java
@@ -1,0 +1,111 @@
+package uk.gov.pay.connector.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.util.Errors;
+import uk.gov.pay.connector.validations.RequestValidator;
+
+import java.util.Optional;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_API_TOKEN;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_TEMPLATE_ID;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION_PATH;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_VALUES;
+
+public class GatewayAccountRequestValidatorTest {
+
+    private GatewayAccountRequestValidator validator;
+
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void before() throws Exception {
+        validator = new GatewayAccountRequestValidator(new RequestValidator());
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    public void shouldError_whenFieldsAreMissing() throws Exception {
+        JsonNode jsonNode = new ObjectMapper()
+                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+                        FIELD_OPERATION_PATH, "notify_settings"));
+        Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
+
+        assertThat(optionalErrors.isPresent(), is(true));
+        Errors errors = optionalErrors.get();
+
+        assertThat(errors.getErrors().size(), is(1));
+        assertThat(errors.getErrors(), hasItems(
+                "Field [value] is required"));
+    }
+
+    @Test
+    public void shouldError_whenFieldsNotValidInValue() throws Exception {
+        JsonNode jsonNode = new ObjectMapper()
+                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+                        FIELD_OPERATION_PATH, "notify_settings",
+                        FIELD_VALUES, ImmutableMap.of("timbuktu", "anapitoken",
+                                "colombo", "atemplateid")));
+        Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
+
+        assertThat(optionalErrors.isPresent(), is(true));
+        assertThat(optionalErrors.get().getErrors().size(), is(2));
+        assertThat(optionalErrors.get().getErrors().get(0), is("Field [api_token] is required"));
+        assertThat(optionalErrors.get().getErrors().get(1), is("Field [template_id] is required"));
+    }
+
+    @Test
+    public void shouldReturnError_whenInvalidPathOnOperation() throws Exception {
+        JsonNode jsonNode = objectMapper.valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+                FIELD_OPERATION_PATH, "service_name"));
+        Optional<Errors> optionalErrors =validator.validatePatchRequest(jsonNode);
+        assertThat(optionalErrors.isPresent(), is(true));
+        assertThat(optionalErrors.get().getErrors().size(), is(1));
+        assertThat(optionalErrors.get().getErrors().get(0), is("Operation [op] not supported for path [service_name]"));
+    }
+
+    @Test
+    public void shouldReturnEmpty_whenAllValidationsPassed() throws Exception {
+        JsonNode jsonNode = new ObjectMapper()
+                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+                FIELD_OPERATION_PATH, "notify_settings",
+                FIELD_VALUES, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "anapitoken",
+                                FIELD_NOTIFY_TEMPLATE_ID, "atemplateid")));
+        Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
+
+        assertThat(optionalErrors.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldReturnError_whenInvalidOperation() throws Exception {
+        JsonNode jsonNode = new ObjectMapper()
+                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "delete",
+                        FIELD_OPERATION_PATH, "notify_settings",
+                        FIELD_VALUES, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "anapitoken",
+                                FIELD_NOTIFY_TEMPLATE_ID, "atemplateid")));
+        Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
+
+        assertThat(optionalErrors.isPresent(), is(true));
+        assertThat(optionalErrors.get().getErrors().size(), is(1));
+        assertThat(optionalErrors.get().getErrors().get(0), is("Operation [delete] is not valid for path [op]"));
+    }
+
+    @Test
+    public void shouldIgnoreEmptyOrMissingValue_whenRemoveOperation() throws Exception {
+        JsonNode jsonNode = new ObjectMapper()
+                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "remove",
+                        FIELD_OPERATION_PATH, "notify_settings",
+                        FIELD_VALUES, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "")));
+        Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
+
+        assertThat(optionalErrors.isPresent(), is(false));
+    }
+}


### PR DESCRIPTION
- add a request validator to be used by GatewayAccountResource
- implement notify_settings specific validation (this is needed as the PATCH request contains nested nodes)
