### PR TITLE
PP-3027 Remove color output from logs in jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
   }
 
   options {
-    ansiColor('xterm')
     timestamps()
   }
 


### PR DESCRIPTION
## WHAT
- According to https://issues.jenkins-ci.org/browse/JENKINS-11752 the ansicolor
  plugin exaggerates log files's size by an order of magnitude.
  As an example, Connector log files go from ~160MB to ~16MB with colours disabled.

