### PR TITLE
PP-2783 add relation between cards and transactions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -43,6 +43,7 @@ import uk.gov.pay.connector.resources.TransactionsSummaryResource;
 import uk.gov.pay.connector.service.Auth3dsDetailsFactory;
 import uk.gov.pay.connector.service.CaptureProcessScheduler;
 import uk.gov.pay.connector.service.CardCaptureProcess;
+import uk.gov.pay.connector.tasks.MigrateAddTransactionIdToCardsTask;
 import uk.gov.pay.connector.tasks.MigrateTransactionEventsTask;
 import uk.gov.pay.connector.util.DependentResourceWaitCommand;
 import uk.gov.pay.connector.util.TrustingSSLSocketFactory;
@@ -115,6 +116,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.healthChecks().register("cardExecutorService", injector.getInstance(CardExecutorServiceHealthCheck.class));
 
         environment.admin().addTask(injector.getInstance(MigrateTransactionEventsTask.class));
+        environment.admin().addTask(injector.getInstance(MigrateAddTransactionIdToCardsTask.class));
 
         setGlobalProxies(configuration);
     }

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.service.CardExecutorService;
 import uk.gov.pay.connector.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.service.PaymentProviders;
 import uk.gov.pay.connector.service.notify.NotifyClientFactoryProvider;
+import uk.gov.pay.connector.tasks.AddTransactionIdToCardsWorker;
 import uk.gov.pay.connector.tasks.PaymentRequestWorker;
 import uk.gov.pay.connector.util.HashUtil;
 import uk.gov.pay.connector.validations.RequestValidator;
@@ -40,6 +41,7 @@ public class ConnectorModule extends AbstractModule {
         bind(RequestValidator.class);
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
         bind(PaymentRequestWorker.class);
+        bind(AddTransactionIdToCardsWorker.class);
 
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(NotifyClientFactoryProvider.class));

--- a/src/main/java/uk/gov/pay/connector/dao/CardDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/CardDao.java
@@ -15,4 +15,10 @@ public class CardDao extends JpaDao<CardEntity> {
         super(entityManager);
     }
 
