### PR TITLE
PP-2783 Add transaction_id column to cards table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1076,4 +1076,15 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add transaction_id column to cards table" author="">
+        <addColumn tableName="cards">
+            <column name="transaction_id" type="bigint">
+                <constraints foreignKeyName="fk__transactions_id"
+                             referencedTableName="transactions"
+                             referencedColumnNames="id"
+                             nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Add a `transaction_id` column to the `cards` table (with a foreign key constraint referencing the `id` column in the `transactions` table). The column is `NULLABLE` for now but we will backfill it in the near future.

Tested by running connector migrations locally.