### PR TITLE
PP-3059: Redacted email in connector logging.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.dao;
 
 import uk.gov.pay.connector.model.TransactionType;
+
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalRefundStatus;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -210,14 +211,27 @@ public class ChargeSearchParams {
     }
 
     public String buildQueryParams() {
+        return this.buildQueryParams(false);
+    }
+
+    public String buildQueryParamsWithPiiRedaction () {
+        return this.buildQueryParams(true);
+    }
+
+    private String buildQueryParams(boolean redactPii) {
         StringBuilder builder = new StringBuilder();
         if (transactionType != null) {
             builder.append("&transaction_type=").append(transactionType.getValue());
         }
         if (isNotBlank(reference))
             builder.append("&reference=").append(reference);
-        if (email != null)
-            builder.append("&email=").append(email);
+        if (email != null) {
+            if (redactPii) {
+                builder.append("&email=*****");
+            } else {
+                builder.append("&email=").append(email);
+            }
+        }
         if (fromDate != null)
             builder.append("&from_date=").append(fromDate);
         if (toDate != null)

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -342,7 +342,7 @@ public class ChargesApiResource {
             logger.info("Charge Search - is feature transactions enabled [{}] took [{}] params [{}]",
                     isFeatureTransactionsEnabled,
                     (endTime - startTime) / 1000000000.0,
-                    searchParams.buildQueryParams());
+                    searchParams.buildQueryParamsWithPiiRedaction());
         }
     }
 
@@ -354,7 +354,7 @@ public class ChargesApiResource {
             long endTime = System.nanoTime();
             logger.info("Transaction Search - took [{}] params [{}]",
                     (endTime - startTime) / 1000000000.0,
-                    searchParams.buildQueryParams());
+                    searchParams.buildQueryParamsWithPiiRedaction());
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
@@ -67,6 +67,34 @@ public class ChargeSearchParamsTest {
     }
 
     @Test
+    public void buildQueryParamsWithPiiRedaction_chargeSearch_withAllParameters() throws Exception {
+
+        String expectedQueryString =
+                "reference=ref" +
+                        "&email=*****" +
+                        "&from_date=2012-06-30T12:30:40Z[UTC]" +
+                        "&to_date=2012-07-30T12:30:40Z[UTC]" +
+                        "&page=2" +
+                        "&display_size=5" +
+                        "&state=created" +
+                        "&card_brand=visa";
+
+        ChargeSearchParams params = new ChargeSearchParams()
+                .withDisplaySize(5L)
+                .withExternalState(EXTERNAL_CREATED.getStatus())
+                .withCardBrand("visa")
+                .withGatewayAccountId(111L)
+                .withPage(2L)
+                .withReferenceLike("ref")
+                .withEmailLike("user")
+                .withFromDate(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]"))
+                .withToDate(ZonedDateTime.parse("2012-07-30T12:30:40Z[UTC]"));
+
+        assertThat(params.buildQueryParamsWithPiiRedaction(), is(expectedQueryString));
+    }
+
+
+    @Test
     public void getInternalStates_chargeSearch_shouldPopulateAllInternalChargeStates_FromExternalFailedState() {
 
         ChargeSearchParams params = new ChargeSearchParams()


### PR DESCRIPTION
This makes a change to ChargeSearchParams so that
buildQueryParams has an option to redactPII.

The redactPII option does not add the email address to the params
but a constant "email=*****".

This is then exposed as a new function that is used whilst
building the query params for logging.



