### PR TITLE
PP-3932: Upgrade Dropwizard from 1.2.2 to 1.2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <version>0.1-SNAPSHOT</version>
     <artifactId>pay-connector</artifactId>
     <properties>
-        <dropwizard.version>1.2.7</dropwizard.version>
+        <dropwizard.version>1.2.8</dropwizard.version>
         <wiremock.version>1.57</wiremock.version>
         <jpa.version>2.6.4</jpa.version>
         <guice.version>4.1.0</guice.version>
@@ -397,7 +397,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>9.4.8.v20171121</version>
+            <version>9.4.11.v20180605</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <version>0.1-SNAPSHOT</version>
     <artifactId>pay-connector</artifactId>
     <properties>
-        <dropwizard.version>1.2.2</dropwizard.version>
+        <dropwizard.version>1.2.7</dropwizard.version>
         <wiremock.version>1.57</wiremock.version>
         <jpa.version>2.6.4</jpa.version>
         <guice.version>4.1.0</guice.version>

--- a/src/test/java/uk/gov/pay/connector/healthcheck/PingTest.java
+++ b/src/test/java/uk/gov/pay/connector/healthcheck/PingTest.java
@@ -3,13 +3,12 @@ package uk.gov.pay.connector.healthcheck;
 import com.codahale.metrics.health.HealthCheck;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
 
 public class PingTest {
 
     @Test
     public void testPing() {
-        assertThat(new Ping().execute(), is(HealthCheck.Result.healthy()));
+        assertTrue(new Ping().execute().isHealthy());
     }
 }


### PR DESCRIPTION
## WHAT
This upgrades Jetty from 9.4.7 to 9.4.11 and upgrades Jackson from 2.9.1 to
2.9.6