### PR TITLE
WIP PP-3239 Removed next_url and next_url_post from search responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -171,15 +171,6 @@ public class ChargeService {
                 .withLink("self", GET, selfUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeId))
                 .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()));
 
-        if (!ChargeStatus.fromString(chargeEntity.getStatus()).toExternal().isFinished()) {
-            TokenEntity token = createNewChargeEntityToken(chargeEntity);
-            return reponseBuilder
-                    .withLink("next_url", GET, nextUrl(token.getToken()))
-                    .withLink("next_url_post", POST, nextUrl(), APPLICATION_FORM_URLENCODED, new HashMap<String, Object>() {{
-                        put("chargeTokenId", token.getToken());
-                    }});
-        }
-
         return reponseBuilder;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -130,17 +130,10 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String documentLocation = expectedChargeLocationFor(accountId, externalChargeId);
         String chargeTokenId = app.getDatabaseTestHelper().getChargeTokenByExternalChargeId(externalChargeId);
 
-        String hrefNextUrl = "http://Frontend" + FRONTEND_CARD_DETAILS_URL + "/" + chargeTokenId;
-        String hrefNextUrlPost = "http://Frontend" + FRONTEND_CARD_DETAILS_URL;
-
         response.header("Location", is(documentLocation))
-                .body("links", hasSize(4))
+                .body("links", hasSize(2))
                 .body("links", containsLink("self", "GET", documentLocation))
-                .body("links", containsLink("refunds", "GET", documentLocation + "/refunds"))
-                .body("links", containsLink("next_url", "GET", hrefNextUrl))
-                .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost, "application/x-www-form-urlencoded", new HashMap<String, Object>() {{
-                    put("chargeTokenId", chargeTokenId);
-                }}));
+                .body("links", containsLink("refunds", "GET", documentLocation + "/refunds"));
 
         ValidatableResponse getChargeResponse = getChargeApi
                 .withAccountId(accountId)
@@ -170,14 +163,9 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String newHrefNextUrl = "http://Frontend" + FRONTEND_CARD_DETAILS_URL + "/" + newChargeTokenId;
 
         getChargeResponse
-                .body("links", hasSize(4))
+                .body("links", hasSize(2))
                 .body("links", containsLink("self", "GET", documentLocation))
