### PR TITLE
PP-3498 Results from 'State' dropdown on transactions filter should

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/api/ExternalChargeState.java
+++ b/src/main/java/uk/gov/pay/connector/model/api/ExternalChargeState.java
@@ -11,33 +11,40 @@ public enum ExternalChargeState {
     EXTERNAL_STARTED("started", false),
     EXTERNAL_SUBMITTED("submitted", false),
     EXTERNAL_SUCCESS("success", true),
-    EXTERNAL_FAILED_REJECTED("failed", true, "P0010", "Payment method rejected"),
-    EXTERNAL_FAILED_EXPIRED("failed", true, "P0020", "Payment expired"),
-    EXTERNAL_FAILED_CANCELLED("failed", true, "P0030", "Payment was cancelled by the user"),
-    EXTERNAL_CANCELLED("cancelled", true, "P0040", "Payment was cancelled by the service"),
-    EXTERNAL_ERROR_GATEWAY("error", true, "P0050", "Payment provider returned an error");
+    EXTERNAL_FAILED_REJECTED("failed", "declined", true, "P0010", "Payment method rejected"),
+    EXTERNAL_FAILED_EXPIRED("failed", "timedout", true, "P0020", "Payment expired"),
+    EXTERNAL_FAILED_CANCELLED("failed", "cancelled", true, "P0030", "Payment was cancelled by the user"),
+    EXTERNAL_CANCELLED("cancelled", "cancelled", true, "P0040", "Payment was cancelled by the service"),
+    EXTERNAL_ERROR_GATEWAY("error", "error", true, "P0050", "Payment provider returned an error");
 
-    private final String value;
+    private final String oldStatus;
+    private final String status;
     private final boolean finished;
     private final String code;
     private final String message;
 
-    ExternalChargeState(String value, boolean finished) {
-        this.value = value;
+    ExternalChargeState(String status, boolean finished) {
+        this.oldStatus = status;
+        this.status = status;
         this.finished = finished;
         this.code = null;
         this.message = null;
     }
 
-    ExternalChargeState(String value, boolean finished, String code, String message) {
-        this.value = value;
+    ExternalChargeState(String oldStatus, String status, boolean finished, String code, String message) {
+        this.oldStatus = oldStatus;
+        this.status = status;
         this.finished = finished;
         this.code = code;
         this.message = message;
     }
 
     public String getStatus() {
-        return value;
+        return oldStatus;
+    }
+
+    public String getStatusV2() {
+        return status;
     }
 
     public boolean isFinished() {
@@ -54,6 +61,21 @@ public enum ExternalChargeState {
 
     public static List<ExternalChargeState> fromStatusString(String status) {
         List<ExternalChargeState> valid = stream(values()).filter(v -> v.getStatus().equals(status)).collect(Collectors.toList());
+        if (valid.isEmpty()) {
+            throw new IllegalArgumentException("External charge state not recognized: " + status);
+        } else {
+            return valid;
+        }
+    }
+
+    public static List<ExternalChargeState> fromStatusStringV2(String status) {
+        //Todo remove once self service change has been released to use the v2 states
+        if (status.equals(EXTERNAL_FAILED_REJECTED.oldStatus)) {
+            return fromStatusString(status);
+        }
+
+        List<ExternalChargeState> valid = stream(values()).filter(v -> v.getStatusV2().equals(status)).collect(Collectors.toList());
+
         if (valid.isEmpty()) {
             throw new IllegalArgumentException("External charge state not recognized: " + status);
         } else {

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -19,12 +19,22 @@ import uk.gov.pay.connector.service.search.TransactionSearchStrategy;
 import uk.gov.pay.connector.util.ResponseUtil;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.time.ZonedDateTime;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -36,7 +46,12 @@ import static uk.gov.pay.connector.model.TransactionType.inferTransactionTypeFro
 import static uk.gov.pay.connector.service.ChargeExpiryService.EXPIRABLE_STATUSES;
 import static uk.gov.pay.connector.service.search.SearchService.TYPE.CHARGE;
 import static uk.gov.pay.connector.service.search.SearchService.TYPE.TRANSACTION;
-import static uk.gov.pay.connector.util.ResponseUtil.*;
+import static uk.gov.pay.connector.util.ResponseUtil.fieldsInvalidResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.fieldsInvalidSizeResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.fieldsMissingResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.responseWithChargeNotFound;
+import static uk.gov.pay.connector.util.ResponseUtil.successResponseWithEntity;
 
 @Path("/")
 public class ChargesApiResource {
@@ -190,7 +205,7 @@ public class ChargesApiResource {
                             .withDisplaySize(displaySize != null ? displaySize : configuration.getTransactionsPaginationConfig().getDisplayPageSize())
                             .withPage(pageNumber != null ? pageNumber : 1)
                             .withTransactionType(inferTransactionTypeFrom(toList(paymentStates), toList(refundStates)))
-                            .addExternalChargeStates(toList(paymentStates))
+                            .addExternalChargeStatesV2(toList(paymentStates))
                             .addExternalRefundStates(toList(refundStates));
 
                     return gatewayAccountDao.findById(accountId)

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
@@ -25,6 +25,10 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRE_CANCEL_FAILED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRE_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCELLED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCEL_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCEL_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCEL_SUBMITTED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCELLED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_ERROR;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_READY;
@@ -154,6 +158,26 @@ public class ChargeSearchParamsTest {
         assertThat(params.getInternalChargeStatuses(), containsInAnyOrder(
                 USER_CANCEL_READY, USER_CANCEL_SUBMITTED, USER_CANCEL_ERROR, USER_CANCELLED, EXPIRE_CANCEL_READY, EXPIRE_CANCEL_SUBMITTED, EXPIRED, EXPIRE_CANCEL_FAILED,
                 AUTHORISATION_REJECTED, AUTHORISATION_CANCELLED, AUTHORISATION_ABORTED, CAPTURE_APPROVED, CAPTURE_APPROVED_RETRY, CAPTURE_READY, CAPTURED, CAPTURE_SUBMITTED));
+
+    }
+
+    @Test
+    public void getInternalChargeStatuses_transactionsSearch_MultipleChargeStatesV2() {
+
+        String expectedQueryString = "payment_states=timedout,declined,cancelled";
+
+        ChargeSearchParams params = new ChargeSearchParams()
+                .addExternalChargeStatesV2(singletonList("declined"))
+                .addExternalChargeStatesV2(singletonList("timedout"))
+                .addExternalChargeStatesV2(singletonList("cancelled"))
+                .withGatewayAccountId(111L);
+
+        assertThat(params.buildQueryParams(), is(expectedQueryString));
+        assertThat(params.getInternalChargeStatuses(),  hasSize(15));
+        assertThat(params.getInternalChargeStatuses(), containsInAnyOrder(
+                USER_CANCEL_READY, USER_CANCEL_SUBMITTED, USER_CANCEL_ERROR, USER_CANCELLED, EXPIRE_CANCEL_READY, EXPIRE_CANCEL_SUBMITTED, EXPIRED, EXPIRE_CANCEL_FAILED,
+                AUTHORISATION_REJECTED, AUTHORISATION_CANCELLED, AUTHORISATION_ABORTED, SYSTEM_CANCEL_ERROR, SYSTEM_CANCEL_READY, SYSTEM_CANCEL_SUBMITTED, SYSTEM_CANCELLED
+        ));
 
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
@@ -23,7 +23,9 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
 
 public class TransactionsApiResourceITest extends ChargingITestBase {
 
@@ -92,11 +94,11 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("total", is(3))
                 .body("count", is(2))
                 .body("page", is(1))
-                .body("_links.next_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=2&display_size=2&payment_states=created%2Csuccess&refund_states=submitted")))
+                .body("_links.next_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=2&display_size=2&payment_states=success%2Ccreated&refund_states=submitted")))
                 .body("_links.prev_page", isEmptyOrNullString())
-                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=1&display_size=2&payment_states=created%2Csuccess&refund_states=submitted")))
-                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=2&display_size=2&payment_states=created%2Csuccess&refund_states=submitted")))
-                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=1&display_size=2&payment_states=created%2Csuccess&refund_states=submitted")))
+                .body("_links.first_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=1&display_size=2&payment_states=success%2Ccreated&refund_states=submitted")))
+                .body("_links.last_page.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=2&display_size=2&payment_states=success%2Ccreated&refund_states=submitted")))
+                .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=ref-3&page=1&display_size=2&payment_states=success%2Ccreated&refund_states=submitted")))
 
                 .body("results[0].transaction_type", is("charge"))
                 .body("results[0].gateway_transaction_id", is(transactionIdCharge1))


### PR DESCRIPTION
only relate to the selected payment state

When you searched in self service for any of the error states it would
bring back all the transactions in any of the states. This is because
they were all being mapped to failed. Changed the external states so we
map to declined, timeout and cancelled.

with @kakumara

