### PR TITLE
WIP PP-3173 read payment request when updating email

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
+import uk.gov.pay.connector.model.domain.Card3dsEntity;
 import uk.gov.pay.connector.model.domain.PersistedCard;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
@@ -185,6 +186,13 @@ public class ChargeResponse {
                     "paRequest='" + paRequest + '\'' +
                     ", issuerUrl='" + issuerUrl + '\'' +
                     '}';
+        }
+
+        public static Auth3dsData from(Card3dsEntity card3ds) {
+            Auth3dsData auth3dsData = new ChargeResponse.Auth3dsData();
+            auth3dsData.setPaRequest(card3ds.getPaRequest());
+            auth3dsData.setIssuerUrl(card3ds.getIssuerUrl());
+            return auth3dsData;
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/PersistedCard.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PersistedCard.java
@@ -62,4 +62,16 @@ public class PersistedCard {
     public void setCardBrand(String cardBrand) {
         this.cardBrand = cardBrand;
     }
+
+    public static PersistedCard from(CardEntity cardEntity, String cardBrand) {
+            PersistedCard card = new PersistedCard();
+            card.setLastDigitsCardNumber(cardEntity.getLastDigitsCardNumber());
+            card.setCardBrand(cardEntity.getCardBrand());
+            card.setBillingAddress(cardEntity.getBillingAddress() != null ? cardEntity.getBillingAddress().toAddress() : null);
+            card.setExpiryDate(cardEntity.getExpiryDate());
+            card.setCardHolderName(cardEntity.getCardHolderName());
+            card.setCardBrand(cardBrand);
+
+            return card;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
@@ -6,13 +6,12 @@ import io.dropwizard.jersey.PATCH;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.dao.CardTypeDao;
-import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 import uk.gov.pay.connector.model.domain.Card3dsEntity;
 import uk.gov.pay.connector.model.domain.CardEntity;
 import uk.gov.pay.connector.model.domain.CardTypeEntity;
-import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
@@ -56,15 +55,15 @@ public class ChargesFrontendResource {
 
     private static final Logger logger = LoggerFactory.getLogger(ChargesFrontendResource.class);
     private static final String NEW_STATUS = "new_status";
-    private final ChargeDao chargeDao;
     private final ChargeService chargeService;
     private final CardTypeDao cardTypeDao;
+    private final PaymentRequestDao paymentRequestDao;
 
     @Inject
-    public ChargesFrontendResource(ChargeDao chargeDao, ChargeService chargeService, CardTypeDao cardTypeDao) {
-        this.chargeDao = chargeDao;
+    public ChargesFrontendResource(ChargeService chargeService, CardTypeDao cardTypeDao, PaymentRequestDao paymentRequestDao) {
         this.chargeService = chargeService;
         this.cardTypeDao = cardTypeDao;
+        this.paymentRequestDao = paymentRequestDao;
     }
 
     @GET
@@ -72,12 +71,9 @@ public class ChargesFrontendResource {
     @Produces(APPLICATION_JSON)
     @JsonView(GatewayAccountEntity.Views.FrontendView.class)
     public Response getCharge(@PathParam("chargeId") String chargeId, @Context UriInfo uriInfo) {
-
-        Optional<ChargeEntity> maybeCharge = chargeDao.findByExternalId(chargeId);
-        logger.debug("charge from DB: " + maybeCharge);
-
-        return maybeCharge
-                .map(charge -> Response.ok(buildChargeResponse(uriInfo, charge)).build())
+        Optional<PaymentRequestEntity> paymentRequestEntity = paymentRequestDao.findByExternalId(chargeId);
+        return paymentRequestEntity
+                .map(paymentRequest -> Response.ok(buildChargeResponse(uriInfo, paymentRequest)).build())
                 .orElseGet(() -> responseWithChargeNotFound(chargeId));
     }
 
@@ -155,38 +151,6 @@ public class ChargesFrontendResource {
                 .stream()
                 .findFirst()
                 .map(CardTypeEntity::getLabel);
-    }
-
-    private ChargeResponse buildChargeResponse(UriInfo uriInfo, ChargeEntity charge) {
-        String chargeId = charge.getExternalId();
-        PersistedCard persistedCard = null;
-        if (charge.getCardDetails() != null) {
-            persistedCard = charge.getCardDetails().toCard();
-            persistedCard.setCardBrand(findCardBrandLabel(charge.getCardDetails().getCardBrand()).orElse(""));
-        }
-
-        ChargeResponse.Auth3dsData auth3dsData = null;
-        if (charge.get3dsDetails() != null) {
-            auth3dsData = new ChargeResponse.Auth3dsData();
-            auth3dsData.setPaRequest(charge.get3dsDetails().getPaRequest());
-            auth3dsData.setIssuerUrl(charge.get3dsDetails().getIssuerUrl());
-        }
-
-        return aFrontendChargeResponse()
-                .withStatus(charge.getStatus())
-                .withChargeId(chargeId)
-                .withAmount(charge.getAmount())
-                .withDescription(charge.getDescription())
-                .withGatewayTransactionId(charge.getGatewayTransactionId())
-                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(charge.getCreatedDate()))
-                .withReturnUrl(charge.getReturnUrl())
-                .withEmail(charge.getEmail())
-                .withChargeCardDetails(persistedCard)
-                .withAuth3dsData(auth3dsData)
-                .withGatewayAccount(charge.getGatewayAccount())
-                .withLink("self", GET, locationUriFor(FRONTEND_CHARGE_API_PATH, uriInfo, chargeId))
-                .withLink("cardAuth", POST, locationUriFor(FRONTEND_CHARGE_AUTHORIZE_API_PATH, uriInfo, chargeId))
-                .withLink("cardCapture", POST, locationUriFor(FRONTEND_CHARGE_CAPTURE_API_PATH, uriInfo, chargeId)).build();
     }
 
     private ChargeResponse buildChargeResponse(UriInfo uriInfo, PaymentRequestEntity paymentRequest) {

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
@@ -9,12 +9,24 @@ import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
-import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.domain.Card3dsEntity;
+import uk.gov.pay.connector.model.domain.CardEntity;
+import uk.gov.pay.connector.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.PersistedCard;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 import uk.gov.pay.connector.service.ChargeService;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -29,10 +41,15 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.model.FrontendChargeResponse.aFrontendChargeResponse;
 import static uk.gov.pay.connector.model.builder.PatchRequestBuilder.aPatchRequestBuilder;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
-import static uk.gov.pay.connector.resources.ApiPaths.*;
+import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_AUTHORIZE_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_CAPTURE_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_STATUS_API_PATH;
 import static uk.gov.pay.connector.resources.ApiValidators.validateChargePatchParams;
 import static uk.gov.pay.connector.resources.ChargesApiResource.EMAIL_KEY;
-import static uk.gov.pay.connector.util.ResponseUtil.*;
+import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.fieldsMissingResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.responseWithChargeNotFound;
 
 @Path("/")
 public class ChargesFrontendResource {
@@ -85,8 +102,8 @@ public class ChargesFrontendResource {
             return badRequestResponse("Invalid patch parameters" + chargePatchMap.toString());
         }
 
-        return chargeService.updateCharge(chargeId, chargePatchRequest)
-                .map(chargeEntity -> Response.ok(buildChargeResponse(uriInfo, chargeEntity)).build())
+        return chargeService.updateEmail(chargeId, chargePatchRequest)
+                .map(paymentRequestEntity -> Response.ok(buildChargeResponse(uriInfo, paymentRequestEntity)).build())
                 .orElseGet(() -> responseWithChargeNotFound(chargeId));
     }
 
@@ -170,6 +187,38 @@ public class ChargesFrontendResource {
                 .withLink("self", GET, locationUriFor(FRONTEND_CHARGE_API_PATH, uriInfo, chargeId))
                 .withLink("cardAuth", POST, locationUriFor(FRONTEND_CHARGE_AUTHORIZE_API_PATH, uriInfo, chargeId))
                 .withLink("cardCapture", POST, locationUriFor(FRONTEND_CHARGE_CAPTURE_API_PATH, uriInfo, chargeId)).build();
+    }
+
+    private ChargeResponse buildChargeResponse(UriInfo uriInfo, PaymentRequestEntity paymentRequest) {
+        String externalId = paymentRequest.getExternalId();
+        PersistedCard persistedCard = null;
+        ChargeTransactionEntity chargeTransaction = paymentRequest.getChargeTransaction();
+        CardEntity cardEntity = chargeTransaction.getCard();
+        if (cardEntity != null) {
+            persistedCard = PersistedCard.from(cardEntity, findCardBrandLabel(cardEntity.getCardBrand()).orElse(""));
+        }
+
+        ChargeResponse.Auth3dsData auth3dsData = null;
+        Card3dsEntity card3ds = chargeTransaction.getCard3ds();
+        if (card3ds != null) {
+            auth3dsData = ChargeResponse.Auth3dsData.from(card3ds);
+        }
+
+        return aFrontendChargeResponse()
+                .withStatus(chargeTransaction.getStatus().getValue())
+                .withChargeId(externalId)
+                .withAmount(chargeTransaction.getAmount())
+                .withDescription(paymentRequest.getDescription())
+                .withGatewayTransactionId(chargeTransaction.getGatewayTransactionId())
+                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(chargeTransaction.getCreatedDate()))
+                .withReturnUrl(paymentRequest.getReturnUrl())
+                .withEmail(chargeTransaction.getEmail())
+                .withChargeCardDetails(persistedCard)
+                .withAuth3dsData(auth3dsData)
+                .withGatewayAccount(paymentRequest.getGatewayAccount())
+                .withLink("self", GET, locationUriFor(FRONTEND_CHARGE_API_PATH, uriInfo, externalId))
+                .withLink("cardAuth", POST, locationUriFor(FRONTEND_CHARGE_AUTHORIZE_API_PATH, uriInfo, externalId))
+                .withLink("cardCapture", POST, locationUriFor(FRONTEND_CHARGE_CAPTURE_API_PATH, uriInfo, externalId)).build();
     }
 
     private URI locationUriFor(String path, UriInfo uriInfo, String chargeId) {

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -106,18 +106,19 @@ public class ChargeService {
     }
 
     @Transactional
-    public Optional<ChargeEntity> updateCharge(String chargeId, PatchRequestBuilder.PatchRequest chargePatchRequest) {
-        return chargeDao.findByExternalId(chargeId)
-                .map(chargeEntity -> {
+    public Optional<PaymentRequestEntity> updateEmail(String externalId, PatchRequestBuilder.PatchRequest chargePatchRequest) {
+        return paymentRequestDao.findByExternalId(externalId)
+                .map(paymentRequestEntity -> {
                     switch (chargePatchRequest.getPath()) {
                         case ChargesApiResource.EMAIL_KEY:
                             final String sanitizedEmail = sanitize(chargePatchRequest.getValue());
-                            chargeEntity.setEmail(sanitizedEmail);
-                            paymentRequestDao.findByExternalId(chargeId)
-                                    .ifPresent(paymentRequestEntity -> paymentRequestEntity
-                                            .getChargeTransaction().setEmail(sanitizedEmail));
+                            paymentRequestEntity.getChargeTransaction().setEmail(sanitizedEmail);
+
+                            chargeDao.findByExternalId(externalId).ifPresent(chargeEntity ->
+                                    chargeEntity.setEmail(sanitizedEmail)
+                            );
                     }
-                    return Optional.of(chargeEntity);
+                    return Optional.of(paymentRequestEntity);
                 })
                 .orElseGet(Optional::empty);
     }

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -12,6 +12,7 @@ import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Rule;
+import uk.gov.pay.connector.model.domain.AuthCardDetails;
 import uk.gov.pay.connector.model.domain.CardFixture;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
@@ -19,6 +20,7 @@ import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.rules.EpdqMockClient;
 import uk.gov.pay.connector.rules.SmartpayMockClient;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.PortFactory;
 import uk.gov.pay.connector.util.RestAssuredClient;
 
@@ -31,11 +33,21 @@ import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static java.lang.String.format;
+import static java.time.ZonedDateTime.now;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
-import static uk.gov.pay.connector.model.domain.GatewayAccount.*;
-import static uk.gov.pay.connector.resources.ApiPaths.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.resources.ApiPaths.CHARGE_CANCEL_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_3DS_AUTHORIZE_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_AUTHORIZE_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_CAPTURE_API_PATH;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
 
@@ -195,7 +207,14 @@ public class ChargingITestBase extends ChargingITestCommon {
     protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId) {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge-" + chargeId;
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, 6234L, status, "returnUrl", gatewayTransactionId);
+        long amount = 6234L;
+        String returnUrl = "returnUrl";
+        DatabaseTestHelper databaseTestHelper = app.getDatabaseTestHelper();
+        databaseTestHelper.addCharge(chargeId, externalChargeId, accountId, amount, status, returnUrl, gatewayTransactionId);
+
+        long paymentRequestId = RandomUtils.nextLong();
+        databaseTestHelper.addPaymentRequest(paymentRequestId, amount, Long.valueOf(accountId), returnUrl, "Test description", "test reference", now(), externalChargeId);
+        databaseTestHelper.addChargeTransaction(RandomUtils.nextLong(), gatewayTransactionId, amount, status, paymentRequestId);
         return externalChargeId;
     }
 
@@ -283,12 +302,22 @@ public class ChargingITestBase extends ChargingITestCommon {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, "http://somereturn.gov.uk", gatewayTransactionId, reference, fromDate);
+        String returnUrl = "http://somereturn.gov.uk";
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, gatewayTransactionId, reference, fromDate);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
+        AuthCardDetails cardDetails = CardFixture.aValidCard().withCardNo("1234").build();
         app.getDatabaseTestHelper().updateChargeCardDetails(
                 chargeId,
-                CardFixture.aValidCard().withCardNo("1234").build());
+                cardDetails);
+
+        long paymentRequestId = RandomUtils.nextLong();
+        app.getDatabaseTestHelper().addPaymentRequest(paymentRequestId, AMOUNT, Long.valueOf(accountId), returnUrl, "Test description", reference, fromDate, externalChargeId);
+        long chargeTransactionId = RandomUtils.nextLong();
+        app.getDatabaseTestHelper().addChargeTransaction(chargeTransactionId, gatewayTransactionId, AMOUNT, status, paymentRequestId);
+        app.getDatabaseTestHelper().addChargeTransactionEvent(chargeTransactionId, chargeStatus, now());
+        app.getDatabaseTestHelper().addCard(RandomUtils.nextLong(), chargeTransactionId, cardDetails);
+
         return externalChargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -206,7 +206,7 @@ public class ChargeServiceTest {
 
         assertThat(paymentRequestEntity.getChargeTransaction().getEmail(), is(nullValue()));
 
-        service.updateCharge(chargeEntityExternalId, patchRequest);
+        service.updateEmail(chargeEntityExternalId, patchRequest);
 
         verify(mockedPaymentRequestDao).findByExternalId(chargeEntityExternalId);
         String emailFromTransaction = paymentRequestEntity.getChargeTransaction().getEmail();

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -557,12 +557,17 @@ public class DatabaseTestHelper {
         );
     }
 
+    public void addChargeTransaction(long transactionId, String gatewayTransactionId, Long amount, ChargeStatus chargeStatus, long paymentRequestId) {
+        addChargeTransaction(transactionId, gatewayTransactionId, amount, chargeStatus, paymentRequestId, now());
+    }
+
     public void addChargeTransaction(
             long transactionId,
             String gatewayTransactionId,
             Long amount,
             ChargeStatus chargeStatus,
-            long paymentRequestId
+            long paymentRequestId,
+            ZonedDateTime dateCreated
             ) {
         jdbi.withHandle(h ->
                 h.update(
@@ -572,16 +577,18 @@ public class DatabaseTestHelper {
                                 "gateway_transaction_id," +
                                 "amount," +
                                 "status," +
-                                "operation" +
+                                "operation," +
+                                "created_date" +
                                 ")" +
                                 "VALUES (" +
-                                "?, ?, ?, ?, ?, 'CHARGE'" +
+                                "?, ?, ?, ?, ?, 'CHARGE', ?" +
                                 ")",
                         transactionId,
                         paymentRequestId,
                         gatewayTransactionId,
                         amount,
-                        chargeStatus.name()
+                        chargeStatus.name(),
+                        Timestamp.from(dateCreated.toInstant())
                 )
         );
     }
@@ -652,38 +659,57 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void addCard(Long cardId, Long chargeId, Long transactionId) {
+    public void addCard(Long cardId, Long transactionId, AuthCardDetails cardDetails) {
         jdbi.withHandle(h -> h.update(
                 "INSERT INTO cards(" +
                         "id," +
-                        "charge_id," +
+                        "transaction_id," +
                         "card_brand," +
-                        "transaction_id" +
+                        "last_digits_card_number," +
+                        "cardholder_name," +
+                        "expiry_date," +
+                        "address_line1," +
+                        "address_line2," +
+                        "address_postcode," +
+                        "address_city," +
+                        "address_county," +
+                        "address_country" +
+                        "" +
                         ")" +
                         "VALUES (" +
-                        "?, ?, 'some_brand', ?" +
+                        "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?" +
                         ")",
-                cardId,
-                chargeId,
-                transactionId)
+                    cardId,
+                    transactionId,
+                    cardDetails.getCardBrand(),
+                    cardDetails.getCardNo(),
+                    cardDetails.getCardHolder(),
+                    cardDetails.getEndDate(),
+                    cardDetails.getAddress().getLine1(),
+                    cardDetails.getAddress().getLine2(),
+                    cardDetails.getAddress().getPostcode(),
+                    cardDetails.getAddress().getCity(),
+                    cardDetails.getAddress().getCounty(),
+                    cardDetails.getAddress().getCountry()
+                )
         );
     }
 
-    public void addCard3ds(Long cardId, Long chargeId, Long transactionId) {
+    public void addCard3ds(Long cardId, Long transactionId, String paRequest, String issuerUrl) {
         jdbi.withHandle(h -> h.update(
                 "INSERT INTO card_3ds(" +
                         "id," +
-                        "charge_id," +
                         "transaction_id," +
                         "pa_request," +
                         "issuer_url" +
                         ")" +
                         "VALUES (" +
-                        "?, ?, ?, 'some_ps_request', 'some_issuer_url'" +
+                        "?, ?, ?, ?" +
                         ")",
                 cardId,
-                chargeId,
-                transactionId)
+                transactionId,
+                paRequest,
+                issuerUrl)
         );
     }
 


### PR DESCRIPTION
Change the code that passes round a ChargeEntity to use a
PaymentRequestEntity instead. This is because we are now using the new
PaymentRequest tables and want to start reading from them. Eventually
we will stop updating the Charges table and delete the code. Still need
to keep updating Charges until everything is updated but after this
change that should be trivial.

-Read payment request when updating email.
-Read payment request when getting a charge.


