### PR TITLE
BAU: Restrict performance report to live payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/PerformanceReportDao.java
@@ -5,6 +5,7 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.model.domain.report.PerformanceReportEntity;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.GatewayAccountEntity.Type.LIVE;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -29,8 +30,14 @@ public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {
 
     public PerformanceReportEntity aggregateNumberAndValueOfPayments() {
             return (PerformanceReportEntity) entityManager.get()
-                    .createQuery("SELECT NEW uk.gov.pay.connector.model.domain.report.PerformanceReportEntity(COUNT(c.amount), SUM(c.amount), AVG(c.amount)) FROM ChargeEntity c WHERE c.status = :status")
+                    .createQuery("SELECT NEW uk.gov.pay.connector.model.domain.report.PerformanceReportEntity(COUNT(c.amount), SUM(c.amount), AVG(c.amount))"
+                                + " FROM ChargeEntity c"
+                                + " WHERE c.status = :status"
+                                + " AND   c.gateway_account_id IN"
+                                + " (SELECT id FROM gateway_accounts as g WHERE g.type = :type)"
+                                )
                     .setParameter("status", CAPTURED.toString())
+                    .setParameter("type", LIVE.toString())
                     .setMaxResults(1)
                     .getSingleResult();
     }


### PR DESCRIPTION
The performance report also showed test payments, which it shouldn't
have

JOIN and WHERE ... IN have the same query plan

```
connector=> explain select count(*) from charges as c where c.status = 'CAPTURED' and c.gateway_account_id in (select id from gateway_accounts as g where g.type = 'TEST');
                                     QUERY PLAN
-------------------------------------------------------------------------------------
 Aggregate  (cost=59310.70..59310.71 rows=1 width=8)
   ->  Hash Semi Join  (cost=2.10..58025.46 rows=514097 width=0)
         Hash Cond: (c.gateway_account_id = g.id)
         ->  Seq Scan on charges c  (cost=0.00..50954.53 rows=514097 width=8)
               Filter: (status = 'CAPTURED'::text)
         ->  Hash  (cost=1.55..1.55 rows=44 width=8)
               ->  Seq Scan on gateway_accounts g  (cost=0.00..1.55 rows=44 width=8)
                     Filter: ((type)::text = 'TEST'::text)
(8 rows)

connector=> explain select count(*) from (charges join gateway_accounts on charges.gateway_account_id = gateway_accounts.id) where charges.status = 'CAPTURED' and gateway_accounts.type = 'TEST';
                                    QUERY PLAN
-----------------------------------------------------------------------------------
 Aggregate  (cost=59310.70..59310.71 rows=1 width=8)
   ->  Hash Join  (cost=2.10..58025.46 rows=514097 width=0)
         Hash Cond: (charges.gateway_account_id = gateway_accounts.id)
         ->  Seq Scan on charges  (cost=0.00..50954.53 rows=514097 width=8)
               Filter: (status = 'CAPTURED'::text)
         ->  Hash  (cost=1.55..1.55 rows=44 width=8)
               ->  Seq Scan on gateway_accounts  (cost=0.00..1.55 rows=44 width=8)
                     Filter: ((type)::text = 'TEST'::text)
(8 rows)
```

Bikeshedding time, which is more intuitive ⬆️ ⁉️ 

solo @tlwr


