### PR TITLE
PP-2784 Drop column charge_id from table card_3ds

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1239,4 +1239,8 @@
         <dropSequence sequenceName="card_3ds_charge_id_seq"/>
     </changeSet>
 
+    <changeSet id="drop charge_id from card_3ds table" author="">
+        <dropColumn tableName="card_3ds" columnName="charge_id"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
- This column has been used for backfilling, which is complete,
so this column can go


