### PR TITLE
PP-3526 smartpay 3ds required request handling

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
@@ -13,6 +13,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
@@ -148,6 +149,9 @@ public class ChargeResponse {
         @JsonProperty("htmlOut")
         private String htmlOut;
 
+        @JsonProperty("md")
+        private String md;
+
         public String getPaRequest() {
             return paRequest;
         }
@@ -172,24 +176,28 @@ public class ChargeResponse {
             this.htmlOut = htmlOut;
         }
 
+        public void setMd(String md) {
+            this.md = md;
+        }
+
+        public String getMd() {
+            return md;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-
             Auth3dsData that = (Auth3dsData) o;
-
-            if (paRequest != null ? !paRequest.equals(that.paRequest) : that.paRequest != null) return false;
-            if (issuerUrl != null ? !issuerUrl.equals(that.issuerUrl) : that.issuerUrl != null) return false;
-            return htmlOut != null ? htmlOut.equals(that.htmlOut) : that.htmlOut == null;
+            return Objects.equals(paRequest, that.paRequest) &&
+                    Objects.equals(issuerUrl, that.issuerUrl) &&
+                    Objects.equals(htmlOut, that.htmlOut) &&
+                    Objects.equals(md, that.md);
         }
 
         @Override
         public int hashCode() {
-            int result = paRequest != null ? paRequest.hashCode() : 0;
-            result = 31 * result + (issuerUrl != null ? issuerUrl.hashCode() : 0);
-            result = 31 * result + (htmlOut != null ? htmlOut.hashCode() : 0);
-            return result;
+            return Objects.hash(paRequest, issuerUrl, htmlOut, md);
         }
 
         @Override
@@ -198,6 +206,7 @@ public class ChargeResponse {
                     "paRequest='" + paRequest + '\'' +
                     ", issuerUrl='" + issuerUrl + '\'' +
                     ", htmlOut='" + htmlOut + '\'' +
+                    ", md='" + md + '\'' +
                     '}';
         }
     }

