### PR TITLE
Change error message when gateway responds with unexpected HTTP status code

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/service/GatewayClient.java
@@ -77,7 +77,7 @@ public class GatewayClient {
             } else {
                 logger.error("Gateway returned unexpected status code: {}, for gateway url={} with type {}", statusCode, gatewayUrl, account.getType());
                 incrementFailureCounter(metricRegistry, metricsPrefix);
-                return left(unexpectedStatusCodeFromGateway("Unexpected Response Code From Gateway"));
+                return left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code " + statusCode + " from gateway"));
             }
         } catch (ProcessingException pe) {
             incrementFailureCounter(metricRegistry, metricsPrefix);

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
@@ -93,7 +93,7 @@ public class GatewayAuthFailuresITest {
     public void shouldFailAuthWhenUnexpectedHttpStatusCodeFromGateway() throws Exception {
         gatewayStub.respondWithUnexpectedResponseCodeWhenCardAuth();
 
-        String errorMessage = "Unexpected Response Code From Gateway";
+        String errorMessage = "Unexpected HTTP status code 999 from gateway";
         String cardAuthUrl = "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeTestRecord.getExternalChargeId());
 
         given().config(RestAssured.config().connectionConfig(connectionConfig().closeIdleConnectionsAfterEachResponse()))

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
@@ -64,7 +64,8 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise(buildTestAuthorisationRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected Response Code From Gateway", UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
     @Test
@@ -90,7 +91,8 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         GatewayResponse<EpdqCaptureResponse> response = provider.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected Response Code From Gateway", UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
     @Test
@@ -116,7 +118,8 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         GatewayResponse<EpdqCaptureResponse> response = provider.cancel(buildTestCancelRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected Response Code From Gateway", UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
     @Test
@@ -151,7 +154,8 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         GatewayResponse<EpdqRefundResponse> response = provider.refund(buildTestRefundRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected Response Code From Gateway", UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
@@ -185,7 +185,8 @@ public class WorldpayPaymentProviderTest {
 
         Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
         when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
-        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected Response Code From Gateway")));
+        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+                .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway")));
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(gatewayClientEnumMap, false, null, externalRefundAvailabilityCalculator);
         worldpayPaymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity));
@@ -230,7 +231,8 @@ public class WorldpayPaymentProviderTest {
         Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
         when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
         when(mockGatewayAccountEntity.isRequires3ds()).thenReturn(false);
-        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected Response Code From Gateway")));
+        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+                .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway")));
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(gatewayClientEnumMap, false, null, externalRefundAvailabilityCalculator);
 
@@ -267,7 +269,8 @@ public class WorldpayPaymentProviderTest {
         Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
         when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
         when(mockGatewayAccountEntity.isRequires3ds()).thenReturn(true);
-        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected Response Code From Gateway")));
+        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+                .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway")));
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(gatewayClientEnumMap, false, null, externalRefundAvailabilityCalculator);
 
@@ -301,7 +304,8 @@ public class WorldpayPaymentProviderTest {
         Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
         when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
         when(mockGatewayAccountEntity.isRequires3ds()).thenReturn(true);
-        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected Response Code From Gateway")));
+        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+                .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 401 from gateway")));
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(gatewayClientEnumMap, false, null, externalRefundAvailabilityCalculator);
 
@@ -337,7 +341,8 @@ public class WorldpayPaymentProviderTest {
         Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
         when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
         when(mockGatewayAccountEntity.isRequires3ds()).thenReturn(true);
-        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected Response Code From Gateway")));
+        when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+                .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway")));
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(gatewayClientEnumMap, false, null, externalRefundAvailabilityCalculator);
 
@@ -374,7 +379,8 @@ public class WorldpayPaymentProviderTest {
         assertThat(response.isFailed(), is(true));
         assertFalse(response.getSessionIdentifier().isPresent());
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected Response Code From Gateway", UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 401 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
     @Test
@@ -393,7 +399,8 @@ public class WorldpayPaymentProviderTest {
         GatewayResponse<WorldpayCaptureResponse> response = provider.capture(getCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected Response Code From Gateway", UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
     @Test


### PR DESCRIPTION
Change the error message returned when a payment gateway responds to a request with a non-200 HTTP status code from:

“Unexpected Response Code From Gateway”

… to:

“Unexpected HTTP status code _XXX_ from gateway”

… where _XXX_ is the actual HTTP status code received e.g. 401, 500 etc.

The status code is really useful for diagnosing problems (it already gets logged in a different error logging line, which is unfortunately devoid of most other context about the request so unlikely to be found in a log search).

We add “HTTP” to make it explicit that it’s an HTTP status code and not a code internal to the gateway. We use “status code” rather than “Response Code” because that’s what it’s called in HTTP.