### PR TITLE
PP-3239 Get ready to use new data structure in search

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -44,6 +44,7 @@ import uk.gov.pay.connector.service.Auth3dsDetailsFactory;
 import uk.gov.pay.connector.service.CaptureProcessScheduler;
 import uk.gov.pay.connector.service.CardCaptureProcess;
 import uk.gov.pay.connector.tasks.BackfillCreatedDateOnTransactionsTask;
+import uk.gov.pay.connector.tasks.BackfillGatewayAccountIdOnTransactionsTask;
 import uk.gov.pay.connector.tasks.MigrateCaptureApprovedRetryEventTask;
 import uk.gov.pay.connector.tasks.MigrateEmailTask;
 import uk.gov.pay.connector.tasks.MigrateTransactionEventsTask;
@@ -119,6 +120,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
         environment.admin().addTask(injector.getInstance(MigrateTransactionEventsTask.class));
         environment.admin().addTask(injector.getInstance(BackfillCreatedDateOnTransactionsTask.class));
+        environment.admin().addTask(injector.getInstance(BackfillGatewayAccountIdOnTransactionsTask.class));
         environment.admin().addTask(injector.getInstance(MigrateCaptureApprovedRetryEventTask.class));
         environment.admin().addTask(injector.getInstance(MigrateEmailTask.class));
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
@@ -43,6 +43,10 @@ public abstract class TransactionEntity<S extends Status, T extends TransactionE
     @ManyToOne
     @JoinColumn(name = "payment_request_id", referencedColumnName = "id", updatable = false)
     private PaymentRequestEntity paymentRequest;
