### PR TITLE
PP-3512 Extend expiry window time to 90 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The [API Specification](docs/api_specification.md) provides more detail on the p
 
 | Path                          | Supported Methods | Description                        |
 | ----------------------------- | ----------------- | ---------------------------------- |
-|[```/v1/tasks/expired-charges-sweep```](docs/api_specification.md#post-v1tasksexpired-charges-sweep)  | POST    |  Spawns a task to expire charges with a default window of 1 Hr |   
+|[```/v1/tasks/expired-charges-sweep```](docs/api_specification.md#post-v1tasksexpired-charges-sweep)  | POST    |  Spawns a task to expire charges with a default window of 90 minutes|   
 
 ### Command line tasks
 

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -1,7 +1,7 @@
 # API Specification
 ## POST /v1/tasks/expired-charges-sweep
 
-This starts a task to expire the charges with a default window of 1 Hr. The default value can be overridden by setting an environment variable CHARGE_EXPIRY_WINDOW_SECONDS in seconds. Response of the call will tell you how many charges were successfully expired and how many of them failed for some reason.
+This starts a task to expire the charges with a default window of 90 minutes. The default value can be overridden by setting an environment variable CHARGE_EXPIRY_WINDOW_SECONDS in seconds. Response of the call will tell you how many charges were successfully expired and how many of them failed for some reason.
 
 ### Request example
 

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -76,7 +76,7 @@ public class ChargesApiResource {
     private static final String PAGE = "page";
     private static final String DISPLAY_SIZE = "display_size";
     private static final Set<String> CHARGE_REQUEST_KEYS_THAT_MAY_HAVE_PII = Collections.singleton("description");
-    private static final int ONE_HOUR = 3600;
+    private static final int ONE_HOUR_AND_A_HALF = 5400;
     private static final String CHARGE_EXPIRY_WINDOW = "CHARGE_EXPIRY_WINDOW_SECONDS";
     private static final Logger logger = LoggerFactory.getLogger(ChargesApiResource.class);
     static int MIN_AMOUNT = 1;
@@ -304,7 +304,7 @@ public class ChargesApiResource {
     }
 
     private ZonedDateTime getExpiryDate() {
-        int chargeExpiryWindowSeconds = ONE_HOUR;
+        int chargeExpiryWindowSeconds = ONE_HOUR_AND_A_HALF;
         if (StringUtils.isNotBlank(System.getenv(CHARGE_EXPIRY_WINDOW))) {
             chargeExpiryWindowSeconds = Integer.parseInt(System.getenv(CHARGE_EXPIRY_WINDOW));
         }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -765,7 +765,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     @Test
     public void shouldGetSuccessAndFailedResponseForExpiryChargeTask() {
         //create charge
-        String extChargeId = addChargeAndCardDetails(CREATED, "ref", ZonedDateTime.now().minusHours(1));
+        String extChargeId = addChargeAndCardDetails(CREATED, "ref", ZonedDateTime.now().minusMinutes(90));
 
         // run expiry task
         getChargeApi
@@ -789,7 +789,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldGetSuccessResponseForExpiryChargeTaskFor3dsRequiredPayments() {
-        String extChargeId = addChargeAndCardDetails(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusHours(1));
+        String extChargeId = addChargeAndCardDetails(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusMinutes(90));
 
         getChargeApi
                 .postChargeExpiryTask()


### PR DESCRIPTION
## WHAT
 - In frontend we have a 90 min window of validity for the session cookie,
   while in connector we sweep-expire all charges which have been inactive for > 60 minutes.
 - This PR increase the expiry window to 90 minutes, to match what we have in frontend. Update to our tech docs will follow.


