### PR TITLE
PP-3239 Use new data structure in search

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1255,4 +1255,18 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add gateway_account_id to transactions table" author="">
+        <addColumn tableName="transactions">
+            <column name="gateway_account_id" type="bigint">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="createIndex transactions.gateway_account_id" author="" runInTransaction="false">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_transactions_gateway_account_id ON transactions (gateway_account_id);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
The new search is a bit slower than we would like. One of the biggest
reasons for this is joining payment_requests to transactions when we
have a large amount of data. This is the case if you just load
transactions for a given gateway_account_id (if you search by reference
also on payment_requests you are reducing the amount of rows by enough
for this not to be inefficient). Adding the gateway_account_id to
transactions which we will back fill with the gateway_account_id on
payment_requests will allow us to do this search without joining
payment_requests. Although we will set this in the java code will
probably not expose it, we will just use it when searching transactions.

- Added gateway_account_id to transactions table.
- Added index to gateway_account_id.


