### PR TITLE
Pp 3893 daily report endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ $ java -jar target/pay-connector-0.1-SNAPSHOT-allinone.jar
 |[```/v1/api/accounts/{accountId}/transactions-summary```](docs/api_specification.md#get-v1apiaccountsaccountidtransactions-summary)|GET|Retrieves payment summary totals for a given `accountId`
 |[```/v1/api/reports/performance-report```](docs/api_specification.md#get-v1apireportsperformance-report)|GET|Retrieves performance summary |
 |[```/v1/api/reports/gateway-account-performance-report```](docs/api_specification.md#get-v1apireportsgateway-account-performance-report)|GET|Retrieves performance summary segmented by gateway account |
+|[```/v1/api/reports/daily-performance-report```](docs/api_specification.md#get-v1apireportsdaily-performance-report)|GET|Retrieves performance summary for a given day |
 
 ### Frontend namespace
 

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -1739,3 +1739,42 @@ The following fields are present for each gateway account returned.
 | `max_amount`     | X              | Maximum value of all successful payment  |
 
 This endpoint will not return any statistics for any account that has not conducted a live payment.
+
+## GET /v1/api/reports/daily-performance-report
+
+Retrieves performance summary scoped by day
+
+### Request query param description
+
+| Field       | Always present | Description                                |
+| ------------|:--------------:| ------------------------------------------ |
+| `date`      | X              | Date for which report should be generated  |
+
+
+### Request example
+
+```
+GET /v1/api/reports/daily-performance-report?date=2018-06-21T00:00:00Z
+```
+
+### Response example
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+
+  "total_volume": 12345,
+  "total_amount": 12345,
+  "average_amount": 1
+}
+```
+
+### Response field description
+
+| Field            | Always present | Description                           |
+| -----------------|:--------------:| --------------------------------------|
+| `total_volume`   | X              | Count of successful payments          |
+| `total_amount`   | X              | Sum of successful payments            |
+| `average_amount` | X              | Average value of successful payments  |

--- a/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.connector.dao.GatewayAccountDao;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 
+import java.time.format.DateTimeFormatter;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.HashMap;
@@ -138,7 +139,7 @@ class ApiValidators {
         return left(errors);
     }
 
-    private static Optional<ZonedDateTime> parseZonedDateTime(String zdt) {
+    static Optional<ZonedDateTime> parseZonedDateTime(String zdt) {
         if (zdt == null) {
             return Optional.empty();
         }
@@ -148,5 +149,4 @@ class ApiValidators {
             return Optional.empty();
         }
     }
-
 }

--- a/src/main/java/uk/gov/pay/connector/resources/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/PerformanceReportResource.java
@@ -5,19 +5,23 @@ import com.google.inject.Inject;
 import uk.gov.pay.connector.dao.PerformanceReportDao;
 import uk.gov.pay.connector.model.domain.report.PerformanceReportEntity;
 import uk.gov.pay.connector.model.domain.report.GatewayAccountPerformanceReportEntity;
+import static uk.gov.pay.connector.resources.ApiValidators.parseZonedDateTime;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.QueryParam;
 import java.util.List;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static javax.ws.rs.core.Response.ok;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 
 @Path("/")
 public class PerformanceReportResource {
@@ -39,6 +43,30 @@ public class PerformanceReportResource {
                 "total_amount", performanceReport.getTotalAmount(),
                 "average_amount", performanceReport.getAverageAmount());
         return ok().entity(responsePayload).build();
+    }
+
+    @GET
+    @Path("/v1/api/reports/daily-performance-report")
+    @Produces(APPLICATION_JSON)
+    public Response getDailyPerformanceReport(@QueryParam("date") String rawDate) {
+        return parseZonedDateTime(rawDate)
+          .map(date -> {
+            PerformanceReportEntity performanceReport = performanceReportDao.aggregateNumberAndValueOfPaymentsForAGivenDay(date);
+
+            ImmutableMap<String, Object> responsePayload = ImmutableMap.of(
+                    "total_volume", performanceReport.getTotalVolume(),
+                    "total_amount", performanceReport.getTotalAmount(),
+                    "average_amount", performanceReport.getAverageAmount());
+
+            return ok().entity(responsePayload).build();
+          })
+          .orElseGet(() -> {
+            return Response
+              .status(Response.Status.BAD_REQUEST)
+              .entity("Could not parse date: " + rawDate)
+              .type(TEXT_PLAIN)
+              .build();
+          });
     }
 
     @GET

--- a/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
@@ -15,6 +16,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.resources.ApiValidators.validateChargePatchParams;
 import static uk.gov.pay.connector.resources.ApiValidators.validateFromDateIsBeforeToDate;
+import static uk.gov.pay.connector.resources.ApiValidators.parseZonedDateTime;
 
 public class ApiValidatorsTest {
 
@@ -100,4 +102,16 @@ public class ApiValidatorsTest {
         assertThat(result.left().value().get(0), is("query param 'to_date' not in correct format"));
     }
 
+    @Test
+    public void parseZonedDateTimeParsesZonedDateTimes() {
+        String rawDate = "2018-06-20T00:00:00Z";
+        Optional<ZonedDateTime> maybeDate = parseZonedDateTime(rawDate);
+
+        assert(maybeDate.isPresent());
+
+        ZonedDateTime date = maybeDate.get();
+        assertThat(date.getDayOfMonth(), is(20));
+        assertThat(date.getMonthValue(), is(06));
+        assertThat(date.getYear(),       is(2018));
+    }
 }


### PR DESCRIPTION
Adds a daily report endpoint to connector, this is so we can get information for the performance platform. This is separate from the /reports/performance-report endpoint as it scopes the value of payments to a single day

@tlwr @mrlumbu 
