### PR TITLE
Pp 3154 backfill created date on transactions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -43,6 +43,7 @@ import uk.gov.pay.connector.resources.TransactionsSummaryResource;
 import uk.gov.pay.connector.service.Auth3dsDetailsFactory;
 import uk.gov.pay.connector.service.CaptureProcessScheduler;
 import uk.gov.pay.connector.service.CardCaptureProcess;
+import uk.gov.pay.connector.tasks.BackfillCreatedDateOnTransactionsTask;
 import uk.gov.pay.connector.tasks.MigrateAddTransactionIdToCard3dsTask;
 import uk.gov.pay.connector.tasks.MigrateCaptureApprovedRetryEventTask;
 import uk.gov.pay.connector.tasks.MigrateTransactionEventsTask;
@@ -118,6 +119,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
         environment.admin().addTask(injector.getInstance(MigrateTransactionEventsTask.class));
         environment.admin().addTask(injector.getInstance(MigrateAddTransactionIdToCard3dsTask.class));
+        environment.admin().addTask(injector.getInstance(BackfillCreatedDateOnTransactionsTask.class));
         environment.admin().addTask(injector.getInstance(MigrateCaptureApprovedRetryEventTask.class));
 
         setGlobalProxies(configuration);

--- a/src/main/java/uk/gov/pay/connector/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/RefundDao.java
@@ -87,4 +87,14 @@ public class RefundDao extends JpaDao<RefundEntity> {
                 .setParameter(1, chargeId)
                 .getResultList();
     }
