### PR TITLE
PP-3497 CSV download including incorrect payment states

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/ChargesPaginationResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesPaginationResponseBuilder.java
@@ -84,7 +84,7 @@ public class ChargesPaginationResponseBuilder {
 
     private URI uriWithParams(String params) {
         return uriInfo.getBaseUriBuilder()
-                .path("/v1/api/accounts/{accountId}/charges")
+                .path(uriInfo.getPath())
                 .replaceQuery(params)
                 .build(searchParams.getGatewayAccountId());
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -590,7 +590,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
 
     private String expectedChargesLocationFor(String accountId, String queryParams) {
         return "https://localhost:" + app.getLocalPort()
-                + "/v1/api/accounts/{accountId}/charges".replace("{accountId}", accountId)
+                + "/v1/api/accounts/{accountId}/transactions".replace("{accountId}", accountId)
                 + queryParams;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
@@ -228,7 +228,7 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
 
     private String expectedChargesLocationFor(String accountId, String queryParams) {
         return "https://localhost:" + app.getLocalPort()
-                + "/v1/api/accounts/{accountId}/charges".replace("{accountId}", accountId)
+                + "/v2/api/accounts/{accountId}/charges".replace("{accountId}", accountId)
                 + queryParams;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/resources/ChargesPaginationResponseBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/ChargesPaginationResponseBuilderTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
-import uk.gov.pay.connector.model.domain.ChargeStatus;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -40,6 +39,8 @@ public class ChargesPaginationResponseBuilderTest {
         when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://app.com"),
                 UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"),
                 UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"));
+
+        when(mockUriInfo.getPath()).thenReturn("/v1/api/accounts/1/charges");
 
         // when
         Response response = new ChargesPaginationResponseBuilder(searchParams, mockUriInfo)


### PR DESCRIPTION
The problem is because the next link is being generated for the old
search end point not the new one. For the csv download we follow the
next link recursively to download all the transactions. We were do the
search correctly for the first 500 result then using the old search
which has a different parameter name for status for the next page. We
kept the parameter names the same so we used the new parameters with
the old search.

To fix use the path from the UriInfo object which we are already using
to get the base uri.

with @kakumara 


