### PR TITLE
PP-3154 Rename column to be consistent

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1217,7 +1217,7 @@
 
     <changeSet id="add column date_created to table transactions" author="">
         <addColumn tableName="transactions">
-            <column name="date_created" type="timestamp without timezone">
+            <column name="created_date" type="timestamp without timezone">
                 <constraints nullable="true"/>
             </column>
         </addColumn>


### PR DESCRIPTION
- Renamed column to `created_date` to be consistent with table
payment_requests



