### PR TITLE
PP-3239 use new data structure in search

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
@@ -5,7 +5,6 @@ import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalRefundStatus;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
-import uk.gov.pay.connector.resources.CommaDelimitedSetParameter;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -97,7 +96,7 @@ public class ChargeSearchParams {
         return this;
     }
 
-    public ChargeSearchParams addExternalChargeStates(CommaDelimitedSetParameter states) {
+    public ChargeSearchParams addExternalChargeStates(List<String> states) {
         if (states != null) {
             this.internalChargeStatuses.addAll(states.stream()
                     .map(this::parseChargeState)
@@ -110,7 +109,7 @@ public class ChargeSearchParams {
         return this;
     }
 
-    public ChargeSearchParams addExternalRefundStates(CommaDelimitedSetParameter states) {
+    public ChargeSearchParams addExternalRefundStates(List<String> states) {
         if (states != null) {
             this.internalRefundStatuses.addAll(states.stream()
                     .map(ExternalRefundStatus::fromPublicStatusLabel)

--- a/src/main/java/uk/gov/pay/connector/dao/NewTransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/NewTransactionDao.java
@@ -1,0 +1,179 @@
+package uk.gov.pay.connector.dao;
+
+import com.google.common.collect.Streams;
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.model.TransactionType;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+
+@Transactional
+public class NewTransactionDao extends JpaDao<TransactionEntity> {
+
+    private final UTCDateTimeConverter utcDateTimeConverter;
+
+    @Inject
+    protected NewTransactionDao(Provider<EntityManager> entityManager, UTCDateTimeConverter utcDateTimeConverter) {
+        super(entityManager);
+        this.utcDateTimeConverter = utcDateTimeConverter;
+    }
+
+    public List<TransactionEntity> search(ChargeSearchParams params) {
+
+        List<String> statuses = getStatuses(params);
+        StringBuilder query = buildQueryString("SELECT t.* FROM transactions t ", params, statuses);
+
+        query.append(" ORDER BY t.created_date DESC");
+
+        Query typedQuery = entityManager.get().createNativeQuery(query.toString(), TransactionEntity.class);
+        typedQuery = setParams(typedQuery, params, statuses);
+        typedQuery = addPagination(params, typedQuery);
+
+        return (List<TransactionEntity>) typedQuery.getResultList();
+    }
+
+    public long getTotal(ChargeSearchParams params) {
+        List<String> statuses = getStatuses(params);
+        StringBuilder query = buildQueryString("SELECT count(t.*) FROM transactions t ", params, statuses);
+
+        Query typedQuery = entityManager.get().createNativeQuery(query.toString());
+        typedQuery = setParams(typedQuery, params, statuses);
+
+        return (Long) typedQuery.getSingleResult();
+    }
+
+    private Query addPagination(ChargeSearchParams params, Query typedQuery) {
+        if (params.getPage() != null && params.getDisplaySize() != null) {
+            final long displaySize = params.getDisplaySize().intValue();
+            long offset = (params.getPage() - 1) * displaySize;
+            typedQuery = typedQuery.setFirstResult((int) offset).setMaxResults((int) displaySize);
+        }
+        return typedQuery;
+    }
+
+    private List<String> getStatuses(ChargeSearchParams params) {
+        Set<ChargeStatus> internalStates = params.getInternalStates();
+
+        Set<ChargeStatus> internalChargeStatuses = params.getInternalChargeStatuses();
+        List<String> statuses = Stream.concat(internalStates.stream(), internalChargeStatuses.stream())
+                .map(Enum::name)
+                .collect(toList());
+        statuses.addAll(params.getInternalRefundStatuses().stream()
+                .map(Enum::name)
+                .collect(toList()));
+        return statuses;
+    }
+
+    private Query setParams(Query typedQuery, ChargeSearchParams params, List<String> statuses) {
+        typedQuery.setParameter("gatewayAccountId", params.getGatewayAccountId());
+
+        // here add the values for the optional params
+        if (isNotEmpty(params.getEmail())) {
+            String formattedEmail = getEscapedString(params.getEmail());
+            typedQuery.setParameter("email", "%" + formattedEmail + "%");
+        }
+
+        if (isNotEmpty(params.getReference())) {
+            typedQuery.setParameter("reference", "%" + getEscapedString(params.getReference()) + "%");
+        }
+
+        if (params.getFromDate() != null) {
+            final Timestamp databaseFormatted = utcDateTimeConverter.convertToDatabaseColumn(params.getFromDate());
+            typedQuery.setParameter("createdDate", databaseFormatted);
+        }
+
+        if (params.getToDate() != null) {
+            final Timestamp databaseFormatted = utcDateTimeConverter.convertToDatabaseColumn(params.getToDate());
+            typedQuery.setParameter("toDate", databaseFormatted);
+        }
+
+        if (params.getTransactionType() != null) {
+            TransactionOperation operation = params.getTransactionType().equals(TransactionType.PAYMENT) ?
+                    TransactionOperation.CHARGE : TransactionOperation.REFUND;
+            typedQuery.setParameter("operation", operation.name());
+        }
+
+        addInParameters(typedQuery, params.getCardBrands(), "cardBrand");
+        addInParameters(typedQuery, statuses, "status");
+
+        return typedQuery;
+    }
+
+    private StringBuilder buildQueryString(String queryString, ChargeSearchParams params, List<String> statuses) {
+        StringBuilder query = new StringBuilder(queryString);
+        if (isNotEmpty(params.getReference())) {
+            query.append("JOIN payment_requests p ON t.payment_request_id = p.id ");
+        }
+        if (isNotEmpty(params.getEmail()) || !params.getCardBrands().isEmpty()) {
+            query.append("JOIN transactions t2 ON t.payment_request_id = t2.payment_request_id AND t2.operation = 'CHARGE' ");
+        }
+        if (!params.getCardBrands().isEmpty()) {
+            query.append("LEFT JOIN cards c ON t2.id = c.transaction_id ");
+        }
+
+        query.append("WHERE t.gateway_account_id = ?gatewayAccountId ");
+
+        // here add the optional params
+        if (isNotEmpty(params.getEmail())) {
+            query.append("AND LOWER(t2.email) LIKE ?email ");
+        }
+
+        if (isNotEmpty(params.getReference())) {
+            query.append("AND LOWER(p.reference) LIKE ?reference ");
+        }
+
+        if (params.getFromDate() != null) {
+            query.append("AND t.created_date >= ?createdDate ");
+        }
+
+        if (params.getToDate() != null) {
+            query.append("AND t.created_date < ?toDate ");
+        }
+
+        if (params.getTransactionType() != null) {
+            query.append("AND t.operation = ?operation ");
+        }
+
+        addInToQueryString(query, params.getCardBrands(), "cardBrand", "c.card_brand");
+        addInToQueryString(query, statuses, "status", "t.status");
+        return query;
+    }
+
+    //Had to add as EclipseLink addParameter cannot work out lists.
+    private void addInToQueryString(StringBuilder query, List<?> values, String parameterName, String tableColumnName) {
+        if (!values.isEmpty()) {
+            final String arguments = Streams.mapWithIndex(values.stream(), (status, counter) -> "?" + parameterName + counter)
+                    .collect(Collectors.joining(","));
+            query.append("AND ").append(tableColumnName).append(" IN (").append(arguments).append(") ");
+        }
+    }
+
+    //Had to add as EclipseLink addParameter cannot work out lists.
+    private void addInParameters(Query typedQuery, List<String> values, String parameterName) {
+        if (!values.isEmpty()) {
+            for (int counter = 0; counter < values.size(); counter++) {
+                typedQuery.setParameter(parameterName + counter, values.get(counter));
+            }
+        }
+    }
+
+    private String getEscapedString(String inputString) {
+        return inputString.toLowerCase()
+                .replaceAll("_", "\\\\_")
+                .replaceAll("%", "\\\\%");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
@@ -125,7 +125,7 @@ public class ChargeResponse {
             result = 31 * result + (capturedTime != null ? capturedTime.hashCode() : 0);
             return result;
         }
-        
+
         @Override
         public String toString() {
             return "SettlementSummary{" +
@@ -167,7 +167,8 @@ public class ChargeResponse {
 
             Auth3dsData that = (Auth3dsData) o;
 
-            if (paRequest != null ? !paRequest.equals(that.paRequest) : that.paRequest != null) return false;
+            if (paRequest != null ? !paRequest.equals(that.paRequest) : that.paRequest != null)
+                return false;
             return issuerUrl != null ? issuerUrl.equals(that.issuerUrl) : that.issuerUrl == null;
 
         }
@@ -347,24 +348,33 @@ public class ChargeResponse {
 
         ChargeResponse that = (ChargeResponse) o;
 
-        if (dataLinks != null ? !dataLinks.equals(that.dataLinks) : that.dataLinks != null) return false;
-        if (chargeId != null ? !chargeId.equals(that.chargeId) : that.chargeId != null) return false;
+        if (dataLinks != null ? !dataLinks.equals(that.dataLinks) : that.dataLinks != null)
+            return false;
+        if (chargeId != null ? !chargeId.equals(that.chargeId) : that.chargeId != null)
+            return false;
         if (amount != null ? !amount.equals(that.amount) : that.amount != null) return false;
         if (state != null ? !state.equals(that.state) : that.state != null) return false;
-        if (cardBrand != null ? !cardBrand.equals(that.cardBrand) : that.cardBrand != null) return false;
+        if (cardBrand != null ? !cardBrand.equals(that.cardBrand) : that.cardBrand != null)
+            return false;
         if (gatewayTransactionId != null ? !gatewayTransactionId.equals(that.gatewayTransactionId) : that.gatewayTransactionId != null)
             return false;
-        if (returnUrl != null ? !returnUrl.equals(that.returnUrl) : that.returnUrl != null) return false;
+        if (returnUrl != null ? !returnUrl.equals(that.returnUrl) : that.returnUrl != null)
+            return false;
         if (email != null ? !email.equals(that.email) : that.email != null) return false;
-        if (description != null ? !description.equals(that.description) : that.description != null) return false;
-        if (reference != null ? !reference.equals(that.reference) : that.reference != null) return false;
-        if (providerName != null ? !providerName.equals(that.providerName) : that.providerName != null) return false;
-        if (createdDate != null ? !createdDate.equals(that.createdDate) : that.createdDate != null) return false;
+        if (description != null ? !description.equals(that.description) : that.description != null)
+            return false;
+        if (reference != null ? !reference.equals(that.reference) : that.reference != null)
+            return false;
+        if (providerName != null ? !providerName.equals(that.providerName) : that.providerName != null)
+            return false;
+        if (createdDate != null ? !createdDate.equals(that.createdDate) : that.createdDate != null)
+            return false;
         if (refundSummary != null ? !refundSummary.equals(that.refundSummary) : that.refundSummary != null)
             return false;
         if (settlementSummary != null ? !settlementSummary.equals(that.settlementSummary) : that.settlementSummary != null)
             return false;
-        if (auth3dsData != null ? !auth3dsData.equals(that.auth3dsData) : that.auth3dsData != null) return false;
+        if (auth3dsData != null ? !auth3dsData.equals(that.auth3dsData) : that.auth3dsData != null)
+            return false;
         return cardDetails != null ? cardDetails.equals(that.cardDetails) : that.cardDetails == null;
 
     }

--- a/src/main/java/uk/gov/pay/connector/model/TransactionType.java
+++ b/src/main/java/uk/gov/pay/connector/model/TransactionType.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.model;
 
-import uk.gov.pay.connector.resources.CommaDelimitedSetParameter;
+import java.util.List;
 
 public enum TransactionType {
     PAYMENT("payment"), REFUND("refund");
@@ -11,7 +11,7 @@ public enum TransactionType {
         this.value = value;
     }
 
-    public static TransactionType inferTransactionTypeFrom(CommaDelimitedSetParameter paymentStates, CommaDelimitedSetParameter refundStates) {
+    public static TransactionType inferTransactionTypeFrom(List<String> paymentStates, List<String> refundStates) {
 
         TransactionType transactionType = null;
         boolean hasSpecifiedPaymentStates = paymentStates != null && !paymentStates.isEmpty();

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntity.java
@@ -7,11 +7,9 @@ import uk.gov.pay.connector.model.domain.CardEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.PaymentGatewayStateTransitions;
-import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.Convert;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -42,9 +40,6 @@ public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus, Cha
     private CardEntity card;
     @OneToOne(mappedBy = "chargeTransactionEntity", cascade = CascadeType.PERSIST)
     private Card3dsEntity card3ds;
-    @Column(name = "created_date")
-    @Convert(converter = UTCDateTimeConverter.class)
-    private ZonedDateTime createdDate;
     @Column(name = "email")
     private String email;
 
@@ -70,6 +65,7 @@ public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus, Cha
         this.gatewayTransactionId = gatewayTransactionId;
     }
 
+    //todo this should be an optional
     public CardEntity getCard() {
         return card;
     }
@@ -126,16 +122,6 @@ public class ChargeTransactionEntity extends TransactionEntity<ChargeStatus, Cha
 
     public List<ChargeTransactionEventEntity> getTransactionEvents() {
         return transactionEvents;
-    }
-
-    @Override
-    public ZonedDateTime getCreatedDate() {
-        return createdDate;
-    }
-
-    @Override
-    public void setCreatedDate(ZonedDateTime createdDate) {
-        this.createdDate = createdDate;
     }
 
     public String getEmail() {

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntity.java
@@ -2,18 +2,15 @@ package uk.gov.pay.connector.model.domain.transaction;
 
 import uk.gov.pay.connector.model.domain.RefundEntity;
 import uk.gov.pay.connector.model.domain.RefundStatus;
-import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
-import javax.persistence.Convert;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,9 +29,6 @@ public class RefundTransactionEntity extends TransactionEntity<RefundStatus, Ref
     @OneToMany(mappedBy = "transaction", cascade = CascadeType.ALL)
     @OrderBy("updated DESC")
     private List<RefundTransactionEventEntity> transactionEvents = new ArrayList<>();
-    @Column(name = "created_date")
-    @Convert(converter = UTCDateTimeConverter.class)
-    private ZonedDateTime createdDate;
 
     public RefundTransactionEntity() {
         super(TransactionOperation.REFUND);
@@ -45,6 +39,7 @@ public class RefundTransactionEntity extends TransactionEntity<RefundStatus, Ref
         return status;
     }
 
+    // make this package protected after removing PaymentRequestWorker
     @Override
     public void setStatus(RefundStatus status) {
         this.status = status;
@@ -92,14 +87,5 @@ public class RefundTransactionEntity extends TransactionEntity<RefundStatus, Ref
 
     public List<RefundTransactionEventEntity> getTransactionEvents() {
         return transactionEvents;
-    }
-
-    @Override
-    public ZonedDateTime getCreatedDate() {
-        return createdDate;
-    }
-    @Override
-    public void setCreatedDate(ZonedDateTime createdDate) {
-        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
 import uk.gov.pay.connector.model.domain.Status;
+import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
 
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -43,6 +45,9 @@ public abstract class TransactionEntity<S extends Status, T extends TransactionE
     @ManyToOne
     @JoinColumn(name = "payment_request_id", referencedColumnName = "id", updatable = false)
     private PaymentRequestEntity paymentRequest;
+    @Column(name = "created_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime createdDate;
     @Column(name = "gateway_account_id")
     // This just needs to be set when we save the transaction. It is then used to optimise
     // transaction search don't access in Java code.
@@ -107,9 +112,13 @@ public abstract class TransactionEntity<S extends Status, T extends TransactionE
         getTransactionEvents().add(0, transactionEvent);
     }
 
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
     protected abstract T createNewTransactionEvent();
-
-    public abstract ZonedDateTime getCreatedDate();
-
-    public abstract void setCreatedDate(ZonedDateTime createdDate);
 }

--- a/src/main/java/uk/gov/pay/connector/resources/ApiPaths.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ApiPaths.java
@@ -25,6 +25,7 @@ public interface ApiPaths {
     String FRONTEND_ACCOUNT_CARDTYPES_API_PATH = API_VERSION_PATH + "/frontend/accounts/{accountId}/card-types";
 
     String CHARGES_API_PATH = API_VERSION_PATH +"/api/accounts/{accountId}/charges";
+    String TRANSACTIONS_API_PATH = API_VERSION_PATH +"/api/accounts/{accountId}/transactions";
     String CHARGE_API_PATH = API_VERSION_PATH +"/api/accounts/{accountId}/charges/{chargeId}";
     String CHARGE_CANCEL_API_PATH = API_VERSION_PATH +"/api/accounts/{accountId}/charges/{chargeId}/cancel";
     String CHARGE_EVENTS_API_PATH = API_VERSION_PATH +"/api/accounts/{accountId}/charges/{chargeId}/events";

--- a/src/main/java/uk/gov/pay/connector/service/search/AbstractSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/AbstractSearchStrategy.java
@@ -1,17 +1,26 @@
 package uk.gov.pay.connector.service.search;
 
+import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
 import uk.gov.pay.connector.model.ChargeResponse;
+import uk.gov.pay.connector.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.resources.ChargesPaginationResponseBuilder;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 
 public abstract class AbstractSearchStrategy<T> implements SearchStrategy {
+
+    private final CardTypeDao cardTypeDao;
+
+    protected AbstractSearchStrategy(CardTypeDao cardTypeDao) {
+        this.cardTypeDao = cardTypeDao;
+    }
 
     @Override
     public Response search(ChargeSearchParams searchParams, UriInfo uriInfo) {
@@ -23,11 +32,13 @@ public abstract class AbstractSearchStrategy<T> implements SearchStrategy {
                 return notFoundResponse("the requested page not found");
             }
         }
+        Map<String, String> cardBrandToLabel = cardTypeDao.findAll().stream().collect(
+                Collectors.toMap(CardTypeEntity::getBrand, CardTypeEntity::getLabel, (label1, label2) -> label1));
 
         List<T> transactions = findAllBy(searchParams);
         List<ChargeResponse> chargesResponse =
                 transactions.stream()
-                        .map(transaction -> buildResponse(uriInfo, transaction)
+                        .map(transaction -> buildResponse(uriInfo, transaction, cardBrandToLabel)
                         ).collect(Collectors.toList());
 
         return new ChargesPaginationResponseBuilder(searchParams, uriInfo)
@@ -40,6 +51,6 @@ public abstract class AbstractSearchStrategy<T> implements SearchStrategy {
 
     abstract protected List<T> findAllBy(ChargeSearchParams params);
 
-    abstract protected ChargeResponse buildResponse(UriInfo uriInfo, T transaction);
+    abstract protected ChargeResponse buildResponse(UriInfo uriInfo, T transaction, Map<String, String> cardBrandToLabel);
 
 }

--- a/src/main/java/uk/gov/pay/connector/service/search/ChargeSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/ChargeSearchStrategy.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service.search;
 
+import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
 import uk.gov.pay.connector.model.ChargeResponse;
@@ -8,6 +9,7 @@ import uk.gov.pay.connector.service.ChargeService;
 
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
+import java.util.Map;
 
 import static uk.gov.pay.connector.model.ChargeResponse.aChargeResponseBuilder;
 
@@ -16,7 +18,8 @@ public class ChargeSearchStrategy extends AbstractSearchStrategy<ChargeEntity> i
     private ChargeService chargeService;
     private ChargeDao chargeDao;
 
-    public ChargeSearchStrategy(ChargeService chargeService, ChargeDao chargeDao) {
+    public ChargeSearchStrategy(ChargeService chargeService, ChargeDao chargeDao, CardTypeDao cardTypeDao) {
+        super(cardTypeDao);
         this.chargeService = chargeService;
         this.chargeDao = chargeDao;
     }
@@ -32,7 +35,7 @@ public class ChargeSearchStrategy extends AbstractSearchStrategy<ChargeEntity> i
     }
 
     @Override
-    protected ChargeResponse buildResponse(UriInfo uriInfo, ChargeEntity chargeEntity) {
+    protected ChargeResponse buildResponse(UriInfo uriInfo, ChargeEntity chargeEntity, Map<String, String> cardBrandToLabel) {
         return chargeService.populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity).build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/search/CommonSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/CommonSearchStrategy.java
@@ -1,0 +1,108 @@
+package uk.gov.pay.connector.service.search;
+
+import uk.gov.pay.connector.dao.CardTypeDao;
+import uk.gov.pay.connector.dao.ChargeSearchParams;
+import uk.gov.pay.connector.dao.NewTransactionDao;
+import uk.gov.pay.connector.model.ChargeResponse;
+import uk.gov.pay.connector.model.TransactionResponse;
+import uk.gov.pay.connector.model.TransactionType;
+import uk.gov.pay.connector.model.api.ExternalChargeState;
+import uk.gov.pay.connector.model.api.ExternalRefundStatus;
+import uk.gov.pay.connector.model.api.ExternalTransactionState;
+import uk.gov.pay.connector.model.domain.Card3dsEntity;
+import uk.gov.pay.connector.model.domain.CardEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.PersistedCard;
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+import uk.gov.pay.connector.util.DateTimeUtils;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.Map;
+
+import static javax.ws.rs.HttpMethod.GET;
+import static uk.gov.pay.connector.resources.ApiPaths.CHARGE_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.REFUNDS_API_PATH;
+
+public class CommonSearchStrategy extends AbstractSearchStrategy<TransactionEntity> {
+
+    private final NewTransactionDao transactionDao;
+
+    @Inject
+    public CommonSearchStrategy(NewTransactionDao transactionDao, CardTypeDao cardTypeDao) {
+        super(cardTypeDao);
+        this.transactionDao = transactionDao;
+    }
+
+    @Override
+    protected long getTotalFor(ChargeSearchParams params) {
+        return transactionDao.getTotal(params);
+    }
+
+    @Override
+    protected List<TransactionEntity> findAllBy(ChargeSearchParams params) {
+        return transactionDao.search(params);
+    }
+
+    @Override
+    protected ChargeResponse buildResponse(UriInfo uriInfo, TransactionEntity transaction, Map<String, String> cardBrandToLabel) {
+        ExternalTransactionState externalTransactionState;
+        TransactionType transactionType;
+        if (transaction.getOperation().equals(TransactionOperation.CHARGE)) {
+            ChargeTransactionEntity chargeTransactionEntity = (ChargeTransactionEntity) transaction;
+            ExternalChargeState externalChargeState = chargeTransactionEntity.getStatus().toExternal();
+            externalTransactionState = new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage());
+            transactionType = TransactionType.PAYMENT;
+        } else {
+            RefundTransactionEntity refundTransactionEntity = (RefundTransactionEntity) transaction;
+            ExternalRefundStatus externalRefundStatus = refundTransactionEntity.getStatus().toExternal();
+            externalTransactionState = new ExternalTransactionState(externalRefundStatus.getStatus(), externalRefundStatus.isFinished());
+            transactionType = TransactionType.REFUND;
+        }
+
+        PersistedCard cardDetails = new PersistedCard();
+        PaymentRequestEntity paymentRequest = transaction.getPaymentRequest();
+        ChargeTransactionEntity chargeTransaction = paymentRequest.getChargeTransaction();
+        CardEntity card = chargeTransaction.getCard();
+        if (card != null) {
+            cardDetails.setCardBrand(cardBrandToLabel.get(card.getCardBrand()));
+            cardDetails.setCardHolderName(card.getCardHolderName());
+            cardDetails.setExpiryDate(card.getExpiryDate());
+            cardDetails.setLastDigitsCardNumber(card.getLastDigitsCardNumber());
+        }
+
+        ChargeResponse.Auth3dsData auth3dsData = null;
+        Card3dsEntity card3ds = paymentRequest.getChargeTransaction().getCard3ds();
+        if (card3ds != null) {
+            auth3dsData = new ChargeResponse.Auth3dsData();
+            auth3dsData.setPaRequest(card3ds.getPaRequest());
+            auth3dsData.setIssuerUrl(card3ds.getIssuerUrl());
+        }
+
+        return TransactionResponse.aTransactionResponseBuilder()
+                .withChargeId(paymentRequest.getExternalId())
+                .withAmount(transaction.getAmount())
+                .withReference(paymentRequest.getReference())
+                .withDescription(paymentRequest.getDescription())
+                .withState(externalTransactionState)
+                .withGatewayTransactionId(chargeTransaction.getGatewayTransactionId())
+                .withProviderName(paymentRequest.getGatewayAccount().getGatewayName())
+                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(transaction.getCreatedDate()))
+                .withReturnUrl(paymentRequest.getReturnUrl())
+                .withEmail(chargeTransaction.getEmail())
+                .withCardDetails(cardDetails)
+                .withAuth3dsData(auth3dsData)
+                .withTransactionType(transactionType.getValue())
+                .withLink("self", GET, uriInfo.getBaseUriBuilder()
+                        .path(CHARGE_API_PATH)
+                        .build(paymentRequest.getGatewayAccount().getId(), paymentRequest.getExternalId()))
+                .withLink("refunds", GET, uriInfo.getBaseUriBuilder()
+                        .path(REFUNDS_API_PATH)
+                        .build(paymentRequest.getGatewayAccount().getId(), paymentRequest.getExternalId()))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/service/search/SearchService.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/SearchService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service.search;
 
+import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.TransactionDao;
 import uk.gov.pay.connector.service.ChargeService;
@@ -13,20 +14,22 @@ public class SearchService {
     private ChargeDao chargeDao;
     private TransactionDao transactionDao;
     private ChargeService chargeService;
+    private final CardTypeDao cardTypeDao;
 
     @Inject
-    public SearchService(ChargeDao chargeDao, TransactionDao transactionDao, ChargeService chargeService) {
+    public SearchService(ChargeDao chargeDao, TransactionDao transactionDao, ChargeService chargeService, CardTypeDao cardTypeDao) {
         this.chargeDao = chargeDao;
         this.transactionDao = transactionDao;
         this.chargeService = chargeService;
+        this.cardTypeDao = cardTypeDao;
     }
 
     public SearchStrategy ofType(TYPE type) {
         switch (type) {
             case TRANSACTION:
-                return new TransactionSearchStrategy(transactionDao);
+                return new TransactionSearchStrategy(transactionDao, cardTypeDao);
             default:
-                return new ChargeSearchStrategy(chargeService, chargeDao);
+                return new ChargeSearchStrategy(chargeService, chargeDao, cardTypeDao);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/search/TransactionSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/TransactionSearchStrategy.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service.search;
 
+import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
 import uk.gov.pay.connector.dao.TransactionDao;
 import uk.gov.pay.connector.model.ChargeResponse;
@@ -15,6 +16,7 @@ import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
+import java.util.Map;
 
 import static javax.ws.rs.HttpMethod.GET;
 import static uk.gov.pay.connector.model.TransactionResponse.aTransactionResponseBuilder;
@@ -25,7 +27,8 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
 
     private TransactionDao transactionDao;
 
-    public TransactionSearchStrategy(TransactionDao transactionDao) {
+    public TransactionSearchStrategy(TransactionDao transactionDao, CardTypeDao cardTypeDao) {
+        super(cardTypeDao);
         this.transactionDao = transactionDao;
     }
 
@@ -40,8 +43,7 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
     }
 
     @Override
-    protected ChargeResponse buildResponse(UriInfo uriInfo, Transaction transaction) {
-
+    protected ChargeResponse buildResponse(UriInfo uriInfo, Transaction transaction, Map<String, String> cardBrandToLabel) {
         ExternalTransactionState externalTransactionState;
         if (TransactionType.REFUND.getValue().equals(transaction.getTransactionType())) {
             ExternalRefundStatus externalRefundStatus = RefundStatus.fromString(transaction.getStatus()).toExternal();

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
@@ -2,11 +2,11 @@ package uk.gov.pay.connector.dao;
 
 import org.junit.Test;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
-import uk.gov.pay.connector.resources.CommaDelimitedSetParameter;
 
 import java.time.ZonedDateTime;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
@@ -105,8 +105,8 @@ public class ChargeSearchParamsTest {
         ChargeSearchParams params = new ChargeSearchParams()
                 .withDisplaySize(5L)
                 .withTransactionType(PAYMENT)
-                .addExternalChargeStates(new CommaDelimitedSetParameter("created"))
-                .addExternalRefundStates(new CommaDelimitedSetParameter("submitted"))
+                .addExternalChargeStates(singletonList("created"))
+                .addExternalRefundStates(singletonList("submitted"))
                 .withCardBrands(asList("visa", "master-card"))
                 .withGatewayAccountId(111L)
                 .withPage(2L)
@@ -129,8 +129,8 @@ public class ChargeSearchParamsTest {
                         "&refund_states=success";
 
         ChargeSearchParams params = new ChargeSearchParams()
-                .addExternalChargeStates(new CommaDelimitedSetParameter("success"))
-                .addExternalRefundStates(new CommaDelimitedSetParameter("success"))
+                .addExternalChargeStates(singletonList("success"))
+                .addExternalRefundStates(singletonList("success"))
                 .withGatewayAccountId(111L)
                 .withPage(2L)
                 .withReferenceLike("ref")
@@ -145,8 +145,8 @@ public class ChargeSearchParamsTest {
         String expectedQueryString = "payment_states=success,failed";
 
         ChargeSearchParams params = new ChargeSearchParams()
-                .addExternalChargeStates(new CommaDelimitedSetParameter("success"))
-                .addExternalChargeStates(new CommaDelimitedSetParameter("failed"))
+                .addExternalChargeStates(singletonList("success"))
+                .addExternalChargeStates(singletonList("failed"))
                 .withGatewayAccountId(111L);
 
         assertThat(params.buildQueryParams(), is(expectedQueryString));
@@ -161,7 +161,7 @@ public class ChargeSearchParamsTest {
     public void getInternalChargeStatuses_transactionsSearch_shouldPopulateAllInternalChargeStates_FromExternalFailedState() {
 
         ChargeSearchParams params = new ChargeSearchParams()
-                .addExternalChargeStates(new CommaDelimitedSetParameter(ExternalChargeState.EXTERNAL_FAILED_CANCELLED.getStatus()));
+                .addExternalChargeStates(singletonList(ExternalChargeState.EXTERNAL_FAILED_CANCELLED.getStatus()));
 
         assertThat(params.buildQueryParams(), is("payment_states=failed"));
         assertThat(params.getInternalChargeStatuses(),  hasSize(11));
@@ -169,18 +169,4 @@ public class ChargeSearchParamsTest {
                 USER_CANCEL_READY, USER_CANCEL_SUBMITTED, USER_CANCEL_ERROR, USER_CANCELLED, EXPIRE_CANCEL_READY, EXPIRE_CANCEL_SUBMITTED, EXPIRED, EXPIRE_CANCEL_FAILED,
                 AUTHORISATION_REJECTED, AUTHORISATION_CANCELLED, AUTHORISATION_ABORTED));
     }
-
-    @Test
-    public void getStates_shouldReturnEmpty_whenParsingEmptyStates() {
-
-        ChargeSearchParams params = new ChargeSearchParams()
-                .withExternalState(" ")
-                .addExternalChargeStates(new CommaDelimitedSetParameter(" "))
-                .addExternalRefundStates(new CommaDelimitedSetParameter(" "));
-
-        assertThat(params.getInternalStates(), hasSize(0));
-        assertThat(params.getInternalChargeStatuses(),  hasSize(0));
-        assertThat(params.getInternalRefundStatuses(),  hasSize(0));
-    }
-
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/GuicedTestEnvironment.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GuicedTestEnvironment.java
@@ -44,6 +44,7 @@ public class GuicedTestEnvironment {
             bind(GatewayAccountDao.class).in(Singleton.class);
             bind(PaymentRequestDao.class).in(Singleton.class);
             bind(CardDao.class).in(Singleton.class);
+            bind(NewTransactionDao.class).in(Singleton.class);
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/NewTransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/NewTransactionDaoITest.java
@@ -1,0 +1,703 @@
+package uk.gov.pay.connector.it.dao;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.dao.ChargeSearchParams;
+import uk.gov.pay.connector.dao.NewTransactionDao;
+import uk.gov.pay.connector.dao.PaymentRequestDao;
+import uk.gov.pay.connector.model.TransactionType;
+import uk.gov.pay.connector.model.domain.CardEntity;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.PaymentRequestEntity;
+import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
+import uk.gov.pay.connector.model.domain.transaction.TransactionOperation;
+
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.model.TransactionType.REFUND;
+import static uk.gov.pay.connector.model.domain.CardEntityBuilder.aCardEntity;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture.aValidPaymentRequestEntity;
+import static uk.gov.pay.connector.model.domain.PaymentRequestEntityFixture.aValidPaymentRequestEntityWithRefund;
+import static uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntityBuilder.aChargeTransactionEntity;
+
+public class NewTransactionDaoITest extends DaoITestBase {
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+    private GatewayAccountEntity gatewayAccount;
+    private PaymentRequestDao paymentRequestDao;
+    private NewTransactionDao transactionDao;
+
+    @Before
+    public void setUp() {
+        paymentRequestDao = env.getInstance(PaymentRequestDao.class);
+        transactionDao = env.getInstance(NewTransactionDao.class);
+
+        insertTestAccount();
+
+        gatewayAccount = new GatewayAccountEntity(
+                defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount.setId(defaultTestAccount.getAccountId());
+    }
+
+    @Test
+    public void shouldReturnTransactions_byGatewayAccountId() {
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        final Long expectedId = gatewayAccount.getId();
+        searchParams.withGatewayAccountId(expectedId);
+
+        final List<TransactionEntity> entityList = transactionDao.search(searchParams);
+        assertThat(entityList.size(), is(2));
+        assertThat(entityList.get(0).getPaymentRequest().getGatewayAccount().getId(), is(expectedId));
+        assertThat(entityList.get(1).getPaymentRequest().getGatewayAccount().getId(), is(expectedId));
+    }
+
+    @Test
+    public void shouldCountTransactions_byGatewayAccountId() {
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        final Long expectedId = gatewayAccount.getId();
+        searchParams.withGatewayAccountId(expectedId);
+
+        final Long total = transactionDao.getTotal(searchParams);
+        assertThat(total, is(2L));
+    }
+
+    @Test
+    public void shouldCountTransactions_GetMoreThanDisplaySize() {
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        final Long expectedId = gatewayAccount.getId();
+        searchParams.withGatewayAccountId(expectedId);
+        searchParams.withDisplaySize(1L);
+
+        final Long total = transactionDao.getTotal(searchParams);
+        assertThat(total, is(2L));
+    }
+
+    @Test
+    public void shouldCountTransactions_IncludesBeforeCurrentPage() {
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        final Long expectedId = gatewayAccount.getId();
+        searchParams.withGatewayAccountId(expectedId);
+        searchParams.withDisplaySize(1L);
+        searchParams.withPage(2L);
+
+        final Long total = transactionDao.getTotal(searchParams);
+        assertThat(total, is(2L));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byGatewayAccountId_whenMultipleGatewayAccountsExist() {
+        final PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build();
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        DatabaseFixtures.TestAccount defaultTestAccount2 = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper).aTestAccount().insert();
+        GatewayAccountEntity gatewayAccount2 = new GatewayAccountEntity(
+                defaultTestAccount2.getPaymentProvider(), new HashMap<>(), TEST);
+        gatewayAccount2.setId(defaultTestAccount2.getAccountId());
+
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount2).build());
+
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        final Long expectedId = gatewayAccount.getId();
+        searchParams.withGatewayAccountId(expectedId);
+
+        assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byEmail_whenMultipleTransactionsWithDifferentEmails() {
+        PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        final String expectedEmail = "abc@example.com";
+        paymentRequestEntity1.getChargeTransaction().setEmail(expectedEmail);
+        paymentRequestDao.persist(paymentRequestEntity1);
+
+        final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build();
+        paymentRequestEntity2.getChargeTransaction().setEmail("zzz@example.com");
+        paymentRequestDao.persist(paymentRequestEntity2);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withEmailLike(expectedEmail);
+
+        assertTransactionByExternalId(paymentRequestEntity1.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byEmailWithDifferentCasing() {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        final String expectedEmail = "Abc@example.com";
+        paymentRequestEntity.getChargeTransaction().setEmail(expectedEmail);
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withEmailLike(expectedEmail.toLowerCase());
+
+        assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byEmailWithLowCaseInDb() {
+        PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        final String expectedEmail = "abc@example.com";
+        paymentRequestEntity1.getChargeTransaction().setEmail(expectedEmail);
+        paymentRequestDao.persist(paymentRequestEntity1);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withEmailLike(expectedEmail.toUpperCase());
+
+        assertTransactionByExternalId(paymentRequestEntity1.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byEmailWithPartialMatch() {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        final String expectedEmail = "abc@example.com";
+        paymentRequestEntity.getChargeTransaction().setEmail(expectedEmail);
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withEmailLike("abc");
+
+        assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnRefundTransactions_byEmailWithPartialMatch() {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        final String expectedEmail = "abc@example.com";
+        paymentRequestEntity.getChargeTransaction().setEmail(expectedEmail);
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withEmailLike("abc");
+        searchParams.withTransactionType(REFUND);
+
+        assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byEmailWithUnderscore() {
+        PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        final String expectedEmail = "a_c@example.com";
+        paymentRequestEntity1.getChargeTransaction().setEmail(expectedEmail);
+        paymentRequestDao.persist(paymentRequestEntity1);
+
+        final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build();
+        paymentRequestEntity2.getChargeTransaction().setEmail("abc@example.com");
+        paymentRequestDao.persist(paymentRequestEntity2);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withEmailLike(expectedEmail);
+
+        assertTransactionByExternalId(paymentRequestEntity1.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byEmailWithPercent() {
+        PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        final String expectedEmail = "a%c@example.com";
+        paymentRequestEntity1.getChargeTransaction().setEmail(expectedEmail);
+        paymentRequestDao.persist(paymentRequestEntity1);
+
+        final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build();
+        paymentRequestEntity2.getChargeTransaction().setEmail("abc@example.com");
+        paymentRequestDao.persist(paymentRequestEntity2);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withEmailLike(expectedEmail);
+
+        assertTransactionByExternalId(paymentRequestEntity1.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byReference() {
+        final String expectedReference = "some random reference";
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withReference(expectedReference)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withReferenceLike(expectedReference);
+
+        assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byReferenceWithUnderscore() {
+        final String expectedReference = "a_cedkdkwd";
+
+        PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withReference(expectedReference)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity1);
+
+        final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).withReference("abcedkdkwd").build();
+        paymentRequestDao.persist(paymentRequestEntity2);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withReferenceLike(expectedReference);
+
+        assertTransactionByExternalId(paymentRequestEntity1.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byReferenceWithPercent() {
+        final String expectedReference = "a%cedkdkwd";
+
+        PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withReference(expectedReference)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity1);
+
+        final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withReference("abcedkdkwd")
+                .build();
+        paymentRequestDao.persist(paymentRequestEntity2);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withReferenceLike(expectedReference);
+
+        assertTransactionByExternalId(paymentRequestEntity1.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byReferenceWithUppercase() {
+        final String expectedReference = "ABCEdkdkwd";
+
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withReference(expectedReference)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withReferenceLike(expectedReference);
+
+        assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byReferenceWithUppercaseInRequest() {
+        final String expectedReference = "dkdkwd";
+
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withReference(expectedReference)
+                .build();
+
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withReferenceLike(expectedReference.toUpperCase());
+
+        assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byFromDate() {
+        final ZonedDateTime paymentDate = ZonedDateTime.now().minusMinutes(10);
+
+        final PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestEntity.getChargeTransaction().setCreatedDate(paymentDate);
+        final String expectedExternalId = paymentRequestEntity.getExternalId();
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestEntity2.getChargeTransaction().setCreatedDate(paymentDate.minusMinutes(5));
+        paymentRequestDao.persist(paymentRequestEntity2);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withFromDate(paymentDate);
+
+        assertTransactionByExternalId(expectedExternalId, transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byToDate() {
+        final ZonedDateTime paymentDate = ZonedDateTime.now().minusMinutes(10);
+
+        final PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestEntity.getChargeTransaction().setCreatedDate(paymentDate);
+        final String expectedExternalId = paymentRequestEntity.getExternalId();
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestEntity2.getChargeTransaction().setCreatedDate(paymentDate.plusMinutes(5));
+        paymentRequestDao.persist(paymentRequestEntity2);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withToDate(paymentDate.plusMinutes(1));
+
+        assertTransactionByExternalId(expectedExternalId, transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnRefundTransactions_byTransactionType() {
+        final PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        final String expectedExternalId = paymentRequestEntity.getRefundTransactions().get(0).getRefundExternalId();
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withTransactionType(REFUND);
+
+        final List<TransactionEntity> searchResult = transactionDao.search(searchParams);
+        assertIsTransactionOperation(searchResult, TransactionOperation.REFUND);
+        final String actualExternalId = ((RefundTransactionEntity) searchResult.get(0)).getRefundExternalId();
+        assertThat(actualExternalId, is(expectedExternalId));
+    }
+
+    @Test
+    public void shouldReturnChargeTransactions_byTransactionType() {
+        final PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        paymentRequestDao.persist(paymentRequestEntity);
+        final long chargeTransactionId = paymentRequestEntity.getChargeTransaction().getId();
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withTransactionType(TransactionType.PAYMENT);
+
+        final List<TransactionEntity> searchResult = transactionDao.search(searchParams);
+        assertIsTransactionOperation(searchResult, TransactionOperation.CHARGE);
+        final long actualChargeTransactionId = searchResult.get(0).getId();
+        assertThat(actualChargeTransactionId, is(chargeTransactionId));
+    }
+
+    private void assertIsTransactionOperation(List<TransactionEntity> searchResult, TransactionOperation charge) {
+        assertThat(searchResult.size(), is(1));
+        assertThat(searchResult.get(0).getOperation(), is(charge));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byCardBrand() {
+        final String cardBrand = "visa";
+        final PaymentRequestEntity paymentRequestEntity = persistPaymentRequestForCardBrand(cardBrand);
+        persistPaymentRequestForCardBrand("mastercard");
+
+        final Long chargeTransactionId = paymentRequestEntity.getChargeTransaction().getId();
+        final Long refundTransactionId = paymentRequestEntity.getRefundTransactions().get(0).getId();
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withCardBrand(cardBrand);
+
+        final List<TransactionEntity> searchResult = transactionDao.search(searchParams);
+        assertThat(searchResult.size(), is(2));
+        assertThat(searchResult.get(0).getId(), is(refundTransactionId));
+        assertThat(searchResult.get(1).getId(), is(chargeTransactionId));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byMultipleCardBrand() {
+        final String visaCardBrand = "visa";
+        final PaymentRequestEntity visaPaymentRequestEntity = persistPaymentRequestForCardBrand(visaCardBrand);
+        final String mastercardCardBrand = "master-card";
+        final PaymentRequestEntity mastercardPaymentRequestEntity = persistPaymentRequestForCardBrand(mastercardCardBrand);
+        persistPaymentRequestForCardBrand("anotherCardBrand");
+
+        final Long visaChargeTransactionId = visaPaymentRequestEntity.getChargeTransaction().getId();
+        final Long visaRefundTransactionId = visaPaymentRequestEntity.getRefundTransactions().get(0).getId();
+        final Long mastercardChargeTransactionId = mastercardPaymentRequestEntity.getChargeTransaction().getId();
+        final Long mastercardRefundTransactionId = mastercardPaymentRequestEntity.getRefundTransactions().get(0).getId();
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withCardBrands(asList(visaCardBrand, mastercardCardBrand));
+
+        final List<TransactionEntity> searchResult = transactionDao.search(searchParams);
+        assertThat(searchResult.size(), is(4));
+        assertThat(searchResult.get(0).getId(), is(mastercardRefundTransactionId));
+        assertThat(searchResult.get(1).getId(), is(mastercardChargeTransactionId));
+        assertThat(searchResult.get(2).getId(), is(visaRefundTransactionId));
+        assertThat(searchResult.get(3).getId(), is(visaChargeTransactionId));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byStatus() {
+        final ChargeStatus chargeStatus = ChargeStatus.CAPTURED;
+        final PaymentRequestEntity paymentRequestEntity =
+                persistPaymentRequestForStatus(chargeStatus, RefundStatus.REFUNDED);
+
+        final Long chargeTransactionId = paymentRequestEntity.getChargeTransaction().getId();
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withExternalState(chargeStatus.toExternal().getStatus());
+
+        assertTransactionById(chargeTransactionId, transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byChargeStatus() {
+        final ChargeStatus chargeStatus = ChargeStatus.CAPTURED;
+        final PaymentRequestEntity paymentRequestEntity =
+                persistPaymentRequestForStatus(chargeStatus, RefundStatus.REFUNDED);
+
+        final Long chargeTransactionId = paymentRequestEntity.getChargeTransaction().getId();
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.addExternalChargeStates(singletonList(chargeStatus.toExternal().getStatus()));
+
+        assertTransactionById(chargeTransactionId, transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byRefundStatus() {
+        final RefundStatus refundStatus = RefundStatus.REFUNDED;
+        final PaymentRequestEntity paymentRequestEntity =
+                persistPaymentRequestForStatus(ChargeStatus.CAPTURED, refundStatus);
+
+        final Long refundTransactionId = paymentRequestEntity.getRefundTransactions().get(0).getId();
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.addExternalRefundStates(singletonList(refundStatus.toExternal().getStatus()));
+
+        assertTransactionById(refundTransactionId, transactionDao.search(searchParams));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byMultipleStatues() {
+        final ChargeStatus chargeStatus = ChargeStatus.CAPTURED;
+        final RefundStatus refundStatus = RefundStatus.REFUNDED;
+        final PaymentRequestEntity paymentRequestEntity =
+                persistPaymentRequestForStatus(chargeStatus, refundStatus);
+
+        final Long chargeTransactionId = paymentRequestEntity.getChargeTransaction().getId();
+        final Long refundTransactionId = paymentRequestEntity.getRefundTransactions().get(0).getId();
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.addExternalChargeStates(singletonList(
+                chargeStatus.toExternal().getStatus()
+        ));
+        searchParams.addExternalRefundStates(singletonList(
+                refundStatus.toExternal().getStatus())
+        );
+
+        final List<TransactionEntity> searchResult = transactionDao.search(searchParams);
+        assertThat(searchResult.size(), is(2));
+        assertThat(searchResult.get(0).getId(), is(refundTransactionId));
+        assertThat(searchResult.get(1).getId(), is(chargeTransactionId));
+    }
+
+    @Test
+    public void shouldReturnTransactions_byDisplaySize() {
+        final PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount).build();
+        paymentRequestDao.persist(paymentRequestEntity);
+        paymentRequestDao.persist(aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount).build());
+        paymentRequestDao.persist(aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = createSearchParams();
+        searchParams.withPage(2L);
+        searchParams.withDisplaySize(4L);
+
+        final List<TransactionEntity> searchResult = transactionDao.search(searchParams);
+        assertThat(searchResult.size(), is(2));
+        final Long refundId = paymentRequestEntity.getRefundTransactions().get(0).getId();
+        assertThat(searchResult.get(0).getId(), is(refundId));
+        final Long chargeId = paymentRequestEntity.getChargeTransaction().getId();
+        assertThat(searchResult.get(1).getId(), is(chargeId));
+    }
+
+    @Test
+    public void shouldReturnTransactions_AllParametersSet() throws Exception {
+        String ref = "ref1";
+        String email = "foo@foo.com";
+        String cardBrand = "visa";
+
+        ZonedDateTime createdTime = ZonedDateTime.now();
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
+                .withReference(ref)
+                .withTransactions(aChargeTransactionEntity()
+                        .withEmail(email)
+                        .withCard(aCardEntity()
+                                .withCardBrand(cardBrand)
+                                .build())
+                        .withCreatedDate(createdTime)
+                        .withStatus(ChargeStatus.CREATED)
+                        .build())
+                .withGatewayAccountEntity(gatewayAccount).build();
+        paymentRequestDao.persist(paymentRequestEntity);
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        final Long expectedId = gatewayAccount.getId();
+        searchParams.withGatewayAccountId(expectedId);
+        searchParams.withReferenceLike(ref);
+        searchParams.withEmailLike(email);
+        searchParams.withCardBrand(cardBrand);
+        searchParams.withFromDate(createdTime.minusSeconds(5));
+        searchParams.withToDate(createdTime.plusSeconds(5));
+        searchParams.withTransactionType(TransactionType.PAYMENT);
+        searchParams.addExternalChargeStates(singletonList(ChargeStatus.CREATED.toExternal().getStatus()));
+        searchParams.addExternalRefundStates(singletonList(RefundStatus.CREATED.toExternal().getStatus()));
+
+        final List<TransactionEntity> searchResult = transactionDao.search(searchParams);
+        assertThat(searchResult.size(), is(1));
+        final Long refundId = paymentRequestEntity.getChargeTransaction().getId();
+        assertThat(searchResult.get(0).getId(), is(refundId));
+    }
+
+    @Test
+    public void shouldCountTransactions_AllParametersSet() throws Exception {
+        String ref = "ref1";
+        String email = "foo@foo.com";
+        String cardBrand = "visa";
+
+        ZonedDateTime createdTime = ZonedDateTime.now();
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withReference(ref)
+                .withTransactions(aChargeTransactionEntity()
+                        .withEmail(email)
+                        .withCard(aCardEntity()
+                                .withCardBrand(cardBrand)
+                                .build())
+                        .withCreatedDate(createdTime)
+                        .withStatus(ChargeStatus.CREATED)
+                        .build())
+                .withGatewayAccountEntity(gatewayAccount).build());
+        paymentRequestDao.persist(aValidPaymentRequestEntity()
+                .withGatewayAccountEntity(gatewayAccount).build());
+
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        final Long expectedId = gatewayAccount.getId();
+        searchParams.withGatewayAccountId(expectedId);
+        searchParams.withReferenceLike(ref);
+        searchParams.withEmailLike(email);
+        searchParams.withCardBrand(cardBrand);
+        searchParams.withFromDate(createdTime.minusSeconds(5));
+        searchParams.withToDate(createdTime.plusSeconds(5));
+        searchParams.withTransactionType(TransactionType.PAYMENT);
+        searchParams.addExternalChargeStates(singletonList(ChargeStatus.CREATED.toExternal().getStatus()));
+        searchParams.addExternalRefundStates(singletonList(RefundStatus.CREATED.toExternal().getStatus()));
+
+        final Long total = transactionDao.getTotal(searchParams);
+        assertThat(total, is(1L));
+    }
+
+    private ChargeSearchParams createSearchParams() {
+        ChargeSearchParams searchParams = new ChargeSearchParams();
+        searchParams.withGatewayAccountId(gatewayAccount.getId());
+        return searchParams;
+    }
+
+    private PaymentRequestEntity persistPaymentRequestForStatus(ChargeStatus chargeStatus, RefundStatus refundStatus) {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        paymentRequestEntity.getChargeTransaction().updateStatus(chargeStatus);
+        paymentRequestEntity.getRefundTransactions().get(0).updateStatus(refundStatus);
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        return paymentRequestEntity;
+    }
+
+    private PaymentRequestEntity persistPaymentRequestForCardBrand(String cardBrand) {
+        PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntityWithRefund()
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        final CardEntity card = aCardEntity()
+                .withCardBrand(cardBrand)
+                .build();
+        paymentRequestEntity.getChargeTransaction().setCard(card);
+        paymentRequestDao.persist(paymentRequestEntity);
+
+        return paymentRequestEntity;
+    }
+
+    private void assertTransactionByExternalId(String expectedExternalId, List<TransactionEntity> searchResult) {
+        assertThat(searchResult.size(), is(1));
+        final String actualExternalId = searchResult.get(0).getPaymentRequest().getExternalId();
+        assertThat(actualExternalId, is(expectedExternalId));
+    }
+
+    private void assertTransactionById(Long expectedId, List<TransactionEntity> searchResult) {
+        assertThat(searchResult.size(), is(1));
+        assertThat(searchResult.get(0).getId(), is(expectedId));
+    }
+
+    private void insertTestAccount() {
+        this.defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
@@ -7,7 +7,6 @@ import uk.gov.pay.connector.dao.TransactionDao;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
 import uk.gov.pay.connector.model.domain.Transaction;
-import uk.gov.pay.connector.resources.CommaDelimitedSetParameter;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
 import java.time.ZonedDateTime;
@@ -16,6 +15,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.time.ZonedDateTime.now;
+import static java.util.Collections.singletonList;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -517,7 +517,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withReferenceLike(testCharge.getReference())
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()));
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -558,7 +558,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withReferenceLike(testCharge.getReference())
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()))
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
                 .withFromDate(ZonedDateTime.parse(FROM_DATE))
                 .withToDate(ZonedDateTime.parse(TO_DATE));
 
@@ -600,7 +600,7 @@ public class TransactionDaoITest extends DaoITestBase {
         ChargeSearchParams params = new ChargeSearchParams()
                 .withTransactionType(PAYMENT)
                 .withReferenceLike(testCharge.getReference())
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()))
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
                 .withFromDate(ZonedDateTime.parse(FROM_DATE));
 
         // when
@@ -631,7 +631,7 @@ public class TransactionDaoITest extends DaoITestBase {
         ChargeSearchParams params = new ChargeSearchParams()
                 .withTransactionType(REFUND)
                 .withReferenceLike(testCharge.getReference())
-                .addExternalRefundStates(new CommaDelimitedSetParameter(EXTERNAL_SUBMITTED.getStatus()))
+                .addExternalRefundStates(singletonList(EXTERNAL_SUBMITTED.getStatus()))
                 .withFromDate(ZonedDateTime.parse(FROM_DATE));
 
         // when
@@ -694,7 +694,7 @@ public class TransactionDaoITest extends DaoITestBase {
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_STARTED.getStatus()));
+                .addExternalChargeStates(singletonList(EXTERNAL_STARTED.getStatus()));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -754,8 +754,8 @@ public class TransactionDaoITest extends DaoITestBase {
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_STARTED.getStatus()))
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()));
+                .addExternalChargeStates(singletonList(EXTERNAL_STARTED.getStatus()))
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -817,7 +817,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withTransactionType(PAYMENT)
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_STARTED.getStatus()));
+                .addExternalChargeStates(singletonList(EXTERNAL_STARTED.getStatus()));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -873,7 +873,7 @@ public class TransactionDaoITest extends DaoITestBase {
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
-                .addExternalRefundStates(new CommaDelimitedSetParameter(EXTERNAL_SUCCESS.getStatus()));
+                .addExternalRefundStates(singletonList(EXTERNAL_SUCCESS.getStatus()));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -933,8 +933,8 @@ public class TransactionDaoITest extends DaoITestBase {
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
-                .addExternalRefundStates(new CommaDelimitedSetParameter(EXTERNAL_SUBMITTED.getStatus()))
-                .addExternalRefundStates(new CommaDelimitedSetParameter(EXTERNAL_SUCCESS.getStatus()));
+                .addExternalRefundStates(singletonList(EXTERNAL_SUBMITTED.getStatus()))
+                .addExternalRefundStates(singletonList(EXTERNAL_SUCCESS.getStatus()));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -996,7 +996,7 @@ public class TransactionDaoITest extends DaoITestBase {
                 .insert();
         ChargeSearchParams params = new ChargeSearchParams()
                 .withTransactionType(REFUND)
-                .addExternalRefundStates(new CommaDelimitedSetParameter(EXTERNAL_SUCCESS.getStatus()));
+                .addExternalRefundStates(singletonList(EXTERNAL_SUCCESS.getStatus()));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -1017,7 +1017,7 @@ public class TransactionDaoITest extends DaoITestBase {
         ChargeSearchParams params = new ChargeSearchParams()
                 .withTransactionType(PAYMENT)
                 .withReferenceLike(testCharge.getReference())
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()))
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
                 .withCardBrand(testCardDetails.getCardBrand())
                 .withEmailLike(testCharge.getEmail())
                 .withFromDate(ZonedDateTime.parse(FROM_DATE))
@@ -1051,7 +1051,7 @@ public class TransactionDaoITest extends DaoITestBase {
         ChargeSearchParams params = new ChargeSearchParams()
                 .withTransactionType(PAYMENT)
                 .withReferenceLike(testCharge.getReference())
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()))
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
                 .withToDate(ZonedDateTime.parse(TO_DATE));
 
         // when
@@ -1081,7 +1081,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withReferenceLike(testCharge.getReference())
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()))
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
                 .withFromDate(ZonedDateTime.parse(TO_DATE));
 
         // when
@@ -1100,7 +1100,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withReferenceLike(testCharge.getReference())
-                .addExternalChargeStates(new CommaDelimitedSetParameter(EXTERNAL_CREATED.getStatus()))
+                .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
                 .withToDate(ZonedDateTime.parse(FROM_DATE));
 
         // when

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -1,0 +1,600 @@
+package uk.gov.pay.connector.it.resources;
+
+import com.google.common.collect.ImmutableList;
+import com.jayway.restassured.response.Header;
+import com.jayway.restassured.response.ValidatableResponse;
+import org.junit.Test;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.util.DateTimeUtils;
+import uk.gov.pay.connector.util.RestAssuredClient;
+
+import javax.ws.rs.core.HttpHeaders;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.http.ContentType.JSON;
+import static java.time.ZonedDateTime.now;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.util.Arrays.asList;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.apache.commons.lang.math.RandomUtils.nextInt;
+import static org.apache.commons.lang.math.RandomUtils.nextLong;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.resources.ApiPaths.CHARGES_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.TRANSACTIONS_API_PATH;
+import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
+
+public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
+    private static final String PROVIDER_NAME = "sandbox";
+    private static final String RETURN_URL = "http://service.url/success-page/";
+    private static final String EMAIL = randomAlphabetic(242) + "@example.com";
+    private String returnUrl = "http://service.url/success-page/";
+    private String email = randomAlphabetic(242) + "@example.com";
+
+    private RestAssuredClient getChargeApi = new RestAssuredClient(app, accountId);
+
+    public ChargesApiResourceGetChargesJsonITest() {
+        super(PROVIDER_NAME);
+    }
+
+    @Test
+    public void shouldReturn404OnGetTransactionsWhenAccountIdIsNonNumeric() {
+        getChargeApi
+                .withAccountId("invalidAccountId")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .contentType(JSON)
+                .statusCode(NOT_FOUND.getStatusCode())
+                .body("code", is(404))
+                .body("message", is("HTTP 404 Not Found"));
+    }
+
+    @Test
+    public void shouldGetChargeTransactionsForJSONAcceptHeader() throws Exception {
+        long chargeId = nextInt();
+        String externalChargeId = "charge3";
+
+        ChargeStatus chargeStatus = AUTHORISATION_SUCCESS;
+        ZonedDateTime createdDate = ZonedDateTime.of(2016, 1, 26, 13, 45, 32, 123, ZoneId.of("UTC"));
+        UUID card = UUID.randomUUID();
+        app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
+        app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null, "My reference", createdDate);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "VISA", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
+        app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
+
+        String description = "Test description";
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, description, "My reference", createdDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, createdDate, email);
+        app.getDatabaseTestHelper().addCard(chargeId, "VISA", chargeId);
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results[0].charge_id", is(externalChargeId))
+                .body("results[0].state.status", is(EXTERNAL_SUBMITTED.getStatus()))
+                .body("results[0].amount", is(6234))
+                .body("results[0].card_details", notNullValue())
+                .body("results[0].gateway_account", nullValue())
+                .body("results[0].reference", is("My reference"))
+                .body("results[0].return_url", is(returnUrl))
+                .body("results[0].description", is(description))
+                .body("results[0].created_date", is("2016-01-26T13:45:32Z"))
+                .body("results[0].payment_provider", is(PROVIDER_NAME));
+    }
+
+    @Test
+    public void shouldGetChargeLegacyTransactions() throws Exception {
+
+        long chargeId = nextInt();
+        String externalChargeId = "charge3";
+
+        ChargeStatus chargeStatus = AUTHORISATION_SUCCESS;
+        ZonedDateTime createdDate = ZonedDateTime.of(2016, 1, 26, 13, 45, 32, 123, ZoneId.of("UTC"));
+        UUID card = UUID.randomUUID();
+        app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
+        app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null, "My reference", createdDate);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "visa", null, null, null, null, null, null, null, null, null);
+        app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
+        app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
+
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, "Test description", "My reference", createdDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, createdDate, email);
+        app.getDatabaseTestHelper().addCard(chargeId, "visa", chargeId);
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results[0].charge_id", is(externalChargeId))
+                .body("results[0].amount", is(6234))
+                .body("results[0].card_details", notNullValue())
+                .body("results[0].card_details.card_brand", is("Visa"))
+                .body("results[0].card_details.cardholder_name", nullValue())
+                .body("results[0].card_details.last_digits_card_number", nullValue())
+                .body("results[0].card_details.expiry_date", nullValue());
+    }
+
+    @Test
+    public void shouldFilterTransactionsByCardBrand() throws Exception {
+        String searchedCardBrand = "visa";
+
+        addChargeAndCardDetails(CREATED, "ref-1", now(), searchedCardBrand);
+        addChargeAndCardDetails(CREATED, "ref-2", now(), "master-card");
+        addChargeAndCardDetails(CREATED, "ref-3", now().minusDays(2), searchedCardBrand);
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("card_brand", searchedCardBrand)
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("results[0].card_details.card_brand", endsWith("Visa"))
+                .body("results[1].card_details.card_brand", endsWith("Visa"));
+    }
+
+    @Test
+    public void shouldFilterTransactionsByBlankCardBrand() throws Exception {
+        addChargeAndCardDetails(CREATED, "ref-1", now(), "visa");
+        addChargeAndCardDetails(CREATED, "ref-2", now(), "master-card");
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("card_brand", "")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("results[0].card_details.card_brand", endsWith("Mastercard"))
+                .body("results[1].card_details.card_brand", endsWith("Visa"));
+    }
+    
+    @Test
+    public void shouldFilterTransactionsByMultipleCardBrand() {
+        String visa = "visa";
+        String mastercard = "master-card";
+
+        addChargeAndCardDetails(CREATED, "ref-1", now(), visa);
+        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now().minusHours(1), mastercard);
+        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2), "american-express");
+
+        getChargeApi
+                .withQueryParams("card_brand", asList(visa, mastercard))
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("results[0].card_details.card_brand", endsWith("Visa"))
+                .body("results[1].card_details.card_brand", endsWith("Mastercard"));
+    }
+
+    @Test
+    public void shouldGetAllTransactionsForDefault_page_1_size_100_inCreationDateOrder2() {
+        String id_1 = addChargeAndCardDetails(CREATED, "ref-1", now());
+        String id_2 = addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now().plusHours(1));
+        String id_3 = addChargeAndCardDetails(CREATED, "ref-3", now().plusHours(2));
+        String id_4 = addChargeAndCardDetails(CREATED, "ref-4", now().plusHours(3));
+        String id_5 = addChargeAndCardDetails(CREATED, "ref-5", now().plusHours(4));
+
+        int expectedTotalRows = 5;
+
+        ValidatableResponse response = given().port(app.getLocalPort())
+                .header(new Header(HttpHeaders.ACCEPT, APPLICATION_JSON))
+                .get(TRANSACTIONS_API_PATH.replace("{accountId}", accountId))
+                .then()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(5))
+                .body("total", is(expectedTotalRows));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "charge_id");
+        assertThat(references, is(ImmutableList.of(id_5, id_4, id_3, id_2, id_1)));
+    }
+
+    @Test
+    public void shouldGetTransactionsForPageAndSizeParams_inCreationDateOrder2() throws Exception {
+        String id_1 = addChargeAndCardDetails(CREATED, "ref-1", now());
+        String id_2 = addChargeAndCardDetails(CREATED, "ref-2", now().plusHours(1));
+        String id_3 = addChargeAndCardDetails(CREATED, "ref-3", now().plusHours(2));
+        String id_4 = addChargeAndCardDetails(CREATED, "ref-4", now().plusHours(3));
+        String id_5 = addChargeAndCardDetails(CREATED, "ref-5", now().plusHours(4));
+        int expectedTotalRows = 5;
+
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("display_size", "2")
+                .withQueryParam("page", "1")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("total", is(expectedTotalRows));
+
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> charge_ids = collect(results, "charge_id");
+        assertThat(charge_ids, is(ImmutableList.of(id_5, id_4)));
+
+        response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("display_size", "2")
+                .withQueryParam("page", "2")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("total", is(expectedTotalRows));
+
+        results = response.extract().body().jsonPath().getList("results");
+        charge_ids = collect(results, "charge_id");
+        assertThat(charge_ids, is(ImmutableList.of(id_3, id_2)));
+
+        response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("display_size", "2")
+                .withQueryParam("page", "3")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(1))
+                .body("total", is(expectedTotalRows));
+
+        results = response.extract().body().jsonPath().getList("results");
+        charge_ids = collect(results, "charge_id");
+        assertThat(charge_ids, is(ImmutableList.of(id_1)));
+    }
+
+    @Test
+    public void shouldShowValidationsForDateAndPageDisplaySize() {
+        ImmutableList<String> expectedList = ImmutableList.of(
+                "query param 'from_date' not in correct format",
+                "query param 'to_date' not in correct format",
+                "query param 'display_size' should be a non zero positive integer",
+                "query param 'page' should be a non zero positive integer");
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("to_date", "-1")
+                .withQueryParam("from_date", "-1")
+                .withQueryParam("page", "-1")
+                .withQueryParam("display_size", "-2")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .contentType(JSON)
+                .body("message", is(expectedList));
+    }
+
+    @Test
+    public void shouldFilterTransactionsBasedOnFromAndToDates() {
+
+        addChargeAndCardDetails(CREATED, "ref-1", now());
+        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now());
+        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2));
+
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("from_date", DateTimeUtils.toUTCDateTimeString(now().minusDays(1)))
+                .withQueryParam("to_date", DateTimeUtils.toUTCDateTimeString(now().plusDays(1)))
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "reference");
+        assertThat(references, containsInAnyOrder("ref-1", "ref-2"));
+        assertThat(references, not(contains("ref-3")));
+
+        // collect statuses from states
+        List<Object> statuses = results
+                .stream()
+                .map(result -> ((Map<Object, Object>) result.get("state")).get("status"))
+                .collect(Collectors.toList());
+
+        assertThat(statuses, containsInAnyOrder("created", "started"));
+        assertThat(statuses, not(contains("confirmed")));
+
+        List<String> createdDateStrings = collect(results, "created_date");
+        datesFrom(createdDateStrings).forEach(createdDate ->
+                assertThat(createdDate, is(within(1, DAYS, now())))
+        );
+        List<String> emails = collect(results, "email");
+        assertThat(emails, contains(EMAIL, EMAIL));
+    }
+
+    @Test
+    public void shouldFilterTransactionsByEmail() throws Exception {
+
+        addChargeAndCardDetails(CREATED, "ref-1", now());
+        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now());
+        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2));
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("email", "@example.com")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(3))
+                .body("results[0].email", endsWith("example.com"));
+    }
+
+    @Test
+    public void shouldShowTotalCountResultsAndHalLinksForCharges() throws Exception {
+        addChargeAndCardDetails(CREATED, "ref-1", now());
+        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now().minusDays(1));
+        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2));
+        addChargeAndCardDetails(CAPTURED, "ref-4", now().minusDays(3));
+        addChargeAndCardDetails(CAPTURED, "ref-5", now().minusDays(4));
+
+        assertNavigationLinksWhenNoResultFound();
+        assertResultsWhenPageAndDisplaySizeNotSet();
+        assertResultsAndJustSelfLinkWhenJustOneResult();
+        assertResultsAndNoPrevLinkWhenOnFirstPage();
+        assertResultsAndAllLinksWhenOnMiddlePage();
+        assertResultsAndNoNextLinksWhenOnLastPage();
+        assert404WhenRequestingInvalidPage();
+        assertBadRequestForNegativePageDisplaySize();
+    }
+
+    private List<ZonedDateTime> datesFrom(List<String> createdDateStrings) {
+        List<ZonedDateTime> dateTimes = newArrayList();
+        createdDateStrings.forEach(aDateString -> dateTimes.add(toUTCZonedDateTime(aDateString).get()));
+        return dateTimes;
+    }
+
+    private String addChargeAndCardDetails(ChargeStatus status, String reference, ZonedDateTime fromDate, String cardBrand) {
+        return addChargeAndCardDetails(nextLong(), status, reference, fromDate, cardBrand);
+    }
+
+    private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, String reference, ZonedDateTime fromDate, String cardBrand) {
+        String externalChargeId = "charge" + chargeId;
+        ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, RETURN_URL, null, reference, fromDate, EMAIL);
+        app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
+        app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, cardBrand, "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), RETURN_URL, "some description", reference, fromDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, fromDate, EMAIL);
+        app.getDatabaseTestHelper().addCard(chargeId, cardBrand, chargeId);
+
+        return externalChargeId;
+    }
+
+    private List<String> collect(List<Map<String, Object>> results, String field) {
+        return results.stream().map(result -> result.get(field).toString()).collect(Collectors.toList());
+    }
+
+    private String addChargeAndCardDetails(ChargeStatus status, String reference, ZonedDateTime fromDate) {
+        return addChargeAndCardDetails(status, reference, fromDate, "");
+    }
+
+    private void assertResultsWhenPageAndDisplaySizeNotSet() {
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "ref-1")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(1))
+                .body("total", is(1))
+                .body("count", is(1))
+                .body("_links.next_page", isEmptyOrNullString())
+                .body("_links.prev_page", isEmptyOrNullString())
+                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-1&page=1&display_size=500")))
+                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-1&page=1&display_size=500")))
+                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=ref-1&page=1&display_size=500")));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "reference");
+        assertThat(references, containsInAnyOrder("ref-1"));
+        assertThat(references, not(contains("ref-1", "ref-3", "ref-4", "ref-5")));
+    }
+    
+    private void assertNavigationLinksWhenNoResultFound() {
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "junk-yard")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(0))
+                .body("total", is(0))
+                .body("count", is(0))
+                .body("_links.next_page", isEmptyOrNullString())
+                .body("_links.prev_page", isEmptyOrNullString())
+                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=junk-yard&page=1&display_size=500")))
+                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=junk-yard&page=1&display_size=500")))
+                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=junk-yard&page=1&display_size=500")));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "reference");
+        assertTrue(results.isEmpty());
+    }
+
+    private void assertResultsAndNoPrevLinkWhenOnFirstPage() {
+        // when 5 charges are there, page is 1, display-size is 2
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "ref")
+                .withQueryParam("page", "1")
+                .withQueryParam("display_size", "2")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("total", is(5))
+                .body("count", is(2))
+                .body("_links.next_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=2&display_size=2")))
+                .body("_links.prev_page", isEmptyOrNullString())
+                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=1&display_size=2")))
+                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=3&display_size=2")))
+                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=1&display_size=2")));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "reference");
+        assertThat(references, containsInAnyOrder("ref-1", "ref-2"));
+        assertThat(references, not(contains("ref-3", "ref-4", "ref-5")));
+    }
+
+    private void assertResultsAndAllLinksWhenOnMiddlePage() {
+        // when 5 charges are there, page is 2, display-size is 2
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "ref")
+                .withQueryParam("page", "2")
+                .withQueryParam("display_size", "2")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(2))
+                .body("total", is(5))
+                .body("count", is(2))
+                .body("_links.next_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=3&display_size=2")))
+                .body("_links.prev_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=1&display_size=2")))
+                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=1&display_size=2")))
+                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=3&display_size=2")))
+                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=2&display_size=2")));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "reference");
+        assertThat(references, containsInAnyOrder("ref-3", "ref-4"));
+        assertThat(references, not(contains("ref-1", "ref-2", "ref-5")));
+    }
+
+    private void assertResultsAndNoNextLinksWhenOnLastPage() {
+        // when 5 charges are there, page is 3, display-size is 2
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "ref")
+                .withQueryParam("page", "3")
+                .withQueryParam("display_size", "2")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(1))
+                .body("total", is(5))
+                .body("count", is(1))
+                .body("_links.next_page", isEmptyOrNullString())
+                .body("_links.prev_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=2&display_size=2")))
+                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=1&display_size=2")))
+                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=3&display_size=2")))
+                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=ref&page=3&display_size=2")));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "reference");
+        assertThat(references, containsInAnyOrder("ref-5"));
+        assertThat(references, not(contains("ref-1", "ref-2", "ref-3", "ref-4")));
+    }
+
+    private void assertResultsAndJustSelfLinkWhenJustOneResult() {
+        // when 5 charges are there, page is 1, display-size is 2
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "ref-1")
+                .withQueryParam("page", "1")
+                .withQueryParam("display_size", "1")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(1))
+                .body("total", is(1))
+                .body("count", is(1))
+                .body("_links.next_page", isEmptyOrNullString())
+                .body("_links.prev_page", isEmptyOrNullString())
+                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-1&page=1&display_size=1")))
+                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-1&page=1&display_size=1")))
+                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=ref-1&page=1&display_size=1")));
+
+        List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
+        List<String> references = collect(results, "reference");
+        assertThat(references, containsInAnyOrder("ref-1"));
+        assertThat(references, not(contains("ref-1", "ref-3", "ref-4", "ref-5")));
+    }
+
+    private void assert404WhenRequestingInvalidPage() {
+        // when 5 charges are there, page is 10, display-size is 2
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "ref")
+                .withQueryParam("page", "10")
+                .withQueryParam("display_size", "2")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(NOT_FOUND.getStatusCode())
+                .body("message", is("the requested page not found"));
+    }
+
+    private void assertBadRequestForNegativePageDisplaySize() {
+        ImmutableList<String> expectedList = ImmutableList.of(
+                "query param 'display_size' should be a non zero positive integer",
+                "query param 'page' should be a non zero positive integer");
+
+        ValidatableResponse response = getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("reference", "ref")
+                .withQueryParam("page", "-1")
+                .withQueryParam("display_size", "-2")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(BAD_REQUEST.getStatusCode())
+                .contentType(JSON)
+                .body("message", is(expectedList));
+    }
+
+    private String expectedChargesLocationFor(String accountId, String queryParams) {
+        return "https://localhost:" + app.getLocalPort()
+                + CHARGES_API_PATH.replace("{accountId}", accountId)
+                + queryParams;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -404,12 +404,18 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         ChargeStatus chargeStatus = AUTHORISATION_SUCCESS;
         ZonedDateTime createdDate = ZonedDateTime.of(2016, 1, 26, 13, 45, 32, 123, ZoneId.of("UTC"));
         UUID card = UUID.randomUUID();
-        app.getDatabaseTestHelper().addCardType(card, "label", "type", "brand", false);
+        app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
         app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null, "My reference", createdDate);
         app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "VISA", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
+
+        String description = "Test description";
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, description, "My reference", createdDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, createdDate, email);
+        app.getDatabaseTestHelper().addCard(chargeId, "VISA", chargeId);
+
         getChargeApi
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -423,7 +429,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("results[0].gateway_account", nullValue())
                 .body("results[0].reference", is("My reference"))
                 .body("results[0].return_url", is(returnUrl))
