### PR TITLE
PP-3498 Results from 'State' dropdown on transactions filter should

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/search/OldTransactionSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/OldTransactionSearchStrategy.java
@@ -49,7 +49,7 @@ public class OldTransactionSearchStrategy extends AbstractSearchStrategy<Transac
             externalTransactionState = new ExternalTransactionState(externalRefundStatus.getStatus(), externalRefundStatus.isFinished());
         } else {
             ExternalChargeState externalChargeState = ChargeStatus.fromString(transaction.getStatus()).toExternal();
-            externalTransactionState = new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage());
+            externalTransactionState = new ExternalTransactionState(externalChargeState.getStatusV2(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage());
         }
 
         PersistedCard cardDetails = new PersistedCard();

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
@@ -111,7 +111,7 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
                 .body("results[0].description", is("Test description"))
                 .body("results[0].reference", is("ref-3-que"))
                 .body("results[0].state.finished", is(true))
-                .body("results[0].state.status", is("failed"))
+                .body("results[0].state.status", is("timedout"))
                 .body("results[0].state.code", is("P0020"))
                 .body("results[0].state.message", is("Payment expired"))
                 .body("results[0].card_details.card_brand", is(nullValue()))


### PR DESCRIPTION
only relate to the selected payment state

When you searched in self service for any of the error states it would
bring back all the transactions in any of the states. This is because
they were all being mapped to failed. We had changed so we searched by
declined, timeout and cancelled but the results were all mapped to
failed. This will also change the reponses to also be declined, timeout
and cancelled. Had to do this is a separate commit as self service
needed to be updated to hand these before we could send them.


