### PR TITLE
PP-1503 Integration with Smartpay works even if payer does not fill the second line of address

### DIFF
--- a/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
@@ -18,7 +18,7 @@
                     <ns1:number>${authCardDetails.cardNo}</ns1:number>
                     <ns1:billingAddress>
                         <ns2:houseNumberOrName>${authCardDetails.address.line1?xml}</ns2:houseNumberOrName>
-                        <ns2:street><#if authCardDetails.address.line2??>${authCardDetails.address.line2?xml}</#if></ns2:street>
+                        <ns2:street><#if authCardDetails.address.line2?has_content>${authCardDetails.address.line2?xml}<#else>N/A</#if></ns2:street>
                         <ns2:postalCode>${authCardDetails.address.postcode?xml}</ns2:postalCode>
                         <ns2:stateOrProvince><#if authCardDetails.address.county??>${authCardDetails.address.county?xml}</#if></ns2:stateOrProvince>
                         <ns2:city>${authCardDetails.address.city?xml}</ns2:city>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-minimal.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-minimal.xml
@@ -18,7 +18,7 @@
                     <ns1:number>5555444433331111</ns1:number>
                     <ns1:billingAddress>
                         <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
-                        <ns2:street></ns2:street>
+                        <ns2:street>N/A</ns2:street>
                         <ns2:postalCode>EC2A 1AE</ns2:postalCode>
                         <ns2:stateOrProvince></ns2:stateOrProvince>
                         <ns2:city>London</ns2:city>


### PR DESCRIPTION
We had a bug where the authorisation with Smartpay was failing if the user was not filling the second line of the address on our Pay frontend.

This PR detects whether that information is missing and, in that case, feeds a dummy string ("N/A").

It is OK not to be accurate with what we pass as `houseNumberOrName` and `street` fields to Smartpay, as long as, if AVS checking is enable, that is enabled only for the postcode.
[Anyway, it would be error-prone for us to try to extract a house number/name out of the free text the user inputs on frontend.]

That will be something we need to specify in our Smartpay integration guide.

Probably, we should try to set the right AVS-checking setting on Smartpay (postcode-only), and see if we can avoid sending the address information altogether (obviously, we would still need to send the postcode). However, I think for now it is better to release this to patch the issue, and then think about alternative solutions.