+
+    public Optional<RefundEntity> findByExternalId(String externalId) {
+        String query = "SELECT refund FROM RefundEntity refund " +
+                "WHERE refund.externalId = :externalId";
+
+        return entityManager.get()
+                .createQuery(query, RefundEntity.class)
+                .setParameter("externalId", externalId)
+                .getResultList().stream().findFirst();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/BackfillCreatedDateOnTransactionsTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/BackfillCreatedDateOnTransactionsTask.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+import javax.inject.Inject;
+import java.io.PrintWriter;
+
+public class BackfillCreatedDateOnTransactionsTask extends Task {
+    private static final String TASK_NAME = "backfill-created-date-on-transactions";
+
+    private BackfillCreatedDateOnTransactionsWorker worker;
+
+    private BackfillCreatedDateOnTransactionsTask(String name) {
+        super(name);
+    }
+
+    @Inject
+    public BackfillCreatedDateOnTransactionsTask(BackfillCreatedDateOnTransactionsWorker worker) {
+        this(TASK_NAME);
+        this.worker = worker;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        String queryParam = "startId";
+        Long startId = 1L;
+        if (!parameters.isEmpty() && parameters.containsKey(queryParam)) {
+            startId = Long.valueOf(parameters.get(queryParam).asList().get(0));
+        }
+        worker.execute(startId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/BackfillCreatedDateOnTransactionsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/BackfillCreatedDateOnTransactionsWorker.java
@@ -1,0 +1,80 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.RandomUtils;
+import org.jboss.logging.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.dao.RefundDao;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
+
+public class BackfillCreatedDateOnTransactionsWorker {
+    private final ChargeDao chargeDao;
+    private final PaymentRequestDao paymentRequestDao;
+    private final RefundDao refundDao;
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    public BackfillCreatedDateOnTransactionsWorker(ChargeDao chargeDao,
+                                                   PaymentRequestDao paymentRequestDao,
+                                                   RefundDao refundDao) {
+        this.chargeDao = chargeDao;
+        this.paymentRequestDao = paymentRequestDao;
+        this.refundDao = refundDao;
+    }
+
+    public void execute(Long startId) {
+        MDC.put(HEADER_REQUEST_ID, "Back fill created_date on transactions " + RandomUtils.nextLong(0, 10000));
+        logger.info("Running migration worker");
+        Long maxId = paymentRequestDao.findMaxId();
+        for (long paymentRequestId = startId; paymentRequestId <= maxId; paymentRequestId++) {
+            int retries = 0;
+            updateTransactionsWithRetry(paymentRequestId, retries);
+        }
+    }
+
+    private void updateTransactionsWithRetry(long paymentRequestId, long retries) {
+        try {
+            setCreatedDateOnTransactions(paymentRequestId);
+        } catch (Exception exc) {
+            if (retries < 3) {
+                logger.error("Problem migrating [" + paymentRequestId + "] " + " retry count [" + retries + "]", exc );
+                updateTransactionsWithRetry(paymentRequestId, retries + 1);
+            } else {
+                throw exc;
+            }
+        }
+    }
+
+    @Transactional
+    public void setCreatedDateOnTransactions(long paymentRequestId) {
+        logger.info("Backfilling transactions for payment request [" + paymentRequestId + "]");
+
+        paymentRequestDao.findById(PaymentRequestEntity.class, paymentRequestId)
+                .ifPresent(paymentRequestEntity -> {
+                    final Optional<ChargeEntity> chargeEntity = chargeDao.findByExternalId(paymentRequestEntity.getExternalId());
+                    chargeEntity.ifPresent(charge ->
+                            paymentRequestEntity.getChargeTransaction().setCreatedDate(charge.getCreatedDate())
+                    );
+                    paymentRequestEntity.getRefundTransactions().forEach(
+                            this::updateRefundTransactionEntity);
+                });
+    }
+
+    private void updateRefundTransactionEntity(RefundTransactionEntity refundTransactionEntity) {
+        final String refundExternalId = refundTransactionEntity.getRefundExternalId();
+        refundDao.findByExternalId(refundExternalId).ifPresent(
+                refundEntity -> refundTransactionEntity.setCreatedDate(refundEntity.getCreatedDate()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/tasks/BackfillCreatedDateOnTransactionsWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/BackfillCreatedDateOnTransactionsWorkerITest.java
@@ -1,0 +1,165 @@
+package uk.gov.pay.connector.tasks;
+
+import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.tasks.TaskITestBase;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+
+public class BackfillCreatedDateOnTransactionsWorkerITest extends TaskITestBase {
+    private static AtomicLong nextId = new AtomicLong(10);
+
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
+    private BackfillCreatedDateOnTransactionsWorker worker;
+
+    @Before
+    public void setUp() {
+        worker = env.getInstance(BackfillCreatedDateOnTransactionsWorker.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldAddDateToChargeTransaction() {
+        DatabaseFixtures.TestCharge testCharge = createCharge();
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        worker.execute(1L);
+        final Map<String, Object> chargeTransaction = databaseTestHelper.getChargeTransaction(ids.getLeft());
+        assertThat(chargeTransaction.get("created_date"), is(notNullValue()));
+
+    }
+
+    @Test
+    public void shouldAddDateToRefundTransaction() {
+        DatabaseFixtures.TestCharge testCharge = createCharge();
+        DatabaseFixtures.TestRefund testRefund = createRefund(testCharge);
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        addRefundTransactions(ids.getLeft(), testRefund);
+        worker.execute(1L);
+        final List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransactions(ids.getLeft());
+        UTCDateTimeConverter dateTimeConverter = new UTCDateTimeConverter();
+        refundTransactions.forEach(refundTransaction ->
+                assertThat(refundTransaction.get("created_date"),
+                        is(dateTimeConverter.convertToDatabaseColumn(testRefund.getCreatedDate())))
+        );
+    }
+
+    @Test
+    public void shouldAddDateToMultipleRefundTransactions() {
+        DatabaseFixtures.TestCharge testCharge = createCharge();
+        DatabaseFixtures.TestRefund testRefund1 = createRefund(testCharge);
+        DatabaseFixtures.TestRefund testRefund2 = createRefund(testCharge);
+        DatabaseFixtures.TestRefund testRefund3 = createRefund(testCharge);
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        addRefundTransactions(ids.getLeft(), testRefund1);
+        addRefundTransactions(ids.getLeft(), testRefund2);
+        addRefundTransactions(ids.getLeft(), testRefund3);
+        worker.execute(1L);
+        final List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransactions(ids.getLeft());
+        UTCDateTimeConverter dateTimeConverter = new UTCDateTimeConverter();
+        final Map<String, Object> refundObject1 = refundTransactions.get(0);
+        assertThat(refundObject1.get("created_date"), is(dateTimeConverter.convertToDatabaseColumn(testRefund1.getCreatedDate())));
+        final Map<String, Object> refundObject2 = refundTransactions.get(1);
+        assertThat(refundObject2.get("created_date"), is(dateTimeConverter.convertToDatabaseColumn(testRefund2.getCreatedDate())));
+        final Map<String, Object> refundObject3 = refundTransactions.get(2);
+        assertThat(refundObject3.get("created_date"), is(dateTimeConverter.convertToDatabaseColumn(testRefund3.getCreatedDate())));
+    }
+
+    private Pair<Long, Long> createPaymentRequest(DatabaseFixtures.TestCharge chargeEntity) {
+        long paymentRequestId = nextId.getAndIncrement();
+        databaseTestHelper.addPaymentRequest(
+                paymentRequestId,
+                chargeEntity.getAmount(),
+                chargeEntity.getTestAccount().getAccountId(),
+                chargeEntity.getReturnUrl(),
+                chargeEntity.getDescription(),
+                chargeEntity.getReference(),
+                chargeEntity.getCreatedDate(),
+                chargeEntity.getExternalChargeId());
+
+        long transactionId = nextId.getAndIncrement();
+        databaseTestHelper.addChargeTransaction(
+                transactionId,
+                chargeEntity.getTransactionId(),
+                chargeEntity.getAmount(),
+                chargeEntity.getChargeStatus(),
+                paymentRequestId
+        );
+
+        return new ImmutablePair<>(paymentRequestId, transactionId);
+    }
+
+    private List<Long> addRefundTransactions(long paymentRequestId, DatabaseFixtures.TestRefund... refundEntities) {
+        List<Long> refundTransactionsIds = new ArrayList<>();
+        for (DatabaseFixtures.TestRefund refundEntity : refundEntities) {
+            long refundTransactionId = nextId.getAndIncrement();
+            refundTransactionsIds.add(refundTransactionId);
+            databaseTestHelper.addRefundTransaction(
+                    refundTransactionId,
+                    paymentRequestId,
+                    refundEntity.getAmount(),
+                    refundEntity.getExternalRefundId(),
+                    refundEntity.getSubmittedByUserExternalId(),
+                    refundEntity.getStatus(),
+                    refundEntity.getReference()
+            );
+        }
+
+        return refundTransactionsIds;
+    }
+
+    private DatabaseFixtures.TestCharge createCharge() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+
+        final Long chargeId = RandomUtils.nextLong();
+        final String externalChargeId = RandomIdGenerator.newId();
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withTransactionId("gatewayTransactionId");
+        testCharge.insert();
+
+        return testCharge;
+    }
+
+    private DatabaseFixtures.TestRefund createRefund(DatabaseFixtures.TestCharge testCharge) {
+        DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestRefund()
+                .withReference(randomAlphanumeric(10).trim())
+                .withTestCharge(testCharge)
+                .insert();
+
+
+        return testRefund;
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/tasks/PaymentRequestWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/PaymentRequestWorkerITest.java
@@ -222,7 +222,7 @@ public class PaymentRequestWorkerITest extends TaskITestBase {
 
         worker.execute(1L);
 
-        List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransaction(ids.getLeft());
+        List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransactions(ids.getLeft());
         assertThat(refundTransactions.size(), is(1));
         Map<String, Object> refundTransaction = refundTransactions.get(0);
         assertThat(refundTransaction.get("id"), is(refundTransactionIds.get(0)));
@@ -366,7 +366,7 @@ public class PaymentRequestWorkerITest extends TaskITestBase {
     }
 
     private void assertRefundTransactions(Long paymentRequestId, DatabaseFixtures.TestRefund... testRefunds) {
-        List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransaction(paymentRequestId);
+        List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransactions(paymentRequestId);
         assertThat(refundTransactions.size(), is(testRefunds.length));
         List<String> refundReferences = refundTransactions.stream().map(refund -> (String)refund.get("refund_external_id")).collect(toList());
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -694,7 +694,7 @@ public class DatabaseTestHelper {
                         .list());
     }
 
-    public List<Map<String, Object>> getRefundTransaction(Long paymentRequestId) {
+    public List<Map<String, Object>> getRefundTransactions(Long paymentRequestId) {
         return jdbi.withHandle(h ->
                 h.createQuery("Select * from transactions where payment_request_id = :paymentRequestId and operation='REFUND' order by id asc")
                         .bind("paymentRequestId", paymentRequestId)
@@ -713,5 +713,20 @@ public class DatabaseTestHelper {
                 h.createQuery("Select * from card_3ds where id = :card3dsId")
                         .bind("card3dsId", card3dsId)
                         .first());
+    }
+
+    public Map<String, Object> getChargeTransaction(Long paymentRequestId) {
+        List<Map<String, Object>> chargeTransactions = jdbi.withHandle(h ->
+                h.createQuery("Select * from transactions where payment_request_id = :paymentRequestId and operation='CHARGE' order by id asc")
+                        .bind("paymentRequestId", paymentRequestId)
+                        .list());
+
+        if (chargeTransactions.size() == 1) {
+            return chargeTransactions.get(0);
+
+        } else {
+            throw new IllegalStateException(
+                    "Found [" + chargeTransactions.size() + "] Charge Transactions for payment request id [" + paymentRequestId + "]");
+        }
     }
 }


### PR DESCRIPTION
A DropWizard Task to backfill `createdDate` on Charge and Refund Transactions


