### PR TITLE
PP-2783 Backfill transaction_id column in cards table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1133,4 +1133,17 @@
         <dropForeignKeyConstraint baseTableName="cards" constraintName="fk__cards_charges"/>
     </changeSet>
 
+    <changeSet id="backfill transaction_id column in cards table" author="">
+        <sql stripComments="true">
+            UPDATE cards
+            SET transaction_id = transactions.id
+            FROM charges, payment_requests, transactions
+            WHERE cards.transaction_id IS NULL
+            AND charges.id = cards.charge_id
+            AND payment_requests.external_id = charges.external_id
+            AND transactions.payment_request_id = payment_requests.id
+            AND transactions.operation = 'CHARGE';
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Currently, some rows in the `cards` table have the `charge_id` column populated (referencing the `id` column of the `charges` table) while others have the `transaction_id` column populated (referencing the `id` column of the `transactions` table).

Backfill the `transaction_id` column so it is always populated, in preparation for the `charge_id` column being dropped.