### PR TITLE
BAU: Add performance report resource

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.resources.EmailNotificationResource;
 import uk.gov.pay.connector.resources.GatewayAccountResource;
 import uk.gov.pay.connector.resources.HealthCheckResource;
 import uk.gov.pay.connector.resources.NotificationResource;
+import uk.gov.pay.connector.resources.PerformanceReportResource;
 import uk.gov.pay.connector.resources.SecurityTokensResource;
 import uk.gov.pay.connector.resources.TransactionsSummaryResource;
 import uk.gov.pay.connector.service.CaptureProcessScheduler;
@@ -98,6 +99,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(HealthCheckResource.class));
         environment.jersey().register(injector.getInstance(EmailNotificationResource.class));
         environment.jersey().register(injector.getInstance(SchemeRewriteFilter.class));
+        environment.jersey().register(injector.getInstance(PerformanceReportResource.class));
 
         setupSchedulers(configuration, environment, injector);
 

--- a/src/main/java/uk/gov/pay/connector/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/PerformanceReportDao.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.model.domain.report.PerformanceReportEntity;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Transactional
+public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {
+    @Inject
+    public PerformanceReportDao(final Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+
+    public PerformanceReportEntity aggregateNumberAndValueOfPayments() {
+            return (PerformanceReportEntity) entityManager.get()
+                    .createQuery("SELECT NEW uk.gov.pay.connector.model.domain.report.PerformanceReportEntity(COUNT(c.amount), SUM(c.amount), AVG(c.amount)) FROM ChargeEntity c WHERE c.status = :status")
+                    .setParameter("status", CAPTURED.toString())
+                    .setMaxResults(1)
+                    .getSingleResult();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/report/PerformanceReportEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/report/PerformanceReportEntity.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.model.domain.report;
+
+public class PerformanceReportEntity {
+    private final long totalVolume;
+    private final long totalAmount;
+    private final double averageAmount;
+
+    public PerformanceReportEntity(long totalVolume, long totalAmount, double averageAmount) {
+        this.totalVolume = totalVolume;
+        this.totalAmount = totalAmount;
+        this.averageAmount = averageAmount;
+    }
+
+    public long getTotalVolume() {
+        return totalVolume;
+    }
+
+    public long getTotalAmount() {
+        return totalAmount;
+    }
+
+    public double getAverageAmount() {
+        return averageAmount;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/resources/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/PerformanceReportResource.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.resources;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import uk.gov.pay.connector.dao.PerformanceReportDao;
+import uk.gov.pay.connector.model.domain.report.PerformanceReportEntity;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.ok;
+
+@Path("/")
+public class PerformanceReportResource {
+    private PerformanceReportDao performanceReportDao;
+
+    @Inject
+    public PerformanceReportResource(PerformanceReportDao performanceReportDao) {
+        this.performanceReportDao = performanceReportDao;
+    }
+
+    @GET
+    @Path("/v1/api/reports/performance-report")
+    @Produces(APPLICATION_JSON)
+    public Response getPerformanceReport() {
+        PerformanceReportEntity performanceReport = performanceReportDao.aggregateNumberAndValueOfPayments();
+
+        ImmutableMap<String, Object> responsePayload = ImmutableMap.of(
+                "total_volume", performanceReport.getTotalVolume(),
+                "total_amount", performanceReport.getTotalAmount(),
+                "average_amount", performanceReport.getAverageAmount());
+        return ok().entity(responsePayload).build();
+    }
+}


### PR DESCRIPTION
We need a better way to get performance platform data, I propose we
query the database, to do this we need an API endpoint which returns to
us the relevant data.

This creates a resource at `/v1/api/reports/performance-report`.

We can then query this from an ad-hoc task within our infrastructure which will ensure this gets to the relevant people and to the performance platform.

I fully expect to get roasted with this PR as I haven't written serious
java in about 4 or 5 years. Especially because I used vim and so there are probably a ton of unused imports. Also no tests...

@alexbishop1 :eyes: pls

solo @tlwr
