### PR TITLE
PP-2781 Back fill CAPTURE_APPROVED_RETRY events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -44,6 +44,7 @@ import uk.gov.pay.connector.service.Auth3dsDetailsFactory;
 import uk.gov.pay.connector.service.CaptureProcessScheduler;
 import uk.gov.pay.connector.service.CardCaptureProcess;
 import uk.gov.pay.connector.tasks.MigrateAddTransactionIdToCard3dsTask;
+import uk.gov.pay.connector.tasks.MigrateCaptureApprovedRetryEventTask;
 import uk.gov.pay.connector.tasks.MigrateTransactionEventsTask;
 import uk.gov.pay.connector.util.DependentResourceWaitCommand;
 import uk.gov.pay.connector.util.TrustingSSLSocketFactory;
@@ -117,6 +118,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
         environment.admin().addTask(injector.getInstance(MigrateTransactionEventsTask.class));
         environment.admin().addTask(injector.getInstance(MigrateAddTransactionIdToCard3dsTask.class));
+        environment.admin().addTask(injector.getInstance(MigrateCaptureApprovedRetryEventTask.class));
 
         setGlobalProxies(configuration);
     }

--- a/src/main/java/uk/gov/pay/connector/tasks/MigrateCaptureApprovedRetryEventTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/MigrateCaptureApprovedRetryEventTask.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+import javax.inject.Inject;
+import java.io.PrintWriter;
+
+public class MigrateCaptureApprovedRetryEventTask extends Task {
+
+    private static final String TASK_NAME = "migrate-capture-approved-retry-events";
+
+    private MigrateCaptureApprovedRetryEventsWorker worker;
+
+    private MigrateCaptureApprovedRetryEventTask(String name) {
+        super(name);
+    }
+
+    @Inject
+    public MigrateCaptureApprovedRetryEventTask(MigrateCaptureApprovedRetryEventsWorker worker) {
+        this(TASK_NAME);
+        this.worker = worker;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        String queryParam = "startId";
+        Long startId = 1L;
+        if (!parameters.isEmpty() && parameters.containsKey(queryParam)) {
+            startId = Long.valueOf(parameters.get(queryParam).asList().get(0));
+        }
+        worker.execute(startId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/MigrateCaptureApprovedRetryEventsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/MigrateCaptureApprovedRetryEventsWorker.java
@@ -1,0 +1,109 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.RandomUtils;
+import org.jboss.logging.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEventEntity;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
+
+public class MigrateCaptureApprovedRetryEventsWorker {
+
+    private final ChargeDao chargeDao;
+    private final PaymentRequestDao paymentRequestDao;
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    public MigrateCaptureApprovedRetryEventsWorker(ChargeDao chargeDao,
+                                                   PaymentRequestDao paymentRequestDao) {
+        this.chargeDao = chargeDao;
+        this.paymentRequestDao = paymentRequestDao;
+    }
+
+    /**
+     * The entry point into the processing pipeline.
+     * It will fetch the MAX(id) from {@link PaymentRequestEntity} and
+     * for each smaller <code>id</code> it will fetch the entity and
+     * process it
+     */
+    public void execute(Long startId) {
+        MDC.put(HEADER_REQUEST_ID, "Backfill RETRY events " + RandomUtils.nextLong(0, 10000));
+        Long maxId = paymentRequestDao.findMaxId();
+        logger.info("Running migration worker from startId [" + startId + "] to maxId [" + maxId + "]");
+        for (long paymentRequestId = startId; paymentRequestId <= maxId; paymentRequestId++) {
+            int retries = 0;
+            updatePaymentRequestWithRetry(paymentRequestId, retries);
+        }
+    }
+
+    private void updatePaymentRequestWithRetry(long paymentRequestId, long retries) {
+        try {
+            updatePaymentRequest(paymentRequestId);
+        } catch (Exception exc) {
+            if (retries < 3) {
+                logger.error("Problem migrating [" + paymentRequestId +"] " + exc.getMessage() + " retry count [" + retries + "]");
+                updatePaymentRequestWithRetry(paymentRequestId, retries + 1);
+            } else {
+                throw exc;
+            }
+        }
+    }
+
+    //Needs to be public to put the transaction here
+    @SuppressWarnings("WeakerAccess")
+    @Transactional
+    public void updatePaymentRequest(long paymentRequestId) {
+        logger.info("Migrating payment request [" + paymentRequestId + "]");
+        paymentRequestDao.findById(PaymentRequestEntity.class, paymentRequestId)
+                .ifPresent(this::processPaymentRequest);
+    }
+
+    private void processPaymentRequest(PaymentRequestEntity paymentRequest) {
+        //Should make this a lot quicker
+        if (paymentRequest.getChargeTransaction().getTransactionEvents().stream().anyMatch(transactionEvent -> transactionEvent.getStatus().equals(CAPTURE_APPROVED_RETRY))) {
+            chargeDao.findByExternalId(paymentRequest.getExternalId())
+                    .ifPresent(chargeEntity -> processCharge(chargeEntity, paymentRequest));
+        }
+    }
+
+    private void processCharge(ChargeEntity charge, PaymentRequestEntity paymentRequestEntity) {
+        charge.getEvents()
+                .forEach(chargeEventEntity -> processChargeEvent(chargeEventEntity, paymentRequestEntity));
+    }
+
+    private void processChargeEvent(ChargeEventEntity chargeEvent, PaymentRequestEntity paymentRequestEntity) {
+        final ChargeTransactionEntity chargeTransaction = paymentRequestEntity.getChargeTransaction();
+
+        if (chargeEvent.getStatus().equals(CAPTURE_APPROVED_RETRY))
+            if (chargeTransaction.getTransactionEvents()
+                    .stream()
+                    .filter(transactionEvent -> transactionEvent.getStatus().equals(CAPTURE_APPROVED_RETRY))
+                    .noneMatch(transactionEvent -> transactionEvent.getUpdated().equals(chargeEvent.getUpdated()))) {
+
+            logger.info("Adding charge event for paymentRequest [" + paymentRequestEntity.getId() +
+                    "] transaction [" + chargeTransaction.getId() + "] status [" + chargeEvent.getStatus() + "]");
+            ChargeTransactionEventEntity chargeTransactionEventEntity = new ChargeTransactionEventEntity();
+            chargeTransactionEventEntity.setStatus(chargeEvent.getStatus());
+            chargeTransactionEventEntity.setUpdated(chargeEvent.getUpdated());
+            chargeEvent.getGatewayEventDate().ifPresent(chargeTransactionEventEntity::setGatewayEventDate);
+            chargeTransaction.getTransactionEvents().add(chargeTransactionEventEntity);
+            chargeTransactionEventEntity.setTransaction(chargeTransaction);
+        } else {
+            logger.info("Not adding charge event for paymentRequest [" + paymentRequestEntity.getId() +
+                    "] transaction [" + chargeTransaction.getId() + "] status [" + chargeEvent.getStatus() + "]");
+        }
+
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/tasks/MigrateCaptureApprovedRetryEventsWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/MigrateCaptureApprovedRetryEventsWorkerITest.java
@@ -1,0 +1,113 @@
+package uk.gov.pay.connector.tasks;
+
+import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.tasks.TaskITestBase;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+
+public class MigrateCaptureApprovedRetryEventsWorkerITest extends TaskITestBase {
+    private static AtomicLong nextId = new AtomicLong(10);
+
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
+    private MigrateCaptureApprovedRetryEventsWorker worker;
+
+    @Before
+    public void setUp() {
+        worker = env.getInstance(MigrateCaptureApprovedRetryEventsWorker.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldAddCaptureApprovedRetryEventsThatDoNotExistToChargeTransaction() {
+        DatabaseFixtures.TestCharge chargeEntity = createCharge();
+        ZonedDateTime chargeEventUpdateDate1 = ZonedDateTime.now().minusSeconds(10);
+        databaseTestHelper.addEvent(chargeEntity.getChargeId(), ChargeStatus.CAPTURE_APPROVED_RETRY.getValue(), chargeEventUpdateDate1);
+        ZonedDateTime chargeEventUpdateDate2 = ZonedDateTime.now();
+        databaseTestHelper.addEvent(chargeEntity.getChargeId(), ChargeStatus.CAPTURE_APPROVED_RETRY.getValue(), chargeEventUpdateDate2);
+
+        Pair<Long, Long> ids = createPaymentRequest(chargeEntity, chargeEventUpdateDate2);
+
+        worker.execute(1L);
+
+        List<Map<String, Object>> events = databaseTestHelper.loadTransactionEvents(ids.getRight());
+
+        assertThat(events.size(), is(2));
+        assertEvent(chargeEventUpdateDate2, events.get(0));
+        assertEvent(chargeEventUpdateDate1, events.get(1));
+    }
+
+    private void assertEvent(ZonedDateTime expectedUpdateDate, Map<String, Object> event) {
+        assertThat(event.get("status"), is(ChargeStatus.CAPTURE_APPROVED_RETRY.name()));
+        assertThat(event.get("updated"), is(new UTCDateTimeConverter().convertToDatabaseColumn(expectedUpdateDate)));
+    }
+
+    private DatabaseFixtures.TestCharge createCharge() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+
+        final Long chargeId = RandomUtils.nextLong();
+        final String externalChargeId = RandomIdGenerator.newId();
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withTransactionId("gatewayTransactionId");
+        testCharge.insert();
+
+        return testCharge;
+    }
+
+    private Pair<Long, Long> createPaymentRequest(DatabaseFixtures.TestCharge chargeEntity, ZonedDateTime captureApprovedRetryUpdateDate) {
+        long paymentRequestId = nextId.getAndIncrement();
+        databaseTestHelper.addPaymentRequest(
+                paymentRequestId,
+                chargeEntity.getAmount(),
+                chargeEntity.getTestAccount().getAccountId(),
+                chargeEntity.getReturnUrl(),
+                chargeEntity.getDescription(),
+                chargeEntity.getReference(),
+                chargeEntity.getCreatedDate(),
+                chargeEntity.getExternalChargeId());
+
+        long transactionId = nextId.getAndIncrement();
+        databaseTestHelper.addChargeTransaction(
+                transactionId,
+                chargeEntity.getTransactionId(),
+                chargeEntity.getAmount(),
+                chargeEntity.getChargeStatus(),
+                paymentRequestId
+        );
+
+        databaseTestHelper.addChargeTransactionEvent(transactionId, ChargeStatus.CAPTURE_APPROVED_RETRY, captureApprovedRetryUpdateDate);
+
+        return new ImmutablePair<>(paymentRequestId, transactionId);
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}


### PR DESCRIPTION
When we originally migrated charge_events to transaction_events we
thought they were all unique for a charge. However you can have
multiple CAPTURE_APPROVED_RETRY events for a charge. This meant we had
only migrated across the last one. This will migrate across the missing
events.
