### PR TITLE
PP3322 - Connector has standard startup script

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,3 +1,17 @@
 #!/usr/bin/env bash
-java -jar *-allinone.jar waitOnDependencies *.yaml && \
+
+set -eu
+RUN_MIGRATION=${RUN_MIGRATION:-false}
+RUN_APP=${RUN_APP:-true}
+
+java -jar *-allinone.jar waitOnDependencies *.yaml
+
+if [ "$RUN_MIGRATION" == "true" ]; then
+  java -jar *-allinone.jar db migrate *.yaml
+fi
+
+if [ "$RUN_APP" == "true" ]; then
   java $JAVA_OPTS -jar *-allinone.jar server *.yaml
+fi
+
+exit 0


### PR DESCRIPTION
Right now the startup script cannot run database migrations, it should
have this functionality inside

Once this is merged and pay-scripts has been updated I will remove
docker startup with db migrations

solo @tlwr


