### PR TITLE
PP-1503 Making an automatic test more meaningful

### DIFF
--- a/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayOrderRequestBuilderTest.java
@@ -84,7 +84,7 @@ public class SmartpayOrderRequestBuilderTest {
     public void shouldGenerateValidAuthoriseOrderRequestForAddressWithOptionalFieldsMissing() throws Exception {
 
         Address address = Address.anAddress();
-        address.setLine1("41");
+        address.setLine1("41 Acacia Avenue");
         address.setCity("London");
         address.setPostcode("EC2A 1AE");
         address.setCountry("GB");

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-minimal.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-minimal.xml
@@ -17,7 +17,7 @@
                     <ns1:holderName>Mr. Payment</ns1:holderName>
                     <ns1:number>5555444433331111</ns1:number>
                     <ns1:billingAddress>
-                        <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
+                        <ns2:houseNumberOrName>41 Acacia Avenue</ns2:houseNumberOrName>
                         <ns2:street>N/A</ns2:street>
                         <ns2:postalCode>EC2A 1AE</ns2:postalCode>
                         <ns2:stateOrProvince></ns2:stateOrProvince>


### PR DESCRIPTION
The automated test in question is about a user filling only the
first line of the address on Pay frontend.
If they do so, they would probably not type only their house number
but also the street name in said field.


