### PR TITLE
PP-2756 Add NotifySettings endpoint to GatewayAccountResource

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -11,6 +11,7 @@ import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.model.builder.EntityBuilder;
 import uk.gov.pay.connector.resources.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.service.CardExecutorService;
+import uk.gov.pay.connector.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.service.PaymentProviders;
 import uk.gov.pay.connector.service.notify.NotifyClientFactoryProvider;
 import uk.gov.pay.connector.util.HashUtil;
@@ -40,6 +41,7 @@ public class ConnectorModule extends AbstractModule {
 
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(NotifyClientFactoryProvider.class));
+        install(new FactoryModuleBuilder().build(GatewayAccountServicesFactory.class));
     }
 
     private JpaPersistModule jpaModule(ConnectorConfiguration configuration) {

--- a/src/main/java/uk/gov/pay/connector/model/NotifySettingsUpdateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/model/NotifySettingsUpdateRequest.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION_PATH;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_VALUE;
+
+public class NotifySettingsUpdateRequest {
+
+    public static final String OP_REMOVE = "remove";
+    public static final String OP_REPLACE = "replace";
+    private String op;
+    private String path;
+    private Map<String, String> value;
+
+    public NotifySettingsUpdateRequest(String op, String path, Map<String, String> value) {
+        this.op = op;
+        this.path = path;
+        this.value = value;
+    }
+
+    public static NotifySettingsUpdateRequest from(JsonNode payload) {
+        try {
+            Map<String, String> value = payload.get(FIELD_VALUE) == null ? null
+                    : new ObjectMapper().readValue(payload.get(FIELD_VALUE).traverse(),
+                    new TypeReference<Map<String, String>>() {});
+            String operation  = payload.get(FIELD_OPERATION).asText();
+            String path = payload.get(FIELD_OPERATION_PATH).asText();
+
+            return new NotifySettingsUpdateRequest(operation, path, value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getOp() {
+        return op;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public Map<String, String> getValue() {
+        return value;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccount.java
@@ -13,7 +13,7 @@ public class GatewayAccount {
     public static final String CREDENTIALS_SHA_OUT_PASSPHRASE = "sha_out_passphrase";
     public static final String FIELD_OPERATION = "op";
     public static final String FIELD_OPERATION_PATH = "path";
-    public static final String FIELD_VALUES = "value";
+    public static final String FIELD_VALUE = "value";
     public static final String FIELD_NOTIFY_API_TOKEN = "api_token";
     public static final String FIELD_NOTIFY_TEMPLATE_ID = "template_id";
 

--- a/src/main/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidator.java
@@ -16,7 +16,7 @@ import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_API_
 import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_TEMPLATE_ID;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION_PATH;
-import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_VALUES;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_VALUE;
 
 
 public class GatewayAccountRequestValidator {
@@ -55,9 +55,9 @@ public class GatewayAccountRequestValidator {
         if(op.equals("remove")) {
             return Optional.empty();
         }
-        JsonNode valueNode = payload.get(FIELD_VALUES);
+        JsonNode valueNode = payload.get(FIELD_VALUE);
         if(null == valueNode) {
-            return Optional.of(asList(format("Field [%s] is required", FIELD_VALUES)));
+            return Optional.of(asList(format("Field [%s] is required", FIELD_VALUE)));
         }
         return requestValidator.checkIfExistsOrEmpty(valueNode, FIELD_NOTIFY_API_TOKEN, FIELD_NOTIFY_TEMPLATE_ID);
     }

--- a/src/main/java/uk/gov/pay/connector/service/GatewayAccountServicesFactory.java
+++ b/src/main/java/uk/gov/pay/connector/service/GatewayAccountServicesFactory.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.service;
+
+import uk.gov.pay.connector.service.notify.NotifySettingsUpdateService;
+
+public interface GatewayAccountServicesFactory {
+
+    NotifySettingsUpdateService getNotifySettingsUpdateService();
+}

--- a/src/main/java/uk/gov/pay/connector/service/notify/NotifySettingsUpdateService.java
+++ b/src/main/java/uk/gov/pay/connector/service/notify/NotifySettingsUpdateService.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.connector.service.notify;
+
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.dao.GatewayAccountDao;
+import uk.gov.pay.connector.model.NotifySettingsUpdateRequest;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.model.NotifySettingsUpdateRequest.OP_REMOVE;
+import static uk.gov.pay.connector.model.NotifySettingsUpdateRequest.OP_REPLACE;
+
+public class NotifySettingsUpdateService {
+
+    private final GatewayAccountDao gatewayAccountDao;
+
+    @Inject
+    public NotifySettingsUpdateService(GatewayAccountDao gatewayAccountDao) {
+        this.gatewayAccountDao = gatewayAccountDao;
+    }
+
+    @Transactional
+    public Optional<GatewayAccountEntity> update(Long gatewayAccountId, NotifySettingsUpdateRequest updateRequest) {
+        return gatewayAccountDao.findById(gatewayAccountId)
+                .map(gatewayAccountEntity -> {
+                    if(updateRequest.getOp().equals(OP_REPLACE)) {
+                        gatewayAccountEntity.setNotifySettings(updateRequest.getValue());
+                    } else if (updateRequest.getOp().equals(OP_REMOVE)) {
+                        gatewayAccountEntity.setNotifySettings(null);
+                    } else {
+                        throw new RuntimeException(format("Invalid Notify Settings Update operation [%s]", updateRequest.getOp()));
+                    }
+                    gatewayAccountDao.merge(gatewayAccountEntity);
+
+                    return Optional.of(gatewayAccountEntity);
+                })
+        .orElseGet(() -> Optional.empty());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/GatewayAccountRequestValidatorTest.java
@@ -10,7 +10,6 @@ import uk.gov.pay.connector.validations.RequestValidator;
 
 import java.util.Optional;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
@@ -18,7 +17,7 @@ import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_API_
 import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_NOTIFY_TEMPLATE_ID;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_OPERATION_PATH;
-import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_VALUES;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.FIELD_VALUE;
 
 public class GatewayAccountRequestValidatorTest {
 
@@ -52,7 +51,7 @@ public class GatewayAccountRequestValidatorTest {
         JsonNode jsonNode = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
                         FIELD_OPERATION_PATH, "notify_settings",
-                        FIELD_VALUES, ImmutableMap.of("timbuktu", "anapitoken",
+                        FIELD_VALUE, ImmutableMap.of("timbuktu", "anapitoken",
                                 "colombo", "atemplateid")));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
 
@@ -77,7 +76,7 @@ public class GatewayAccountRequestValidatorTest {
         JsonNode jsonNode = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
                 FIELD_OPERATION_PATH, "notify_settings",
-                FIELD_VALUES, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "anapitoken",
+                        FIELD_VALUE, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "anapitoken",
                                 FIELD_NOTIFY_TEMPLATE_ID, "atemplateid")));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
 
@@ -89,7 +88,7 @@ public class GatewayAccountRequestValidatorTest {
         JsonNode jsonNode = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(FIELD_OPERATION, "delete",
                         FIELD_OPERATION_PATH, "notify_settings",
-                        FIELD_VALUES, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "anapitoken",
+                        FIELD_VALUE, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "anapitoken",
                                 FIELD_NOTIFY_TEMPLATE_ID, "atemplateid")));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
 
@@ -103,7 +102,7 @@ public class GatewayAccountRequestValidatorTest {
         JsonNode jsonNode = new ObjectMapper()
                 .valueToTree(ImmutableMap.of(FIELD_OPERATION, "remove",
                         FIELD_OPERATION_PATH, "notify_settings",
-                        FIELD_VALUES, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "")));
+                        FIELD_VALUE, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "")));
         Optional<Errors> optionalErrors = validator.validatePatchRequest(jsonNode);
 
         assertThat(optionalErrors.isPresent(), is(false));

--- a/src/test/java/uk/gov/pay/connector/service/notify/NotifySettingsUpdateServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/notify/NotifySettingsUpdateServiceTest.java
@@ -1,0 +1,80 @@
+package uk.gov.pay.connector.service.notify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.connector.dao.GatewayAccountDao;
+import uk.gov.pay.connector.model.NotifySettingsUpdateRequest;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class NotifySettingsUpdateServiceTest {
+
+    @Mock
+    private GatewayAccountDao gatewayAccountDao;
+
+    private NotifySettingsUpdateService notifySettingsUpdateService;
+
+    @Before
+    public void setUp() throws Exception {
+        notifySettingsUpdateService = new NotifySettingsUpdateService(gatewayAccountDao);
+    }
+
+    @Test
+    public void shouldReturnOptionalOfGatewayEntity_whenSuccessfullReplace() throws Exception{
+        Long gatewayAccountId = 1l;
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+                "path", "notify_settings",
+                "value", ImmutableMap.of("api_token", "anapitoken",
+                        "template_id", "atemplateid")));
+        NotifySettingsUpdateRequest request = NotifySettingsUpdateRequest.from(payload);
+
+        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity();
+        gatewayAccountEntity.setId(gatewayAccountId);
+        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(gatewayAccountEntity));
+        Optional<GatewayAccountEntity> optionalEntity = notifySettingsUpdateService.update(gatewayAccountId, request);
+
+        assertThat(optionalEntity.isPresent(), is(true));
+        assertThat(optionalEntity.get().getNotifySettings().values(), hasItems("anapitoken", "atemplateid"));
+    }
+
+    @Test
+    public void shouldReturnOptionalOfGatewayEntity_whenSuccessfullRemove() {
+        Long gatewayAccountId = 1l;
+        Map<String, String> value = ImmutableMap.of();
+        JsonNode payload = new ObjectMapper().valueToTree(ImmutableMap.of("op", "remove",
+                "path", "notify_settings"));
+        NotifySettingsUpdateRequest request = NotifySettingsUpdateRequest.from(payload);
+
+        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity();
+        gatewayAccountEntity.setId(gatewayAccountId);
+        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(gatewayAccountEntity));
+        Optional<GatewayAccountEntity> optionalEntity = notifySettingsUpdateService.update(gatewayAccountId, request);
+
+        assertThat(optionalEntity.isPresent(), is(true));
+        assertThat(optionalEntity.get().getNotifySettings(), is(nullValue()));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void shouldThrowAnException_whenNotAllowedOperation() {
+        Long gatewayAccountId = 1l;
+        Map<String, String> value = ImmutableMap.of("api_token", "anapitoken",
+                "template_id", "atemplateid");
+        NotifySettingsUpdateRequest request = new NotifySettingsUpdateRequest("insert", "notify_settings", value);
+        notifySettingsUpdateService.update(gatewayAccountId, request);
+    }
+}


### PR DESCRIPTION
## WHAT

- add an endpoint to GatewayAccountResource that can update/delete notify_settings field in gatway_accounts

## HOW 

- create a notify settings request class
- add fields to GatewayAccount
- create GatewayAccountRequestValidator
- create a factory for GatewayAccountServices
- create a service for notify settings update
- add/update relevant tests

with @kakumara




