### PR TITLE
PP-2756 send payment confirmation email based on custom branding settings

### DIFF
--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.model.domain;
 
+import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.ZoneId;
@@ -123,6 +124,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withProviderSessionId(String providerSessionId) {
         this.providerSessionId = providerSessionId;
+        return this;
+    }
+
+    public ChargeEntityFixture withNotifySettings(ImmutableMap<String, String> notifySettings) {
+        this.gatewayAccountEntity.setNotifySettings(notifySettings);
         return this;
     }
 


### PR DESCRIPTION
## WHAT

If the gateway account contains a custom notify account api key and its relevant template it should use that to send the email instead of the default govuk.pay email. Otherwise the default Pay email will be sent as usual.

Removed the unused `checkDeliveryStatus` method and its corresponding test