### PR TITLE
PP-2705 Allow transaction searches for multiple card brands

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -150,7 +150,7 @@ public class ChargesApiResource {
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
                             .withReferenceLike(reference)
-                            .withCardBrands(cardBrands)
+                            .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))
                             .withToDate(parseDate(toDate))
                             .withDisplaySize(displaySize != null ? displaySize : configuration.getTransactionsPaginationConfig().getDisplayPageSize())
@@ -168,6 +168,10 @@ public class ChargesApiResource {
                     return reduce(validateGatewayAccountReference(gatewayAccountDao, accountId)
                             .bimap(handleError, listCharges(searchParams, isFeatureTransactionsEnabled, uriInfo)));
                 }); // always the first page if its missing
+    }
+
+    private List<String> removeBlanks(List<String> cardBrands) {
+        return cardBrands.stream().filter(StringUtils::isNotBlank).collect(Collectors.toList());
     }
 
     @POST

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -530,8 +530,8 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String searchedCardBrand = "visa";
 
         addChargeAndCardDetails(CREATED, "ref-1", now(), searchedCardBrand);
-        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now(), "mastercard");
-        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2), searchedCardBrand);
+        addChargeAndCardDetails(CREATED, "ref-2", now(), "master-card");
+        addChargeAndCardDetails(CREATED, "ref-3", now().minusDays(2), searchedCardBrand);
 
         getChargeApi
                 .withAccountId(accountId)
@@ -542,6 +542,23 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .contentType(JSON)
                 .body("results.size()", is(2))
                 .body("results[0].card_details.card_brand", endsWith("Visa"))
+                .body("results[1].card_details.card_brand", endsWith("Visa"));
+    }
+
+    @Test
+    public void shouldFilterTransactionsByBlankCardBrand() throws Exception {
+        addChargeAndCardDetails(CREATED, "ref-1", now(), "visa");
+        addChargeAndCardDetails(CREATED, "ref-2", now(), "master-card");
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("card_brand", "")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactions()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("results[0].card_details.card_brand", endsWith("Mastercard"))
                 .body("results[1].card_details.card_brand", endsWith("Visa"));
     }
 


### PR DESCRIPTION
Found a bug where you did not select a card-brand in self service. This
submitted the transaction search with a blank card_brand argument and
resulted in a List of length 1 containing "". Search was then looking
for card_brand in ("").

- Filter these blanks in the controller.
- Add a test for card_brand=