### PR TITLE
PP-3059: Remove thread name filter

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -5,6 +5,7 @@ server:
   adminConnectors:
     - type: http
       port: ${ADMIN_PORT:-0}
+  enableThreadNameFilter: false
 
 logging:
     level: INFO


### PR DESCRIPTION
During trying to verify a previous PR I noticed email addresses in another location.

This turns out to be the thread name. Dropwizard has a fun thing where it puts the
full request in the thread name like.
```
{"tags":{"environment":"production-2","host":"production-2-connector-ecs-i-02ebabaa818aa3190","service":"docker"},"message":"2018-06-26T14:59:42+00:00 ip6-localhost ecs-production-2_connector-18-connector-c2e6f3bf90abeace9301[7540]: [2018-06-26 14:59:42.461] [dw-1089 - GET /v2/api/accounts/207/charges?reference=P10044308&email=UNREDACTED&card_brand=&from_date=&to_date=&page=1&display_size=100] #033[34mINFO #033[0;39m #033[36mu.g.p.c.r.ChargesApiResource#033[0;39m [requestID=6e2d456c-d841-4cf9-cc1a-1742a618bd90] - Charge Search - is feature transactions enabled [true] took [1.221554082] params [reference=P10044308&email=*****&page=2&display_size=100] "} 
```

Removing these params will make things harder to debug. We will have to make sure that we log appropriately in other places.

However as we are moving to debugging with sentry this should be
less of a problem.

Thoughts?


