### PR TITLE
PP-2783 Drop cards table charge_id column default, index and constraints

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1113,4 +1113,24 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="drop default value from charge_id column in cards table" author="">
+        <dropDefaultValue tableName="cards" columnName="charge_id"/>
+    </changeSet>
+
+    <changeSet id="drop cards_charge_id_seq sequence" author="">
+        <dropSequence sequenceName="cards_charge_id_seq"/>
+    </changeSet>
+
+    <changeSet id="drop charge_id index in cards table" author="">
+        <dropIndex tableName="cards" indexName="idx_cards_charge_id"/>
+    </changeSet>
+
+    <changeSet id="drop not null constraint on charge_id column in cards table" author="">
+        <dropNotNullConstraint tableName="cards" columnName="charge_id"/>
+    </changeSet>
+
+    <changeSet id="drop foreign key constraint that charge_id column in cards table references id column in charges" author="">
+        <dropForeignKeyConstraint baseTableName="cards" constraintName="fk__cards_charges"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
We want to stop writing to the `charge_id` column in the `cards` table (because we’re going to start writing to the `transaction_id` column instead). However, it has a unique index, `NOT NULL` constraint and — incorrectly — a default value from a sequence. This means that if we stop inserting data into the `charge_id` column, it will be filled with a meaningless default value from the sequence. In addition to being completely wrong, the value might, by chance, conflict with an existing `charge_id` value, violating the unique key.

This makes the following changes (in order):

- Drop the default value from `charge_id` column
- Drop the `cards_charge_id_seq` sequence used by the aforementioned default
- Drop the (unique) index on the `charge_id` column
- Drop the `NOT NULL` constraint on the `charge_id` column
- Drop the foreign key constraint that makes the `charge_id` column reference the `id` column in the `charges` table

For now, we will continue to write to `charge_id` column.

with @chrisgrimble