### PR TITLE
PP-3650 Warn if return_url is non-https on live account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
@@ -242,4 +242,8 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public void setId(Long id) {
         this.id = id;
     }
+    
+    public boolean isLive() {
+        return Type.LIVE.equals(type);
+    }
 }


### PR DESCRIPTION
We are planning to relax restriction that the return_url set on a payment
be https. As part of this, we want some way of monitoring if partners
ever do set http return urls on live accounts, in order to guauge if this
is a problem, and whether we need to build more fine grained control
of this sort of thing.
To monitor this, this commit just logs an info
whenever a payment is created against a live account with a non-https url.