### PR TITLE
PP-2783 Replace CardEntity chargeId Long with chargeTransactionEntity object

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -8,6 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -37,8 +39,8 @@ public class CardEntity extends AbstractVersionedEntity {
     @Embedded
     private AddressEntity billingAddress;
 
-    @Column(name = "charge_id")
-    private Long chargeId;
+    @JoinColumn(name = "transaction_id", referencedColumnName = "id", updatable = false)
+    private ChargeTransactionEntity chargeTransactionEntity;
 
     public CardEntity() {
     }
@@ -91,54 +93,24 @@ public class CardEntity extends AbstractVersionedEntity {
         this.cardBrand = cardBrand;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        CardEntity that = (CardEntity) o;
-
-        if (lastDigitsCardNumber != null ? !lastDigitsCardNumber.equals(that.lastDigitsCardNumber) : that.lastDigitsCardNumber != null)
-            return false;
-        if (cardHolderName != null ? !cardHolderName.equals(that.cardHolderName) : that.cardHolderName != null)
-            return false;
-        if (expiryDate != null ? !expiryDate.equals(that.expiryDate) : that.expiryDate != null)
-            return false;
-        if (cardBrand != null ? !cardBrand.equals(that.cardBrand) : that.cardBrand != null)
-            return false;
-        if (chargeId != null ? !chargeId.equals(that.chargeId) : that.chargeId != null)
-            return false;
-        return billingAddress != null ? billingAddress.equals(that.billingAddress) : that.billingAddress == null;
+    public ChargeTransactionEntity getChargeTransactionEntity() {
+        return chargeTransactionEntity;
     }
 
-    @Override
-    public int hashCode() {
-        int result = lastDigitsCardNumber != null ? lastDigitsCardNumber.hashCode() : 0;
-        result = 31 * result + (cardHolderName != null ? cardHolderName.hashCode() : 0);
-        result = 31 * result + (expiryDate != null ? expiryDate.hashCode() : 0);
-        result = 31 * result + (cardBrand != null ? cardBrand.hashCode() : 0);
-        result = 31 * result + (billingAddress != null ? billingAddress.hashCode() : 0);
-        result = 31 * result + (chargeId != null ? chargeId.hashCode() : 0);
-        return result;
+    public void setChargeTransactionEntity(ChargeTransactionEntity chargeTransactionEntity) {
+        this.chargeTransactionEntity = chargeTransactionEntity;
     }
 
-    public static CardEntity from(CardDetailsEntity cardDetailsEntity, String email, Long chargeId) {
+    public static CardEntity from(CardDetailsEntity cardDetailsEntity, ChargeTransactionEntity chargeTransactionEntity) {
         CardEntity entity = new CardEntity();
         entity.setBillingAddress(cardDetailsEntity.getBillingAddress());
         entity.setCardBrand(cardDetailsEntity.getCardBrand());
         entity.setCardHolderName(cardDetailsEntity.getCardHolderName());
         entity.setExpiryDate(cardDetailsEntity.getExpiryDate());
         entity.setLastDigitsCardNumber(cardDetailsEntity.getLastDigitsCardNumber());
-        entity.setChargeId(chargeId);
+        entity.setChargeTransactionEntity(chargeTransactionEntity);
 
         return entity;
     }
 
-    public Long getChargeId() {
-        return chargeId;
-    }
-
-    public void setChargeId(Long chargeId) {
-        this.chargeId = chargeId;
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -154,11 +154,15 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
             CardDetailsEntity detailsEntity = buildCardDetailsEntity(authCardDetails);
             chargeEntity.setCardDetails(detailsEntity);
-            CardEntity cardEntity = CardEntity
-                    .from(detailsEntity, chargeEntity.getEmail(), chargeEntity.getId());
+
+            if (paymentRequestEntity.isPresent()) {
+                CardEntity cardEntity = CardEntity.from(detailsEntity, paymentRequestEntity.get().getChargeTransaction());
+                cardDao.persist(cardEntity);
+            } else {
+                logger.error("Cannot find payment request with external ID {} — this is a bug: the card details will not be saved in the cards table");
+            }
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
-            cardDao.persist(cardEntity);
             persistCard3ds(chargeEntity);
             logger.info("Stored confirmation details for charge - charge_external_id={}",
                     chargeEntity.getExternalId());

--- a/src/test/java/uk/gov/pay/connector/it/dao/CardDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/CardDaoITest.java
@@ -6,10 +6,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.dao.CardDao;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.model.domain.CardDetailsEntity;
 import uk.gov.pay.connector.model.domain.CardEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 
 import java.util.HashMap;
 
@@ -25,6 +28,7 @@ public class CardDaoITest extends DaoITestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private CardDao cardDao;
     private ChargeDao chargeDao;
+    private PaymentRequestDao paymentRequestDao;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -34,30 +38,30 @@ public class CardDaoITest extends DaoITestBase {
     public void setUp() throws Exception {
         cardDao = env.getInstance(CardDao.class);
         chargeDao = env.getInstance(ChargeDao.class);
+        paymentRequestDao = env.getInstance(PaymentRequestDao.class);
         insertTestAccount();
     }
 
     @Test
     public void shouldCreateACardEntity() throws Exception {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
-                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
         gatewayAccount.setId(defaultTestAccount.getAccountId());
 
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
-
         chargeDao.persist(chargeEntity);
 
+        ChargeTransactionEntity chargeTransactionEntity = ChargeTransactionEntity.from(chargeEntity);
+
+        PaymentRequestEntity paymentRequestEntity = PaymentRequestEntity.from(chargeEntity, chargeTransactionEntity);
+        paymentRequestDao.persist(paymentRequestEntity);
+
         CardDetailsEntity cardDetailsEntity = aValidCardDetailsEntity().build();
-
-        CardEntity cardEntity = CardEntity
-                .from(cardDetailsEntity, "payment@example.com", chargeEntity.getId());
-
+        CardEntity cardEntity = CardEntity.from(cardDetailsEntity, chargeTransactionEntity);
         cardDao.persist(cardEntity);
 
         assertThat(cardEntity.getId(), is(notNullValue()));
-
     }
 
     private void insertTestAccount() {
@@ -66,4 +70,5 @@ public class CardDaoITest extends DaoITestBase {
                 .aTestAccount()
                 .insert();
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -363,8 +364,20 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(cardDetails.getBillingAddress().getCountry(), is(country));
         assertThat(cardDetails.getBillingAddress().getCounty(), is(county));
 
-        CardEntity cardEntity = CardEntity.from(cardDetails, charge.getEmail(), charge.getId());
-        verify(mockCardDao).persist(cardEntity);
+        ArgumentCaptor<CardEntity> cardEntityArg = ArgumentCaptor.forClass(CardEntity.class);
+        verify(mockCardDao).persist(cardEntityArg.capture());
+
+        CardEntity card = cardEntityArg.getValue();
+        assertThat(card.getCardHolderName(), is(cardholderName));
+        assertThat(card.getCardBrand(), is(cardBrand));
+        assertThat(card.getExpiryDate(), is(expiryDate));
+        assertThat(card.getLastDigitsCardNumber(), is("4242"));
+        assertThat(card.getBillingAddress().getLine1(), is(addressLine1));
+        assertThat(card.getBillingAddress().getLine2(), is(addressLine2));
+        assertThat(card.getBillingAddress().getPostcode(), is(postcode));
+        assertThat(card.getBillingAddress().getCity(), is(city));
+        assertThat(card.getBillingAddress().getCountry(), is(country));
+        assertThat(card.getBillingAddress().getCounty(), is(county));
     }
 
     @Test
@@ -377,8 +390,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         CardDetailsEntity cardDetails = charge.getCardDetails();
         assertThat(cardDetails, is(notNullValue()));
 
-        CardEntity cardEntity = CardEntity.from(cardDetails, charge.getEmail(), charge.getId());
-        verify(mockCardDao).persist(cardEntity);
+        verify(mockCardDao).persist(any(CardEntity.class));
     }
 
     @Test
@@ -391,8 +403,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         CardDetailsEntity cardDetails = charge.getCardDetails();
         assertThat(cardDetails, is(notNullValue()));
 
-        CardEntity cardEntity = CardEntity.from(cardDetails, charge.getEmail(), charge.getId());
-        verify(mockCardDao).persist(cardEntity);
+        verify(mockCardDao).persist(any(CardEntity.class));
     }
 
     @Test


### PR DESCRIPTION
In CardEntity, replace the `Long` field `chargeId` (mapped to the `charge_id` column in the `charges` table) with a `ChargeTransactionEntity` field `chargeTransactionEntity` (using the `transaction_id` column in the `cards` table to join to the `transactions` table on its `id` column).

Currently, the `CardEntity` is created and persisted but then never used again. In addition, we never read in existing `CardEntity` entities. Nothing is relying on the `chargeId` field so we’re OK removing it.

Also remove the `equals` and `hashCode` methods from `CardEntity`. Again, nothing is relying on them and most of our other entities don’t have these methods, relying instead on reference equality. In addition, the `CardEntity`’s `equals` method does actually rely on `AddressEntity`’s `equals` method, which uses reference equality, which could give someone a nasty surprise. We can add the methods back if we find a genuine need for them other than making unit tests slightly easier (if you mind the `AddressEntity` caveat), which appears to be why they were added in the first place.