### PR TITLE
PP-3079 Add field `email` to entity ChargeTransaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
@@ -45,6 +45,8 @@ public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus, Cha
     @Column(name = "created_date")
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime createdDate;
+    @Column(name = "email")
+    private String email;
 
     public ChargeTransactionEntity() {
         super(TransactionOperation.CHARGE);
@@ -134,5 +136,13 @@ public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus, Cha
     @Override
     public void setCreatedDate(ZonedDateTime createdDate) {
         this.createdDate = createdDate;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -111,7 +111,11 @@ public class ChargeService {
                 .map(chargeEntity -> {
                     switch (chargePatchRequest.getPath()) {
                         case ChargesApiResource.EMAIL_KEY:
-                            chargeEntity.setEmail(sanitize(chargePatchRequest.getValue()));
+                            final String sanitizedEmail = sanitize(chargePatchRequest.getValue());
+                            chargeEntity.setEmail(sanitizedEmail);
+                            paymentRequestDao.findByExternalId(chargeId)
+                                    .ifPresent(paymentRequestEntity -> paymentRequestEntity
+                                            .getChargeTransaction().setEmail(sanitizedEmail));
                     }
                     return Optional.of(chargeEntity);
                 })


### PR DESCRIPTION
## WHAT
Store `email` into one of the new entities

## HOW 
Add field `email` on `ChargeTransaction` and set this field when the email is set on 
`Charge` (dual-write to both places)

with @sandorarpa

