### PR TITLE
PP-3864 Increase width of notification_credentials username, password

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1317,4 +1317,15 @@
             </column>
         </addColumn>
     </changeSet>
+
+    <changeSet id="increase width of notification_credentials username, password columns" author="">
+        <modifyDataType
+            tableName="notification_credentials"
+            columnName="username"
+            newDataType="varchar(255)"/>
+        <modifyDataType
+            tableName="notification_credentials"
+            columnName="password"
+            newDataType="varchar(255)"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
These were unnecessarily tight, and pg is clever enoough not to
allocate unused space, so giving them both 255.

See https://www.postgresql.org/docs/9.3/static/datatype-character.html
```
If the string to be stored is shorter than the declared length, values of
type character will be space-padded; values of type character varying will
simply store the shorter string.
```