### PR TITLE
PP-3070 Use Windows-1252 rather than UTF-8 for ePDQ payloads

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.util.templates.PayloadBuilder;
 import uk.gov.pay.connector.util.templates.PayloadDefinition;
 
 import javax.ws.rs.core.MediaType;
+import java.nio.charset.Charset;
 
 import static uk.gov.pay.connector.service.epdq.EpdqSignedPayloadDefinition.EpdqSignedPayloadDefinitionFactory.anEpdqSignedPayloadDefinitionFactory;
 
@@ -75,6 +76,8 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
     public static final String REFUND_OPERATION_TYPE = "RFD";
     public static final String CANCEL_OPERATION_TYPE = "DES";
 
+    private static final Charset WINDOWS_1252 = Charset.forName("windows-1252");
+
     private static EpdqSignedPayloadDefinitionFactory signedPayloadDefinitionFactory = anEpdqSignedPayloadDefinitionFactory(new EpdqSha512SignatureGenerator());
 
     public static final PayloadBuilder AUTHORISE_ORDER_TEMPLATE_BUILDER = createPayloadBuilderForNewOrder();
@@ -86,12 +89,12 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
 
     private static PayloadBuilder createPayloadBuilderForNewOrder() {
         PayloadDefinition payloadDefinition = signedPayloadDefinitionFactory.create(new EpdqPayloadDefinitionForNewOrder());
-        return new FormUrlEncodedStringBuilder(payloadDefinition);
+        return new FormUrlEncodedStringBuilder(payloadDefinition, WINDOWS_1252);
     }
 
     private static PayloadBuilder createPayloadBuilderForMaintenanceOrder() {
         PayloadDefinition payloadDefinition = signedPayloadDefinitionFactory.create(new EpdqPayloadDefinitionForMaintenanceOrder());
-        return new FormUrlEncodedStringBuilder(payloadDefinition);
+        return new FormUrlEncodedStringBuilder(payloadDefinition, WINDOWS_1252);
     }
 
     public static EpdqOrderRequestBuilder anEpdqAuthoriseOrderRequestBuilder() {

--- a/src/main/java/uk/gov/pay/connector/util/templates/FormUrlEncodedStringBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/util/templates/FormUrlEncodedStringBuilder.java
@@ -3,18 +3,20 @@ package uk.gov.pay.connector.util.templates;
 import org.apache.http.client.utils.URLEncodedUtils;
 import uk.gov.pay.connector.service.OrderRequestBuilder.TemplateData;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 
 public class FormUrlEncodedStringBuilder implements PayloadBuilder {
 
     private final PayloadDefinition payloadDefinition;
+    private final Charset charset;
 
-    public FormUrlEncodedStringBuilder(PayloadDefinition payloadDefinition) {
+    public FormUrlEncodedStringBuilder(PayloadDefinition payloadDefinition, Charset charset) {
         this.payloadDefinition = payloadDefinition;
+        this.charset = charset;
     }
 
     public String buildWith(TemplateData templateData) {
-        return URLEncodedUtils.format(payloadDefinition.extract(templateData), StandardCharsets.UTF_8.toString());
+        return URLEncodedUtils.format(payloadDefinition.extract(templateData), charset);
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -105,6 +105,15 @@ public class EpdqPaymentProviderTest {
     }
 
     @Test
+    public void shouldAuthoriseSuccessfullyWhenCardholderNameContainsRightSingleQuotationMark() throws Exception {
+        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        String cardholderName = "John O’Connor"; // That’s a U+2019 RIGHT SINGLE QUOTATION MARK, not a U+0027 APOSTROPHE
+        AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity, cardholderName);
+        GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
+        assertThat(response.isSuccessful(), is(true));
+    }
+
+    @Test
     public void shouldCaptureSuccessfully() throws Exception {
         PaymentProvider paymentProvider = getEpdqPaymentProvider();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
@@ -170,6 +179,10 @@ public class EpdqPaymentProviderTest {
     }
 
     private static AuthorisationGatewayRequest buildAuthorisationRequest(ChargeEntity chargeEntity) {
+        return buildAuthorisationRequest(chargeEntity, "Mr. Payment");
+    }
+
+    private static AuthorisationGatewayRequest buildAuthorisationRequest(ChargeEntity chargeEntity, String cardholderName) {
         Address address = Address.anAddress();
         address.setLine1("41");
         address.setLine2("Scala Street");
@@ -179,6 +192,7 @@ public class EpdqPaymentProviderTest {
         address.setCountry("GB");
 
         AuthCardDetails authCardDetails = aValidEpdqCard();
+        authCardDetails.setCardHolder(cardholderName);
         authCardDetails.setAddress(address);
 
         return new AuthorisationGatewayRequest(chargeEntity, authCardDetails);


### PR DESCRIPTION
When constructing `application/x-www-form-urlencoded` payloads to send to ePDQ, use Windows-1252 encoding instead of UTF-8.

It is our belief that ePDQ assumes incoming `application/x-www-form-urlencoded payloads` are encoded in Windows-1252 and decodes them as such. (ePDQ have not yet officially confirmed this but our discussions and testing indicate this is the case.)

With this change, we can successfully send payloads containing characters like ’ U+2019 RIGHT SINGLE QUOTATION MARK (which encodes to `%E2%80%99` in UTF-8 but `%92` in Windows-1252) in payloads. We know that users with such characters in their names etc. have problems making payments (the first hurdle that’s hit is the `SHASIGN` signature verification fails: `%E2%80%99` decodes to â€™ in Windows-1252, so “John O’Connor” becomes “John Oâ€™Connor”, which has a different SHA-512 digest).

This change makes no difference for the majority of payloads because UTF-8 and Windows-1252 encode all printable ASCII characters in the same way.

When generating the `SHASIGN` signature, we continue to take the UTF-8 bytes of the string, generate a SHA-512 digest of those bytes and return the result as a hexadecimal string. (We use UTF-8 because that’s what we always set in our ePDQ accounts at _Configuration →
Technical information → Global security parameters → Hashing method_, alongside SHA-512.)