### PR TITLE
PP-3450 handle epdq 3ds result

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/EpdqParamsFor3ds.java
+++ b/src/main/java/uk/gov/pay/connector/model/EpdqParamsFor3ds.java
@@ -2,11 +2,11 @@ package uk.gov.pay.connector.model;
 
 import uk.gov.pay.connector.model.domain.Auth3dsDetailsEntity;
 
-public class EpdqParamsFor3DSecure implements GatewayParamsFor3DSecure {
+public class EpdqParamsFor3ds implements GatewayParamsFor3ds {
 
-    public final String htmlOut;
+    private final String htmlOut;
 
-    public EpdqParamsFor3DSecure(String htmlOut) {
+    public EpdqParamsFor3ds(String htmlOut) {
         this.htmlOut = htmlOut;
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/GatewayParamsFor3ds.java
+++ b/src/main/java/uk/gov/pay/connector/model/GatewayParamsFor3ds.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.model;
 
 import uk.gov.pay.connector.model.domain.Auth3dsDetailsEntity;
 
-public interface GatewayParamsFor3DSecure {
+public interface GatewayParamsFor3ds {
 
     Auth3dsDetailsEntity toAuth3dsDetailsEntity();
 }

--- a/src/main/java/uk/gov/pay/connector/model/WorldpayParamsFor3ds.java
+++ b/src/main/java/uk/gov/pay/connector/model/WorldpayParamsFor3ds.java
@@ -2,12 +2,12 @@ package uk.gov.pay.connector.model;
 
 import uk.gov.pay.connector.model.domain.Auth3dsDetailsEntity;
 
-public class WorldpayParamsFor3DSecure implements GatewayParamsFor3DSecure {
+public class WorldpayParamsFor3ds implements GatewayParamsFor3ds {
 
-    public final String issuerUrl;
-    public final String paRequest;
+    private final String issuerUrl;
+    private final String paRequest;
 
-    public WorldpayParamsFor3DSecure(String issuerUrl, String paRequest) {
+    public WorldpayParamsFor3ds(String issuerUrl, String paRequest) {
         this.issuerUrl = issuerUrl;
         this.paRequest = paRequest;
     }

--- a/src/main/java/uk/gov/pay/connector/model/domain/Auth3dsDetails.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Auth3dsDetails.java
@@ -4,7 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Auth3dsDetails implements AuthorisationDetails {
 
+    public enum Auth3DResult {
+        AUTHORISED, DECLINED, ERROR
+    }
+
     private String paResponse;
+
+    private Auth3DResult auth3DResult;
 
     @JsonProperty("pa_response")
     public void setPaResponse(String paResponse) {
@@ -15,4 +21,12 @@ public class Auth3dsDetails implements AuthorisationDetails {
             return paResponse;
         }
 
+    public Auth3DResult getAuth3DResult() {
+        return auth3DResult;
+    }
+
+    @JsonProperty("auth_3d_result")
+    public void setAuth3DResult(String auth3DResult) {
+        this.auth3DResult = auth3DResult == null ? null : Auth3DResult.valueOf(auth3DResult);
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/Auth3dsDetails.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Auth3dsDetails.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Auth3dsDetails implements AuthorisationDetails {
 
-    public enum Auth3DResult {
+    public enum Auth3dsResult {
         AUTHORISED, DECLINED, ERROR
     }
 
     private String paResponse;
 
-    private Auth3DResult auth3DResult;
+    private Auth3dsResult auth3DsResult;
 
     @JsonProperty("pa_response")
     public void setPaResponse(String paResponse) {
@@ -21,12 +21,12 @@ public class Auth3dsDetails implements AuthorisationDetails {
             return paResponse;
         }
 
-    public Auth3DResult getAuth3DResult() {
-        return auth3DResult;
+    public Auth3dsResult getAuth3DsResult() {
+        return auth3DsResult;
     }
 
-    @JsonProperty("auth_3d_result")
-    public void setAuth3DResult(String auth3DResult) {
-        this.auth3DResult = auth3DResult == null ? null : Auth3DResult.valueOf(auth3DResult);
+    @JsonProperty("auth_3ds_result")
+    public void setAuth3dsResult(String auth3dsResult) {
+        this.auth3DsResult = auth3dsResult == null ? Auth3dsResult.ERROR : Auth3dsResult.valueOf(auth3dsResult);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/service/BaseAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/BaseAuthoriseResponse.java
@@ -11,7 +11,7 @@ public interface BaseAuthoriseResponse extends BaseResponse {
 
     AuthoriseStatus authoriseStatus();
 
-    Optional<? extends GatewayParamsFor3ds> getAuth3dsDetails();
+    Optional<? extends GatewayParamsFor3ds> getGatewayParamsFor3ds();
 
     enum AuthoriseStatus {
         SUBMITTED(ChargeStatus.AUTHORISATION_SUBMITTED),

--- a/src/main/java/uk/gov/pay/connector/service/BaseAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/BaseAuthoriseResponse.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.service;
 
-import uk.gov.pay.connector.model.GatewayParamsFor3DSecure;
+import uk.gov.pay.connector.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 
 import java.util.Optional;
@@ -11,7 +11,7 @@ public interface BaseAuthoriseResponse extends BaseResponse {
 
     AuthoriseStatus authoriseStatus();
 
-    Optional<? extends GatewayParamsFor3DSecure> getAuth3dsDetails();
+    Optional<? extends GatewayParamsFor3ds> getAuth3dsDetails();
 
     enum AuthoriseStatus {
         SUBMITTED(ChargeStatus.AUTHORISATION_SUBMITTED),

--- a/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/service/Card3dsResponseAuthService.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 
@@ -75,12 +76,9 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
             chargeStatusUpdater.updateChargeTransactionStatus(chargeEntity.getExternalId(), status);
             Optional<PaymentRequestEntity> paymentRequestEntity = paymentRequestDao.findByExternalId(chargeEntity.getExternalId());
 
-            if (StringUtils.isBlank(transactionId)) {
-                logger.warn("Auth3DSDetails authorisation response received with no transaction id. -  charge_external_id={}", chargeId);
-            } else {
+            if (!isBlank(transactionId)) {
                 setGatewayTransactionId(chargeEntity, transactionId, paymentRequestEntity);
             }
-
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
             return operationResponse;
 

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -139,7 +139,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
             chargeEntity.setStatus(status);
             operationResponse.getBaseResponse().ifPresent(response ->
-                    response.getAuth3dsDetails().map(GatewayParamsFor3ds::toAuth3dsDetailsEntity)
+                    response.getGatewayParamsFor3ds().map(GatewayParamsFor3ds::toAuth3dsDetailsEntity)
                             .ifPresent(chargeEntity::set3dsDetails)
             );
 

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseService.java
@@ -11,7 +11,7 @@ import uk.gov.pay.connector.dao.ChargeEventDao;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.model.GatewayError;
-import uk.gov.pay.connector.model.GatewayParamsFor3DSecure;
+import uk.gov.pay.connector.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.model.domain.AddressEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetails;
 import uk.gov.pay.connector.model.domain.Card3dsEntity;
@@ -139,7 +139,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
             chargeEntity.setStatus(status);
             operationResponse.getBaseResponse().ifPresent(response ->
-                    response.getAuth3dsDetails().map(GatewayParamsFor3DSecure::toAuth3dsDetailsEntity)
+                    response.getAuth3dsDetails().map(GatewayParamsFor3ds::toAuth3dsDetailsEntity)
                             .ifPresent(chargeEntity::set3dsDetails)
             );
 

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.service.epdq;
 
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.model.EpdqParamsFor3DSecure;
+import uk.gov.pay.connector.model.domain.Auth3dsDetails;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 
 import javax.xml.bind.annotation.XmlAttribute;
@@ -18,6 +19,18 @@ public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseA
     private static final String WAITING_EXTERNAL = "50";
     private static final String WAITING = "51";
     private static final String REJECTED = "2";
+
+    public static EpdqAuthorisationResponse createPost3dsResponseFor(Auth3dsDetails.Auth3DResult threeDsResult) {
+        EpdqAuthorisationResponse response = new EpdqAuthorisationResponse();
+        if (threeDsResult == null || Auth3dsDetails.Auth3DResult.ERROR.equals(threeDsResult)) {
+            response.status = "ERROR";
+        } else if (Auth3dsDetails.Auth3DResult.AUTHORISED.equals(threeDsResult)) {
+            response.status = AUTHORISED;
+        } else if (Auth3dsDetails.Auth3DResult.DECLINED.equals(threeDsResult)) {
+            response.status = REJECTED;
+        }
+        return response;
+    }
 
     private String status;
     private String htmlAnswer;

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.service.epdq;
 
 import org.apache.commons.lang3.StringUtils;
-import uk.gov.pay.connector.model.EpdqParamsFor3DSecure;
+import uk.gov.pay.connector.model.EpdqParamsFor3ds;
 import uk.gov.pay.connector.model.domain.Auth3dsDetails;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 
@@ -44,8 +44,7 @@ public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseA
             return AuthoriseStatus.AUTHORISED;
         }
 
-        if (WAITING_EXTERNAL.equals(status) ||
-                WAITING.equals(status)) {
+        if (WAITING_EXTERNAL.equals(status) || WAITING.equals(status)) {
             return AuthoriseStatus.SUBMITTED;
         }
 
@@ -60,9 +59,9 @@ public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseA
     }
 
     @Override
-    public Optional<EpdqParamsFor3DSecure> getAuth3dsDetails() {
+    public Optional<EpdqParamsFor3ds> getAuth3dsDetails() {
         if (htmlAnswer != null) {
-            return Optional.of(new EpdqParamsFor3DSecure(htmlAnswer));
+            return Optional.of(new EpdqParamsFor3ds(htmlAnswer));
         }
         return Optional.empty();
     }

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponse.java
@@ -20,14 +20,14 @@ public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseA
     private static final String WAITING = "51";
     private static final String REJECTED = "2";
 
-    public static EpdqAuthorisationResponse createPost3dsResponseFor(Auth3dsDetails.Auth3DResult threeDsResult) {
+    public static EpdqAuthorisationResponse createPost3dsResponseFor(Auth3dsDetails.Auth3dsResult threeDsResult) {
         EpdqAuthorisationResponse response = new EpdqAuthorisationResponse();
-        if (threeDsResult == null || Auth3dsDetails.Auth3DResult.ERROR.equals(threeDsResult)) {
-            response.status = "ERROR";
-        } else if (Auth3dsDetails.Auth3DResult.AUTHORISED.equals(threeDsResult)) {
+        if (Auth3dsDetails.Auth3dsResult.AUTHORISED.equals(threeDsResult)) {
             response.status = AUTHORISED;
-        } else if (Auth3dsDetails.Auth3DResult.DECLINED.equals(threeDsResult)) {
+        } else if (Auth3dsDetails.Auth3dsResult.DECLINED.equals(threeDsResult)) {
             response.status = REJECTED;
+        } else {
+            response.status = "ERROR";
         }
         return response;
     }
@@ -59,7 +59,7 @@ public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseA
     }
 
     @Override
-    public Optional<EpdqParamsFor3ds> getAuth3dsDetails() {
+    public Optional<EpdqParamsFor3ds> getGatewayParamsFor3ds() {
         if (htmlAnswer != null) {
             return Optional.of(new EpdqParamsFor3ds(htmlAnswer));
         }

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
@@ -20,7 +20,7 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
         private String userId;
         private String shaInPassphrase;
         private String amount;
-        private String frontendUrl;
+        private String frontendBaseUrl;
 
         public String getOperationType() {
             return operationType;
@@ -72,11 +72,11 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
         }
 
         public void setFrontendUrl(String frontendUrl) {
-            this.frontendUrl = frontendUrl;
+            this.frontendBaseUrl = frontendUrl;
         }
 
         public String getFrontendUrl() {
-            return frontendUrl;
+            return frontendBaseUrl;
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
@@ -4,7 +4,6 @@ import fj.data.Either;
 import org.apache.http.NameValuePair;
 import uk.gov.pay.connector.model.CancelGatewayRequest;
 import uk.gov.pay.connector.model.CaptureGatewayRequest;
-import uk.gov.pay.connector.model.GatewayError;
 import uk.gov.pay.connector.model.Notification;
 import uk.gov.pay.connector.model.Notifications;
 import uk.gov.pay.connector.model.RefundGatewayRequest;
@@ -33,18 +32,18 @@ import java.util.function.Function;
 import static fj.data.Either.left;
 import static fj.data.Either.right;
 import static java.util.stream.Collectors.toList;
-import static uk.gov.pay.connector.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.model.gateway.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.service.epdq.EpdqNotification.SHASIGN;
+import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdq3DsAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdqAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdqCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdqCaptureOrderRequestBuilder;
 import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdqRefundOrderRequestBuilder;
-import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdq3DsAuthoriseOrderRequestBuilder;
 
 
 public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, String> {
@@ -79,7 +78,8 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
 
     @Override
     public GatewayResponse<BaseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        return GatewayResponse.with(new GatewayError("3D Secure not implemented for Epdq", GENERIC_GATEWAY_ERROR));
+        return responseBuilder()
+                .withResponse(EpdqAuthorisationResponse.createPost3dsResponseFor(request.getAuth3DsDetails().getAuth3DResult())).build();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
@@ -79,7 +79,7 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
     @Override
     public GatewayResponse<BaseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         return responseBuilder()
-                .withResponse(EpdqAuthorisationResponse.createPost3dsResponseFor(request.getAuth3DsDetails().getAuth3DResult())).build();
+                .withResponse(EpdqAuthorisationResponse.createPost3dsResponseFor(request.getAuth3DsDetails().getAuth3DsResult())).build();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProvider.java
@@ -152,7 +152,7 @@ public class SandboxPaymentProvider extends BasePaymentProvider<BaseResponse, St
             }
 
             @Override
-            public Optional<GatewayParamsFor3ds> getAuth3dsDetails() {
+            public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
                 return Optional.empty();
             }
 

--- a/src/main/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/sandbox/SandboxPaymentProvider.java
@@ -4,7 +4,7 @@ import fj.data.Either;
 import uk.gov.pay.connector.model.CancelGatewayRequest;
 import uk.gov.pay.connector.model.CaptureGatewayRequest;
 import uk.gov.pay.connector.model.GatewayError;
-import uk.gov.pay.connector.model.GatewayParamsFor3DSecure;
+import uk.gov.pay.connector.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.model.Notification;
 import uk.gov.pay.connector.model.Notifications;
 import uk.gov.pay.connector.model.RefundGatewayRequest;
@@ -152,7 +152,7 @@ public class SandboxPaymentProvider extends BasePaymentProvider<BaseResponse, St
             }
 
             @Override
-            public Optional<GatewayParamsFor3DSecure> getAuth3dsDetails() {
+            public Optional<GatewayParamsFor3ds> getAuth3dsDetails() {
                 return Optional.empty();
             }
 

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.service.smartpay;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
-import uk.gov.pay.connector.model.GatewayParamsFor3DSecure;
+import uk.gov.pay.connector.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -30,7 +30,7 @@ public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implemen
     }
 
     @Override
-    public Optional<GatewayParamsFor3DSecure> getAuth3dsDetails() {
+    public Optional<GatewayParamsFor3ds> getAuth3dsDetails() {
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
@@ -30,7 +30,7 @@ public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implemen
     }
 
     @Override
-    public Optional<GatewayParamsFor3ds> getAuth3dsDetails() {
+    public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderStatusResponse.java
@@ -122,7 +122,7 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         return trim(errorMessage);
     }
 
-    public Optional<WorldpayParamsFor3ds> getAuth3dsDetails() {
+    public Optional<WorldpayParamsFor3ds> getGatewayParamsFor3ds() {
         if (issuerUrl != null && paRequest != null) {
             return Optional.of(new WorldpayParamsFor3ds(issuerUrl, paRequest));
         }

--- a/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/worldpay/WorldpayOrderStatusResponse.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.service.worldpay;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
-import uk.gov.pay.connector.model.WorldpayParamsFor3DSecure;
+import uk.gov.pay.connector.model.WorldpayParamsFor3ds;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 import uk.gov.pay.connector.service.BaseCancelResponse;
 import uk.gov.pay.connector.service.BaseInquiryResponse;
@@ -122,9 +122,9 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         return trim(errorMessage);
     }
 
-    public Optional<WorldpayParamsFor3DSecure> getAuth3dsDetails() {
+    public Optional<WorldpayParamsFor3ds> getAuth3dsDetails() {
         if (issuerUrl != null && paRequest != null) {
-            return Optional.of(new WorldpayParamsFor3DSecure(issuerUrl, paRequest));
+            return Optional.of(new WorldpayParamsFor3ds(issuerUrl, paRequest));
         }
         return Optional.empty();
     }

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -231,8 +231,8 @@ public class EpdqPaymentProviderTest {
     }
 
     private static AuthCardDetails aValidEpdqCard() {
-        String validSandboxCard = "4000000000000002";
-        return buildAuthCardDetails(validSandboxCard, "737", "08/18", "visa");
+        String validEpdqCard = "4000000000000002";
+        return buildAuthCardDetails(validEpdqCard, "737", "08/18", "visa");
     }
 
     private CancelGatewayRequest buildCancelRequest(ChargeEntity chargeEntity, String transactionId) {

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -122,9 +122,9 @@ public class WorldpayPaymentProviderTest {
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
         response.getBaseResponse().ifPresent(res -> {
-            assertThat(res.getAuth3dsDetails().isPresent(), is(true));
-            assertThat(res.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getPaRequest(), is(notNullValue()));
-            assertThat(res.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getIssuerUrl(), is(notNullValue()));
+            assertThat(res.getGatewayParamsFor3ds().isPresent(), is(true));
+            assertThat(res.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getPaRequest(), is(notNullValue()));
+            assertThat(res.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getIssuerUrl(), is(notNullValue()));
         });
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -123,8 +123,8 @@ public class WorldpayPaymentProviderTest {
         assertTrue(response.getSessionIdentifier().isPresent());
         response.getBaseResponse().ifPresent(res -> {
             assertThat(res.getAuth3dsDetails().isPresent(), is(true));
-            assertThat(res.getAuth3dsDetails().get().paRequest, is(notNullValue()));
-            assertThat(res.getAuth3dsDetails().get().issuerUrl, is(notNullValue()));
+            assertThat(res.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getPaRequest(), is(notNullValue()));
+            assertThat(res.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getIssuerUrl(), is(notNullValue()));
         });
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.model.domain.Auth3dsDetails.Auth3dsResult.AUTHORISED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
@@ -42,7 +43,7 @@ public class EpdqCardResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldSuccessfully_authoriseForAChargeRequiring3ds() {
+    public void shouldAuthorise_whenRequires3dsAnd3dsAuthenticationSuccessful() {
         app.getDatabaseTestHelper().enable3dsForGatewayAccount(Long.parseLong(accountId));
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         epdq.mockAuthorisation3dsSuccess();
@@ -64,7 +65,7 @@ public class EpdqCardResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().enable3dsForGatewayAccount(Long.parseLong(accountId));
         String chargeId = createNewChargeWith(AUTHORISATION_3DS_REQUIRED, RandomIdGenerator.newId());
 
-        Map<String, String> payload = ImmutableMap.of("auth_3d_result", "AUTHORISED");
+        Map<String, String> payload = ImmutableMap.of("auth_3ds_result", AUTHORISED.name());
 
         givenSetup()
                 .body(new ObjectMapper().writeValueAsString(payload))

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
@@ -1,16 +1,15 @@
 package uk.gov.pay.connector.it.resources.epdq;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.jayway.restassured.response.ValidatableResponse;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.util.Map;
 
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
@@ -36,7 +35,7 @@ public class EpdqCardResourceITest extends ChargingITestBase {
                 .body(authorisationDetails)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
-                .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))
+                .body("status", is(AUTHORISATION_SUCCESS.toString()))
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
@@ -54,7 +53,7 @@ public class EpdqCardResourceITest extends ChargingITestBase {
                 .then();
 
         response
-                .body("status", Matchers.is(AUTHORISATION_3DS_REQUIRED.toString()))
+                .body("status", is(AUTHORISATION_3DS_REQUIRED.toString()))
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_3DS_REQUIRED.toString());

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -35,9 +35,6 @@ import uk.gov.pay.connector.service.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.service.epdq.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.service.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.util.AuthUtils;
-import uk.gov.pay.connector.util.TestTemplateResourceLoader;
-import uk.gov.pay.connector.util.XMLUnmarshaller;
-import uk.gov.pay.connector.util.XMLUnmarshallerException;
 
 import javax.persistence.OptimisticLockException;
 import java.util.Map;
@@ -78,7 +75,6 @@ import static uk.gov.pay.connector.service.CardExecutorService.ExecutionStatus.I
 import static uk.gov.pay.connector.util.AuthUtils.aValidAuthorisationDetails;
 import static uk.gov.pay.connector.util.AuthUtils.addressFor;
 import static uk.gov.pay.connector.util.AuthUtils.buildAuthCardDetails;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_SUCCESS_3D_RESPONSE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CardAuthoriseServiceTest extends CardServiceTest {
@@ -133,7 +129,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(worldpayResponse.getTransactionId()).thenReturn(TRANSACTION_ID);
         when(worldpayResponse.authoriseStatus()).thenReturn(authoriseStatus);
         when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
-        when(worldpayResponse.getAuth3dsDetails()).thenReturn(Optional.empty());
+        when(worldpayResponse.getGatewayParamsFor3ds()).thenReturn(Optional.empty());
         GatewayResponseBuilder<WorldpayOrderStatusResponse> gatewayResponseBuilder = responseBuilder();
         return gatewayResponseBuilder
                 .withResponse(worldpayResponse)

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponseTest.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.service.epdq;
+
+import org.junit.Test;
+import uk.gov.pay.connector.model.domain.Auth3dsDetails;
+import uk.gov.pay.connector.service.BaseAuthoriseResponse;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class EpdqAuthorisationResponseTest {
+
+    @Test
+    public void shouldMapToAuthorisedSuccess_fromAuthorisedAuth3DResult() {
+        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3DResult.AUTHORISED);
+        assertThat(response.authoriseStatus(),is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
+    }
+
+    @Test
+    public void shouldMapToAuthorisedRejected_fromDeclinedAuth3DResult() {
+        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3DResult.DECLINED);
+        assertThat(response.authoriseStatus(),is(BaseAuthoriseResponse.AuthoriseStatus.REJECTED));
+    }
+
+    @Test
+    public void shouldMapToAuthorisedError_fromErrorAuth3DResult() {
+        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3DResult.ERROR);
+        assertThat(response.authoriseStatus(),is(BaseAuthoriseResponse.AuthoriseStatus.ERROR));
+    }
+
+    @Test
+    public void shouldMapToAuthorisedError_fromNullAuth3DResult() {
+        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(null);
+        assertThat(response.authoriseStatus(),is(BaseAuthoriseResponse.AuthoriseStatus.ERROR));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqAuthorisationResponseTest.java
@@ -5,25 +5,25 @@ import uk.gov.pay.connector.model.domain.Auth3dsDetails;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class EpdqAuthorisationResponseTest {
 
     @Test
     public void shouldMapToAuthorisedSuccess_fromAuthorisedAuth3DResult() {
-        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3DResult.AUTHORISED);
+        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3dsResult.AUTHORISED);
         assertThat(response.authoriseStatus(),is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
     }
 
     @Test
     public void shouldMapToAuthorisedRejected_fromDeclinedAuth3DResult() {
-        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3DResult.DECLINED);
+        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3dsResult.DECLINED);
         assertThat(response.authoriseStatus(),is(BaseAuthoriseResponse.AuthoriseStatus.REJECTED));
     }
 
     @Test
     public void shouldMapToAuthorisedError_fromErrorAuth3DResult() {
-        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3DResult.ERROR);
+        EpdqAuthorisationResponse response = EpdqAuthorisationResponse.createPost3dsResponseFor(Auth3dsDetails.Auth3dsResult.ERROR);
         assertThat(response.authoriseStatus(),is(BaseAuthoriseResponse.AuthoriseStatus.ERROR));
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -115,8 +115,8 @@ public class WorldpayXMLUnmarshallerTest {
         assertNull(response.getErrorMessage());
 
         assertThat(response.getAuth3dsDetails().isPresent(), is(true));
-        assertThat(response.getAuth3dsDetails().get().paRequest, is("eJxVUsFuwjAM/ZWK80aSUgpFJogNpHEo2hjTzl"));
-        assertThat(response.getAuth3dsDetails().get().issuerUrl, is("https://secure-test.worldpay.com/jsp/test/shopper/ThreeDResponseSimulator.jsp"));
+        assertThat(response.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getPaRequest(), is("eJxVUsFuwjAM/ZWK80aSUgpFJogNpHEo2hjTzl"));
+        assertThat(response.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getIssuerUrl(), is("https://secure-test.worldpay.com/jsp/test/shopper/ThreeDResponseSimulator.jsp"));
 
         assertThat(response.authoriseStatus(), is(AuthoriseStatus.REQUIRES_3DS));
     }

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -114,9 +114,9 @@ public class WorldpayXMLUnmarshallerTest {
         assertNull(response.getErrorCode());
         assertNull(response.getErrorMessage());
 
-        assertThat(response.getAuth3dsDetails().isPresent(), is(true));
-        assertThat(response.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getPaRequest(), is("eJxVUsFuwjAM/ZWK80aSUgpFJogNpHEo2hjTzl"));
-        assertThat(response.getAuth3dsDetails().get().toAuth3dsDetailsEntity().getIssuerUrl(), is("https://secure-test.worldpay.com/jsp/test/shopper/ThreeDResponseSimulator.jsp"));
+        assertThat(response.getGatewayParamsFor3ds().isPresent(), is(true));
+        assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getPaRequest(), is("eJxVUsFuwjAM/ZWK80aSUgpFJogNpHEo2hjTzl"));
+        assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getIssuerUrl(), is("https://secure-test.worldpay.com/jsp/test/shopper/ThreeDResponseSimulator.jsp"));
 
         assertThat(response.authoriseStatus(), is(AuthoriseStatus.REQUIRES_3DS));
     }


### PR DESCRIPTION
This needs to wait until https://github.com/alphagov/pay-connector/pull/587
## WHAT
Using the same transaction flow (pre, op, post) so that we stick to the same state transitions. The main difference is that we construct a success authorisation response in the `operation` (and not invoking any epdq gateway operation as there i no need) so that we can fit in to the same 3ds flow.

Introduced a `auth_3d_result` payload entry which will only be used by epds 3ds flow.

with @chrisgrimble