### PR TITLE
BAU: Debug logging and jackson 2.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <jpa.version>2.6.4</jpa.version>
         <guice.version>4.1.0</guice.version>
         <docker-client.version>8.9.2</docker-client.version>
-        <jackson.version>2.9.4</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
     </properties>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <jpa.version>2.6.4</jpa.version>
         <guice.version>4.1.0</guice.version>
         <docker-client.version>8.9.2</docker-client.version>
-        <jackson.version>2.9.6</jackson.version>
+        <jackson.version>2.9.4</jackson.version>
     </properties>
     <repositories>
         <repository>

--- a/src/test/java/uk/gov/pay/connector/filters/LoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/connector/filters/LoggingFilterTest.java
@@ -52,6 +52,7 @@ public class LoggingFilterTest {
     public void setup() {
         loggingFilter = new LoggingFilter();
         Logger root = (Logger) LoggerFactory.getLogger(LoggingFilter.class);
+        root.setLevel(Level.INFO);
         mockAppender = mockAppender();
         root.addAppender(mockAppender);
     }

--- a/src/test/java/uk/gov/pay/connector/filters/RestClientLoggingFilterTest.java
+++ b/src/test/java/uk/gov/pay/connector/filters/RestClientLoggingFilterTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.filters;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -52,6 +53,7 @@ public class RestClientLoggingFilterTest {
         loggingFilter = new RestClientLoggingFilter();
         Logger root = (Logger) LoggerFactory.getLogger(RestClientLoggingFilter.class);
         mockAppender = mock(Appender.class);
+        root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/BaseGatewayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/BaseGatewayITest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -76,6 +77,7 @@ abstract public class BaseGatewayITest {
 
     public void setupLoggerMockAppender() {
         Logger root = (Logger) LoggerFactory.getLogger(GatewayClient.class);
+        root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -86,6 +87,7 @@ public class GatewayAuthFailuresITest {
         this.chargeTestRecord = testCharge.insert();
 
         Logger root = (Logger) LoggerFactory.getLogger(GatewayClient.class);
+        root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.service;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -97,6 +98,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         cardCaptureService = new CardCaptureService(mockedChargeDao, mockedChargeEventDao, mockedProviders, mockUserNotificationService, mockEnvironment, mockPaymentRequestDao, mockChargeStatusUpdater);
 
         Logger root = (Logger) LoggerFactory.getLogger(CardCaptureService.class);
+        root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -44,6 +44,7 @@ public class ApplicationStartupApplicationStartupDependentResourceCheckerTest {
     public void setup() {
         Logger root = (Logger) LoggerFactory.getLogger(ApplicationStartupDependentResourceChecker.class);
         mockAppender = mockAppender();
+        root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/ApplicationStartupApplicationStartupDependentResourceCheckerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.util;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -7,7 +7,7 @@ server:
       port: 0
 
 logging:
-    level: INFO
+    level: WARN
     appenders:
       - type: console
         threshold: ALL

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -7,7 +7,7 @@ server:
       port: 0
 
 logging:
-    level: INFO
+    level: WARN
     appenders:
       - type: console
         threshold: ALL

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,7 @@
+<configuration debug="false">
+  <logger name="liquibase" level="WARN" />
+  <logger name="org.apache.http" level="WARN" />
+  <logger name="com.spotify" level="WARN" />
+  <logger name="uk.gov.pay." level="INFO" />
+  <root level="WARN"/>
+</configuration>

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -2,6 +2,6 @@
   <logger name="liquibase" level="WARN" />
   <logger name="org.apache.http" level="WARN" />
   <logger name="com.spotify" level="WARN" />
-  <logger name="uk.gov.pay." level="INFO" />
+  <logger name="uk.gov.pay." level="WARN" />
   <root level="WARN"/>
 </configuration>


### PR DESCRIPTION
- warn logging level - reduces logging size per build about 60mb
- dropwizard/jetty upgrade uses 2.9.6 jackson so we update that too

solo @tlwr


