### PR TITLE
PP-2784 add relationship cards3ds to transactions

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1193,4 +1193,15 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add transaction_id column to card_3ds table" author="">
+        <addColumn tableName="card_3ds">
+            <column name="transaction_id" type="bigint">
+                <constraints foreignKeyName="fk__transactions_id"
+                             referencedTableName="transactions"
+                             referencedColumnNames="id"
+                             nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Currently the card_3ds table references the charge_id. As we will be
deleting the charges tables we want to reference the transaction_id of
the ChargeTransaction. This is the first step where we will add the new
column to the database. In the next release we will back fill and start
writing to the column.