### PR TITLE
PP-3081 Back fill the email column from the charges table to Charge Transactions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -45,6 +45,7 @@ import uk.gov.pay.connector.service.CaptureProcessScheduler;
 import uk.gov.pay.connector.service.CardCaptureProcess;
 import uk.gov.pay.connector.tasks.BackfillCreatedDateOnTransactionsTask;
 import uk.gov.pay.connector.tasks.MigrateCaptureApprovedRetryEventTask;
+import uk.gov.pay.connector.tasks.MigrateEmailTask;
 import uk.gov.pay.connector.tasks.MigrateTransactionEventsTask;
 import uk.gov.pay.connector.util.DependentResourceWaitCommand;
 import uk.gov.pay.connector.util.TrustingSSLSocketFactory;
@@ -119,6 +120,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.admin().addTask(injector.getInstance(MigrateTransactionEventsTask.class));
         environment.admin().addTask(injector.getInstance(BackfillCreatedDateOnTransactionsTask.class));
         environment.admin().addTask(injector.getInstance(MigrateCaptureApprovedRetryEventTask.class));
+        environment.admin().addTask(injector.getInstance(MigrateEmailTask.class));
 
         setGlobalProxies(configuration);
     }

--- a/src/main/java/uk/gov/pay/connector/tasks/MigrateEmailTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/MigrateEmailTask.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+import javax.inject.Inject;
+import java.io.PrintWriter;
+
+public class MigrateEmailTask extends Task {
+
+    private static final String TASK_NAME = "migrate-email";
+
+    private MigrateEmailWorker worker;
+
+    private MigrateEmailTask(String name) {
+        super(name);
+    }
+
+    //Used by Guice injection
+    @SuppressWarnings("unused")
+    @Inject
+    public MigrateEmailTask(MigrateEmailWorker worker) {
+        this(TASK_NAME);
+        this.worker = worker;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        String queryParam = "startId";
+        Long startId = 1L;
+        if (!parameters.isEmpty() && parameters.containsKey(queryParam)) {
+            startId = Long.valueOf(parameters.get(queryParam).asList().get(0));
+        }
+        worker.execute(startId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/MigrateEmailWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/MigrateEmailWorker.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.RandomUtils;
+import org.jboss.logging.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
+
+public class MigrateEmailWorker {
+    private final ChargeDao chargeDao;
+    private final PaymentRequestDao paymentRequestDao;
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    public MigrateEmailWorker(ChargeDao chargeDao,
+                              PaymentRequestDao paymentRequestDao) {
+        this.chargeDao = chargeDao;
+        this.paymentRequestDao = paymentRequestDao;
+    }
+
+    public void execute(Long startId) {
+        MDC.put(HEADER_REQUEST_ID, "Back fill email on transactions " + RandomUtils.nextLong(0, 10000));
+        logger.info("Running migration worker");
+        Long maxId = paymentRequestDao.findMaxId();
+        for (long paymentRequestId = startId; paymentRequestId <= maxId; paymentRequestId++) {
+            int retries = 0;
+            updateTransactionsWithRetry(paymentRequestId, retries);
+        }
+    }
+
+    private void updateTransactionsWithRetry(long paymentRequestId, long retries) {
+        try {
+            setEmailOnChargeTransaction(paymentRequestId);
+        } catch (Exception exc) {
+            if (retries < 3) {
+                logger.error("Problem migrating [" + paymentRequestId + "] " + " retry count [" + retries + "]", exc );
+                updateTransactionsWithRetry(paymentRequestId, retries + 1);
+            } else {
+                throw exc;
+            }
+        }
+    }
+
+    //Needs to be public to put the transaction here
+    @SuppressWarnings("WeakerAccess")
+    @Transactional
+    public void setEmailOnChargeTransaction(long paymentRequestId) {
+        logger.info("Back filling transactions for payment request [" + paymentRequestId + "]");
+
+        paymentRequestDao.findById(PaymentRequestEntity.class, paymentRequestId)
+                .ifPresent(paymentRequestEntity -> {
+                    final Optional<ChargeEntity> chargeEntity = chargeDao.findByExternalId(paymentRequestEntity.getExternalId());
+                    chargeEntity.ifPresent(charge ->
+                            paymentRequestEntity.getChargeTransaction().setEmail(charge.getEmail())
+                    );
+                });
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/tasks/MigrateEmailWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/MigrateEmailWorkerITest.java
@@ -1,0 +1,103 @@
+package uk.gov.pay.connector.tasks;
+
+import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.tasks.TaskITestBase;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+
+public class MigrateEmailWorkerITest extends TaskITestBase {
+    private static AtomicLong nextId = new AtomicLong(10);
+
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
+    private MigrateEmailWorker worker;
+
+    @Before
+    public void setUp() {
+        worker = env.getInstance(MigrateEmailWorker.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldAddEmailToMultipleChargeTransaction() {
+        String emailAddress1 = "some@email.com";
+        DatabaseFixtures.TestCharge testCharge1 = createChargeWithEmail(emailAddress1);
+        Pair<Long, Long> ids1 = createPaymentRequest(testCharge1);
+
+        String emailAddress2 = "some@email2.com";
+        DatabaseFixtures.TestCharge testCharge2 = createChargeWithEmail(emailAddress2);
+        Pair<Long, Long> ids2 = createPaymentRequest(testCharge2);
+
+        worker.execute(1L);
+
+        final Map<String, Object> chargeTransaction1 = databaseTestHelper.getChargeTransaction(ids1.getLeft());
+        assertThat(chargeTransaction1.get("email"), is(emailAddress1));
+
+        final Map<String, Object> chargeTransaction2 = databaseTestHelper.getChargeTransaction(ids2.getLeft());
+        assertThat(chargeTransaction2.get("email"), is(emailAddress2));
+    }
+
+    private Pair<Long, Long> createPaymentRequest(DatabaseFixtures.TestCharge chargeEntity) {
+        long paymentRequestId = nextId.getAndIncrement();
+        databaseTestHelper.addPaymentRequest(
+                paymentRequestId,
+                chargeEntity.getAmount(),
+                chargeEntity.getTestAccount().getAccountId(),
+                chargeEntity.getReturnUrl(),
+                chargeEntity.getDescription(),
+                chargeEntity.getReference(),
+                chargeEntity.getCreatedDate(),
+                chargeEntity.getExternalChargeId());
+
+        long transactionId = nextId.getAndIncrement();
+        databaseTestHelper.addChargeTransaction(
+                transactionId,
+                chargeEntity.getTransactionId(),
+                chargeEntity.getAmount(),
+                chargeEntity.getChargeStatus(),
+                paymentRequestId
+        );
+
+        return new ImmutablePair<>(paymentRequestId, transactionId);
+    }
+
+    private DatabaseFixtures.TestCharge createChargeWithEmail(String emailAddress) {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+
+        final Long chargeId = RandomUtils.nextLong();
+        final String externalChargeId = RandomIdGenerator.newId();
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withTransactionId("gatewayTransactionId")
+                .withEmail(emailAddress);
+        testCharge.insert();
+
+        return testCharge;
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}


### PR DESCRIPTION
Added admin task that can be run under url /migrate-email that will
migrate the email address on the charges table to the email address on
the transactions table for charge transactions.