+    public Long findMaxId() {
+        final Long singleResult = entityManager.get()
+                .createQuery("SELECT MAX(c.id) FROM CardEntity c", Long.class)
+                .getSingleResult();
+        return singleResult == null ? 0 : singleResult;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
@@ -39,8 +39,12 @@ public class CardEntity extends AbstractVersionedEntity {
     @Embedded
     private AddressEntity billingAddress;
 
-    @JoinColumn(name = "transaction_id", referencedColumnName = "id", updatable = false)
+    @JoinColumn(name = "transaction_id", referencedColumnName = "id")
     private ChargeTransactionEntity chargeTransactionEntity;
+
+    //Only needed for loading old data from database never set this in Java code
+    @Column(name = "charge_id")
+    private Long chargeId;
 
     public CardEntity() {
     }
@@ -99,6 +103,10 @@ public class CardEntity extends AbstractVersionedEntity {
 
     public void setChargeTransactionEntity(ChargeTransactionEntity chargeTransactionEntity) {
         this.chargeTransactionEntity = chargeTransactionEntity;
+    }
+
+    public Long getChargeId() {
+        return chargeId;
     }
 
     public static CardEntity from(CardDetailsEntity cardDetailsEntity, ChargeTransactionEntity chargeTransactionEntity) {

--- a/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCardsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCardsWorker.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.RandomUtils;
+import org.jboss.logging.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.dao.CardDao;
+import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.domain.CardEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
+
+public class AddTransactionIdToCardsWorker {
+    private final ChargeDao chargeDao;
+    private final PaymentRequestDao paymentRequestDao;
+    private final CardDao cardDao;
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    public AddTransactionIdToCardsWorker(ChargeDao chargeDao, PaymentRequestDao paymentRequestDao, CardDao cardDao) {
+        this.chargeDao = chargeDao;
+        this.paymentRequestDao = paymentRequestDao;
+        this.cardDao = cardDao;
+    }
+
+    public void execute(Long startId) {
+        MDC.put(HEADER_REQUEST_ID, "Back fill transaction id on cards " + RandomUtils.nextLong(0, 10000));
+        logger.info("Running migration worker");
+        Long maxId = cardDao.findMaxId();
+        for (long cardId = startId; cardId <= maxId; cardId++) {
+            int retries = 0;
+            updateCardWithRetry(cardId, retries);
+        }
+    }
+
+    private void updateCardWithRetry(long cardId, long retries) {
+        try {
+            setChargeTransactionOnCard(cardId);
+        } catch (Exception exc) {
+            if (retries < 3) {
+                logger.error("Problem migrating [" + cardId + "] " + exc.getMessage() + " retry count [" + retries + "]");
+                updateCardWithRetry(cardId, retries + 1);
+            } else {
+                throw exc;
+            }
+        }
+    }
+
+    @Transactional
+    public void setChargeTransactionOnCard(long cardId) {
+        logger.info("Migrating card [" + cardId + "]");
+
+        cardDao.findById(CardEntity.class, cardId)
+                .filter(card -> card.getChargeTransactionEntity() == null)
+                .ifPresent(card ->
+                        chargeDao.findById(card.getChargeId())
+                                .ifPresent(charge -> loadPaymentRequestAndAddToCard(card, charge))
+                );
+    }
+
+    private void loadPaymentRequestAndAddToCard(CardEntity card, ChargeEntity charge) {
+        paymentRequestDao.findByExternalId(charge.getExternalId()).ifPresent(paymentRequest -> {
+                    ChargeTransactionEntity chargeTransaction = paymentRequest.getChargeTransaction();
+                    card.setChargeTransactionEntity(chargeTransaction);
+
+                    logger.info("Adding charge transaction [" + chargeTransaction.getId() + "] to card [" + card.getId() + "]");
+                }
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/MigrateAddTransactionIdToCardsTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/MigrateAddTransactionIdToCardsTask.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+import javax.inject.Inject;
+import java.io.PrintWriter;
+
+public class MigrateAddTransactionIdToCardsTask extends Task {
+
+    private static final String TASK_NAME = "migrate-add-transaction-id-to-cards";
+
+    private AddTransactionIdToCardsWorker worker;
+
+    @Inject
+    public MigrateAddTransactionIdToCardsTask(AddTransactionIdToCardsWorker worker) {
+        super(TASK_NAME);
+        this.worker = worker;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        String queryParam = "startId";
+        Long startId = 1L;
+        if (parameters.containsKey(queryParam)) {
+            startId = Long.valueOf(parameters.get(queryParam).asList().get(0));
+        }
+        worker.execute(startId);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/tasks/AddTransactionIdToCardsWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/AddTransactionIdToCardsWorkerITest.java
@@ -1,0 +1,128 @@
+package uk.gov.pay.connector.tasks;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.tasks.TaskITestBase;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AddTransactionIdToCardsWorkerITest extends TaskITestBase {
+    private static AtomicLong nextId = new AtomicLong(10);
+
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
+    private AddTransactionIdToCardsWorker worker;
+
+    @Before
+    public void setUp() {
+        worker = env.getInstance(AddTransactionIdToCardsWorker.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldAddTransactionIdToCard() {
+        DatabaseFixtures.TestCharge testCharge = addCharge();
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        long cardId = nextId.getAndIncrement();
+        databaseTestHelper.addCard(cardId, testCharge.getChargeId(), null);
+
+        worker.execute(1L);
+
+        Map<String, Object> card = databaseTestHelper.getCard(cardId);
+        assertThat(card.get("transaction_id"), is(ids.getRight()));
+    }
+
+    @Test
+    public void shouldNotModifyCardThatAlreadyHasATransactionId() {
+        DatabaseFixtures.TestCharge testCharge = addCharge();
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        long cardId = nextId.getAndIncrement();
+        databaseTestHelper.addCard(cardId, null, ids.getRight());
+
+        Map<String, Object> originalCard = databaseTestHelper.getCard(cardId);
+
+        worker.execute(1L);
+
+        Map<String, Object> card = databaseTestHelper.getCard(cardId);
+        assertThat(card.get("version"), is(originalCard.get("version")));
+        assertThat(card.get("transaction_id"), is(ids.getRight()));
+    }
+
+    @Test
+    public void shouldOnlyAddTransactionIdToCardPastStartId() {
+        DatabaseFixtures.TestCharge testCharge1 = addCharge();
+        long cardId1 = nextId.getAndIncrement();
+        databaseTestHelper.addCard(cardId1, testCharge1.getChargeId(), null);
+
+        DatabaseFixtures.TestCharge testCharge2 = addCharge();
+        Pair<Long, Long> ids2 = createPaymentRequest(testCharge2);
+        long cardId2 = nextId.getAndIncrement();
+        databaseTestHelper.addCard(cardId2, testCharge2.getChargeId(), null);
+
+        worker.execute(cardId2);
+
+        Map<String, Object> card1 = databaseTestHelper.getCard(cardId1);
+        assertThat(card1.get("transaction_id"), nullValue());
+
+        Map<String, Object> card2 = databaseTestHelper.getCard(cardId2);
+        assertThat(card2.get("transaction_id"), is(ids2.getRight()));
+    }
+
+    private DatabaseFixtures.TestCharge addCharge() {
+        long chargeId = nextId.getAndIncrement();
+        String externalChargeId = RandomIdGenerator.newId();
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withTransactionId("gatewayTransactionId");
+        testCharge.insert();
+
+        return testCharge;
+
+    }
+
+    private Pair<Long, Long> createPaymentRequest(DatabaseFixtures.TestCharge chargeEntity) {
+        long paymentRequestId = nextId.getAndIncrement();
+        databaseTestHelper.addPaymentRequest(
+                paymentRequestId,
+                chargeEntity.getAmount(),
+                chargeEntity.getTestAccount().getAccountId(),
+                chargeEntity.getReturnUrl(),
+                chargeEntity.getDescription(),
+                chargeEntity.getReference(),
+                chargeEntity.getCreatedDate(),
+                chargeEntity.getExternalChargeId());
+
+        long transactionId = nextId.getAndIncrement();
+        databaseTestHelper.addChargeTransaction(
+                transactionId,
+                chargeEntity.getTransactionId(),
+                chargeEntity.getAmount(),
+                chargeEntity.getChargeStatus(),
+                paymentRequestId
+        );
+
+        return new ImmutablePair<>(paymentRequestId, transactionId);
+    }
+
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -652,6 +652,25 @@ public class DatabaseTestHelper {
         );
     }
 
+    public void addCard(Long cardId, Long chargeId, Long transactionId) {
+        jdbi.withHandle(h -> h.update(
+                "INSERT INTO cards(" +
+                        "id," +
+                        "charge_id," +
+                        "card_brand," +
+                        "transaction_id" +
+                        ")" +
+                        "VALUES (" +
+                        "?, ?, 'some_brand', ?" +
+                        ")",
+                cardId,
+                chargeId,
+                transactionId)
+        );
+
+
+    }
+
     public List<Map<String, Object>> loadTransactionEvents(Long transactionId) {
         return jdbi.withHandle(h ->
                 h.createQuery("Select * from transaction_events where transaction_id = :transactionId order by updated desc")
@@ -664,5 +683,12 @@ public class DatabaseTestHelper {
                 h.createQuery("Select * from transactions where payment_request_id = :paymentRequestId and operation='REFUND' order by id asc")
                         .bind("paymentRequestId", paymentRequestId)
                         .list());
+    }
+
+    public Map<String, Object> getCard(long cardId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("Select * from cards where id = :cardId")
+                        .bind("cardId", cardId)
+                        .first());
     }
 }


### PR DESCRIPTION
Currently the cards table references the charge_id. As we will be
deleting the charges tables we want to reference the transaction_id of
the ChargeTransaction. The column has already been added and for new
entires in cards is being populated. This will back fill the entries in
cards that are missing the transaction_id with a Task which can be run
from the admin port of the app.



  