### PR TITLE
PP-3176 External ids getting padded with spaces

### DIFF
--- a/src/main/java/uk/gov/pay/connector/util/RandomIdGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/util/RandomIdGenerator.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.math.BigInteger;
 import java.security.SecureRandom;
 
@@ -19,6 +21,8 @@ public class RandomIdGenerator {
      * @return a random number in base32 (in string format)
      */
     public static String newId() {
-        return new BigInteger(130, RANDOM).toString(32);
+        String id = new BigInteger(130, RANDOM).toString(32);
+
+        return StringUtils.leftPad(id, 26, '0');
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/RandomIdGeneratorTest.java
@@ -29,7 +29,16 @@ public class RandomIdGeneratorTest {
         assertThat(randomIds.size(), is(100));
 
         // then 2. expects dictionary in Base32
-        randomIds.stream().forEach(id ->
+        randomIds.forEach(id ->
                 assertThat(containsAll(BASE32_DICTIONARY, asList(id.toCharArray())), is(true)));
+    }
+
+    @Test
+    public void shouldGenerateIdsOf26CharsInLength() throws Exception {
+        Set<String> randomIds = IntStream.range(0, 100)
+                .parallel()
+                .mapToObj(value -> newId()).collect(Collectors.toSet());
+
+        randomIds.forEach(id -> assertThat(id.length(), is(26)));
     }
 }


### PR DESCRIPTION
Some tests are failing as they have an external id with a space at the
end. This appears to be when the external id we generated has less than
26 characters in it. The database stores them in a fixed width column
of 26 chars. JPA trims off any trailing padding but jDBI does not.

- Added padding when we generate the ids so they are always 26 chars
long.