--- a/src/main/java/uk/gov/pay/connector/model/SmartpayParamsFor3ds.java
+++ b/src/main/java/uk/gov/pay/connector/model/SmartpayParamsFor3ds.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.model;
+
+import uk.gov.pay.connector.model.domain.Auth3dsDetailsEntity;
+
+public class SmartpayParamsFor3ds implements GatewayParamsFor3ds {
+
+    private final String issuerUrl;
+    private final String paRequest;
+    private final String md;
+
+    public SmartpayParamsFor3ds(String issuerUrl, String paRequest, String md) {
+        this.issuerUrl = issuerUrl;
+        this.paRequest = paRequest;
+        this.md = md;
+    }
+
+    @Override
+    public Auth3dsDetailsEntity toAuth3dsDetailsEntity() {
+        Auth3dsDetailsEntity auth3dsDetailsEntity = new Auth3dsDetailsEntity();
+        auth3dsDetailsEntity.setPaRequest(paRequest);
+        auth3dsDetailsEntity.setIssuerUrl(issuerUrl);
+        auth3dsDetailsEntity.setMd(md);
+        return auth3dsDetailsEntity;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/Auth3dsDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Auth3dsDetailsEntity.java
@@ -15,6 +15,9 @@ public class Auth3dsDetailsEntity {
     @Column(name = "html_out_3ds")
     private String htmlOut;
 
+    @Column(name = "md_3ds")
+    private String md;
+
     public String getPaRequest() {
         return paRequest;
     }
@@ -37,5 +40,13 @@ public class Auth3dsDetailsEntity {
 
     public void setHtmlOut(String htmlOut) {
         this.htmlOut = htmlOut;
+    }
+
+    public void setMd(String md) {
+        this.md = md;
+    }
+
+    public String getMd() {
+        return md;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Card3dsEntity.java
@@ -12,6 +12,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.util.Objects;
 
 
 @Entity
@@ -31,11 +32,16 @@ public class Card3dsEntity extends AbstractVersionedEntity {
     @Column(name = "issuer_url")
     private String issuerUrl;
 
+    //TODO: rename this column to provider_session_id if we decide to continue with this table in the longer run.
+     // For now this column is Worldpay specific. And this table is currently kept only for backward compatibility with the transaction table changes.
     @Column(name = "worldpay_machine_cookie")
-    private String worldpayMachineCookie;
+    private String providerSessionId;
 
     @Column(name="html_out")
     private String htmlOut;
+
+    @Column(name="md")
+    private String md;
 
     @OneToOne
     @JoinColumn(name = "transaction_id", referencedColumnName = "id", updatable = true)
@@ -68,12 +74,12 @@ public class Card3dsEntity extends AbstractVersionedEntity {
         this.issuerUrl = issuerUrl;
     }
 
-    public String getWorldpayMachineCookie() {
-        return worldpayMachineCookie;
+    public String getProviderSessionId() {
+        return providerSessionId;
     }
 
-    public void setWorldpayMachineCookie(String worldpayMachineCookie) {
-        this.worldpayMachineCookie = worldpayMachineCookie;
+    public void setProviderSessionId(String providerSessionId) {
+        this.providerSessionId = providerSessionId;
     }
 
     public ChargeTransactionEntity getChargeTransactionEntity() {
@@ -92,13 +98,21 @@ public class Card3dsEntity extends AbstractVersionedEntity {
         this.htmlOut = htmlOut;
     }
 
+    public String getMd() {
+        return md;
+    }
+
+    public void setMd(String md) {
+        this.md = md;
+    }
+
     public static Card3dsEntity from(ChargeEntity chargeEntity) {
         Card3dsEntity entity = new Card3dsEntity();
         entity.setIssuerUrl(chargeEntity.get3dsDetails().getIssuerUrl());
         entity.setPaRequest(chargeEntity.get3dsDetails().getPaRequest());
-        entity.setWorldpayMachineCookie(chargeEntity.getProviderSessionId());
+        entity.setProviderSessionId(chargeEntity.getProviderSessionId());
         entity.setHtmlOut(chargeEntity.get3dsDetails().getHtmlOut());
-
+        entity.setMd(chargeEntity.get3dsDetails().getMd());
         return entity;
     }
 
@@ -106,26 +120,19 @@ public class Card3dsEntity extends AbstractVersionedEntity {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         Card3dsEntity that = (Card3dsEntity) o;
-
-        if (id != null ? !id.equals(that.id) : that.id != null) return false;
-        if (paRequest != null ? !paRequest.equals(that.paRequest) : that.paRequest != null) return false;
-        if (issuerUrl != null ? !issuerUrl.equals(that.issuerUrl) : that.issuerUrl != null) return false;
-        if (worldpayMachineCookie != null ? !worldpayMachineCookie.equals(that.worldpayMachineCookie) : that.worldpayMachineCookie != null)
-            return false;
-        if (htmlOut != null ? !htmlOut.equals(that.htmlOut) : that.htmlOut != null) return false;
-        return chargeTransactionEntity != null ? chargeTransactionEntity.equals(that.chargeTransactionEntity) : that.chargeTransactionEntity == null;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(paRequest, that.paRequest) &&
+                Objects.equals(issuerUrl, that.issuerUrl) &&
+                Objects.equals(providerSessionId, that.providerSessionId) &&
+                Objects.equals(htmlOut, that.htmlOut) &&
+                Objects.equals(md, that.md) &&
+                Objects.equals(chargeTransactionEntity, that.chargeTransactionEntity);
     }
 
     @Override
     public int hashCode() {
-        int result = id != null ? id.hashCode() : 0;
-        result = 31 * result + (paRequest != null ? paRequest.hashCode() : 0);
-        result = 31 * result + (issuerUrl != null ? issuerUrl.hashCode() : 0);
-        result = 31 * result + (worldpayMachineCookie != null ? worldpayMachineCookie.hashCode() : 0);
-        result = 31 * result + (htmlOut != null ? htmlOut.hashCode() : 0);
-        result = 31 * result + (chargeTransactionEntity != null ? chargeTransactionEntity.hashCode() : 0);
-        return result;
+
+        return Objects.hash(id, paRequest, issuerUrl, providerSessionId, htmlOut, md, chargeTransactionEntity);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
@@ -163,6 +163,7 @@ public class ChargesFrontendResource {
             auth3dsData.setPaRequest(charge.get3dsDetails().getPaRequest());
             auth3dsData.setIssuerUrl(charge.get3dsDetails().getIssuerUrl());
             auth3dsData.setHtmlOut(charge.get3dsDetails().getHtmlOut());
+            auth3dsData.setMd(charge.get3dsDetails().getMd());
         }
 
         return aFrontendChargeResponse()

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
@@ -129,7 +129,7 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
     public static EpdqOrderRequestBuilder anEpdq3DsAuthoriseOrderRequestBuilder(String frontendUrl) {
         EpdqTemplateData epdqTemplateData = new EpdqTemplateData();
         epdqTemplateData.setFrontendUrl(frontendUrl);
-        return new EpdqOrderRequestBuilder(epdqTemplateData, AUTHORISE_3DS_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE, AUTHORISE_OPERATION_TYPE);
+        return new EpdqOrderRequestBuilder(epdqTemplateData, AUTHORISE_3DS_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE_3DS, AUTHORISE_OPERATION_TYPE);
     }
 
     public static EpdqOrderRequestBuilder anEpdqCaptureOrderRequestBuilder() {

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
@@ -15,6 +15,7 @@ public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implemen
 
     private static final String AUTHORISED = "Authorised";
     private static final String REDIRECT_SHOPPER = "RedirectShopper";
+    private static final String REFUSED = "Refused";
 
     @XmlPath("soap:Body/ns1:authoriseResponse/ns1:paymentResult/ns1:resultCode/text()")
     private String result;
@@ -37,13 +38,18 @@ public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implemen
 
     @Override
     public AuthoriseStatus authoriseStatus() {
+        if (result == null) {
+            return AuthoriseStatus.ERROR;
+        }
         switch (result) {
             case AUTHORISED:
                 return AuthoriseStatus.AUTHORISED;
             case REDIRECT_SHOPPER:
                 return AuthoriseStatus.REQUIRES_3DS;
-            default:
+            case REFUSED:
                 return AuthoriseStatus.REJECTED;
+            default:
+                return AuthoriseStatus.ERROR;
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayAuthorisationResponse.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.service.smartpay;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
 import uk.gov.pay.connector.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.model.SmartpayParamsFor3ds;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -13,6 +14,7 @@ import java.util.StringJoiner;
 public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implements BaseAuthoriseResponse {
 
     private static final String AUTHORISED = "Authorised";
+    private static final String REDIRECT_SHOPPER = "RedirectShopper";
 
     @XmlPath("soap:Body/ns1:authoriseResponse/ns1:paymentResult/ns1:resultCode/text()")
     private String result;
@@ -20,23 +22,51 @@ public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implemen
     @XmlPath("soap:Body/ns1:authoriseResponse/ns1:paymentResult/ns1:pspReference/text()")
     private String pspReference;
 
+    @XmlPath("soap:Body/ns1:authoriseResponse/ns1:paymentResult/ns1:issuerUrl/text()")
+    private String issuerUrl;
+
+    @XmlPath("soap:Body/ns1:authoriseResponse/ns1:paymentResult/ns1:paRequest/text()")
+    private String paRequest;
+
+    @XmlPath("soap:Body/ns1:authoriseResponse/ns1:paymentResult/ns1:md/text()")
+    private String md;
+
     public String getPspReference() {
         return pspReference;
     }
 
     @Override
     public AuthoriseStatus authoriseStatus() {
-        return AUTHORISED.equals(result) ? AuthoriseStatus.AUTHORISED : AuthoriseStatus.REJECTED;
+        switch (result) {
+            case AUTHORISED:
+                return AuthoriseStatus.AUTHORISED;
+            case REDIRECT_SHOPPER:
+                return AuthoriseStatus.REQUIRES_3DS;
+            default:
+                return AuthoriseStatus.REJECTED;
+        }
     }
 
     @Override
     public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
-        return Optional.empty();
+        return Optional.of(new SmartpayParamsFor3ds(issuerUrl, paRequest, md));
     }
 
     @Override
     public String getTransactionId() {
         return pspReference;
+    }
+
+    public String getIssuerUrl() {
+        return issuerUrl;
+    }
+
+    public String getPaRequest() {
+        return paRequest;
+    }
+
+    public String getMd() {
+        return md;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayOrderRequestBuilder.java
@@ -20,6 +20,7 @@ public class SmartpayOrderRequestBuilder extends OrderRequestBuilder {
     }
 
     public static final TemplateBuilder AUTHORISE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/smartpay/SmartpayAuthoriseOrderTemplate.xml");
+    public static final TemplateBuilder AUTHORISE_3DS_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/smartpay/SmartpayAuthorise3dsOrderTemplate.xml");
     public static final TemplateBuilder CAPTURE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/smartpay/SmartpayCaptureOrderTemplate.xml");
     public static final TemplateBuilder CANCEL_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/smartpay/SmartpayCancelOrderTemplate.xml");
     public static final TemplateBuilder REFUND_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/smartpay/SmartpayRefundOrderTemplate.xml");
@@ -28,6 +29,10 @@ public class SmartpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public static SmartpayOrderRequestBuilder aSmartpayAuthoriseOrderRequestBuilder() {
         return new SmartpayOrderRequestBuilder(new SmartpayTemplateData(), AUTHORISE_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
+    }
+
+    public static SmartpayOrderRequestBuilder aSmartpayAuthorise3dsOrderRequestBuilder() {
+        return new SmartpayOrderRequestBuilder(new SmartpayTemplateData(), AUTHORISE_3DS_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE_3DS);
     }
 
     public static SmartpayOrderRequestBuilder aSmartpayCaptureOrderRequestBuilder() {

--- a/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProvider.java
@@ -36,6 +36,7 @@ import static fj.data.Either.left;
 import static fj.data.Either.right;
 import static uk.gov.pay.connector.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.service.smartpay.SmartpayOrderRequestBuilder.aSmartpayAuthorise3dsOrderRequestBuilder;
 import static uk.gov.pay.connector.service.smartpay.SmartpayOrderRequestBuilder.aSmartpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.service.smartpay.SmartpayOrderRequestBuilder.aSmartpayCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.service.smartpay.SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder;
@@ -143,13 +144,18 @@ public class SmartpayPaymentProvider extends BasePaymentProvider<BaseResponse, P
     }
 
     private Function<AuthorisationGatewayRequest, GatewayOrder> buildAuthoriseOrderFor() {
-        return request -> aSmartpayAuthoriseOrderRequestBuilder()
-                .withMerchantCode(getMerchantCode(request))
-                .withPaymentPlatformReference(request.getChargeExternalId())
-                .withDescription(request.getDescription())
-                .withAmount(request.getAmount())
-                .withAuthorisationDetails(request.getAuthCardDetails())
-                .build();
+        return request -> {
+            SmartpayOrderRequestBuilder smartpayOrderRequestBuilder = request.getGatewayAccount().isRequires3ds() ?
+                    aSmartpayAuthorise3dsOrderRequestBuilder() : aSmartpayAuthoriseOrderRequestBuilder();
+
+            return smartpayOrderRequestBuilder
+                    .withMerchantCode(getMerchantCode(request))
+                    .withPaymentPlatformReference(request.getChargeExternalId())
+                    .withDescription(request.getDescription())
+                    .withAmount(request.getAmount())
+                    .withAuthorisationDetails(request.getAuthCardDetails())
+                    .build();
+        };
     }
 
     private Function<CaptureGatewayRequest, GatewayOrder> buildCaptureOrderFor() {

--- a/src/main/resources/templates/smartpay/SmartpayAuthorise3dsOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/SmartpayAuthorise3dsOrderTemplate.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://payment.services.adyen.com"
+        xmlns:ns2="http://common.services.adyen.com">
+    <soap:Body>
+        <ns1:authorise>
+            <ns1:paymentRequest>
+                <additionalData xmlns="http://payment.services.adyen.com">
+                    <entry>
+                        <key xsi:type="xsd:string">executeThreeD</key>
+                        <value xsi:type="xsd:string">true</value>
+                    </entry>
+                </additionalData>
+                <browserInfo xmlns="http://payment.services.adyen.com">
+                    <acceptHeader xmlns="http://common.services.adyen.com">${authCardDetails.acceptHeader?xml}</acceptHeader>
+                    <userAgent xmlns="http://common.services.adyen.com">${authCardDetails.userAgentHeader?xml}</userAgent>
+                </browserInfo>
+                <ns1:amount>
+                    <ns2:currency>GBP</ns2:currency>
+                    <ns2:value>${amount}</ns2:value>
+                </ns1:amount>
+                <ns1:card>
+                    <ns1:cvc>${authCardDetails.cvc}</ns1:cvc>
+                    <ns1:expiryMonth>${authCardDetails.endDate?split('/')?first}</ns1:expiryMonth>
+                    <ns1:expiryYear>20${authCardDetails.endDate?split('/')?last}</ns1:expiryYear>
+                    <ns1:holderName>${authCardDetails.cardHolder?xml}</ns1:holderName>
+                    <ns1:number>${authCardDetails.cardNo}</ns1:number>
+                    <ns1:billingAddress>
+                        <ns2:houseNumberOrName>${authCardDetails.address.line1?xml}</ns2:houseNumberOrName>
+                        <ns2:street><#if authCardDetails.address.line2?has_content>${authCardDetails.address.line2?xml}<#else>N/A</#if></ns2:street>
+                        <ns2:postalCode>${authCardDetails.address.postcode?xml}</ns2:postalCode>
+                        <ns2:stateOrProvince><#if authCardDetails.address.county??>${authCardDetails.address.county?xml}</#if></ns2:stateOrProvince>
+                        <ns2:city>${authCardDetails.address.city?xml}</ns2:city>
+                        <ns2:country>${authCardDetails.address.country?xml}</ns2:country>
+                    </ns1:billingAddress>
+                  </ns1:card>
+                <ns1:merchantAccount>${merchantCode}</ns1:merchantAccount>
+                <ns1:reference>${paymentPlatformReference?xml}</ns1:reference>
+                <ns1:shopperReference>${description?xml}</ns1:shopperReference>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>

--- a/src/main/resources/templates/smartpay/SmartpayAuthorise3dsOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/SmartpayAuthorise3dsOrderTemplate.xml
@@ -2,20 +2,21 @@
 <soap:Envelope
         xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:ns1="http://payment.services.adyen.com"
-        xmlns:ns2="http://common.services.adyen.com">
+        xmlns:ns2="http://common.services.adyen.com"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <soap:Body>
         <ns1:authorise>
             <ns1:paymentRequest>
-                <additionalData xmlns="http://payment.services.adyen.com">
-                    <entry>
-                        <key xsi:type="xsd:string">executeThreeD</key>
-                        <value xsi:type="xsd:string">true</value>
-                    </entry>
-                </additionalData>
-                <browserInfo xmlns="http://payment.services.adyen.com">
-                    <acceptHeader xmlns="http://common.services.adyen.com">${authCardDetails.acceptHeader?xml}</acceptHeader>
-                    <userAgent xmlns="http://common.services.adyen.com">${authCardDetails.userAgentHeader?xml}</userAgent>
-                </browserInfo>
+                <ns1:additionalData>
+                    <ns2:entry>
+                        <ns2:key xsi:type="xsd:string">executeThreeD</ns2:key>
+                        <ns2:value xsi:type="xsd:string">true</ns2:value>
+                    </ns2:entry>
+                </ns1:additionalData>
+                <ns1:browserInfo>
+                    <ns2:acceptHeader>${authCardDetails.acceptHeader?xml}</ns2:acceptHeader>
+                    <ns2:userAgent>${authCardDetails.userAgentHeader?xml}</ns2:userAgent>
+                </ns1:browserInfo>
                 <ns1:amount>
                     <ns2:currency>GBP</ns2:currency>
                     <ns2:value>${amount}</ns2:value>
@@ -29,12 +30,12 @@
                     <ns1:billingAddress>
                         <ns2:houseNumberOrName>${authCardDetails.address.line1?xml}</ns2:houseNumberOrName>
                         <ns2:street><#if authCardDetails.address.line2?has_content>${authCardDetails.address.line2?xml}<#else>N/A</#if></ns2:street>
-                        <ns2:postalCode>${authCardDetails.address.postcode?xml}</ns2:postalCode>
-                        <ns2:stateOrProvince><#if authCardDetails.address.county??>${authCardDetails.address.county?xml}</#if></ns2:stateOrProvince>
-                        <ns2:city>${authCardDetails.address.city?xml}</ns2:city>
-                        <ns2:country>${authCardDetails.address.country?xml}</ns2:country>
+                    <ns2:postalCode>${authCardDetails.address.postcode?xml}</ns2:postalCode>
+                    <ns2:stateOrProvince><#if authCardDetails.address.county??>${authCardDetails.address.county?xml}</#if></ns2:stateOrProvince>
+                    <ns2:city>${authCardDetails.address.city?xml}</ns2:city>
+                    <ns2:country>${authCardDetails.address.country?xml}</ns2:country>
                     </ns1:billingAddress>
-                  </ns1:card>
+                </ns1:card>
                 <ns1:merchantAccount>${merchantCode}</ns1:merchantAccount>
                 <ns1:reference>${paymentPlatformReference?xml}</ns1:reference>
                 <ns1:shopperReference>${description?xml}</ns1:shopperReference>

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -111,13 +111,11 @@ public class SmartpayPaymentProviderTest {
         testCardAuthorisation(paymentProvider, chargeEntity);
     }
 
-    @Ignore
     @Test
-    //TODO: fix this before merging
     public void shouldSendA3dsOrderForMerchantSuccessfully() throws Exception {
         gatewayAccountEntity.setRequires3ds(true);
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
-        AuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
+        AuthorisationGatewayRequest request = getCard3dsAuthorisationRequest(chargeEntity);
         GatewayResponse<SmartpayAuthorisationResponse> response = paymentProvider.authorise(request);
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getIssuerUrl(), is(notNullValue()));
@@ -243,6 +241,20 @@ public class SmartpayPaymentProviderTest {
 
         AuthCardDetails authCardDetails = aValidSmartpayCard();
         authCardDetails.setAddress(address);
+        return new AuthorisationGatewayRequest(chargeEntity, authCardDetails);
+    }
+
+    public static AuthorisationGatewayRequest getCard3dsAuthorisationRequest(ChargeEntity chargeEntity) {
+        Address address = Address.anAddress();
+        address.setLine1("6-60");
+        address.setLine2("Simon Carmiggeltstraat");
+        address.setCity("Amsterdam");
+        address.setCounty("NH");
+        address.setPostcode("1011DJ");
+        address.setCountry("NL");
+
+        AuthCardDetails authCardDetails = aValidSmartpay3dsCard();
+        authCardDetails.setAddress(address);
         authCardDetails.setAcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
         authCardDetails.setUserAgentHeader("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9) Gecko/2008052912 Firefox/3.0");
 
@@ -252,6 +264,11 @@ public class SmartpayPaymentProviderTest {
     public static AuthCardDetails aValidSmartpayCard() {
         String validSandboxCard = "5555444433331111";
         return buildAuthCardDetails(validSandboxCard, "737", "08/18", "visa");
+    }
+
+    public static AuthCardDetails aValidSmartpay3dsCard() {
+        String validSandboxCard = "5212345678901234";
+        return buildAuthCardDetails(validSandboxCard, "737", "08/18", "master");
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertFalse;
@@ -67,6 +68,7 @@ public class SmartpayPaymentProviderTest {
     private String username;
     private String password;
     private ChargeEntity chargeEntity;
+    private GatewayAccountEntity gatewayAccountEntity;
     private MetricRegistry mockMetricRegistry;
     private Histogram mockHistogram;
     private Counter mockCounter;
@@ -87,14 +89,14 @@ public class SmartpayPaymentProviderTest {
                 "merchant_id", "DCOTest",
                 "username", username,
                 "password", password);
-        GatewayAccountEntity validGatewayAccount = new GatewayAccountEntity();
-        validGatewayAccount.setId(123L);
-        validGatewayAccount.setGatewayName("smartpay");
-        validGatewayAccount.setCredentials(validSmartPayCredentials);
-        validGatewayAccount.setType(TEST);
+        gatewayAccountEntity = new GatewayAccountEntity();
+        gatewayAccountEntity.setId(123L);
+        gatewayAccountEntity.setGatewayName("smartpay");
+        gatewayAccountEntity.setCredentials(validSmartPayCredentials);
+        gatewayAccountEntity.setType(TEST);
 
         chargeEntity = aValidChargeEntity()
-                .withGatewayAccountEntity(validGatewayAccount).build();
+                .withGatewayAccountEntity(gatewayAccountEntity).build();
 
         mockMetricRegistry = mock(MetricRegistry.class);
         mockHistogram = mock(Histogram.class);
@@ -107,6 +109,20 @@ public class SmartpayPaymentProviderTest {
     public void shouldSendSuccessfullyAnOrderForMerchant() throws Exception {
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
         testCardAuthorisation(paymentProvider, chargeEntity);
+    }
+
+    @Ignore
+    @Test
+    //TODO: fix this before merging
+    public void shouldSendA3dsOrderForMerchantSuccessfully() throws Exception {
+        gatewayAccountEntity.setRequires3ds(true);
+        PaymentProvider paymentProvider = getSmartpayPaymentProvider();
+        AuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
+        GatewayResponse<SmartpayAuthorisationResponse> response = paymentProvider.authorise(request);
+        assertTrue(response.isSuccessful());
+        assertThat(response.getBaseResponse().get().getIssuerUrl(), is(notNullValue()));
+        assertThat(response.getBaseResponse().get().getMd(), is(notNullValue()));
+        assertThat(response.getBaseResponse().get().getPaRequest(), is(notNullValue()));
     }
 
     @Test
@@ -192,7 +208,7 @@ public class SmartpayPaymentProviderTest {
     private PaymentProvider getSmartpayPaymentProvider() throws Exception {
         Client client = TestClientFactory.createJerseyClient();
         GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
-            SmartpayPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
+                SmartpayPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
         EnumMap<GatewayOperation, GatewayClient> gatewayClients = GatewayOperationClientBuilder.builder()
                 .authClient(gatewayClient)
                 .captureClient(gatewayClient)
@@ -227,6 +243,8 @@ public class SmartpayPaymentProviderTest {
 
         AuthCardDetails authCardDetails = aValidSmartpayCard();
         authCardDetails.setAddress(address);
+        authCardDetails.setAcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+        authCardDetails.setUserAgentHeader("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9) Gecko/2008052912 Firefox/3.0");
 
         return new AuthorisationGatewayRequest(chargeEntity, authCardDetails);
     }

--- a/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
@@ -20,6 +20,12 @@ public class SmartpayMockClient {
         mockAuthorisationWithTransactionId(randomUUID().toString());
     }
 
+    public void mockAuthorisation3dsRequired() {
+        String authoriseResponse = TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE)
+                .replace("{{pspReference}}", randomUUID().toString());
+        paymentServiceResponse(authoriseResponse);
+    }
+
     public void mockAuthorisationFailure() {
         String authoriseResponse = TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_FAILED_RESPONSE);
         paymentServiceResponse(authoriseResponse);

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -242,7 +242,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         Card3dsEntity card3ds = paymentRequest.getChargeTransaction().getCard3ds();
         assertThat(card3ds.getIssuerUrl(), is(ISSUER_URL_FROM_PROVIDER));
         assertThat(card3ds.getPaRequest(), is(PA_REQ_VALUE_FROM_PROVIDER));
-        assertThat(card3ds.getWorldpayMachineCookie(), is(SESSION_IDENTIFIER));
+        assertThat(card3ds.getProviderSessionId(), is(SESSION_IDENTIFIER));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/SmartpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/SmartpayXMLUnmarshallerTest.java
@@ -46,7 +46,7 @@ public class SmartpayXMLUnmarshallerTest {
         String errorPayload = TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_ERROR_RESPONSE);
         SmartpayAuthorisationResponse response = XMLUnmarshaller.unmarshall(errorPayload, SmartpayAuthorisationResponse.class);
 
-        assertThat(response.authoriseStatus(), is(AuthoriseStatus.REJECTED));
+        assertThat(response.authoriseStatus(), is(AuthoriseStatus.ERROR));
         assertThat(response.getTransactionId(), nullValue());
 
         assertThat(response.getErrorCode(), is("soap:Server"));

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -47,6 +47,7 @@ public class TestTemplateResourceLoader {
     private static final String SMARTPAY_BASE_NAME = TEMPLATE_BASE_NAME + "/smartpay";
 
     public static final String SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-success-response.xml";
+    public static final String SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-3ds-required-response.xml";
     public static final String SMARTPAY_AUTHORISATION_FAILED_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-failed-response.xml";
     public static final String SMARTPAY_AUTHORISATION_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-request.xml";

--- a/src/test/resources/templates/smartpay/authorisation-3ds-required-response.xml
+++ b/src/test/resources/templates/smartpay/authorisation-3ds-required-response.xml
@@ -1,0 +1,20 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soap:Body>
+        <ns1:authoriseResponse xmlns:ns1="http://payment.services.adyen.com">
+            <ns1:paymentResult>
+                <additionalData xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <authCode xmlns="http://payment.services.adyen.com">87802</authCode>
+                <dccAmount xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <dccSignature xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <fraudResult xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <issuerUrl xmlns="http://payment.services.adyen.com" xsi:nil="true">https://issuer-url-here.com</issuerUrl>
+                <md xmlns="http://payment.services.adyen.com" xsi:nil="true">NnheOml4nhgrnxpP6oBb3KQqKXiYGL3X8=</md>
+                <paRequest xmlns="http://payment.services.adyen.com" xsi:nil="true">eNpVUttygjAQRjI+ts3+f4Afk4a3Y</paRequest>
+                <pspReference xmlns="http://payment.services.adyen.com">{{pspReference}}</pspReference>
+                <refusalReason xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <resultCode xmlns="http://payment.services.adyen.com">RedirectShopper</resultCode>
+            </ns1:paymentResult>
+        </ns1:authoriseResponse>
+    </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
This must wait for https://github.com/alphagov/pay-connector/pull/602 and until we get a success response for the contract test. 
## WHAT

Includes:
- 3ds require elements added to the smartpay order template based on Gateway account 3ds require flag.
- Card3dsEntity and Auth3dsDetailsEntity extended to use the new field `md` specific to smartpay.
- extended SmartpayAuthorisationResponse to extract the 3ds required elements out of the XML response. (issuerUrl, paRequest, md). Also determining the authorisationStatus() based on `RedirectShopper` status.

