### PR TITLE
PP-3347 Upgrade dropwizard to 1.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,12 @@
     <version>0.1-SNAPSHOT</version>
     <artifactId>pay-connector</artifactId>
     <properties>
-        <dropwizard.version>1.0.6</dropwizard.version>
+        <dropwizard.version>1.2.2</dropwizard.version>
         <wiremock.version>1.57</wiremock.version>
         <jpa.version>2.6.4</jpa.version>
         <guice.version>4.1.0</guice.version>
-        <jersey2.version>2.25.1</jersey2.version>
         <docker-client.version>8.9.2</docker-client.version>
-        <jackson.version>2.8.11</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
     </properties>
     <repositories>
         <repository>
@@ -144,16 +143,6 @@
             <version>4.5.3</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>${jersey2.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-jaxb</artifactId>
-            <version>${jersey2.version}</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.2.2</version>
@@ -239,6 +228,12 @@
             <version>3.9.5</version>
         </dependency>
         <!-- testing -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.0.54-beta</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path-assert</artifactId>
@@ -382,7 +377,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.3.22.v20171030</version>
+            <version>9.4.8.v20171121</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
## WHAT
* Upgraded Dropwizard to latest version 1.2.2:
	* Since version 1.1.0, Dropwizard dropped dependency to `org.mockito`intentional. The Mockito dependency was only accidentally Maven's "compile" scope and has since moved into the correct "test" scope. See https://github.com/dropwizard/dropwizard/pull/1851 for details. Since Dropwizard itself has no dependency on Mockito anymore, a dependency had to be added to the project explicitly.
  
* Removed explicit dependency of jersey version 2.25.1 which is not anymore needed since Dropwizard 1.2.2 already ships with that version. Note: jersey 2.25.1 is reported to have a medium vulnerability “XML Entity Expansion (XEE)” which has not yet been addressed in any subsequent version.

* Pinned Jackson to version 2.9.4 which has a fix to address a vulnerability detected in version 2.9.1 which would otherwise be pulled by Dropwizard 1.2.2.

* Upgraded jetty-util to latest version 9.4.8.v20171121 which addresses VULNERABILITY ARTIFACT SID-4247 (Timing Attack)

* NOTE Hibernate Validator version 5.4.1.Final pulled down with Dropwizard 1.2.2 is reported to have a “Privilege Escalation” vulnerability issue. Upgrading to 6.0.7.Final as recommended breaks the build due to api incompatibilities. The security issue has to do with Java Security manager which is not been used therefore we are safe to leave it as it is.


