### PR TITLE
PP-2781 Backfill charge events to transaction events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/RefundDao.java
@@ -75,4 +75,16 @@ public class RefundDao extends JpaDao<RefundEntity> {
                 .setParameter(2, RefundStatus.CREATED.getValue())
                 .getResultList();
     }
+
+    public List<RefundHistory> searchAllHistoryByChargeId(Long chargeId) {
+
+        String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, history_start_date, history_end_date, user_external_id " +
+                "FROM refunds_history r " +
+                "WHERE charge_id = ?1";
+
+        return entityManager.get()
+                .createNativeQuery(query, "RefundEntityHistoryMapping")
+                .setParameter(1, chargeId)
+                .getResultList();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/tasks/PaymentRequestWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/PaymentRequestWorkerITest.java
@@ -136,6 +136,19 @@ public class PaymentRequestWorkerITest extends TaskITestBase {
     }
 
     @Test
+    public void shouldCreateCreatedRefundTransactionEvents() {
+        DatabaseFixtures.TestCharge testCharge = createCharge();
+        DatabaseFixtures.TestRefund testRefund = createRefund(testCharge);
+        addRefundHistoryEvent(testRefund, RefundStatus.CREATED, testRefund.getCreatedDate().plusSeconds(1));
+        long paymentRequestId = createPaymentRequest(testCharge).getLeft();
+        List<Long> refundTransactionIds = addRefundTransactions(paymentRequestId, testRefund);
+
+        worker.execute(1L);
+
+        assertTransactionEventsFor(refundTransactionIds.get(0), RefundStatus.CREATED);
+    }
+
+    @Test
     public void shouldCreateRefundTransactionEventsWhenMultipleRefundsPerPaymentRequest() {
         DatabaseFixtures.TestCharge chargeEntity = createCharge();
         DatabaseFixtures.TestRefund testRefund1 = createRefund(chargeEntity);


### PR DESCRIPTION
Fixed a bug where CREATED status were not being added to transaction
events for refund transactions and improved logging.

- Added new method to RefundDao to select all refunds_history objects
don't exclude the CREATED ones as we were doing before.
- Added the payment_request_id to all log statements in migration to
make it easier to search for all logs for a payment_request.

with @georgeracu

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


