### PR TITLE
Suppress verbose logging during tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!--
+      This configuration is used by test code which
+      spins up before dropwizard has booted.
+
+      It should not affect production logging behaviours.
+
+      Use dropwizard's config.yaml to set that.
+    -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>
+                [TEST] %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
For some of our tests, especially integration tests, there's quite a lot of
setup code which runs before dropwizard has booted. This means that
dropwizard's configuration system hasn't kicked in and hasn't read the
logging config from confg.yaml.

So if we drop in a logback-test.xml config into the class path it will get
picked up by logback's configuration engine and used as the standard
configuration for logging when tests are running.

Also Update logback-classic to 1.2.3

There was a [bug](https://jira.qos.ch/browse/LOGBACK-1292) in logback, a
stray println was writing some annoying output.