### PR TITLE
PP-2705 Allow transaction searches for multiple card brands

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
@@ -148,8 +148,9 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
             predicates.add(likePredicate(cb, charge.get(EMAIL), params.getEmail()));
         if (params.getInternalStates() != null && !params.getInternalStates().isEmpty())
             predicates.add(charge.get(STATUS).in(params.getInternalStates()));
-        if (StringUtils.isNotBlank(params.getCardBrand()))
-            predicates.add(charge.get(CARD_DETAILS).get("cardBrand").in(params.getCardBrand()));
+        if (!params.getCardBrands().isEmpty()) {
+            predicates.add(charge.get(CARD_DETAILS).get("cardBrand").in(params.getCardBrands()));
+        }
         if (params.getFromDate() != null)
             predicates.add(cb.greaterThanOrEqualTo(charge.get(CREATED_DATE), params.getFromDate()));
         if (params.getToDate() != null)

--- a/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
@@ -8,7 +8,12 @@ import uk.gov.pay.connector.model.domain.RefundStatus;
 import uk.gov.pay.connector.resources.CommaDelimitedSetParameter;
 
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -25,7 +30,7 @@ public class ChargeSearchParams {
     private ZonedDateTime toDate;
     private Long page;
     private Long displaySize;
-    private String cardBrand;
+    private List<String> cardBrands = new ArrayList<>();
     private Set<ChargeStatus> internalStates = new HashSet<>();
     private Set<ChargeStatus> internalChargeStatuses = new HashSet<>();
     private Set<RefundStatus> internalRefundStatuses = new HashSet<>();
@@ -121,7 +126,12 @@ public class ChargeSearchParams {
     }
 
     public ChargeSearchParams withCardBrand(String cardBrand) {
-        this.cardBrand = cardBrand;
+        this.cardBrands = Collections.singletonList(cardBrand);
+        return this;
+    }
+
+    public ChargeSearchParams withCardBrands(List<String> cardBrands) {
+        this.cardBrands = cardBrands;
         return this;
     }
 
@@ -178,8 +188,8 @@ public class ChargeSearchParams {
         return this;
     }
 
-    public String getCardBrand() {
-        return cardBrand;
+    public List<String> getCardBrands() {
+        return cardBrands;
     }
 
     public String buildQueryParams() {
@@ -218,8 +228,8 @@ public class ChargeSearchParams {
             builder.append("&refund_states=").append(refundStates);
         }
 
-        if (isNotBlank(cardBrand)) {
-            builder.append("&card_brand=").append(cardBrand);
+        if (!cardBrands.isEmpty()) {
+            cardBrands.forEach(cardBrand -> builder.append("&card_brand=").append(cardBrand));
         }
         return builder.toString().replaceFirst("&", "");
     }

--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -3,7 +3,11 @@ package uk.gov.pay.connector.dao;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
-import org.jooq.*;
+import org.jooq.Condition;
+import org.jooq.SelectConditionStep;
+import org.jooq.SelectJoinStep;
+import org.jooq.SelectOrderByStep;
+import org.jooq.SelectSeekStep1;
 import org.jooq.impl.DSL;
 import uk.gov.pay.connector.model.TransactionType;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -18,7 +22,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.jooq.impl.DSL.*;
+import static org.jooq.impl.DSL.count;
+import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.selectDistinct;
+import static org.jooq.impl.DSL.table;
 
 @Deprecated // This will be removed once the new refunds functionality has been completed.
 @Transactional
@@ -107,9 +114,9 @@ public class TransactionDao {
                     field("c.email").lower().like(buildLikeClauseContaining(params.getEmail().toLowerCase())));
         }
 
-        if (isNotBlank(params.getCardBrand())) {
+        if (!params.getCardBrands().isEmpty()) {
             queryFilters = queryFilters.and(
-                    field("c.card_brand").in(params.getCardBrand()));
+                    field("c.card_brand").in(params.getCardBrands()));
         }
 
         if (isNotBlank(params.getReference())) {

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -18,27 +18,44 @@ import uk.gov.pay.connector.service.search.SearchService;
 import uk.gov.pay.connector.util.ResponseUtil;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static fj.data.Either.reduce;
 import static java.lang.String.format;
-import static java.util.Arrays.*;
+import static java.util.Arrays.stream;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.created;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static uk.gov.pay.connector.model.TransactionType.*;
-import static uk.gov.pay.connector.resources.ApiPaths.*;
+import static uk.gov.pay.connector.model.TransactionType.inferTransactionTypeFrom;
+import static uk.gov.pay.connector.resources.ApiPaths.CHARGES_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.CHARGES_EXPIRE_CHARGES_TASK_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.CHARGE_API_PATH;
 import static uk.gov.pay.connector.resources.ApiValidators.validateGatewayAccountReference;
 import static uk.gov.pay.connector.service.ChargeExpiryService.EXPIRABLE_STATUSES;
 import static uk.gov.pay.connector.service.search.SearchService.TYPE.CHARGE;
 import static uk.gov.pay.connector.service.search.SearchService.TYPE.TRANSACTION;
-import static uk.gov.pay.connector.util.ResponseUtil.*;
+import static uk.gov.pay.connector.util.ResponseUtil.fieldsInvalidResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.fieldsInvalidSizeResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.fieldsMissingResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.responseWithChargeNotFound;
+import static uk.gov.pay.connector.util.ResponseUtil.successResponseWithEntity;
 
 @Path("/")
 public class ChargesApiResource {
@@ -112,7 +129,7 @@ public class ChargesApiResource {
                                    @QueryParam(STATE_KEY) String state,
                                    @QueryParam("payment_states") CommaDelimitedSetParameter paymentStates,
                                    @QueryParam("refund_states") CommaDelimitedSetParameter refundStates,
-                                   @QueryParam(CARD_BRAND_KEY) String cardBrand,
+                                   @QueryParam(CARD_BRAND_KEY) List<String> cardBrands,
                                    @QueryParam(FROM_DATE_KEY) String fromDate,
                                    @QueryParam(TO_DATE_KEY) String toDate,
                                    @QueryParam(PAGE) Long pageNumber,
@@ -133,7 +150,7 @@ public class ChargesApiResource {
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
                             .withReferenceLike(reference)
-                            .withCardBrand(cardBrand)
+                            .withCardBrands(cardBrands)
                             .withFromDate(parseDate(fromDate))
                             .withToDate(parseDate(toDate))
                             .withDisplaySize(displaySize != null ? displaySize : configuration.getTransactionsPaginationConfig().getDisplayPageSize())

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
@@ -5,15 +5,30 @@ import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.resources.CommaDelimitedSetParameter;
 
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.pay.connector.model.TransactionType.*;
+import static uk.gov.pay.connector.model.TransactionType.PAYMENT;
 import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_CREATED;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_ABORTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRE_CANCEL_FAILED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRE_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCELLED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_SUBMITTED;
 
 public class ChargeSearchParamsTest {
 
@@ -65,7 +80,7 @@ public class ChargeSearchParamsTest {
 
         // So internal methods can call findAll with specific states of a charge
         ChargeSearchParams params = new ChargeSearchParams()
-                .withInternalStates(Arrays.asList(CAPTURED, USER_CANCELLED));
+                .withInternalStates(asList(CAPTURED, USER_CANCELLED));
 
         assertThat(params.getInternalStates(), hasSize(2));
         assertThat(params.getInternalStates(), containsInAnyOrder(CAPTURED, USER_CANCELLED));
@@ -84,14 +99,15 @@ public class ChargeSearchParamsTest {
                         "&display_size=5" +
                         "&payment_states=created" +
                         "&refund_states=submitted" +
-                        "&card_brand=visa";
+                        "&card_brand=visa" +
+                        "&card_brand=master-card";
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withDisplaySize(5L)
                 .withTransactionType(PAYMENT)
                 .addExternalChargeStates(new CommaDelimitedSetParameter("created"))
                 .addExternalRefundStates(new CommaDelimitedSetParameter("submitted"))
-                .withCardBrand("visa")
+                .withCardBrands(asList("visa", "master-card"))
                 .withGatewayAccountId(111L)
                 .withPage(2L)
                 .withReferenceLike("ref")


### PR DESCRIPTION
Updated the getChargesJson endpoint so it can now take a list of
cardBrands in the format card_brand=first&card_brand=second.