### PR TITLE
PP-2959 Explicit docker pull postgres image for testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
         <jpa.version>2.6.4</jpa.version>
         <guice.version>4.1.0</guice.version>
         <jersey2.version>2.25.1</jersey2.version>
+        <docker-client.version>8.9.2</docker-client.version>
     </properties>
     <repositories>
         <repository>
@@ -282,7 +283,7 @@
         <dependency>
             <groupId>com.spotify</groupId>
             <artifactId>docker-client</artifactId>
-            <version>8.1.1</version>
+            <version>${docker-client.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## WHAT

- Current integration tests are using a non ideal manually built Postgres image for testing. Even less ideal is pulling the image locally when it does not exist (example as in new machines, docker images clean up, changed a reference to a new image)

- Pull explicitly the docker image before running the tests

- Upgrade docker-client (test scope) version from 8.1.1 -> 8.9.2

