### PR TITLE
PP-3450 EPDQ 3Ds Store request data

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1281,4 +1281,25 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add html_out_3ds to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="html_out_3ds" type="text">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add html_out to card_3ds table" author="">
+        <addColumn tableName="card_3ds">
+            <column name="html_out" type="text">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="make pa_request and issuer_url nullable on card_3ds" author="">
+        <dropNotNullConstraint columnName="pa_request" tableName="card_3ds"/>
+        <dropNotNullConstraint columnName="issuer_url" tableName="card_3ds"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
When we make an authorise request to EPDQ and 3Ds is enabled we will
not get a pa_request or issure_url. Instead we get a block of html
which we will need to send to the user and will redirect them to EPDQ.

- Add a html_out column to charges and card_3ds to store the html.
- Make pa_request and issurer_url nullable on card_3ds as we will have
them or html_out.
