### PR TITLE
PP-2784 add relationship cards3ds to transactions 2

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -43,6 +43,7 @@ import uk.gov.pay.connector.resources.TransactionsSummaryResource;
 import uk.gov.pay.connector.service.Auth3dsDetailsFactory;
 import uk.gov.pay.connector.service.CaptureProcessScheduler;
 import uk.gov.pay.connector.service.CardCaptureProcess;
+import uk.gov.pay.connector.tasks.MigrateAddTransactionIdToCard3dsTask;
 import uk.gov.pay.connector.tasks.MigrateAddTransactionIdToCardsTask;
 import uk.gov.pay.connector.tasks.MigrateTransactionEventsTask;
 import uk.gov.pay.connector.util.DependentResourceWaitCommand;
@@ -117,6 +118,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
         environment.admin().addTask(injector.getInstance(MigrateTransactionEventsTask.class));
         environment.admin().addTask(injector.getInstance(MigrateAddTransactionIdToCardsTask.class));
+        environment.admin().addTask(injector.getInstance(MigrateAddTransactionIdToCard3dsTask.class));
 
         setGlobalProxies(configuration);
     }

--- a/src/main/java/uk/gov/pay/connector/dao/Card3dsDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/Card3dsDao.java
@@ -14,4 +14,11 @@ public class Card3dsDao extends JpaDao<Card3dsEntity> {
     public Card3dsDao(Provider<EntityManager> entityManager) {
         super(entityManager);
     }
+
+    public Long findMaxId() {
+        final Long singleResult = entityManager.get()
+                .createQuery("SELECT MAX(c.id) FROM Card3dsEntity c", Long.class)
+                .getSingleResult();
+        return singleResult == null ? 0 : singleResult;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
@@ -9,6 +9,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -36,6 +37,7 @@ public class Card3dsEntity extends AbstractVersionedEntity {
     @Column(name = "charge_id")
     private Long chargeId;
 
+    @OneToOne
     @JoinColumn(name = "transaction_id", referencedColumnName = "id", updatable = true)
     private ChargeTransactionEntity chargeTransactionEntity;
 
@@ -90,10 +92,9 @@ public class Card3dsEntity extends AbstractVersionedEntity {
         this.chargeTransactionEntity = chargeTransactionEntity;
     }
 
-    public static Card3dsEntity from(ChargeEntity chargeEntity, PaymentRequestEntity paymentRequest) {
+    public static Card3dsEntity from(ChargeEntity chargeEntity) {
         Card3dsEntity entity = new Card3dsEntity();
         entity.setChargeId(chargeEntity.getId());
-        entity.setChargeTransactionEntity(paymentRequest.getChargeTransaction());
         entity.setIssuerUrl(chargeEntity.get3dsDetails().getIssuerUrl());
         entity.setPaRequest(chargeEntity.get3dsDetails().getPaRequest());
         entity.setWorldpayMachineCookie(chargeEntity.getProviderSessionId());

--- a/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
@@ -1,12 +1,14 @@
 package uk.gov.pay.connector.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -33,6 +35,9 @@ public class Card3dsEntity extends AbstractVersionedEntity {
 
     @Column(name = "charge_id")
     private Long chargeId;
+
+    @JoinColumn(name = "transaction_id", referencedColumnName = "id", updatable = true)
+    private ChargeTransactionEntity chargeTransactionEntity;
 
     public Card3dsEntity() {
     }
@@ -77,10 +82,18 @@ public class Card3dsEntity extends AbstractVersionedEntity {
         this.chargeId = chargeId;
     }
 
-    public static Card3dsEntity from(ChargeEntity chargeEntity) {
+    public ChargeTransactionEntity getChargeTransactionEntity() {
+        return chargeTransactionEntity;
+    }
 
+    public void setChargeTransactionEntity(ChargeTransactionEntity chargeTransactionEntity) {
+        this.chargeTransactionEntity = chargeTransactionEntity;
+    }
+
+    public static Card3dsEntity from(ChargeEntity chargeEntity, PaymentRequestEntity paymentRequest) {
         Card3dsEntity entity = new Card3dsEntity();
         entity.setChargeId(chargeEntity.getId());
+        entity.setChargeTransactionEntity(paymentRequest.getChargeTransaction());
         entity.setIssuerUrl(chargeEntity.get3dsDetails().getIssuerUrl());
         entity.setPaRequest(chargeEntity.get3dsDetails().getPaRequest());
         entity.setWorldpayMachineCookie(chargeEntity.getProviderSessionId());

--- a/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/CardEntity.java
@@ -10,6 +10,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -39,6 +40,7 @@ public class CardEntity extends AbstractVersionedEntity {
     @Embedded
     private AddressEntity billingAddress;
 
+    @OneToOne
     @JoinColumn(name = "transaction_id", referencedColumnName = "id")
     private ChargeTransactionEntity chargeTransactionEntity;
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.model.domain.transaction;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.model.domain.Card3dsEntity;
+import uk.gov.pay.connector.model.domain.CardEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions;
@@ -13,6 +15,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -33,6 +36,10 @@ public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus, Cha
     @OneToMany(mappedBy = "transaction", cascade = CascadeType.ALL)
     @OrderBy("updated DESC")
     private List<ChargeTransactionEventEntity> transactionEvents = new ArrayList<>();
+    @OneToOne(mappedBy = "chargeTransactionEntity", cascade = CascadeType.PERSIST)
+    private CardEntity card;
+    @OneToOne(mappedBy = "chargeTransactionEntity", cascade = CascadeType.PERSIST)
+    private Card3dsEntity card3ds;
 
     public ChargeTransactionEntity() {
         super(TransactionOperation.CHARGE);
@@ -54,6 +61,24 @@ public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus, Cha
 
     public void setGatewayTransactionId(String gatewayTransactionId) {
         this.gatewayTransactionId = gatewayTransactionId;
+    }
+
+    public CardEntity getCard() {
+        return card;
+    }
+
+    public void setCard(CardEntity card) {
+        this.card = card;
+        card.setChargeTransactionEntity(this);
+    }
+
+    public Card3dsEntity getCard3ds() {
+        return card3ds;
+    }
+
+    public void setCard3ds(Card3dsEntity card3ds) {
+        this.card3ds = card3ds;
+        card3ds.setChargeTransactionEntity(this);
     }
 
     public void updateStatus(ChargeStatus newStatus, ZonedDateTime gatewayEventTime) {

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.StringUtils;
-import uk.gov.pay.connector.dao.Card3dsDao;
 import uk.gov.pay.connector.dao.CardDao;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
@@ -44,7 +43,6 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
     private final CardTypeDao cardTypeDao;
     private final CardDao cardDao;
     private final Auth3dsDetailsFactory auth3dsDetailsFactory;
-    private final Card3dsDao card3dsDao;
     private final PaymentRequestDao paymentRequestDao;
 
     @Inject
@@ -56,12 +54,11 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
                                 CardExecutorService cardExecutorService,
                                 Auth3dsDetailsFactory auth3dsDetailsFactory,
                                 Environment environment,
-                                Card3dsDao card3dsDao, PaymentRequestDao paymentRequestDao, ChargeStatusUpdater chargeStatusUpdater) {
+                                PaymentRequestDao paymentRequestDao, ChargeStatusUpdater chargeStatusUpdater) {
         super(chargeDao, chargeEventDao, providers, cardExecutorService, environment, chargeStatusUpdater);
         this.cardTypeDao = cardTypeDao;
         this.cardDao = cardDao;
         this.auth3dsDetailsFactory = auth3dsDetailsFactory;
-        this.card3dsDao = card3dsDao;
         this.paymentRequestDao = paymentRequestDao;
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -158,12 +158,12 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
             if (paymentRequestEntity.isPresent()) {
                 CardEntity cardEntity = CardEntity.from(detailsEntity, paymentRequestEntity.get().getChargeTransaction());
                 cardDao.persist(cardEntity);
+                persistCard3ds(chargeEntity, paymentRequestEntity.get());
             } else {
-                logger.error("Cannot find payment request with external ID {} — this is a bug: the card details will not be saved in the cards table");
+                logger.error("Cannot find payment request with external ID {} — this is a bug: the card and cards3ds details will not be saved in the cards and card_3ds tables");
             }
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
-            persistCard3ds(chargeEntity);
             logger.info("Stored confirmation details for charge - charge_external_id={}",
                     chargeEntity.getExternalId());
             return operationResponse;
@@ -192,9 +192,9 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
         return detailsEntity;
     }
 
-    private void persistCard3ds(ChargeEntity chargeEntity){
+    private void persistCard3ds(ChargeEntity chargeEntity, PaymentRequestEntity paymentRequestEntity){
         if(chargeEntity.get3dsDetails() != null) {
-            Card3dsEntity card3dsEntity = Card3dsEntity.from(chargeEntity);
+            Card3dsEntity card3dsEntity = Card3dsEntity.from(chargeEntity, paymentRequestEntity);
             card3dsDao.persist(card3dsEntity);
         }
     }

--- a/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorker.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.RandomUtils;
+import org.jboss.logging.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.dao.Card3dsDao;
+import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.domain.Card3dsEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
+
+public class AddTransactionIdToCard3dsWorker {
+    private final ChargeDao chargeDao;
+    private final PaymentRequestDao paymentRequestDao;
+    private final Card3dsDao card3dsDao;
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    public AddTransactionIdToCard3dsWorker(ChargeDao chargeDao, PaymentRequestDao paymentRequestDao, Card3dsDao card3dsDao) {
+        this.chargeDao = chargeDao;
+        this.paymentRequestDao = paymentRequestDao;
+        this.card3dsDao = card3dsDao;
+    }
+
+    public void execute() {
+        MDC.put(HEADER_REQUEST_ID, "Back fill transaction id on cards " + RandomUtils.nextLong(0, 10000));
+        logger.info("Running migration worker");
+        Long maxId = card3dsDao.findMaxId();
+        for (long card3dsId = 1; card3dsId <= maxId; card3dsId++) {
+            int retries = 0;
+            updateCard3dsWithRetry(card3dsId, retries);
+        }
+    }
+
+    private void updateCard3dsWithRetry(long cardId, long retries) {
+        try {
+            setChargeTransactionOnCard3ds(cardId);
+        } catch (Exception exc) {
+            if (retries < 3) {
+                logger.error("Problem migrating [" + cardId + "] " + exc.getMessage() + " retry count [" + retries + "]");
+                updateCard3dsWithRetry(cardId, retries + 1);
+            } else {
+                throw exc;
+            }
+        }
+    }
+
+    @Transactional
+    public void setChargeTransactionOnCard3ds(long card3dsId) {
+        logger.info("Migrating card3ds [" + card3dsId + "]");
+
+        card3dsDao.findById(Card3dsEntity.class, card3dsId)
+                .filter(card -> card.getChargeTransactionEntity() == null)
+                .ifPresent(card3ds ->
+                        chargeDao.findById(card3ds.getChargeId())
+                                .ifPresent(charge -> loadPaymentRequestAndAddToCard(card3ds, charge))
+                );
+    }
+
+    private void loadPaymentRequestAndAddToCard(Card3dsEntity card3ds, ChargeEntity charge) {
+        paymentRequestDao.findByExternalId(charge.getExternalId()).ifPresent(paymentRequest -> {
+                    ChargeTransactionEntity chargeTransaction = paymentRequest.getChargeTransaction();
+                    card3ds.setChargeTransactionEntity(chargeTransaction);
+
+                    logger.info("Adding charge transaction [" + chargeTransaction.getId() + "] to card3ds [" + card3ds.getId() + "]");
+                }
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorker.java
@@ -68,7 +68,7 @@ public class AddTransactionIdToCard3dsWorker {
     private void loadPaymentRequestAndAddToCard(Card3dsEntity card3ds, ChargeEntity charge) {
         paymentRequestDao.findByExternalId(charge.getExternalId()).ifPresent(paymentRequest -> {
                     ChargeTransactionEntity chargeTransaction = paymentRequest.getChargeTransaction();
-                    card3ds.setChargeTransactionEntity(chargeTransaction);
+                    chargeTransaction.setCard3ds(card3ds);
 
                     logger.info("Adding charge transaction [" + chargeTransaction.getId() + "] to card3ds [" + card3ds.getId() + "]");
                 }

--- a/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorker.java
@@ -30,11 +30,11 @@ public class AddTransactionIdToCard3dsWorker {
         this.card3dsDao = card3dsDao;
     }
 
-    public void execute() {
+    public void execute(Long startId) {
         MDC.put(HEADER_REQUEST_ID, "Back fill transaction id on cards " + RandomUtils.nextLong(0, 10000));
         logger.info("Running migration worker");
         Long maxId = card3dsDao.findMaxId();
-        for (long card3dsId = 1; card3dsId <= maxId; card3dsId++) {
+        for (long card3dsId = startId; card3dsId <= maxId; card3dsId++) {
             int retries = 0;
             updateCard3dsWithRetry(card3dsId, retries);
         }

--- a/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCardsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/AddTransactionIdToCardsWorker.java
@@ -68,7 +68,7 @@ public class AddTransactionIdToCardsWorker {
     private void loadPaymentRequestAndAddToCard(CardEntity card, ChargeEntity charge) {
         paymentRequestDao.findByExternalId(charge.getExternalId()).ifPresent(paymentRequest -> {
                     ChargeTransactionEntity chargeTransaction = paymentRequest.getChargeTransaction();
-                    card.setChargeTransactionEntity(chargeTransaction);
+                    chargeTransaction.setCard(card);
 
                     logger.info("Adding charge transaction [" + chargeTransaction.getId() + "] to card [" + card.getId() + "]");
                 }

--- a/src/main/java/uk/gov/pay/connector/tasks/MigrateAddTransactionIdToCard3dsTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/MigrateAddTransactionIdToCard3dsTask.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+import javax.inject.Inject;
+import java.io.PrintWriter;
+
+public class MigrateAddTransactionIdToCard3dsTask extends Task {
+
+    private static final String TASK_NAME = "migrate-add-transaction-id-to-card3ds";
+
+    private AddTransactionIdToCard3dsWorker worker;
+
+    @Inject
+    public MigrateAddTransactionIdToCard3dsTask(AddTransactionIdToCard3dsWorker worker) {
+        super(TASK_NAME);
+        this.worker = worker;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        worker.execute();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/MigrateAddTransactionIdToCard3dsTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/MigrateAddTransactionIdToCard3dsTask.java
@@ -20,6 +20,11 @@ public class MigrateAddTransactionIdToCard3dsTask extends Task {
 
     @Override
     public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
-        worker.execute();
+        String queryParam = "startId";
+        Long startId = 1L;
+        if (parameters.containsKey(queryParam)) {
+            startId = Long.valueOf(parameters.get(queryParam).asList().get(0));
+        }
+        worker.execute(startId);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/Card3dsDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/Card3dsDaoITest.java
@@ -56,7 +56,7 @@ public class Card3dsDaoITest extends DaoITestBase {private DatabaseFixtures.Test
         paymentRequestDao.persist(paymentRequest);
 
 
-        Card3dsEntity card3dsEntity = Card3dsEntity.from(chargeEntity, paymentRequest);
+        Card3dsEntity card3dsEntity = Card3dsEntity.from(chargeEntity);
 
         card3dsDao.persist(card3dsEntity);
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/Card3dsDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/Card3dsDaoITest.java
@@ -6,9 +6,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.dao.Card3dsDao;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.model.domain.Card3dsEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 
 import java.util.HashMap;
 
@@ -21,6 +24,7 @@ import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
 public class Card3dsDaoITest extends DaoITestBase {private DatabaseFixtures.TestAccount defaultTestAccount;
     private Card3dsDao card3dsDao;
     private ChargeDao chargeDao;
+    private PaymentRequestDao paymentRequestDao;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
@@ -30,6 +34,8 @@ public class Card3dsDaoITest extends DaoITestBase {private DatabaseFixtures.Test
     public void setUp() throws Exception {
         card3dsDao = env.getInstance(Card3dsDao.class);
         chargeDao = env.getInstance(ChargeDao.class);
+        paymentRequestDao = env.getInstance(PaymentRequestDao.class);
+
         insertTestAccount();
     }
 
@@ -46,8 +52,11 @@ public class Card3dsDaoITest extends DaoITestBase {private DatabaseFixtures.Test
                 .build();
 
         chargeDao.persist(chargeEntity);
+        PaymentRequestEntity paymentRequest = PaymentRequestEntity.from(chargeEntity, ChargeTransactionEntity.from(chargeEntity));
+        paymentRequestDao.persist(paymentRequest);
 
-        Card3dsEntity card3dsEntity = Card3dsEntity.from(chargeEntity);
+
+        Card3dsEntity card3dsEntity = Card3dsEntity.from(chargeEntity, paymentRequest);
 
         card3dsDao.persist(card3dsEntity);
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -508,7 +508,7 @@ public class DatabaseFixtures {
 
     public class TestRefund {
         Long id = RandomUtils.nextLong(1, 99999);
-        String externalRefundId = RandomIdGenerator.newId();
+        String externalRefundId = RandomIdGenerator.newId().trim();
         String reference;
         long amount = 101L;
         RefundStatus status = CREATED;

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -508,7 +508,7 @@ public class DatabaseFixtures {
 
     public class TestRefund {
         Long id = RandomUtils.nextLong(1, 99999);
-        String externalRefundId = RandomIdGenerator.newId().trim();
+        String externalRefundId = RandomIdGenerator.newId();
         String reference;
         long amount = 101L;
         RefundStatus status = CREATED;

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -206,13 +206,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
         assertThat(charge.get3dsDetails().getIssuerUrl(), is(ISSUER_URL_FROM_PROVIDER));
         assertThat(charge.get3dsDetails().getPaRequest(), is(PA_REQ_VALUE_FROM_PROVIDER));
-
-        Card3dsEntity card3dsEntity = new Card3dsEntity();
-        card3dsEntity.setChargeId(charge.getId());
-        card3dsEntity.setIssuerUrl(ISSUER_URL_FROM_PROVIDER);
-        card3dsEntity.setPaRequest(PA_REQ_VALUE_FROM_PROVIDER);
-
-        verify(mockCard3dsDao).persist(card3dsEntity);
+        Card3dsEntity card3ds = paymentRequest.getChargeTransaction().getCard3ds();
+        assertThat(card3ds.getIssuerUrl(), is(ISSUER_URL_FROM_PROVIDER));
+        assertThat(card3ds.getPaRequest(), is(PA_REQ_VALUE_FROM_PROVIDER));
     }
 
     @Test
@@ -229,13 +225,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.get3dsDetails().getIssuerUrl(), is(ISSUER_URL_FROM_PROVIDER));
         assertThat(charge.get3dsDetails().getPaRequest(), is(PA_REQ_VALUE_FROM_PROVIDER));
 
-        Card3dsEntity card3dsEntity = new Card3dsEntity();
-        card3dsEntity.setChargeId(charge.getId());
-        card3dsEntity.setIssuerUrl(ISSUER_URL_FROM_PROVIDER);
-        card3dsEntity.setPaRequest(PA_REQ_VALUE_FROM_PROVIDER);
-        card3dsEntity.setWorldpayMachineCookie(SESSION_IDENTIFIER);
-
-        verify(mockCard3dsDao).persist(card3dsEntity);
+        Card3dsEntity card3ds = paymentRequest.getChargeTransaction().getCard3ds();
+        assertThat(card3ds.getIssuerUrl(), is(ISSUER_URL_FROM_PROVIDER));
+        assertThat(card3ds.getPaRequest(), is(PA_REQ_VALUE_FROM_PROVIDER));
+        assertThat(card3ds.getWorldpayMachineCookie(), is(SESSION_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -12,7 +12,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.pay.connector.dao.Card3dsDao;
 import uk.gov.pay.connector.dao.CardDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
@@ -99,9 +98,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private Counter mockCounter;
 
-    @Mock
-    private Card3dsDao mockCard3dsDao;
-
     private CardAuthoriseService cardAuthorisationService;
     private PaymentRequestEntity paymentRequest;
 
@@ -112,7 +108,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         cardAuthorisationService = new CardAuthoriseService(mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockCardDao, mockedProviders, mockExecutorService,
-                auth3dsDetailsFactory, mockEnvironment, mockCard3dsDao, mockPaymentRequestDao, mockChargeStatusUpdater);
+                auth3dsDetailsFactory, mockEnvironment, mockPaymentRequestDao, mockChargeStatusUpdater);
     }
 
     @Before

--- a/src/test/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/AddTransactionIdToCard3dsWorkerITest.java
@@ -1,0 +1,105 @@
+package uk.gov.pay.connector.tasks;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.tasks.TaskITestBase;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AddTransactionIdToCard3dsWorkerITest extends TaskITestBase {
+    private static AtomicLong nextId = new AtomicLong(10);
+
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
+    private AddTransactionIdToCard3dsWorker worker;
+
+    @Before
+    public void setUp() {
+        worker = env.getInstance(AddTransactionIdToCard3dsWorker.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldAddTransactionIdToCard3ds() throws Exception {
+        DatabaseFixtures.TestCharge testCharge = addCharge();
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        long cardId = nextId.getAndIncrement();
+        databaseTestHelper.addCard3ds(cardId, testCharge.getChargeId(), null);
+
+        worker.execute();
+
+        Map<String, Object> card = databaseTestHelper.getCard3ds(cardId);
+        assertThat(card.get("transaction_id"), is(ids.getRight()));
+    }
+
+    @Test
+    public void shouldNotModifyCard3dsThatAlreadyHasATransactionId() throws Exception {
+        DatabaseFixtures.TestCharge testCharge = addCharge();
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        long cardId = nextId.getAndIncrement();
+        databaseTestHelper.addCard3ds(cardId, testCharge.getChargeId(), ids.getRight());
+
+        Map<String, Object> originalCard = databaseTestHelper.getCard3ds(cardId);
+
+        worker.execute();
+
+        Map<String, Object> card = databaseTestHelper.getCard3ds(cardId);
+        assertThat(card.get("version"), is(originalCard.get("version")));
+        assertThat(card.get("transaction_id"), is(ids.getRight()));
+    }
+
+    private DatabaseFixtures.TestCharge addCharge() {
+        long chargeId = nextId.getAndIncrement();
+        String externalChargeId = RandomIdGenerator.newId();
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withTransactionId("gatewayTransactionId");
+        testCharge.insert();
+
+        return testCharge;
+    }
+
+    private Pair<Long, Long> createPaymentRequest(DatabaseFixtures.TestCharge chargeEntity) {
+        long paymentRequestId = nextId.getAndIncrement();
+        databaseTestHelper.addPaymentRequest(
+                paymentRequestId,
+                chargeEntity.getAmount(),
+                chargeEntity.getTestAccount().getAccountId(),
+                chargeEntity.getReturnUrl(),
+                chargeEntity.getDescription(),
+                chargeEntity.getReference(),
+                chargeEntity.getCreatedDate(),
+                chargeEntity.getExternalChargeId());
+
+        long transactionId = nextId.getAndIncrement();
+        databaseTestHelper.addChargeTransaction(
+                transactionId,
+                chargeEntity.getTransactionId(),
+                chargeEntity.getAmount(),
+                chargeEntity.getChargeStatus(),
+                paymentRequestId
+        );
+
+        return new ImmutablePair<>(paymentRequestId, transactionId);
+    }
+
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -667,8 +667,24 @@ public class DatabaseTestHelper {
                 chargeId,
                 transactionId)
         );
+    }
 
-
+    public void addCard3ds(Long cardId, Long chargeId, Long transactionId) {
+        jdbi.withHandle(h -> h.update(
+                "INSERT INTO card_3ds(" +
+                        "id," +
+                        "charge_id," +
+                        "transaction_id," +
+                        "pa_request," +
+                        "issuer_url" +
+                        ")" +
+                        "VALUES (" +
+                        "?, ?, ?, 'some_ps_request', 'some_issuer_url'" +
+                        ")",
+                cardId,
+                chargeId,
+                transactionId)
+        );
     }
 
     public List<Map<String, Object>> loadTransactionEvents(Long transactionId) {
@@ -689,6 +705,13 @@ public class DatabaseTestHelper {
         return jdbi.withHandle(h ->
                 h.createQuery("Select * from cards where id = :cardId")
                         .bind("cardId", cardId)
+                        .first());
+    }
+
+    public Map<String,Object> getCard3ds(long card3dsId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("Select * from card_3ds where id = :card3dsId")
+                        .bind("card3dsId", card3dsId)
                         .first());
     }
 }


### PR DESCRIPTION
Currently the card_3ds table references the charge_id. As we will be
deleting the charges tables we want to reference the transaction_id of
the ChargeTransaction.

- Added a link back to chargeTransaction for Card3ds data
- Back fill script for transaction_id on card_3ds