-                .body("results[0].description", is("Test description"))
+                .body("results[0].description", is(description))
                 .body("results[0].created_date", is("2016-01-26T13:45:32Z"))
                 .body("results[0].payment_provider", is(PROVIDER_NAME));
     }
@@ -437,12 +443,17 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         ChargeStatus chargeStatus = AUTHORISATION_SUCCESS;
         ZonedDateTime createdDate = ZonedDateTime.of(2016, 1, 26, 13, 45, 32, 123, ZoneId.of("UTC"));
         UUID card = UUID.randomUUID();
-        app.getDatabaseTestHelper().addCardType(card, "label", "type", "brand", false);
+        app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
         app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null, "My reference", createdDate);
         app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "visa", null, null, null, null, null, null, null, null, null);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
+
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, "Test description", "My reference", createdDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, createdDate, email);
+        app.getDatabaseTestHelper().addCard(chargeId, "visa", chargeId);
+
         getChargeApi
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -1001,6 +1012,10 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
         app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, cardBrand, "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, "some description", reference, fromDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, fromDate, email);
+        app.getDatabaseTestHelper().addCard(chargeId, cardBrand, chargeId);
+
         return externalChargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/model/domain/CardEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/CardEntityBuilder.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
+
+public final class CardEntityBuilder {
+    private String lastDigitsCardNumber;
+    private String cardHolderName;
+    private String expiryDate;
+    private String cardBrand;
+    private AddressEntity billingAddress;
+    private ChargeTransactionEntity chargeTransactionEntity;
+
+    private CardEntityBuilder() {
+    }
+
+    public static CardEntityBuilder aCardEntity() {
+        return new CardEntityBuilder();
+    }
+
+    public CardEntityBuilder withLastDigitsCardNumber(String lastDigitsCardNumber) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        return this;
+    }
+
+    public CardEntityBuilder withCardHolderName(String cardHolderName) {
+        this.cardHolderName = cardHolderName;
+        return this;
+    }
+
+    public CardEntityBuilder withExpiryDate(String expiryDate) {
+        this.expiryDate = expiryDate;
+        return this;
+    }
+
+    public CardEntityBuilder withCardBrand(String cardBrand) {
+        this.cardBrand = cardBrand;
+        return this;
+    }
+
+    public CardEntityBuilder withBillingAddress(AddressEntity billingAddress) {
+        this.billingAddress = billingAddress;
+        return this;
+    }
+
+    public CardEntityBuilder withChargeTransactionEntity(ChargeTransactionEntity chargeTransactionEntity) {
+        this.chargeTransactionEntity = chargeTransactionEntity;
+        return this;
+    }
+
+    public CardEntity build() {
+        CardEntity cardEntity = new CardEntity();
+        cardEntity.setLastDigitsCardNumber(lastDigitsCardNumber);
+        cardEntity.setCardHolderName(cardHolderName);
+        cardEntity.setExpiryDate(expiryDate);
+        cardEntity.setCardBrand(cardBrand);
+        cardEntity.setBillingAddress(billingAddress);
+        cardEntity.setChargeTransactionEntity(chargeTransactionEntity);
+        return cardEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
@@ -19,7 +19,7 @@ public class PaymentRequestEntityFixture {
     private Long amount = 500L;
     private String returnUrl = "http://return.com";
     private String description = "This is a description";
-    private String reference = "This is a reference";
+    private String reference = RandomIdGenerator.newId();
     private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
     private List<TransactionEntity> transactions = asList(aChargeTransactionEntity().build());
@@ -54,6 +54,21 @@ public class PaymentRequestEntityFixture {
 
     public PaymentRequestEntityFixture withTransactions(TransactionEntity... transactions) {
         this.transactions = Arrays.asList(transactions);
+        return this;
+    }
+
+    public PaymentRequestEntityFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public PaymentRequestEntityFixture withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+    public PaymentRequestEntityFixture withAmount(long amount) {
+        this.amount = amount;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/transaction/ChargeTransactionEntityBuilder.java
@@ -1,11 +1,18 @@
 package uk.gov.pay.connector.model.domain.transaction;
 
+import uk.gov.pay.connector.model.domain.CardEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public final class ChargeTransactionEntityBuilder {
     private String gatewayTransactionId = "someGatewayTransactionId";
     private Long amount = 1234L;
     private ChargeStatus status = ChargeStatus.CREATED;
+    private String email = "email@example.com";
+    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+    private CardEntity card;
 
     private ChargeTransactionEntityBuilder() {
     }
@@ -29,11 +36,31 @@ public final class ChargeTransactionEntityBuilder {
         return this;
     }
 
+    public ChargeTransactionEntityBuilder withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public ChargeTransactionEntityBuilder withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+    public ChargeTransactionEntityBuilder withCard(CardEntity card) {
+        this.card = card;
+        return this;
+    }
+
     public ChargeTransactionEntity build() {
         ChargeTransactionEntity transactionEntity = new ChargeTransactionEntity();
         transactionEntity.setGatewayTransactionId(gatewayTransactionId);
         transactionEntity.setAmount(amount);
         transactionEntity.updateStatus(status);
+        transactionEntity.setEmail(email);
+        transactionEntity.setCreatedDate(createdDate);
+        if (card != null) {
+            transactionEntity.setCard(card);
+        }
         return transactionEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntityBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/transaction/RefundTransactionEntityBuilder.java
@@ -1,13 +1,18 @@
 package uk.gov.pay.connector.model.domain.transaction;
 
 import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public final class RefundTransactionEntityBuilder {
     protected RefundStatus status = RefundStatus.CREATED;
-    private String refundExternalId = "someRefundExternalId";
+    private String refundExternalId = RandomIdGenerator.newId();
     private String userExternalId = "someUserExternalId";
     private Long amount = 123L;
-    private String refundReference = "someRefundReference";
+    private String refundReference = RandomIdGenerator.newId();
+    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
 
     private RefundTransactionEntityBuilder() {
     }
@@ -45,6 +50,11 @@ public final class RefundTransactionEntityBuilder {
         return this;
     }
 
+    public RefundTransactionEntityBuilder withCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
     public RefundTransactionEntity build() {
         RefundTransactionEntity refundTransactionEntity = new RefundTransactionEntity();
         refundTransactionEntity.setStatus(status);
@@ -52,6 +62,7 @@ public final class RefundTransactionEntityBuilder {
         refundTransactionEntity.setUserExternalId(userExternalId);
         refundTransactionEntity.setAmount(amount);
         refundTransactionEntity.setRefundReference(refundReference);
+        refundTransactionEntity.setCreatedDate(createdDate);
         return refundTransactionEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -556,13 +556,37 @@ public class DatabaseTestHelper {
                 )
         );
     }
+    public void addChargeTransaction(
+            long transactionId,
+            String gatewayTransactionId,
+            Long gatewayAccountId,
+            Long amount,
+            ChargeStatus chargeStatus,
+            long paymentRequestId
+    ) {
+        addChargeTransaction(transactionId, gatewayTransactionId, gatewayAccountId, amount, chargeStatus, paymentRequestId, ZonedDateTime.now(), "some@email.com");
+    }
 
+    @Deprecated // Use the addChargeTransaction above that sets the gatewayAccountId
     public void addChargeTransaction(
             long transactionId,
             String gatewayTransactionId,
             Long amount,
             ChargeStatus chargeStatus,
             long paymentRequestId
+    ) {
+        addChargeTransaction(transactionId, gatewayTransactionId, null, amount, chargeStatus, paymentRequestId, ZonedDateTime.now(), "some@email.com");
+    }
+
+    public void addChargeTransaction(
+            long transactionId,
+            String gatewayTransactionId,
+            Long gatewayAccountId,
+            Long amount,
+            ChargeStatus chargeStatus,
+            long paymentRequestId,
+            ZonedDateTime dateCreated,
+            String email
             ) {
         jdbi.withHandle(h ->
                 h.update(
@@ -570,18 +594,24 @@ public class DatabaseTestHelper {
                                 "id," +
                                 "payment_request_id," +
                                 "gateway_transaction_id," +
+                                "gateway_account_id," +
                                 "amount," +
                                 "status," +
-                                "operation" +
+                                "operation, " +
+                                "created_date," +
+                                "email" +
                                 ")" +
                                 "VALUES (" +
-                                "?, ?, ?, ?, ?, 'CHARGE'" +
+                                "?, ?, ?, ?, ?, ?, 'CHARGE', ?, ?" +
                                 ")",
                         transactionId,
                         paymentRequestId,
                         gatewayTransactionId,
+                        gatewayAccountId,
                         amount,
-                        chargeStatus.name()
+                        chargeStatus.name(),
+                        Timestamp.from(dateCreated.toInstant()),
+                        email
                 )
         );
     }
@@ -665,6 +695,22 @@ public class DatabaseTestHelper {
                         ")",
                 cardId,
                 chargeId,
+                transactionId)
+        );
+    }
+
+    public void addCard(Long cardId, String cardBrand, Long transactionId) {
+        jdbi.withHandle(h -> h.update(
+                "INSERT INTO cards(" +
+                        "id," +
+                        "card_brand," +
+                        "transaction_id" +
+                        ")" +
+                        "VALUES (" +
+                        "?, ?, ?" +
+                        ")",
+                cardId,
+                cardBrand,
                 transactionId)
         );
     }

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -18,6 +18,7 @@ import static uk.gov.pay.connector.resources.ApiPaths.CHARGE_EVENTS_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.FRONTEND_CHARGE_CANCEL_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.REFUND_API_PATH;
+import static uk.gov.pay.connector.resources.ApiPaths.TRANSACTIONS_API_PATH;
 import static uk.gov.pay.connector.resources.ApiPaths.TRANSACTIONS_SUMMARY_API_PATH;
 
 public class RestAssuredClient {
@@ -142,6 +143,13 @@ public class RestAssuredClient {
         return addQueryParams(given().port(app.getLocalPort())
                 .headers(headers))
                 .get(CHARGES_API_PATH.replace("{accountId}", accountId))
+                .then();
+    }
+
+    public ValidatableResponse getTransactionsAPI() {
+        return addQueryParams(given().port(app.getLocalPort())
+                .headers(headers))
+                .get(TRANSACTIONS_API_PATH.replace("{accountId}", accountId))
                 .then();
     }
 


### PR DESCRIPTION
Add a new end point /api/accounts/{accountId}/transactions that will
use the new data structure to produce a list of transactions.

- Wrote dao that will search new data structure takes all the old
parameters from the previous search.
- As part of another branch added gateway_account_id on transactions.
The used this gateway_account_id in the search as it is much quicker
than joining to transactions to payment_requests.
- Only join payment_reqyests, cards and cards_3ds tables when needed.
The sort of searches that need these tables will only return a few
results. If we have a large number of results its expensive to join
on these tables and the data is not needed for the search results.
- Split search into two a count to get the total results with limit
and offset to give one page of data.
- Added new end point.
- Duplicated tests that were calling the old endpoint to test the new
one. This resulted in a number of small bug fixes.
- Load CardTypes once for a search result and use this information to
create the objects returned by connector.