+    @Column(name = "gateway_account_id")
+    // This just needs to be set when we save the transaction. It is then used to optimise
+    // transaction search don't access in Java code.
+    private Long gatewayAccountId;
 
     TransactionEntity(TransactionOperation operation) {
         this.operation = operation;
@@ -70,6 +74,12 @@ public abstract class TransactionEntity<S extends Status, T extends TransactionE
 
     public void setPaymentRequest(PaymentRequestEntity paymentRequest) {
         this.paymentRequest = paymentRequest;
+        this.gatewayAccountId = paymentRequest.getGatewayAccount().getId();
+    }
+
+    //todo remove this once we have back filled the gatewayAccountId.
+    public void setGatewayAccountId(Long gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
     }
 
     public TransactionOperation getOperation() {

--- a/src/main/java/uk/gov/pay/connector/tasks/BackfillGatewayAccountIdOnTransactionsTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/BackfillGatewayAccountIdOnTransactionsTask.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.common.collect.ImmutableMultimap;
+import io.dropwizard.servlets.tasks.Task;
+
+import javax.inject.Inject;
+import java.io.PrintWriter;
+
+public class BackfillGatewayAccountIdOnTransactionsTask extends Task {
+    private static final String TASK_NAME = "backfill-gateway-account-id-on-transactions";
+
+    private BackfillGatewayAccountIdOnTransactionsWorker worker;
+
+    private BackfillGatewayAccountIdOnTransactionsTask(String name) {
+        super(name);
+    }
+
+    @Inject
+    public BackfillGatewayAccountIdOnTransactionsTask(BackfillGatewayAccountIdOnTransactionsWorker worker) {
+        this(TASK_NAME);
+        this.worker = worker;
+    }
+
+    @Override
+    public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) {
+        String queryParam = "startId";
+        Long startId = 1L;
+        if (!parameters.isEmpty() && parameters.containsKey(queryParam)) {
+            startId = Long.valueOf(parameters.get(queryParam).asList().get(0));
+        }
+        worker.execute(startId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/BackfillGatewayAccountIdOnTransactionsWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/BackfillGatewayAccountIdOnTransactionsWorker.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.RandomUtils;
+import org.jboss.logging.MDC;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.dao.RefundDao;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
+
+public class BackfillGatewayAccountIdOnTransactionsWorker {
+    private final ChargeDao chargeDao;
+    private final PaymentRequestDao paymentRequestDao;
+    private final RefundDao refundDao;
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    public BackfillGatewayAccountIdOnTransactionsWorker(ChargeDao chargeDao,
+                                                        PaymentRequestDao paymentRequestDao,
+                                                        RefundDao refundDao) {
+        this.chargeDao = chargeDao;
+        this.paymentRequestDao = paymentRequestDao;
+        this.refundDao = refundDao;
+    }
+
+    public void execute(Long startId) {
+        MDC.put(HEADER_REQUEST_ID, "Back fill gateway_account_id on transactions " + RandomUtils.nextLong(0, 10000));
+        logger.info("Running migration worker");
+        Long maxId = paymentRequestDao.findMaxId();
+        for (long paymentRequestId = startId; paymentRequestId <= maxId; paymentRequestId++) {
+            int retries = 0;
+            updateTransactionsWithRetry(paymentRequestId, retries);
+        }
+    }
+
+    private void updateTransactionsWithRetry(long paymentRequestId, long retries) {
+        try {
+            setGatewayAccountOnTransactions(paymentRequestId);
+        } catch (Exception exc) {
+            if (retries < 3) {
+                logger.error("Problem migrating [" + paymentRequestId + "] " + " retry count [" + retries + "]", exc );
+                updateTransactionsWithRetry(paymentRequestId, retries + 1);
+            } else {
+                throw exc;
+            }
+        }
+    }
+
+    @Transactional
+    public void setGatewayAccountOnTransactions(long paymentRequestId) {
+        logger.info("Backfilling transactions for payment request [" + paymentRequestId + "]");
+
+        paymentRequestDao.findById(PaymentRequestEntity.class, paymentRequestId)
+                .ifPresent(paymentRequestEntity -> {
+                    Long gatewayAccountId = paymentRequestEntity.getGatewayAccount().getId();
+                    paymentRequestEntity.getTransactions()
+                            .forEach(transaction -> transaction.setGatewayAccountId(gatewayAccountId));
+                });
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityTest.java
@@ -20,6 +20,9 @@ public class PaymentRequestEntityTest {
         expectedChargeTransaction = new ChargeTransactionEntity();
 
         paymentRequestEntity = new PaymentRequestEntity();
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        paymentRequestEntity.setGatewayAccount(gatewayAccount);
         paymentRequestEntity.addTransaction(expectedChargeTransaction);
     }
 

--- a/src/test/java/uk/gov/pay/connector/tasks/BackfillGatewayAccountIdOnTransactionsWorkerITest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/BackfillGatewayAccountIdOnTransactionsWorkerITest.java
@@ -1,0 +1,165 @@
+package uk.gov.pay.connector.tasks;
+
+import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.tasks.TaskITestBase;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+
+public class BackfillGatewayAccountIdOnTransactionsWorkerITest extends TaskITestBase {
+    private static AtomicLong nextId = new AtomicLong(10);
+
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+
+    private BackfillGatewayAccountIdOnTransactionsWorker worker;
+
+    @Before
+    public void setUp() {
+        worker = env.getInstance(BackfillGatewayAccountIdOnTransactionsWorker.class);
+        insertTestAccount();
+    }
+
+    @Test
+    public void shouldAddGatewayAccountIdToChargeTransaction() {
+        DatabaseFixtures.TestCharge testCharge = createCharge();
+        long expectedGatewayAccountId = testCharge.getTestAccount().getAccountId();
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        worker.execute(1L);
+        final Map<String, Object> chargeTransaction = databaseTestHelper.getChargeTransaction(ids.getLeft());
+        assertThat(chargeTransaction.get("gateway_account_id"), is(expectedGatewayAccountId));
+
+    }
+
+    @Test
+    public void shouldAddGatewayAccountIdToRefundTransaction() {
+        DatabaseFixtures.TestCharge testCharge = createCharge();
+        DatabaseFixtures.TestRefund testRefund = createRefund(testCharge);
+        long expectedGatewayAccountId = testCharge.getTestAccount().getAccountId();
+
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        addRefundTransactions(ids.getLeft(), testRefund);
+        worker.execute(1L);
+        final List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransactions(ids.getLeft());
+        refundTransactions.forEach(refundTransaction ->
+                assertThat(refundTransaction.get("gateway_account_id"), is(expectedGatewayAccountId))
+        );
+    }
+
+    @Test
+    public void shouldAddGatewayAccountIdToMultipleRefundTransactions() {
+        DatabaseFixtures.TestCharge testCharge = createCharge();
+        DatabaseFixtures.TestRefund testRefund1 = createRefund(testCharge);
+        DatabaseFixtures.TestRefund testRefund2 = createRefund(testCharge);
+        DatabaseFixtures.TestRefund testRefund3 = createRefund(testCharge);
+        long expectedGatewayAccountId = testCharge.getTestAccount().getAccountId();
+
+        Pair<Long, Long> ids = createPaymentRequest(testCharge);
+        addRefundTransactions(ids.getLeft(), testRefund1);
+        addRefundTransactions(ids.getLeft(), testRefund2);
+        addRefundTransactions(ids.getLeft(), testRefund3);
+        worker.execute(1L);
+        final List<Map<String, Object>> refundTransactions = databaseTestHelper.getRefundTransactions(ids.getLeft());
+        final Map<String, Object> refundObject1 = refundTransactions.get(0);
+        assertThat(refundObject1.get("gateway_account_id"), is(expectedGatewayAccountId));
+        final Map<String, Object> refundObject2 = refundTransactions.get(1);
+        assertThat(refundObject2.get("gateway_account_id"), is(expectedGatewayAccountId));
+        final Map<String, Object> refundObject3 = refundTransactions.get(2);
+        assertThat(refundObject3.get("gateway_account_id"), is(expectedGatewayAccountId));
+    }
+
+    private Pair<Long, Long> createPaymentRequest(DatabaseFixtures.TestCharge chargeEntity) {
+        long paymentRequestId = nextId.getAndIncrement();
+        databaseTestHelper.addPaymentRequest(
+                paymentRequestId,
+                chargeEntity.getAmount(),
+                chargeEntity.getTestAccount().getAccountId(),
+                chargeEntity.getReturnUrl(),
+                chargeEntity.getDescription(),
+                chargeEntity.getReference(),
+                chargeEntity.getCreatedDate(),
+                chargeEntity.getExternalChargeId());
+
+        long transactionId = nextId.getAndIncrement();
+        databaseTestHelper.addChargeTransaction(
+                transactionId,
+                chargeEntity.getTransactionId(),
+                chargeEntity.getAmount(),
+                chargeEntity.getChargeStatus(),
+                paymentRequestId
+        );
+
+        return new ImmutablePair<>(paymentRequestId, transactionId);
+    }
+
+    private List<Long> addRefundTransactions(long paymentRequestId, DatabaseFixtures.TestRefund... refundEntities) {
+        List<Long> refundTransactionsIds = new ArrayList<>();
+        for (DatabaseFixtures.TestRefund refundEntity : refundEntities) {
+            long refundTransactionId = nextId.getAndIncrement();
+            refundTransactionsIds.add(refundTransactionId);
+            databaseTestHelper.addRefundTransaction(
+                    refundTransactionId,
+                    paymentRequestId,
+                    refundEntity.getAmount(),
+                    refundEntity.getExternalRefundId(),
+                    refundEntity.getSubmittedByUserExternalId(),
+                    refundEntity.getStatus(),
+                    refundEntity.getReference()
+            );
+        }
+
+        return refundTransactionsIds;
+    }
+
+    private DatabaseFixtures.TestCharge createCharge() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+
+        final Long chargeId = RandomUtils.nextLong();
+        final String externalChargeId = RandomIdGenerator.newId();
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withTransactionId("gatewayTransactionId");
+        testCharge.insert();
+
+        return testCharge;
+    }
+
+    private DatabaseFixtures.TestRefund createRefund(DatabaseFixtures.TestCharge testCharge) {
+        DatabaseFixtures.TestRefund testRefund = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestRefund()
+                .withReference(randomAlphanumeric(10).trim())
+                .withTestCharge(testCharge)
+                .insert();
+
+
+        return testRefund;
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}


### PR DESCRIPTION
The new search is a bit slower than we would like. One of the biggest
reasons for this is joining payment_requests to transactions when we
have a large amount of data. This is the case if you just load
transactions for a given gateway_account_id (if you search by reference
also on payment_requests you are reducing the amount of rows by enough
for this not to be inefficient). Adding the gatewayAccountId to
TransactionEntities when we add the Transactions to the
PaymentRequestEntity. We probably do not want expose it in the Java, we
will just use it when searching transactions.

- Added the gatewayAccountId to TransactionEntity and set during
creation.
- Added back fill to set gatewayAccountId on TransactionEntities from
PaymentRequestEntity.
