### PR TITLE
Pp 2778 write refunds to transactions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/RefundTransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/RefundTransactionDao.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
+import uk.gov.pay.connector.service.PaymentGatewayName;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+@Transactional
+public class RefundTransactionDao extends JpaDao<RefundTransactionEntity> {
+    @Inject
+    protected RefundTransactionDao(Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+
+    public Optional<RefundTransactionEntity> findByProviderAndReference(PaymentGatewayName provider, String reference) {
+        String query = "SELECT refund FROM RefundTransactionEntity refund " +
+                "WHERE refund.refundReference = :reference AND " +
+                "refund.paymentRequest.gatewayAccount.gatewayName = :provider";
+
+        return entityManager.get()
+                .createQuery(query, RefundTransactionEntity.class)
+                .setParameter("reference", reference)
+                .setParameter("provider", provider.getName())
+                .getResultList().stream().findFirst();
+    }
+
+    public Optional<RefundTransactionEntity> findByExternalId(String refundExternalId) {
+        String query = "SELECT t FROM RefundTransactionEntity t " +
+                "WHERE t.refundExternalId = :refundExternalId";
+
+        return entityManager.get()
+                .createQuery(query, RefundTransactionEntity.class)
+                .setParameter("refundExternalId", refundExternalId)
+                .getResultList().stream().findFirst();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEventEntity.java
@@ -1,19 +1,26 @@
 package uk.gov.pay.connector.model.domain.transaction;
 
 import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
 
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import java.time.ZonedDateTime;
 
 @Entity
 @DiscriminatorValue(value = "CHARGE")
-public class ChargeTransactionEventEntity extends TransactionEventEntity<ChargeStatus> {
+public class ChargeTransactionEventEntity extends TransactionEventEntity<ChargeStatus, ChargeTransactionEventEntity> {
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private ChargeStatus status;
+
+    @Column(name = "gateway_event_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime gatewayEventDate;
 
     @Override
     public ChargeStatus getStatus() {
@@ -23,5 +30,13 @@ public class ChargeTransactionEventEntity extends TransactionEventEntity<ChargeS
     @Override
     public void setStatus(ChargeStatus status) {
         this.status = status;
+    }
+
+    public ZonedDateTime getGatewayEventDate() {
+        return gatewayEventDate;
+    }
+
+    public void setGatewayEventDate(ZonedDateTime gatewayEventDate) {
+        this.gatewayEventDate = gatewayEventDate;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntity.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+import uk.gov.pay.connector.model.domain.RefundEntity;
+import uk.gov.pay.connector.model.domain.RefundStatus;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Entity
+@DiscriminatorValue(value = "REFUND")
+public class RefundTransactionEntity extends TransactionEntity<RefundStatus, RefundTransactionEventEntity> {
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    protected RefundStatus status;
+    @Column(name = "refund_external_id")
+    private String refundExternalId;
+    @Column(name = "user_external_id")
+    private String userExternalId;
+    @Column(name = "refund_reference")
+    private String refundReference;
+
+
+    public RefundTransactionEntity() {
+        super(TransactionOperation.REFUND);
+    }
+
+    @Override
+    public RefundStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    void setStatus(RefundStatus status) {
+        this.status = status;
+    }
+
+    public String getRefundExternalId() {
+        return refundExternalId;
+    }
+
+    public void setRefundExternalId(String refundExternalId) {
+        this.refundExternalId = refundExternalId;
+    }
+
+    public String getUserExternalId() {
+        return userExternalId;
+    }
+
+    public void setUserExternalId(String userExternalId) {
+        this.userExternalId = userExternalId;
+    }
+
+    public String getRefundReference() {
+        return refundReference;
+    }
+
+    public void setRefundReference(String refundReference) {
+        this.refundReference = refundReference;
+    }
+
+    public static RefundTransactionEntity from(RefundEntity refundEntity) {
+        RefundTransactionEntity refundTransaction = new RefundTransactionEntity();
+        refundTransaction.setAmount(refundEntity.getAmount());
+        refundTransaction.setRefundExternalId(refundEntity.getExternalId());
+        refundTransaction.setUserExternalId(refundEntity.getUserExternalId());
+        refundTransaction.updateStatus(refundEntity.getStatus());
+
+        return refundTransaction;
+    }
+
+    @Override
+    protected RefundTransactionEventEntity createNewTransactionEvent() {
+        return new RefundTransactionEventEntity();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEventEntity.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+import uk.gov.pay.connector.model.domain.RefundStatus;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Entity
+@DiscriminatorValue(value = "REFUND")
+public class RefundTransactionEventEntity extends TransactionEventEntity<RefundStatus, RefundTransactionEventEntity> {
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private RefundStatus status;
+
+    @Override
+    public RefundStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public void setStatus(RefundStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEventEntity.java
@@ -27,7 +27,7 @@ import java.time.ZonedDateTime;
 @SequenceGenerator(name = "transaction_events_id_seq",
         sequenceName = "transaction_events_id_seq",
         allocationSize = 1)
-public abstract class TransactionEventEntity<E extends Status> extends AbstractVersionedEntity {
+public abstract class TransactionEventEntity<S extends Status, T extends TransactionEventEntity<S, T>> extends AbstractVersionedEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "transaction_events_id_seq")
@@ -36,15 +36,11 @@ public abstract class TransactionEventEntity<E extends Status> extends AbstractV
 
     @ManyToOne
     @JoinColumn(name = "transaction_id", referencedColumnName = "id", updatable = false)
-    private TransactionEntity<E> transaction;
+    private TransactionEntity<S, T> transaction;
 
     @Column(name = "updated")
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime updated;
-
-    @Column(name = "gateway_event_date")
-    @Convert(converter = UTCDateTimeConverter.class)
-    private ZonedDateTime gatewayEventDate;
 
     public Long getId() {
         return id;
@@ -54,11 +50,7 @@ public abstract class TransactionEventEntity<E extends Status> extends AbstractV
         this.id = id;
     }
 
-    public TransactionEntity<E> getTransaction() {
-        return transaction;
-    }
-
-    public void setTransaction(TransactionEntity<E> transaction) {
+    public void setTransaction(TransactionEntity<S, T> transaction) {
         this.transaction = transaction;
     }
 
@@ -70,14 +62,6 @@ public abstract class TransactionEventEntity<E extends Status> extends AbstractV
         this.updated = updated;
     }
 
-    public ZonedDateTime getGatewayEventDate() {
-        return gatewayEventDate;
-    }
-
-    public void setGatewayEventDate(ZonedDateTime gatewayEventDate) {
-        this.gatewayEventDate = gatewayEventDate;
-    }
-
-    public abstract void setStatus(E status);
-    public abstract E getStatus();
+    public abstract void setStatus(S status);
+    public abstract S getStatus();
 }

--- a/src/main/java/uk/gov/pay/connector/service/CancelServiceFunctions.java
+++ b/src/main/java/uk/gov/pay/connector/service/CancelServiceFunctions.java
@@ -34,14 +34,14 @@ class CancelServiceFunctions {
 
     private static final Logger logger = LoggerFactory.getLogger(CancelServiceFunctions.class);
 
-    static TransactionalOperation<TransactionContext, ChargeEntity> changeStatusTo(ChargeDao chargeDao, ChargeEventDao chargeEventDao, String chargeId, ChargeStatus targetStatus, Optional<ZonedDateTime> generationTimeOptional, StatusUpdater statusUpdater) {
+    static TransactionalOperation<TransactionContext, ChargeEntity> changeStatusTo(ChargeDao chargeDao, ChargeEventDao chargeEventDao, String chargeId, ChargeStatus targetStatus, Optional<ZonedDateTime> generationTimeOptional, ChargeStatusUpdater chargeStatusUpdater) {
         return context -> chargeDao.findByExternalId(chargeId)
                 .map(chargeEntity -> {
                     logger.info("Charge status to update - charge_external_id={}, status={}, to_status={}",
                             chargeEntity.getExternalId(), chargeEntity.getStatus(), targetStatus);
                     chargeEntity.setStatus(targetStatus);
                     chargeEventDao.persistChargeEventOf(chargeEntity, generationTimeOptional);
-                    statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), targetStatus, generationTimeOptional.orElse(null));
+                    chargeStatusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), targetStatus, generationTimeOptional.orElse(null));
 
                     return chargeEntity;
                 })
@@ -52,7 +52,7 @@ class CancelServiceFunctions {
                                                                                            ChargeEventDao chargeEventDao,
                                                                                            String chargeId,
                                                                                            StatusFlow statusFlow,
-                                                                                           StatusUpdater statusUpdater) {
+                                                                                           ChargeStatusUpdater chargeStatusUpdater) {
         return context -> chargeDao.findByExternalId(chargeId).map(chargeEntity -> {
             ChargeStatus newStatus = statusFlow.getLockState();
             if (!chargeEntity.hasStatus(statusFlow.getTerminatableStatuses())) {
@@ -68,7 +68,7 @@ class CancelServiceFunctions {
                 throw new IllegalStateRuntimeException(chargeId);
             }
             chargeEntity.setStatus(newStatus);
-            statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), newStatus);
+            chargeStatusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), newStatus);
             GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
 
             logger.info("Card cancel request sent - charge_external_id={}, charge_status={}, account_id={}, transaction_id={}, amount={}, operation_type={}, provider={}, provider_type={}, locking_status={}",

--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -31,8 +31,8 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
                                       ChargeEventDao chargeEventDao,
                                       PaymentProviders providers,
                                       CardExecutorService cardExecutorService,
-                                      Environment environment, PaymentRequestDao paymentRequestDao, StatusUpdater statusUpdater) {
-        super(chargeDao, chargeEventDao, providers, cardExecutorService, environment, statusUpdater);
+                                      Environment environment, PaymentRequestDao paymentRequestDao, ChargeStatusUpdater chargeStatusUpdater) {
+        super(chargeDao, chargeEventDao, providers, cardExecutorService, environment, chargeStatusUpdater);
         this.paymentRequestDao = paymentRequestDao;
     }
 
@@ -72,7 +72,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
             metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.authorise-3ds.result.%s", account.getGatewayName(), account.getType(), account.getId(), status.toString())).inc();
 
             chargeEntity.setStatus(status);
-            statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), status);
+            chargeStatusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), status);
             Optional<PaymentRequestEntity> paymentRequestEntity = paymentRequestDao.findByExternalId(chargeEntity.getExternalId());
 
             if (StringUtils.isBlank(transactionId)) {

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
-import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.exception.OperationAlreadyInProgressRuntimeException;
@@ -29,8 +28,8 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
 
     private final CardExecutorService cardExecutorService;
 
-    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment, StatusUpdater statusUpdater) {
-        super(chargeDao, chargeEventDao, providers, environment, statusUpdater);
+    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, CardExecutorService cardExecutorService, Environment environment, ChargeStatusUpdater chargeStatusUpdater) {
+        super(chargeDao, chargeEventDao, providers, environment, chargeStatusUpdater);
         this.cardExecutorService = cardExecutorService;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/CardService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardService.java
@@ -24,7 +24,7 @@ public abstract class CardService<T extends BaseResponse> {
     private final PaymentProviders providers;
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected MetricRegistry metricRegistry;
-    protected final StatusUpdater statusUpdater;
+    protected final ChargeStatusUpdater chargeStatusUpdater;
 
     public enum OperationType {
         CAPTURE("Capture"),
@@ -43,12 +43,12 @@ public abstract class CardService<T extends BaseResponse> {
         }
     }
 
-    protected CardService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, Environment environment, StatusUpdater statusUpdater) {
+    protected CardService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, PaymentProviders providers, Environment environment, ChargeStatusUpdater chargeStatusUpdater) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.providers = providers;
         this.metricRegistry = environment.metrics();
-        this.statusUpdater = statusUpdater;
+        this.chargeStatusUpdater = chargeStatusUpdater;
     }
 
     public ChargeEntity preOperation(ChargeEntity chargeEntity, OperationType operationType, List<ChargeStatus> legalStatuses, ChargeStatus lockingStatus) {
@@ -79,7 +79,7 @@ public abstract class CardService<T extends BaseResponse> {
         }
 
         chargeEntity.setStatus(lockingStatus);
-        statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), lockingStatus);
+        chargeStatusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), lockingStatus);
         return chargeEntity;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeRefundService.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.service;
 
 import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.dao.RefundDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.exception.RefundException;
@@ -12,8 +14,10 @@ import uk.gov.pay.connector.model.RefundRequest;
 import uk.gov.pay.connector.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
 import uk.gov.pay.connector.model.domain.RefundEntity;
 import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
 import uk.gov.pay.connector.service.transaction.NonTransactionalOperation;
 import uk.gov.pay.connector.service.transaction.PreTransactionalOperation;
@@ -27,6 +31,7 @@ import java.util.Optional;
 import static uk.gov.pay.connector.exception.RefundException.ErrorCode.NOT_SUFFICIENT_AMOUNT_AVAILABLE;
 import static uk.gov.pay.connector.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.fromString;
+import static uk.gov.pay.connector.model.domain.RefundStatus.REFUNDED;
 
 public class ChargeRefundService {
 
@@ -53,16 +58,21 @@ public class ChargeRefundService {
 
     private final ChargeDao chargeDao;
     private final RefundDao refundDao;
+    private final PaymentRequestDao paymentRequestDao;
     private final PaymentProviders providers;
     private final Provider<TransactionFlow> transactionFlowProvider;
+    private final RefundStatusUpdater refundStatusUpdater;
 
     @Inject
     public ChargeRefundService(ChargeDao chargeDao, RefundDao refundDao, PaymentProviders providers,
-                               Provider<TransactionFlow> transactionFlowProvider) {
+                               Provider<TransactionFlow> transactionFlowProvider, PaymentRequestDao paymentRequestDao,
+                               RefundStatusUpdater refundStatusUpdater) {
         this.chargeDao = chargeDao;
         this.refundDao = refundDao;
         this.providers = providers;
         this.transactionFlowProvider = transactionFlowProvider;
+        this.paymentRequestDao = paymentRequestDao;
+        this.refundStatusUpdater = refundStatusUpdater;
     }
 
     public Optional<Response> doRefund(Long accountId, String chargeId, RefundRequest refundRequest) {
@@ -82,7 +92,8 @@ public class ChargeRefundService {
             if (refund.getChargeEntity().getPaymentGatewayName() == PaymentGatewayName.SANDBOX
                     && refund.hasStatus(RefundStatus.REFUND_SUBMITTED)) {
                 RefundEntity refundEntity = refundDao.findById(refund.getId()).get();
-                refundEntity.setStatus(RefundStatus.REFUNDED);
+                refundEntity.setStatus(REFUNDED);
+                refundStatusUpdater.updateRefundTransactionStatus(PaymentGatewayName.SANDBOX, refund.getReference(), REFUNDED);
                 response = new Response(response.getRefundGatewayResponse(), refundEntity);
             }
             return response;
@@ -145,14 +156,21 @@ public class ChargeRefundService {
 
             refundEntity.setStatus(status);
             refundEntity.setReference(reference);
+            refundStatusUpdater.setReferenceAndUpdateTransactionStatus(refundEntity.getExternalId(), reference, status);
+
             return new Response(gatewayResponse, refundEntity);
         };
     }
 
+    @Transactional
     private RefundEntity completePrepareRefund(RefundRequest refundRequest, ChargeEntity charge) {
         RefundEntity refundEntity = new RefundEntity(charge, refundRequest.getAmount(), refundRequest.getUserExternalId());
         charge.getRefunds().add(refundEntity);
         refundDao.persist(refundEntity);
+
+        Optional<PaymentRequestEntity> paymentRequestOptional = paymentRequestDao.findByExternalId(charge.getExternalId());
+        paymentRequestOptional.ifPresent(paymentRequest -> paymentRequest.addTransaction(RefundTransactionEntity.from(refundEntity)));
+
         return refundEntity;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/ChargeStatusUpdater.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeStatusUpdater.java
@@ -12,13 +12,13 @@ import java.time.ZonedDateTime;
 import java.util.function.Consumer;
 
 @Transactional
-public class StatusUpdater {
-    private static final Logger logger = LoggerFactory.getLogger(StatusUpdater.class);
+public class ChargeStatusUpdater {
+    private static final Logger logger = LoggerFactory.getLogger(ChargeStatusUpdater.class);
 
     private final PaymentRequestDao paymentRequestDao;
 
     @Inject
-    public StatusUpdater(PaymentRequestDao paymentRequestDao) {
+    public ChargeStatusUpdater(PaymentRequestDao paymentRequestDao) {
         this.paymentRequestDao = paymentRequestDao;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/NotificationService.java
@@ -8,8 +8,16 @@ import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.dao.RefundDao;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
-import uk.gov.pay.connector.model.*;
-import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.EvaluatedChargeStatusNotification;
+import uk.gov.pay.connector.model.EvaluatedNotification;
+import uk.gov.pay.connector.model.EvaluatedRefundStatusNotification;
+import uk.gov.pay.connector.model.Notification;
+import uk.gov.pay.connector.model.Notifications;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.RefundEntity;
+import uk.gov.pay.connector.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.DnsUtils;
 
 import javax.inject.Inject;
@@ -28,17 +36,17 @@ public class NotificationService {
     private final RefundDao refundDao;
     private final PaymentProviders paymentProviders;
     private final DnsUtils dnsUtils;
-    private final StatusUpdater statusUpdater;
+    private final ChargeStatusUpdater chargeStatusUpdater;
     private final RefundStatusUpdater refundStatusUpdater;
 
     @Inject
-    public NotificationService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils, StatusUpdater statusUpdater, RefundStatusUpdater refundStatusUpdater) {
+    public NotificationService(ChargeDao chargeDao, ChargeEventDao chargeEventDao, RefundDao refundDao, PaymentProviders paymentProviders, DnsUtils dnsUtils, ChargeStatusUpdater chargeStatusUpdater, RefundStatusUpdater refundStatusUpdater) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.refundDao = refundDao;
         this.paymentProviders = paymentProviders;
         this.dnsUtils = dnsUtils;
-        this.statusUpdater = statusUpdater;
+        this.chargeStatusUpdater = chargeStatusUpdater;
         this.refundStatusUpdater = refundStatusUpdater;
     }
 
@@ -210,7 +218,7 @@ public class NotificationService {
                     gatewayAccount.getType());
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
-            statusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), newStatus, notification.getGatewayEventDate());
+            chargeStatusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), newStatus, notification.getGatewayEventDate());
         }
 
         private <T> void updateRefundStatus(EvaluatedRefundStatusNotification<T> notification) {

--- a/src/main/java/uk/gov/pay/connector/service/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/PaymentProvider.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public interface PaymentProvider<T extends BaseResponse, R> {
 
-    String getPaymentGatewayName();
+    PaymentGatewayName getPaymentGatewayName();
 
     StatusMapper getStatusMapper();
 

--- a/src/main/java/uk/gov/pay/connector/service/RefundStatusUpdater.java
+++ b/src/main/java/uk/gov/pay/connector/service/RefundStatusUpdater.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.connector.service;
+
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.dao.RefundTransactionDao;
+import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+@Transactional
+public class RefundStatusUpdater {
+    private static final Logger logger = LoggerFactory.getLogger(RefundStatusUpdater.class);
+
+    private final RefundTransactionDao refundTransactionDao;
+
+    @Inject
+    public RefundStatusUpdater(RefundTransactionDao refundTransactionDao) {
+        this.refundTransactionDao = refundTransactionDao;
+    }
+
+    public void updateRefundTransactionStatus(PaymentGatewayName provider, String refundReference, RefundStatus newRefundStatus) {
+        Optional<RefundTransactionEntity> refundTransaction = refundTransactionDao.findByProviderAndReference(provider, refundReference);
+        if (refundTransaction.isPresent()) {
+            updateRefundTransactionStatus(newRefundStatus, refundTransaction.get());
+        } else {
+            logger.warn(format("Not updating refund transaction status for refundReference [%s] to [%s] refund transaction not found",
+                    refundReference,
+                    newRefundStatus.getValue()
+            ));
+        }
+    }
+
+    public void setReferenceAndUpdateTransactionStatus(String refundExternalId, String refundReference, RefundStatus newRefundStatus) {
+        Optional<RefundTransactionEntity> refundTransactionOptional = refundTransactionDao.findByExternalId(refundExternalId);
+        if (refundTransactionOptional.isPresent()) {
+            RefundTransactionEntity refundTransaction = refundTransactionOptional.get();
+            refundTransaction.setRefundReference(refundReference);
+            updateRefundTransactionStatus(newRefundStatus, refundTransaction);
+        } else {
+            logger.warn(format("Not updating refund transaction status for externalId [%s] to [%s] refund transaction not found",
+                        refundExternalId,
+                        newRefundStatus.getValue()
+                ));
+        }
+    }
+
+    private void updateRefundTransactionStatus(RefundStatus newRefundStatus, RefundTransactionEntity refundTransaction) {
+        logger.info("Changing refund transaction status for refundReference [{}] transactionId [{}] [{}]->[{}]",
+                refundTransaction.getRefundReference(),
+                refundTransaction.getRefundExternalId(),
+                refundTransaction.getStatus().getValue(),
+                newRefundStatus.getValue()
+        );
+
+        refundTransaction.updateStatus(newRefundStatus);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/service/StatusUpdater.java
+++ b/src/main/java/uk/gov/pay/connector/service/StatusUpdater.java
@@ -22,14 +22,14 @@ public class StatusUpdater {
         this.paymentRequestDao = paymentRequestDao;
     }
 
-    public  void updateChargeTransactionStatus(String externalId, ChargeStatus newChargeStatus, ZonedDateTime gatewayEventTime) {
+    public void updateChargeTransactionStatus(String externalId, ChargeStatus newChargeStatus, ZonedDateTime gatewayEventTime) {
         updateChargeTransactionStatus(
                 externalId, newChargeStatus,
                 (chargeTransaction) -> chargeTransaction.updateStatus(newChargeStatus, gatewayEventTime)
         );
     }
 
-    public  void updateChargeTransactionStatus(String externalId, ChargeStatus newChargeStatus) {
+    public void updateChargeTransactionStatus(String externalId, ChargeStatus newChargeStatus) {
         updateChargeTransactionStatus(
                 externalId, newChargeStatus,
                 (chargeTransaction) -> chargeTransaction.updateStatus(newChargeStatus)
@@ -40,19 +40,17 @@ public class StatusUpdater {
         paymentRequestDao.findByExternalId(externalId).ifPresent(paymentRequestEntity -> {
             if (paymentRequestEntity.hasChargeTransaction()) {
                 ChargeTransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
-                logger.info(String.format("Changing transaction status for externalId [%s] transactionId [%s] [%s]->[%s]",
+                logger.info("Changing transaction status for externalId [{}] transactionId [{}] [{}]->[{}]",
                         externalId,
-                        chargeTransaction.getId(),
+                        chargeTransaction.getGatewayTransactionId(),
                         chargeTransaction.getStatus().getValue(),
-                        newChargeStatus.getValue())
+                        newChargeStatus.getValue()
                 );
                 updateStatusFunction.accept(chargeTransaction);
             } else {
-                logger.info(
-                        String.format("Not updating transaction status for externalId [%s] to [%s] charge transaction not found",
-                                externalId,
-                                newChargeStatus.getValue()
-                        )
+                logger.info("Not updating transaction status for externalId [{}] to [{}] charge transaction not found",
+                        externalId,
+                        newChargeStatus.getValue()
                 );
             }
         });

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
@@ -60,8 +60,8 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
     }
 
     @Override
-    public String getPaymentGatewayName() {
-        return PaymentGatewayName.EPDQ.getName();
+    public PaymentGatewayName getPaymentGatewayName() {
+        return PaymentGatewayName.EPDQ;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProvider.java
@@ -70,8 +70,8 @@ public class SandboxPaymentProvider extends BasePaymentProvider<BaseResponse, St
     }
 
     @Override
-    public String getPaymentGatewayName() {
-        return PaymentGatewayName.SANDBOX.getName();
+    public PaymentGatewayName getPaymentGatewayName() {
+        return PaymentGatewayName.SANDBOX;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProvider.java
@@ -52,8 +52,8 @@ public class SmartpayPaymentProvider extends BasePaymentProvider<BaseResponse, P
     }
 
     @Override
-    public String getPaymentGatewayName() {
-        return PaymentGatewayName.SMARTPAY.getName();
+    public PaymentGatewayName getPaymentGatewayName() {
+        return PaymentGatewayName.SMARTPAY;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProvider.java
@@ -51,8 +51,8 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
     }
 
     @Override
-    public String getPaymentGatewayName() {
-        return PaymentGatewayName.WORLDPAY.getName();
+    public PaymentGatewayName getPaymentGatewayName() {
+        return PaymentGatewayName.WORLDPAY;
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
@@ -5,12 +5,15 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
-import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
 import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
-import uk.gov.pay.connector.service.StatusUpdater;
+import uk.gov.pay.connector.service.ChargeStatusUpdater;
 
 import java.util.HashMap;
 import java.util.Optional;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -21,7 +24,7 @@ import static uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEnt
 public class PaymentRequestDaoITest extends DaoITestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private PaymentRequestDao paymentRequestDao;
-    private StatusUpdater statusUpdater;
+    private ChargeStatusUpdater chargeStatusUpdater;
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
     private GatewayAccountEntity gatewayAccount;
@@ -30,7 +33,7 @@ public class PaymentRequestDaoITest extends DaoITestBase {
     @Before
     public void setUp() throws Exception {
         paymentRequestDao = env.getInstance(PaymentRequestDao.class);
-        statusUpdater = env.getInstance(StatusUpdater.class);
+        chargeStatusUpdater = env.getInstance(ChargeStatusUpdater.class);
         insertTestAccount();
 
         gatewayAccount = new GatewayAccountEntity(
@@ -62,7 +65,7 @@ public class PaymentRequestDaoITest extends DaoITestBase {
 
         paymentRequestDao.persist(paymentRequestEntity);
 
-        statusUpdater.updateChargeTransactionStatus(paymentRequestEntity.getExternalId(), ChargeStatus.ENTERING_CARD_DETAILS);
+        chargeStatusUpdater.updateChargeTransactionStatus(paymentRequestEntity.getExternalId(), ChargeStatus.ENTERING_CARD_DETAILS);
         final Optional<PaymentRequestEntity> byExternalId =
                 paymentRequestDao.findByExternalId(paymentRequestEntity.getExternalId());
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/PaymentRequestDaoITest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture.aValidPaymentRequestEntity;
-import static uk.gov.pay.connector.model.domain.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
+import static uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
 
 public class PaymentRequestDaoITest extends DaoITestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundTransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundTransactionDaoITest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.connector.it.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.dao.RefundTransactionDao;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
+import uk.gov.pay.connector.service.PaymentGatewayName;
+
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture.aValidPaymentRequestEntity;
+import static uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
+import static uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntityBuilder.aRefundTransactionEntity;
+
+public class RefundTransactionDaoITest extends DaoITestBase {
+
+    private PaymentRequestDao paymentRequestDao;
+    private RefundTransactionDao refundTransactionDao;
+    private GatewayAccountEntity gatewayAccount;
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
+    @Before
+    public void setUp() throws Exception {
+        paymentRequestDao = env.getInstance(PaymentRequestDao.class);
+        refundTransactionDao = env.getInstance(RefundTransactionDao.class);
+
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+
+        gatewayAccount = new GatewayAccountEntity(defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+    }
+
+    @Test
+    public void canFindRefundByProviderAndReference() throws Exception {
+        String refundReference = UUID.randomUUID().toString();
+        RefundTransactionEntity refundTransactionEntity = aRefundTransactionEntity()
+                .withRefundReference(refundReference)
+                .build();
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withTransactions(aChargeTransactionEntity().build(), refundTransactionEntity)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        PaymentGatewayName provider = PaymentGatewayName.valueFrom(gatewayAccount.getGatewayName());
+        Optional<RefundTransactionEntity> loadedRefundTransactionEntityOptional =
+                refundTransactionDao.findByProviderAndReference(provider, refundReference);
+
+        assertThat(loadedRefundTransactionEntityOptional.isPresent(), is(true));
+        assertThat(loadedRefundTransactionEntityOptional.get().getRefundReference(), is(refundReference));
+    }
+
+    @Test
+    public void cannotFindRefundThatDoesNotExist() throws Exception {
+        String refundReferenceThatDoesNotExist = "doesNotExist";
+        PaymentGatewayName provider = PaymentGatewayName.valueFrom(gatewayAccount.getGatewayName());
+        Optional<RefundTransactionEntity> loadedRefundTransactionEntityOptional =
+                refundTransactionDao
+                        .findByProviderAndReference(provider, refundReferenceThatDoesNotExist);
+
+        assertThat(loadedRefundTransactionEntityOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void cannotFindRefundWithRefundReferenceButIncorrectGatewayAccount() throws Exception {
+        String refundReference = UUID.randomUUID().toString();
+        RefundTransactionEntity refundTransactionEntity = aRefundTransactionEntity()
+                .withRefundReference(refundReference)
+                .build();
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withTransactions(aChargeTransactionEntity().build(), refundTransactionEntity)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        Optional<RefundTransactionEntity> loadedRefundTransactionEntityOptional =
+                refundTransactionDao.findByProviderAndReference(PaymentGatewayName.WORLDPAY, refundReference);
+
+        assertThat(loadedRefundTransactionEntityOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void canFindRefundByExternalReference() throws Exception {
+        String refundExternalId = UUID.randomUUID().toString().substring(0, 10);
+        RefundTransactionEntity refundTransactionEntity = aRefundTransactionEntity()
+                .withRefundExternalId(refundExternalId)
+                .build();
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withTransactions(aChargeTransactionEntity().build(), refundTransactionEntity)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        Optional<RefundTransactionEntity> loadedRefundTransaction = refundTransactionDao.findByExternalId(refundExternalId);
+
+        assertThat(loadedRefundTransaction.isPresent(), is(true));
+        assertThat(loadedRefundTransaction.get().getRefundExternalId(), is(refundExternalId));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
@@ -10,6 +10,8 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.defaultGatewayAccountEntity;
+import static uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
+import static uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntityBuilder.aRefundTransactionEntity;
 
 public class PaymentRequestEntityFixture {
 
@@ -20,10 +22,15 @@ public class PaymentRequestEntityFixture {
     private String reference = "This is a reference";
     private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
-    private List<TransactionEntity> transactions = asList(ChargeTransactionEntityBuilder.aChargeTransactionEntity().build());
+    private List<TransactionEntity> transactions = asList(aChargeTransactionEntity().build());
 
     public static PaymentRequestEntityFixture aValidPaymentRequestEntity() {
         return new PaymentRequestEntityFixture();
+    }
+
+    public static PaymentRequestEntityFixture aValidPaymentRequestEntityWithRefund() {
+        return PaymentRequestEntityFixture.aValidPaymentRequestEntity()
+                .withTransactions(aChargeTransactionEntity().build(), aRefundTransactionEntity().build());
     }
 
     public PaymentRequestEntity build() {

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
@@ -3,12 +3,12 @@ package uk.gov.pay.connector.model.domain;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
-import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
 
-import static org.hamcrest.core.Is.is;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.gov.pay.connector.model.domain.transaction.TransactionOperation.CHARGE;
+import static org.hamcrest.core.Is.is;
 
 public class PaymentRequestEntityTest {
 
@@ -18,7 +18,6 @@ public class PaymentRequestEntityTest {
     @Before
     public void setUp() throws Exception {
         expectedChargeTransaction = new ChargeTransactionEntity();
-        expectedChargeTransaction.setOperation(CHARGE);
 
         paymentRequestEntity = new PaymentRequestEntity();
         paymentRequestEntity.addTransaction(expectedChargeTransaction);
@@ -36,12 +35,47 @@ public class PaymentRequestEntityTest {
     }
 
     @Test
-    public void shouldReturnChargeTransactionWhenThereIsManyTransactions() throws Exception {
-        ChargeTransactionEntity refundTransaction = new ChargeTransactionEntity();
-        refundTransaction.setOperation(TransactionOperation.REFUND);
+    public void shouldReturnChargeTransactionWhenThereAreChargeAndRefundTransactions() throws Exception {
+        RefundTransactionEntity refundTransaction = new RefundTransactionEntity();
         paymentRequestEntity.addTransaction(refundTransaction);
 
         ChargeTransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
         assertThat(chargeTransaction, is(expectedChargeTransaction));
+    }
+
+    @Test
+    public void shouldNotReturnRefundTransactionWhenThereIsOnlyAChargeTransaction() throws Exception {
+        List<RefundTransactionEntity> refundTransactions = paymentRequestEntity.getRefundTransactions();
+        assertThat(refundTransactions.isEmpty(), is(true));
+    }
+
+    @Test
+    public void shouldReturnRefundTransactionWhenThereAreChargeAndRefundTransactions() throws Exception {
+        RefundTransactionEntity refundTransaction = new RefundTransactionEntity();
+        String refundExternalId = "someRefundExternalId";
+        refundTransaction.setRefundExternalId(refundExternalId);
+        paymentRequestEntity.addTransaction(refundTransaction);
+
+        List<RefundTransactionEntity> refundTransactions = paymentRequestEntity.getRefundTransactions();
+        assertThat(refundTransactions.size(), is(1));
+        assertThat(refundTransactions.get(0).getRefundExternalId(), is(refundExternalId));
+
+    }
+
+    @Test
+    public void shouldReturnAllRefundTransactionWhenThereAreMutlipleRefundTransactions() throws Exception {
+        RefundTransactionEntity refundTransaction = new RefundTransactionEntity();
+        String refundReference = "someRefundReference";
+        refundTransaction.setRefundExternalId(refundReference);
+        paymentRequestEntity.addTransaction(refundTransaction);
+        RefundTransactionEntity anotherRefundTransaction = new RefundTransactionEntity();
+        String anotherRefundReference = "anotherRefundReference";
+        anotherRefundTransaction.setRefundExternalId(anotherRefundReference);
+        paymentRequestEntity.addTransaction(anotherRefundTransaction);
+
+        List<RefundTransactionEntity> refundTransactions = paymentRequestEntity.getRefundTransactions();
+        assertThat(refundTransactions.size(), is(2));
+        assertThat(refundTransactions.get(0).getRefundExternalId(), is(refundReference));
+        assertThat(refundTransactions.get(1).getRefundExternalId(), is(anotherRefundReference));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -10,6 +10,8 @@ public class RefundEntityFixture {
     private ChargeEntity charge;
     private String reference = "reference";
     public static String userExternalId = "AA213FD51B3801043FBC";
+    private String externalId = "someExternalId";
+
     public static RefundEntityFixture aValidRefundEntity() {
         return new RefundEntityFixture();
     }
@@ -19,6 +21,7 @@ public class RefundEntityFixture {
         RefundEntity refundEntity = new RefundEntity(chargeEntity, amount, userExternalId);
         refundEntity.setStatus(status);
         refundEntity.setReference(reference);
+        refundEntity.setExternalId(externalId);
         return refundEntity;
     }
 
@@ -52,6 +55,11 @@ public class RefundEntityFixture {
 
     public RefundEntityFixture withCharge(ChargeEntity charge) {
         this.charge = charge;
+        return this;
+    }
+
+    public RefundEntityFixture withExternalId(String externalId) {
+        this.externalId = externalId;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntityBuilder.java
@@ -1,13 +1,11 @@
-package uk.gov.pay.connector.model.domain;
+package uk.gov.pay.connector.model.domain.transaction;
 
-import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
-import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
 
 public final class ChargeTransactionEntityBuilder {
     private String gatewayTransactionId = "someGatewayTransactionId";
     private Long amount = 1234L;
     private ChargeStatus status = ChargeStatus.CREATED;
-    private TransactionOperation operation = TransactionOperation.CHARGE;
 
     private ChargeTransactionEntityBuilder() {
     }
@@ -31,17 +29,11 @@ public final class ChargeTransactionEntityBuilder {
         return this;
     }
 
-    public ChargeTransactionEntityBuilder withOperation(TransactionOperation operation) {
-        this.operation = operation;
-        return this;
-    }
-
     public ChargeTransactionEntity build() {
         ChargeTransactionEntity transactionEntity = new ChargeTransactionEntity();
         transactionEntity.setGatewayTransactionId(gatewayTransactionId);
         transactionEntity.setAmount(amount);
         transactionEntity.updateStatus(status);
-        transactionEntity.setOperation(operation);
         return transactionEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntityTest.java
@@ -18,7 +18,7 @@ public class ChargeTransactionEntityTest {
         assertThat(chargeTransactionEntity.getTransactionEvents().size(), is(0));
         chargeTransactionEntity.updateStatus(expectedStatus);
 
-        List<TransactionEventEntity> transactionEvents = chargeTransactionEntity.getTransactionEvents();
+        List<ChargeTransactionEventEntity> transactionEvents = chargeTransactionEntity.getTransactionEvents();
         assertThat(transactionEvents.size(), is(1));
         assertThat(transactionEvents.get(0).getStatus(), is(expectedStatus));
     }
@@ -32,7 +32,7 @@ public class ChargeTransactionEntityTest {
         ChargeStatus expectedStatus2 = ChargeStatus.ENTERING_CARD_DETAILS;
         chargeTransactionEntity.updateStatus(expectedStatus2);
 
-        List<TransactionEventEntity> transactionEvents = chargeTransactionEntity.getTransactionEvents();
+        List<ChargeTransactionEventEntity> transactionEvents = chargeTransactionEntity.getTransactionEvents();
         assertThat(transactionEvents.size(), is(2));
         assertThat(transactionEvents.get(0).getStatus(), is(expectedStatus1));
         assertThat(transactionEvents.get(1).getStatus(), is(expectedStatus2));
@@ -46,10 +46,9 @@ public class ChargeTransactionEntityTest {
         ZonedDateTime gatewayEventTime = ZonedDateTime.now();
         chargeTransactionEntity.updateStatus(expectedStatus, gatewayEventTime);
 
-        List<TransactionEventEntity> transactionEvents = chargeTransactionEntity.getTransactionEvents();
+        List<ChargeTransactionEventEntity> transactionEvents = chargeTransactionEntity.getTransactionEvents();
         assertThat(transactionEvents.size(), is(1));
         assertThat(transactionEvents.get(0).getStatus(), is(expectedStatus));
         assertThat(transactionEvents.get(0).getGatewayEventDate(), is(gatewayEventTime));
-
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntityBuilder.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+import uk.gov.pay.connector.model.domain.RefundStatus;
+
+public final class RefundTransactionEntityBuilder {
+    protected RefundStatus status = RefundStatus.CREATED;
+    private String refundExternalId = "someRefundExternalId";
+    private String userExternalId = "someUserExternalId";
+    private Long amount = 123L;
+    private String refundReference = "someRefundReference";
+
+    private RefundTransactionEntityBuilder() {
+    }
+
+    public static RefundTransactionEntityBuilder aRefundTransactionEntityBuilder() {
+        return new RefundTransactionEntityBuilder();
+    }
+
+    public static RefundTransactionEntityBuilder aRefundTransactionEntity() {
+        return new RefundTransactionEntityBuilder();
+    }
+
+    public RefundTransactionEntityBuilder withStatus(RefundStatus status) {
+        this.status = status;
+        return this;
+    }
+
+    public RefundTransactionEntityBuilder withRefundExternalId(String refundExternalId) {
+        this.refundExternalId = refundExternalId;
+        return this;
+    }
+
+    public RefundTransactionEntityBuilder withUserExternalId(String userExternalId) {
+        this.userExternalId = userExternalId;
+        return this;
+    }
+
+    public RefundTransactionEntityBuilder withAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public RefundTransactionEntityBuilder withRefundReference(String refundReference) {
+        this.refundReference = refundReference;
+        return this;
+    }
+
+    public RefundTransactionEntity build() {
+        RefundTransactionEntity refundTransactionEntity = new RefundTransactionEntity();
+        refundTransactionEntity.setStatus(status);
+        refundTransactionEntity.setRefundExternalId(refundExternalId);
+        refundTransactionEntity.setUserExternalId(userExternalId);
+        refundTransactionEntity.setAmount(amount);
+        refundTransactionEntity.setRefundReference(refundReference);
+        return refundTransactionEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntityTest.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.connector.model.domain.transaction;
+
+import org.junit.Test;
+import uk.gov.pay.connector.model.domain.RefundEntity;
+import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.model.domain.RefundStatus;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class RefundTransactionEntityTest {
+    @Test
+    public void createsARefundTransactionEntityFromRefundEntity() throws Exception {
+        long amount = 123L;
+        String externalId = "someExternalId";
+        String refundReference = "refundReference";
+        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
+                .withAmount(amount)
+                .withExternalId(externalId)
+                .withStatus(RefundStatus.REFUND_ERROR)
+                .withReference(refundReference)
+                .build();
+
+        RefundTransactionEntity transactionEntity = RefundTransactionEntity.from(refundEntity);
+
+        assertThat(transactionEntity.getAmount(), is(amount));
+        assertThat(transactionEntity.getRefundExternalId(), is(externalId));
+        assertThat(transactionEntity.getUserExternalId(), is(RefundEntityFixture.userExternalId));
+        assertThat(transactionEntity.getStatus(), is(RefundStatus.REFUND_ERROR));
+    }
+
+    @Test
+    public void setStatusAddsTransactionEvent() throws Exception {
+        RefundTransactionEntity refundTransactionEntity = new RefundTransactionEntity();
+        RefundStatus expectedStatus = RefundStatus.CREATED;
+
+        assertThat(refundTransactionEntity.getTransactionEvents().size(), is(0));
+        refundTransactionEntity.updateStatus(expectedStatus);
+
+        List<RefundTransactionEventEntity> transactionEvents = refundTransactionEntity.getTransactionEvents();
+        assertThat(transactionEvents.size(), is(1));
+        assertThat(transactionEvents.get(0).getStatus(), is(expectedStatus));
+    }
+
+    @Test
+    public void setMultipleStatusesAddsMultipleTransactionEvent() throws Exception {
+        RefundTransactionEntity refundTransactionEntity = new RefundTransactionEntity();
+
+        RefundStatus expectedStatus1 = RefundStatus.CREATED;
+        refundTransactionEntity.updateStatus(expectedStatus1);
+        RefundStatus expectedStatus2 = RefundStatus.REFUND_SUBMITTED;
+        refundTransactionEntity.updateStatus(expectedStatus2);
+
+        List<RefundTransactionEventEntity> transactionEvents = refundTransactionEntity.getTransactionEvents();
+        assertThat(transactionEvents.size(), is(2));
+        assertThat(transactionEvents.get(0).getStatus(), is(expectedStatus1));
+        assertThat(transactionEvents.get(1).getStatus(), is(expectedStatus2));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardServiceTest.java
@@ -5,7 +5,11 @@ import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
-import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.CardDetailsEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 
 import static org.mockito.Mockito.mock;
 
@@ -18,7 +22,7 @@ public abstract class CardServiceTest {
     protected ChargeEventDao mockedChargeEventDao = mock(ChargeEventDao.class);
     protected CardTypeDao mockedCardTypeDao = mock(CardTypeDao.class);
     protected PaymentRequestDao mockPaymentRequestDao = mock(PaymentRequestDao.class);
-    protected StatusUpdater mockStatusUpdater = mock(StatusUpdater.class);
+    protected ChargeStatusUpdater mockChargeStatusUpdater = mock(ChargeStatusUpdater.class);
 
     protected ChargeEntity createNewChargeWith(Long chargeId, ChargeStatus status) {
         ChargeEntity entity = ChargeEntityFixture

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -37,7 +37,14 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
@@ -69,7 +76,7 @@ public class ChargeRefundServiceTest {
     @Mock
     private PaymentRequestDao mockPaymentRequestDao;
     @Mock
-    private StatusUpdater mockStatusUpdater;
+    private ChargeStatusUpdater mockChargeStatusUpdater;
     @Mock
     private RefundStatusUpdater mockRefundStatusUpdater;
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeStatusUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeStatusUpdaterTest.java
@@ -29,7 +29,7 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAI
 import static uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
 
 @RunWith(MockitoJUnitRunner.class)
-public class StatusUpdaterTest {
+public class ChargeStatusUpdaterTest {
     private static final String SOME_EXTERNAL_ID = "someExternalId";
     @Mock
     private PaymentRequestDao mockPaymentRequestDao;
@@ -42,7 +42,7 @@ public class StatusUpdaterTest {
         when(mockPaymentRequestDao.findByExternalId(SOME_EXTERNAL_ID)).thenReturn(Optional.of(paymentRequest));
 
         ChargeStatus newChargeStatus = ENTERING_CARD_DETAILS;
-        new StatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, newChargeStatus);
+        new ChargeStatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, newChargeStatus);
 
         assertThat(paymentRequest.getChargeTransaction().getStatus(), is(newChargeStatus));
     }
@@ -53,7 +53,7 @@ public class StatusUpdaterTest {
         when(mockPaymentRequestDao.findByExternalId(SOME_EXTERNAL_ID)).thenReturn(Optional.of(paymentRequest));
         when(paymentRequest.hasChargeTransaction()).thenReturn(false);
 
-        new StatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, ENTERING_CARD_DETAILS);
+        new ChargeStatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, ENTERING_CARD_DETAILS);
 
         verify(paymentRequest).hasChargeTransaction();
         verifyNoMoreInteractions(paymentRequest);
@@ -70,7 +70,7 @@ public class StatusUpdaterTest {
 
         ChargeStatus newChargeStatus = ENTERING_CARD_DETAILS;
         ZonedDateTime gatewayEventTime = ZonedDateTime.now();
-        new StatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, newChargeStatus, gatewayEventTime);
+        new ChargeStatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, newChargeStatus, gatewayEventTime);
 
         verify(chargeTransaction).updateStatus(newChargeStatus, gatewayEventTime);
     }
@@ -82,7 +82,7 @@ public class StatusUpdaterTest {
                 .build();
         when(mockPaymentRequestDao.findByExternalId(SOME_EXTERNAL_ID)).thenReturn(Optional.of(paymentRequest));
 
-        new StatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, ENTERING_CARD_DETAILS, null);
+        new ChargeStatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, ENTERING_CARD_DETAILS, null);
 
         List<ChargeTransactionEventEntity> transactionEvents = paymentRequest.getChargeTransaction().getTransactionEvents();
 

--- a/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
@@ -18,9 +18,9 @@ import uk.gov.pay.connector.model.Notifications;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
-import uk.gov.pay.connector.model.domain.Status;
 import uk.gov.pay.connector.model.domain.RefundEntity;
 import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.model.domain.Status;
 import uk.gov.pay.connector.util.DnsUtils;
 
 import java.time.ZonedDateTime;
@@ -76,7 +76,7 @@ public class NotificationServiceTest {
     private ChargeEntity mockedChargeEntity;
 
     @Mock
-    private StatusUpdater mockedStatusUpdater;
+    private ChargeStatusUpdater mockedChargeStatusUpdater;
 
     @Mock
     private RefundStatusUpdater mockedRefundUpdater;
@@ -92,7 +92,7 @@ public class NotificationServiceTest {
 
         when(mockedPaymentProvider.verifyNotification(any(Notification.class), any(GatewayAccountEntity.class))).thenReturn(true);
 
-        notificationService = new NotificationService(mockedChargeDao, mockedChargeEventDao, mockedRefundDao, mockedPaymentProviders, mockDnsUtils, mockedStatusUpdater, mockedRefundUpdater);
+        notificationService = new NotificationService(mockedChargeDao, mockedChargeEventDao, mockedRefundDao, mockedPaymentProviders, mockDnsUtils, mockedChargeStatusUpdater, mockedRefundUpdater);
     }
 
     private Notifications<Pair<String, Boolean>> createNotificationFor(String transactionId, String reference, Pair<String, Boolean> status) {
@@ -320,7 +320,7 @@ public class NotificationServiceTest {
 
         assertTrue(ChronoUnit.SECONDS.between((ZonedDateTime) generatedTimeCaptor.getValue().get(), ZonedDateTime.now()) < 10);
         notifications.get().forEach(notification ->
-                verify(mockedStatusUpdater).updateChargeTransactionStatus(
+                verify(mockedChargeStatusUpdater).updateChargeTransactionStatus(
                         mockedChargeEntity.getExternalId(),
                         ChargeStatus.CAPTURED,
                         notification.getGatewayEventDate()

--- a/src/test/java/uk/gov/pay/connector/service/RefundStatusUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundStatusUpdaterTest.java
@@ -1,0 +1,71 @@
+package uk.gov.pay.connector.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.connector.dao.RefundTransactionDao;
+import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.model.domain.RefundStatus.REFUND_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntityBuilder.aRefundTransactionEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RefundStatusUpdaterTest {
+    @Mock
+    private RefundTransactionDao mockRefundTransactionDao;
+    private String someRefundReference;
+    private PaymentGatewayName someProvider;
+    private RefundStatus newRefundStatus;
+    private RefundTransactionEntity refundTransactionEntity;
+    private String refundExternalId;
+
+    @Before
+    public void setUp() throws Exception {
+        someRefundReference = "someRefundReference";
+        someProvider = PaymentGatewayName.WORLDPAY;
+        newRefundStatus = REFUND_SUBMITTED;
+        refundExternalId = "refundExternalId";
+        refundTransactionEntity = aRefundTransactionEntity()
+                .withRefundExternalId(refundExternalId)
+                .withStatus(RefundStatus.CREATED)
+                .build();
+    }
+
+    @Test
+    public void updatesRefundTransactionAndSetsRefundReference() {
+        when(mockRefundTransactionDao.findByExternalId(refundExternalId)).thenReturn(Optional.of(refundTransactionEntity));
+        new RefundStatusUpdater(mockRefundTransactionDao).setReferenceAndUpdateTransactionStatus(refundExternalId, someRefundReference, newRefundStatus);
+
+        assertThat(refundTransactionEntity.getRefundReference(), is(someRefundReference));
+        assertThat(refundTransactionEntity.getStatus(), is(newRefundStatus));
+
+    }
+
+    @Test
+    public void updatesRefundTransactionStatusWithDaoLoopkup() throws Exception {
+        when(mockRefundTransactionDao.findByProviderAndReference(someProvider, someRefundReference))
+                .thenReturn(Optional.of(refundTransactionEntity));
+
+        new RefundStatusUpdater(mockRefundTransactionDao)
+                .updateRefundTransactionStatus(someProvider, someRefundReference, newRefundStatus);
+
+        assertThat(refundTransactionEntity.getStatus(), is(newRefundStatus));
+    }
+
+    @Test
+    public void canHandleNoRefundBeingFoundWithoutException() throws Exception {
+        when(mockRefundTransactionDao.findByProviderAndReference(someProvider, someRefundReference))
+                .thenReturn(Optional.empty());
+
+        new RefundStatusUpdater(mockRefundTransactionDao)
+                .updateRefundTransactionStatus(someProvider, someRefundReference, REFUND_SUBMITTED);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/StatusUpdaterTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/StatusUpdaterTest.java
@@ -19,14 +19,14 @@ import java.util.function.Predicate;
 
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
-import static uk.gov.pay.connector.model.domain.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
+import static uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StatusUpdaterTest {
@@ -84,10 +84,10 @@ public class StatusUpdaterTest {
 
         new StatusUpdater(mockPaymentRequestDao).updateChargeTransactionStatus(SOME_EXTERNAL_ID, ENTERING_CARD_DETAILS, null);
 
-        List<TransactionEventEntity> transactionEvents = paymentRequest.getChargeTransaction().getTransactionEvents();
+        List<ChargeTransactionEventEntity> transactionEvents = paymentRequest.getChargeTransaction().getTransactionEvents();
 
         assertThat(transactionEvents.stream().anyMatch(hasEventOfType(ENTERING_CARD_DETAILS)), is(true));
-        ChargeTransactionEventEntity enteringCardDetailsEvent = (ChargeTransactionEventEntity) transactionEvents.stream()
+        ChargeTransactionEventEntity enteringCardDetailsEvent = transactionEvents.stream()
                 .filter(hasEventOfType(ENTERING_CARD_DETAILS))
                 .findFirst()
                 .get();

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
@@ -157,7 +157,7 @@ public class EpdqPaymentProviderTest {
 
     @Test
     public void shouldGetPaymentProviderName() {
-        assertThat(provider.getPaymentGatewayName(), is("epdq"));
+        assertThat(provider.getPaymentGatewayName().getName(), is("epdq"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProviderTest.java
@@ -55,7 +55,7 @@ public class SandboxPaymentProviderTest {
 
     @Test
     public void getPaymentGatewayName_shouldGetExpectedName() {
-        Assert.assertThat(provider.getPaymentGatewayName(), is("sandbox"));
+        Assert.assertThat(provider.getPaymentGatewayName().getName(), is("sandbox"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
@@ -128,7 +128,7 @@ public class SmartpayPaymentProviderTest {
 
     @Test
     public void shouldGetPaymentProviderName() {
-        assertThat(provider.getPaymentGatewayName(), is("smartpay"));
+        assertThat(provider.getPaymentGatewayName().getName(), is("smartpay"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
@@ -150,7 +150,7 @@ public class WorldpayPaymentProviderTest {
 
     @Test
     public void shouldGetPaymentProviderName() {
-        Assert.assertThat(provider.getPaymentGatewayName(), is("worldpay"));
+        Assert.assertThat(provider.getPaymentGatewayName().getName(), is("worldpay"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
Start writing to the transactions table whenever we do a refund.
Have also started writing refund events to the 
transaction_events table which had been broken out to a 
different story. This is because this code is shared with 
ChargeTransactions and was easier to leave in than disable.

## HOW 
- Created RefundTransactionEntity and 
RefundTransactionEventEntity.
- Created RefundStatusUpdater to update status on 
RefundTransactionEntity.
- Call method on RefundStatusUpdater whenever we we changing
the status on RefundEntity.
- Set refundReference on RefundTransactions once we have a response 
from the gateway.


