### PR TITLE
Remove backfills for cards transaction_id and completed refunds

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1133,45 +1133,4 @@
         <dropForeignKeyConstraint baseTableName="cards" constraintName="fk__cards_charges"/>
     </changeSet>
 
-    <changeSet id="backfill transaction_id column in cards table" author="">
-        <sql stripComments="true">
-            UPDATE cards
-            SET transaction_id = transactions.id
-            FROM charges, payment_requests, transactions
-            WHERE cards.transaction_id IS NULL
-            AND charges.id = cards.charge_id
-            AND payment_requests.external_id = charges.external_id
-            AND transactions.payment_request_id = payment_requests.id
-            AND transactions.operation = 'CHARGE';
-        </sql>
-    </changeSet>
-    
-    <changeSet id="Backfill completed refunds into refund transactions" author="">
-        <sql>
-            INSERT INTO TRANSACTIONS (
-                payment_request_id,
-                amount,
-                refund_external_id,
-                status,
-                user_external_id,
-                operation,
-                refund_reference
-            )
-            SELECT
-                pr.id,
-                r.amount,
-                r.external_id,
-                REPLACE(r.status, ' ', '_'),
-                r.user_external_id,
-                'REFUND',
-                r.reference
-            FROM refunds r
-            JOIN charges c ON r.charge_id=c.id
-            JOIN payment_requests pr ON c.external_id=pr.external_id
-            LEFT JOIN transactions t ON r.external_id=t.refund_external_id
-            WHERE r.status IN ('REFUND ERROR','REFUNDED')
-            AND t.refund_external_id IS NULL;
-        </sql>
-    </changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
Remove “backfill transaction_id column in cards table” migration and “Backfill completed refunds into refund transactions” migration (f553a722e4ecd6d0361ccefe0d68b71b0d960c42 and 20e031f19653366ede9664111b232526fed2949d, respectively) until we can solve the probable performance problems.

(These were never run on staging or production.)