### PR TITLE
PP-3870: Add performance report endpoints tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/resources/GatewayAccountPerformanceReportResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/GatewayAccountPerformanceReportResourceTest.java
@@ -1,0 +1,97 @@
+package uk.gov.pay.connector.resources;
+
+import java.math.BigDecimal;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.connector.dao.PerformanceReportDao;
+import uk.gov.pay.connector.model.domain.report.GatewayAccountPerformanceReportEntity;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GatewayAccountPerformanceReportResourceTest {
+
+    @Mock
+    private PerformanceReportDao mockPerformanceReportDao;
+
+    @Mock
+    private List<GatewayAccountPerformanceReportEntity> noTransactionsPerformanceReportEntity;
+    @Mock
+    private List<GatewayAccountPerformanceReportEntity> someTransactionsPerformanceReportEntity;
+
+    private final Long totalVolume = 10000L;
+    private final BigDecimal totalAmount = new BigDecimal("10000000");
+    private final BigDecimal averageAmount = new BigDecimal("1000");
+    private final Long minAmount = 1000L;
+    private final Long maxAmount = 1000L;
+
+    private PerformanceReportResource resource;
+
+    @Before
+    public void setUp() {
+        noTransactionsPerformanceReportEntity = new ArrayList<GatewayAccountPerformanceReportEntity>();
+        someTransactionsPerformanceReportEntity = new ArrayList<GatewayAccountPerformanceReportEntity>();
+
+        GatewayAccountPerformanceReportEntity mockedGatewayAccountPerformanceReport = new GatewayAccountPerformanceReportEntity(
+            totalVolume,
+            totalAmount,
+            averageAmount,
+            minAmount,
+            maxAmount,
+            3L
+        );
+
+        someTransactionsPerformanceReportEntity.add(mockedGatewayAccountPerformanceReport);
+
+        resource = new PerformanceReportResource(mockPerformanceReportDao);
+    }
+
+    @Test
+    public void noTransactionsPerformanceReportEntitySerializesCorrectly() {
+        given(mockPerformanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount())
+                .willReturn(noTransactionsPerformanceReportEntity);
+
+        Response result = resource.getGatewayAccountPerformanceReport();
+
+        assertThat(result.getStatus(), is(OK.getStatusCode()));
+
+        HashMap<String, ImmutableMap<String, Object>> unserializedResponse = (HashMap<String, ImmutableMap<String, Object>>) result.getEntity();
+
+        assertThat(unserializedResponse.size(), is(0));
+    }
+
+    @Test
+    public void someTransactionsPerformanceReportEntitySerializesCorrectly() {
+        given(mockPerformanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount())
+                .willReturn(someTransactionsPerformanceReportEntity);
+
+        Response result = resource.getGatewayAccountPerformanceReport();
+
+        assertThat(result.getStatus(), is(OK.getStatusCode()));
+
+        HashMap<String, ImmutableMap<String, Object>> unserializedResponse = (HashMap<String, ImmutableMap<String, Object>>) result.getEntity();
+
+        assertThat(unserializedResponse.size(), is(1));
+
+        ImmutableMap<String, Object> gatewayAccountPerformance = unserializedResponse.get("3");
+
+        assertThat(gatewayAccountPerformance.get("total_volume"),   is(totalVolume));
+        assertThat(gatewayAccountPerformance.get("total_amount"),   is(totalAmount));
+        assertThat(gatewayAccountPerformance.get("average_amount"), is(averageAmount));
+        assertThat(gatewayAccountPerformance.get("min_amount"),     is(minAmount));
+        assertThat(gatewayAccountPerformance.get("max_amount"),     is(maxAmount));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/resources/PerformanceReportResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/PerformanceReportResourceTest.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.connector.resources;
+
+import java.math.BigDecimal;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.connector.dao.PerformanceReportDao;
+import uk.gov.pay.connector.model.domain.report.PerformanceReportEntity;
+
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PerformanceReportResourceTest {
+
+    private final Long totalVolume = 100000000000000L;
+    private final BigDecimal totalAmount = new BigDecimal("10000000000000000");
+    private final BigDecimal averageAmount = new BigDecimal("100");
+
+    @Mock
+    private PerformanceReportDao mockPerformanceReportDao;
+
+    @Mock
+    private PerformanceReportEntity noTransactionsPerformanceReportEntity,
+                                    someTransactionsPerformanceReportEntity;
+
+    private PerformanceReportResource resource;
+
+    @Before
+    public void setUp() {
+        noTransactionsPerformanceReportEntity = new PerformanceReportEntity(
+            0L,
+            BigDecimal.ZERO,
+            BigDecimal.ZERO
+        );
+        someTransactionsPerformanceReportEntity = new PerformanceReportEntity(
+            totalVolume,
+            totalAmount,
+            averageAmount
+        );
+
+        resource = new PerformanceReportResource(mockPerformanceReportDao);
+    }
+
+    @Test
+    public void emptyPerformanceReportSerialisesCorrectly() {
+        given(mockPerformanceReportDao.aggregateNumberAndValueOfPayments())
+                .willReturn(noTransactionsPerformanceReportEntity);
+
+        Response result = resource.getPerformanceReport();
+
+        assertThat(result.getStatus(), is(OK.getStatusCode()));
+
+        ImmutableMap<String, Object> unserializedResponse = (ImmutableMap<String, Object>) result.getEntity();
+
+        assertThat(unserializedResponse.get("total_volume"), is(0L));
+        assertThat(unserializedResponse.get("total_amount"), is(BigDecimal.ZERO));
+        assertThat(unserializedResponse.get("average_amount"), is(BigDecimal.ZERO));
+    }
+
+    @Test
+    public void nonEmptyPerformanceReportSerialisesCorrectly() {
+        given(mockPerformanceReportDao.aggregateNumberAndValueOfPayments())
+                .willReturn(someTransactionsPerformanceReportEntity);
+
+        Response result = resource.getPerformanceReport();
+
+        assertThat(result.getStatus(), is(OK.getStatusCode()));
+
+        ImmutableMap<String, Object> unserializedResponse = (ImmutableMap<String, Object>) result.getEntity();
+
+        assertThat(unserializedResponse.get("total_volume"), is(totalVolume));
+        assertThat(unserializedResponse.get("total_amount"), is(totalAmount));
+        assertThat(unserializedResponse.get("average_amount"), is(averageAmount));
+    }
+}


### PR DESCRIPTION
Adds tests for
- performance report
- gateway account segmented performance report

This just tests serialisation/deserialisation of the entities, doesn't
test JPA interaction.

solo @tlwr


