### PR TITLE
PP-2085 Drop index from pa_request column on card_3ds table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1187,4 +1187,10 @@
         </sql>
     </changeSet>
 
+    <changeSet id="drop index from pa_request column on card_3ds table" runInTransaction="false" author="">
+        <sql>
+            DROP INDEX CONCURRENTLY idx_card_3ds_pa_request;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Adding this index was a mistake. We never look up rows in the `card_3ds` table using the `pa_request`; we use the `charge_id`.