-                .body("links", containsLink("refunds", "GET", documentLocation + "/refunds"))
-                .body("links", containsLink("next_url", "GET", newHrefNextUrl))
-                .body("links", containsLink("next_url_post", "POST", hrefNextUrlPost, "application/x-www-form-urlencoded", new HashMap<String, Object>() {{
-                    put("chargeTokenId", newChargeTokenId);
-                }}));
-
+                .body("links", containsLink("refunds", "GET", documentLocation + "/refunds"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchChargesByDateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchChargesByDateResourceITest.java
@@ -74,7 +74,7 @@ public class SearchChargesByDateResourceITest {
                 .body("results[0].amount", is(AMOUNT))
                 .body("results[0].description", is("Test description"))
                 .body("results[0].state.status", is("created"))
-                .body("results[0].links.size()", is(4))
+                .body("results[0].links.size()", is(2))
                 .body("results[0].return_url", is("http://return.com/1"))
                 .body("results[0].created_date", is("2016-02-02T00:00:00.299Z"))
                 .body("results[0].reference", is("reference"));

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -214,39 +214,20 @@ public class ChargeServiceTest {
     }
 
     @Test
-    public void shouldCreateAToken() throws Exception {
-        service.create(CHARGE_REQUEST, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = forClass(TokenEntity.class);
-        verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
-
-        TokenEntity tokenEntity = tokenEntityArgumentCaptor.getValue();
-        assertThat(tokenEntity.getChargeEntity().getId(), is(CHARGE_ENTITY_ID));
-        assertThat(tokenEntity.getToken(), is(notNullValue()));
-    }
-
-    @Test
     public void shouldCreateAResponse() throws Exception {
         ChargeResponse response = service.create(CHARGE_REQUEST, GATEWAY_ACCOUNT_ID, mockedUriInfo).get();
 
         ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = forClass(TokenEntity.class);
-        verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
-        TokenEntity tokenEntity = tokenEntityArgumentCaptor.getValue();
 
         // Then - expected response is returned
         ChargeResponseBuilder expectedChargeResponse = chargeResponseBuilderOf(createdChargeEntity);
 
         expectedChargeResponse.withLink("self", GET, new URI(SERVICE_HOST + "/v1/api/accounts/1/charges/" + EXTERNAL_CHARGE_ID[0]));
         expectedChargeResponse.withLink("refunds", GET, new URI(SERVICE_HOST + "/v1/api/accounts/1/charges/" + EXTERNAL_CHARGE_ID[0] + "/refunds"));
-        expectedChargeResponse.withLink("next_url", GET, new URI("http://payments.com/secure/" + tokenEntity.getToken()));
-        expectedChargeResponse.withLink("next_url_post", POST, new URI("http://payments.com/secure"), "application/x-www-form-urlencoded", new HashMap<String, Object>() {{
-            put("chargeTokenId", tokenEntity.getToken());
-        }});
 
         assertThat(response, is(expectedChargeResponse.build()));
     }
@@ -273,20 +254,9 @@ public class ChargeServiceTest {
 
         Optional<ChargeResponse> chargeResponseForAccount = service.findChargeForAccount(externalId, accountId, mockedUriInfo);
 
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = ArgumentCaptor.forClass(TokenEntity.class);
-        verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
-
-        TokenEntity tokenEntity = tokenEntityArgumentCaptor.getValue();
-        assertThat(tokenEntity.getChargeEntity().getId(), is(newCharge.getId()));
-        assertThat(tokenEntity.getToken(), is(notNullValue()));
-
         ChargeResponseBuilder expectedChargeResponse = chargeResponseBuilderOf(chargeEntity.get());
         expectedChargeResponse.withLink("self", GET, new URI(SERVICE_HOST + "/v1/api/accounts/1/charges/" + externalId));
         expectedChargeResponse.withLink("refunds", GET, new URI(SERVICE_HOST + "/v1/api/accounts/1/charges/" + externalId + "/refunds"));
-        expectedChargeResponse.withLink("next_url", GET, new URI("http://payments.com/secure/" + tokenEntity.getToken()));
-        expectedChargeResponse.withLink("next_url_post", POST, new URI("http://payments.com/secure"), "application/x-www-form-urlencoded", new HashMap<String, Object>() {{
-            put("chargeTokenId", tokenEntity.getToken());
-        }});
 
         assertThat(chargeResponseForAccount.get(), is(expectedChargeResponse.build()));
     }
@@ -314,19 +284,10 @@ public class ChargeServiceTest {
         Optional<ChargeResponse> chargeResponseForAccount = service.findChargeForAccount(externalId, accountId, mockedUriInfo);
 
         ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = ArgumentCaptor.forClass(TokenEntity.class);
-        verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
-
-        TokenEntity tokenEntity = tokenEntityArgumentCaptor.getValue();
-        assertThat(tokenEntity.getChargeEntity().getId(), is(newCharge.getId()));
-        assertThat(tokenEntity.getToken(), is(notNullValue()));
 
         ChargeResponseBuilder expectedChargeResponse = chargeResponseBuilderOf(chargeEntity.get());
         expectedChargeResponse.withLink("self", GET, new URI(SERVICE_HOST + "/v1/api/accounts/1/charges/" + externalId));
         expectedChargeResponse.withLink("refunds", GET, new URI(SERVICE_HOST + "/v1/api/accounts/1/charges/" + externalId + "/refunds"));
-        expectedChargeResponse.withLink("next_url", GET, new URI("http://payments.com/secure/" + tokenEntity.getToken()));
-        expectedChargeResponse.withLink("next_url_post", POST, new URI("http://payments.com/secure"), "application/x-www-form-urlencoded", new HashMap<String, Object>() {{
-            put("chargeTokenId", tokenEntity.getToken());
-        }});
 
         assertThat(chargeResponseForAccount.get(), is(expectedChargeResponse.build()));
 


### PR DESCRIPTION
Removed the next_url and next_url_post from the result from doing
searches on transactions. We don't think this is used by self service or
public api and is expensive to calculate for large result sets.

