### PR TITLE
PP-3942 Introduce ServicePaymentReference object to connector

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
@@ -142,8 +142,8 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
         List<Predicate> predicates = new ArrayList<>();
         if (params.getGatewayAccountId() != null)
             predicates.add(cb.equal(charge.get(GATEWAY_ACCOUNT).get("id"), params.getGatewayAccountId()));
-        if (StringUtils.isNotBlank(params.getReference()))
-            predicates.add(likePredicate(cb, charge.get(REFERENCE), params.getReference()));
+        if (params.getReference() != null && StringUtils.isNotBlank(params.getReference().toString()))
+            predicates.add(likePredicate(cb, charge.get(REFERENCE), params.getReference().toString()));
         if (StringUtils.isNotBlank(params.getEmail()))
             predicates.add(likePredicate(cb, charge.get(EMAIL), params.getEmail()));
         if (params.getInternalStates() != null && !params.getInternalStates().isEmpty())

--- a/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.dao;
 
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.TransactionType;
-
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalRefundStatus;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -24,7 +24,7 @@ public class ChargeSearchParams {
 
     private TransactionType transactionType;
     private Long gatewayAccountId;
-    private String reference;
+    private ServicePaymentReference reference;
     private String email;
     private ZonedDateTime fromDate;
     private ZonedDateTime toDate;
@@ -153,7 +153,7 @@ public class ChargeSearchParams {
         return this;
     }
 
-    public String getReference() {
+    public ServicePaymentReference getReference() {
         return reference;
     }
 
@@ -161,7 +161,7 @@ public class ChargeSearchParams {
         return email;
     }
 
-    public ChargeSearchParams withReferenceLike(String reference) {
+    public ChargeSearchParams withReferenceLike(ServicePaymentReference reference) {
         this.reference = reference;
         return this;
     }
@@ -223,7 +223,7 @@ public class ChargeSearchParams {
         if (transactionType != null) {
             builder.append("&transaction_type=").append(transactionType.getValue());
         }
-        if (isNotBlank(reference))
+        if (reference != null && isNotBlank(reference.toString()))
             builder.append("&reference=").append(reference);
         if (email != null) {
             if (redactPii) {

--- a/src/main/java/uk/gov/pay/connector/dao/OldTransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/OldTransactionDao.java
@@ -119,9 +119,9 @@ public class OldTransactionDao {
                     field("c.card_brand").in(params.getCardBrands()));
         }
 
-        if (isNotBlank(params.getReference())) {
+        if (params.getReference() != null && isNotBlank(params.getReference().toString())) {
             queryFilters = queryFilters.and(
-                    field("c.reference").lower().like(buildLikeClauseContaining(params.getReference().toLowerCase())));
+                    field("c.reference").lower().like(buildLikeClauseContaining(params.getReference().toString().toLowerCase())));
         }
 
         Condition queryFiltersForCharges = queryFilters;

--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -88,7 +88,7 @@ public class TransactionDao extends JpaDao<TransactionEntity> {
         List<String> statuses = getStatuses(params);
         StringBuilder queryPrefix = new StringBuilder("SELECT count(t.*) FROM transactions t ");
 
-        if (isNotEmpty(params.getReference())) {
+        if (params.getReference() != null && isNotEmpty(params.getReference().toString())) {
             queryPrefix.append("JOIN payment_requests p ON t.payment_request_id = p.id ");
         }
         if (isNotEmpty(params.getEmail()) || !params.getCardBrands().isEmpty()) {
@@ -127,8 +127,8 @@ public class TransactionDao extends JpaDao<TransactionEntity> {
             typedQuery.setParameter("email", "%" + formattedEmail + "%");
         }
 
-        if (isNotEmpty(params.getReference())) {
-            typedQuery.setParameter("reference", "%" + getEscapedString(params.getReference()) + "%");
+        if (params.getReference() != null && isNotEmpty(params.getReference().toString())) {
+            typedQuery.setParameter("reference", "%" + getEscapedString(params.getReference().toString()) + "%");
         }
 
         if (params.getFromDate() != null) {
@@ -161,7 +161,7 @@ public class TransactionDao extends JpaDao<TransactionEntity> {
             query.append("AND t2.email ILIKE ?email ");
         }
 
-        if (isNotEmpty(params.getReference())) {
+        if (params.getReference() != null && isNotEmpty(params.getReference().toString())) {
             query.append("AND p.reference ILIKE ?reference ");
         }
 

--- a/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.model;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.model.domain.PersistedCard;
@@ -255,7 +257,8 @@ public class ChargeResponse {
     private String description;
 
     @JsonProperty
-    private String reference;
+    @JsonSerialize(using = ToStringSerializer.class)
+    private ServicePaymentReference reference;
 
     @JsonProperty("payment_provider")
     private String providerName;
@@ -275,7 +278,10 @@ public class ChargeResponse {
     @JsonProperty("card_details")
     protected PersistedCard cardDetails;
 
-    protected ChargeResponse(String chargeId, Long amount, ExternalTransactionState state, String cardBrand, String gatewayTransactionId, String returnUrl, String email, String description, String reference, String providerName, String createdDate, List<Map<String, Object>> dataLinks, RefundSummary refundSummary, SettlementSummary settlementSummary, PersistedCard cardDetails, Auth3dsData auth3dsData) {
+    protected ChargeResponse(String chargeId, Long amount, ExternalTransactionState state, String cardBrand, String gatewayTransactionId, String returnUrl,
+                             String email, String description, ServicePaymentReference reference, String providerName, String createdDate,
+                             List<Map<String, Object>> dataLinks, RefundSummary refundSummary, SettlementSummary settlementSummary, PersistedCard cardDetails,
+                             Auth3dsData auth3dsData) {
         this.dataLinks = dataLinks;
         this.chargeId = chargeId;
         this.amount = amount;
@@ -330,7 +336,7 @@ public class ChargeResponse {
         return description;
     }
 
-    public String getReference() {
+    public ServicePaymentReference getReference() {
         return reference;
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/FrontendChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/FrontendChargeResponse.java
@@ -60,7 +60,7 @@ public class FrontendChargeResponse extends ChargeResponse {
 
     private FrontendChargeResponse(String chargeId, Long amount, ExternalTransactionState state, String cardBrand,
                                    String gatewayTransactionId, String returnUrl, String email, String description,
-                                   String reference, String providerName, String createdDate,
+                                   ServicePaymentReference reference, String providerName, String createdDate,
                                    List<Map<String, Object>> dataLinks, String status, RefundSummary refundSummary,
                                    SettlementSummary settlementSummary, PersistedCard chargeCardDetails, Auth3dsData auth3dsData,
                                    GatewayAccountEntity gatewayAccount) {

--- a/src/main/java/uk/gov/pay/connector/model/ServicePaymentReference.java
+++ b/src/main/java/uk/gov/pay/connector/model/ServicePaymentReference.java
@@ -10,8 +10,8 @@ public class ServicePaymentReference {
         this.servicePaymentReference = Objects.requireNonNull(servicePaymentReference);
     }
 
-    public static ServicePaymentReference of(String providerMandateReference) {
-        return new ServicePaymentReference(providerMandateReference);
+    public static ServicePaymentReference of(String servicePaymentReference) {
+        return new ServicePaymentReference(servicePaymentReference);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/model/ServicePaymentReference.java
+++ b/src/main/java/uk/gov/pay/connector/model/ServicePaymentReference.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.model;
+
+import java.util.Objects;
+
+public class ServicePaymentReference {
+
+    private final String servicePaymentReference;
+
+    private ServicePaymentReference(String servicePaymentReference) {
+        this.servicePaymentReference = Objects.requireNonNull(servicePaymentReference);
+    }
+
+    public static ServicePaymentReference of(String providerMandateReference) {
+        return new ServicePaymentReference(providerMandateReference);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == ServicePaymentReference.class) {
+            ServicePaymentReference that = (ServicePaymentReference) other;
+            return this.servicePaymentReference.equals(that.servicePaymentReference);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return servicePaymentReference.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return servicePaymentReference;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/model/TransactionResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/TransactionResponse.java
@@ -41,7 +41,7 @@ public class TransactionResponse extends ChargeResponse {
 
     protected TransactionResponse(String transactionType, String chargeId, Long amount, ExternalTransactionState state,
                                   String cardBrand, String gatewayTransactionId, String returnUrl, String email,
-                                  String description, String reference, String providerName, String createdDate,
+                                  String description, ServicePaymentReference reference, String providerName, String createdDate,
                                   List<Map<String, Object>> dataLinks, RefundSummary refundSummary,
                                   SettlementSummary settlementSummary, PersistedCard cardDetails, Auth3dsData auth3dsData) {
         super(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email, description, reference,

--- a/src/main/java/uk/gov/pay/connector/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/model/builder/AbstractChargeResponseBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.model.builder;
 
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.model.ChargeResponse;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.domain.PersistedCard;
 
@@ -20,7 +21,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected String description;
     protected String createdDate;
     protected List<Map<String, Object>> links = new ArrayList<>();
-    protected String reference;
+    protected ServicePaymentReference reference;
     protected String providerName;
     protected String email;
     protected ChargeResponse.RefundSummary refundSummary;
@@ -65,7 +66,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return thisObject();
     }
 
-    public T withReference(String reference) {
+    public T withReference(ServicePaymentReference reference) {
         this.reference = reference;
         return thisObject();
     }

--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
@@ -1,9 +1,12 @@
 package uk.gov.pay.connector.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.service.PaymentGatewayName;
 import uk.gov.pay.connector.util.RandomIdGenerator;
@@ -90,7 +93,9 @@ public class ChargeEntity extends AbstractVersionedEntity {
     private String description;
 
     @Column(name = "reference")
-    private String reference;
+    @Convert(converter = ServicePaymentReferenceConverter.class)
+    @JsonSerialize(using = ToStringSerializer.class)
+    private ServicePaymentReference reference;
 
     @Column(name = "provider_session_id")
     private String providerSessionId;
@@ -103,12 +108,13 @@ public class ChargeEntity extends AbstractVersionedEntity {
         //for jpa
     }
 
-    public ChargeEntity(Long amount, String returnUrl, String description, String reference, GatewayAccountEntity gatewayAccount, String email) {
+    public ChargeEntity(Long amount, String returnUrl, String description, ServicePaymentReference reference,
+                        GatewayAccountEntity gatewayAccount, String email) {
         this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")));
     }
 
     //for fixture
-    ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, String reference,
+    ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, ServicePaymentReference reference,
                  GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate) {
         this.amount = amount;
         this.status = status.getValue();
@@ -153,7 +159,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         return description;
     }
 
-    public String getReference() {
+    public ServicePaymentReference getReference() {
         return reference;
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PaymentRequestEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.transaction.ChargeTransactionEntity;
 import uk.gov.pay.connector.model.domain.transaction.RefundTransactionEntity;
 import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
@@ -57,7 +58,8 @@ public class PaymentRequestEntity extends AbstractVersionedEntity {
     private String description;
 
     @Column(name = "reference")
-    private String reference;
+    @Convert(converter = ServicePaymentReferenceConverter.class)
+    private ServicePaymentReference reference;
 
     @Column(name = "created_date")
     @Convert(converter = UTCDateTimeConverter.class)
@@ -114,11 +116,11 @@ public class PaymentRequestEntity extends AbstractVersionedEntity {
         this.description = description;
     }
 
-    public String getReference() {
+    public ServicePaymentReference getReference() {
         return reference;
     }
 
-    public void setReference(String reference) {
+    public void setReference(ServicePaymentReference reference) {
         this.reference = reference;
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/ServicePaymentReferenceConverter.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ServicePaymentReferenceConverter.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.model.ServicePaymentReference;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class ServicePaymentReferenceConverter implements AttributeConverter<ServicePaymentReference, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ServicePaymentReference serviceProviderReference) {
+        return serviceProviderReference.toString();
+    }
+
+    @Override
+    public ServicePaymentReference convertToEntityAttribute(String serviceProviderReference) {
+        return ServicePaymentReference.of(serviceProviderReference);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
@@ -1,8 +1,13 @@
 package uk.gov.pay.connector.model.domain;
 
 import org.eclipse.persistence.annotations.ReadOnly;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 
-import javax.persistence.*;
+import javax.persistence.ColumnResult;
+import javax.persistence.ConstructorResult;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.SqlResultSetMapping;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 
@@ -120,8 +125,8 @@ public class Transaction {
         return externalId;
     }
 
-    public String getReference() {
-        return reference;
+    public ServicePaymentReference getReference() {
+        return ServicePaymentReference.of(reference);
     }
 
     public String getDescription() {

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
 import uk.gov.pay.connector.dao.GatewayAccountDao;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.service.ChargeExpiryService;
 import uk.gov.pay.connector.service.ChargeService;
@@ -149,7 +150,7 @@ public class ChargesApiResource {
                     ChargeSearchParams searchParams = new ChargeSearchParams()
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
-                            .withReferenceLike(reference)
+                            .withReferenceLike(reference != null ? ServicePaymentReference.of(reference) : null)
                             .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))
                             .withToDate(parseDate(toDate))
@@ -198,7 +199,7 @@ public class ChargesApiResource {
                     ChargeSearchParams searchParams = new ChargeSearchParams()
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
-                            .withReferenceLike(reference)
+                            .withReferenceLike(reference != null ? ServicePaymentReference.of(reference) : null)
                             .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))
                             .withToDate(parseDate(toDate))
@@ -246,7 +247,7 @@ public class ChargesApiResource {
                     ChargeSearchParams searchParams = new ChargeSearchParams()
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
-                            .withReferenceLike(reference)
+                            .withReferenceLike(reference != null ? ServicePaymentReference.of(reference) : null)
                             .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))
                             .withToDate(parseDate(toDate))

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.dao.GatewayAccountDao;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.dao.TokenDao;
 import uk.gov.pay.connector.model.ChargeResponse;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
@@ -87,7 +88,7 @@ public class ChargeService {
             ChargeEntity chargeEntity = new ChargeEntity(new Long(chargeRequest.get("amount")),
                     chargeRequest.get("return_url"),
                     chargeRequest.get("description"),
-                    chargeRequest.get("reference"),
+                    ServicePaymentReference.of(chargeRequest.get("reference")),
                     gatewayAccount,
                     chargeRequest.get("email")
             );

--- a/src/main/java/uk/gov/pay/connector/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/service/UserNotificationService.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 import uk.gov.pay.connector.service.notify.NotifyClientFactory;
 import uk.gov.pay.connector.service.notify.NotifyClientFactoryProvider;
 import uk.gov.pay.connector.util.DateTimeUtils;
-import uk.gov.service.notify.Notification;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
@@ -24,7 +23,11 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.Runtime.getRuntime;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -108,7 +111,7 @@ public class UserNotificationService {
         String customParagraph = emailNotification != null ? emailNotification.getTemplateBody() : "";
         HashMap<String, String> map = new HashMap<>();
 
-        map.put("serviceReference", charge.getReference());
+        map.put("serviceReference", charge.getReference().toString());
         map.put("date", DateTimeUtils.toUserFriendlyDate(charge.getCreatedDate()));
         map.put("amount", formatToPounds(charge.getAmount()));
         map.put("description", charge.getDescription());

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeSearchParamsTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.dao;
 
 import org.junit.Test;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 
 import java.time.ZonedDateTime;
@@ -55,7 +56,7 @@ public class ChargeSearchParamsTest {
                 .withCardBrand("visa")
                 .withGatewayAccountId(111L)
                 .withPage(2L)
-                .withReferenceLike("ref")
+                .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user")
                 .withFromDate(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]"))
                 .withToDate(ZonedDateTime.parse("2012-07-30T12:30:40Z[UTC]"));
@@ -85,7 +86,7 @@ public class ChargeSearchParamsTest {
                 .withCardBrand("visa")
                 .withGatewayAccountId(111L)
                 .withPage(2L)
-                .withReferenceLike("ref")
+                .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user")
                 .withFromDate(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]"))
                 .withToDate(ZonedDateTime.parse("2012-07-30T12:30:40Z[UTC]"));
@@ -142,7 +143,7 @@ public class ChargeSearchParamsTest {
                 .withCardBrands(asList("visa", "master-card"))
                 .withGatewayAccountId(111L)
                 .withPage(2L)
-                .withReferenceLike("ref")
+                .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user@example.com")
                 .withFromDate(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]"))
                 .withToDate(ZonedDateTime.parse("2012-07-30T12:30:40Z[UTC]"));
@@ -165,7 +166,7 @@ public class ChargeSearchParamsTest {
                 .addExternalRefundStates(singletonList("success"))
                 .withGatewayAccountId(111L)
                 .withPage(2L)
-                .withReferenceLike("ref")
+                .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user@example.com");
 
         assertThat(params.buildQueryParams(), is(expectedQueryString));

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -12,6 +12,7 @@ import org.hamcrest.Matchers;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Rule;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.CardFixture;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
@@ -289,7 +290,8 @@ public class ChargingITestBase extends ChargingITestCommon {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, "http://somereturn.gov.uk", gatewayTransactionId, reference, fromDate);
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, "http://somereturn.gov.uk",
+                gatewayTransactionId, ServicePaymentReference.of(reference), fromDate);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
         app.getDatabaseTestHelper().updateChargeCardDetails(

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestCommon.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestCommon.java
@@ -9,6 +9,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.CardFixture;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
@@ -27,8 +28,12 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
-import static uk.gov.pay.connector.model.domain.GatewayAccount.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
 
@@ -240,7 +245,8 @@ abstract public class ChargingITestCommon {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
-        getApplication().getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, "http://somereturn.gov.uk", gatewayTransactionId, reference, fromDate);
+        getApplication().getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, "http://somereturn.gov.uk",
+                gatewayTransactionId, ServicePaymentReference.of(reference), fromDate);
         getApplication().getDatabaseTestHelper().addToken(chargeId, "tokenId");
         getApplication().getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
         getApplication().getDatabaseTestHelper().updateChargeCardDetails(

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
@@ -4,7 +4,13 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.GatewayAccountDao;
-import uk.gov.pay.connector.model.domain.*;
+import uk.gov.pay.connector.model.ServicePaymentReference;
+import uk.gov.pay.connector.model.domain.Address;
+import uk.gov.pay.connector.model.domain.AddressEntity;
+import uk.gov.pay.connector.model.domain.CardDetailsEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -81,7 +87,8 @@ public class ChargeDaoCardDetailsITest extends DaoITestBase {
         gatewayAccountDao.persist(testAccount);
 
         Address billingAddress = aValidAddress().build();
-        ChargeEntity chargeEntity = new ChargeEntity(2323L, "returnUrl", "description", "ref", testAccount, "email@email.com");
+        ChargeEntity chargeEntity = new ChargeEntity(2323L, "returnUrl", "description", 
+                ServicePaymentReference.of("ref"), testAccount, "email@email.com");
         CardDetailsEntity cardDetailsEntity = new CardDetailsEntity();
         cardDetailsEntity.setCardBrand("VISA");
         cardDetailsEntity.setBillingAddress(new AddressEntity(billingAddress));

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
@@ -286,7 +287,7 @@ public class ChargeDaoITest extends DaoITestBase {
     public void searchChargesByPartialReferenceOnly() throws Exception {
         // given
         insertTestCharge();
-        String paymentReference = "Council Tax Payment reference 2";
+        ServicePaymentReference paymentReference = ServicePaymentReference.of("Council Tax Payment reference 2");
         Long chargeId = System.currentTimeMillis();
         String externalChargeId = "chargeabc";
 
@@ -303,7 +304,7 @@ public class ChargeDaoITest extends DaoITestBase {
         String reference = "reference";
         ChargeSearchParams params = new ChargeSearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withReferenceLike(reference);
+                .withReferenceLike(ServicePaymentReference.of(reference));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -324,13 +325,13 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByReferenceAndEmail_with_under_score() throws Exception {
+    public void searchChargesByReferenceAndEmail_with_under_score() {
         // since '_' have special meaning in like queries of postgres this was resulting in undesired results
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withReference("under_score_ref")
+                .withReference(ServicePaymentReference.of("under_score_ref"))
                 .withEmail("under_score@mail.com")
                 .insert();
 
@@ -338,13 +339,13 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withReference("understand")
+                .withReference(ServicePaymentReference.of("understand"))
                 .withEmail("undertaker@mail.com")
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withReferenceLike("under_")
+                .withReferenceLike(ServicePaymentReference.of("under_"))
                 .withEmailLike("under_");
 
         // when
@@ -354,7 +355,7 @@ public class ChargeDaoITest extends DaoITestBase {
         assertThat(charges.size(), is(1));
 
         ChargeEntity charge = charges.get(0);
-        assertThat(charge.getReference(), is("under_score_ref"));
+        assertThat(charge.getReference(), is(ServicePaymentReference.of("under_score_ref")));
         assertThat(charge.getEmail(), is("under_score@mail.com"));
     }
 
@@ -365,19 +366,19 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withReference("percent%ref")
+                .withReference(ServicePaymentReference.of("percent%ref"))
                 .insert();
 
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withReference("percentref")
+                .withReference(ServicePaymentReference.of("percentref"))
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withReferenceLike("percent%");
+                .withReferenceLike(ServicePaymentReference.of("percent%"));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -386,18 +387,18 @@ public class ChargeDaoITest extends DaoITestBase {
         assertThat(charges.size(), is(1));
 
         ChargeEntity charge = charges.get(0);
-        assertThat(charge.getReference(), is("percent%ref"));
+        assertThat(charge.getReference(), is(ServicePaymentReference.of("percent%ref")));
     }
 
     @Test
-    public void searchChargesByReferenceAndEmailShouldBeCaseInsensitive() throws Exception {
+    public void searchChargesByReferenceAndEmailShouldBeCaseInsensitive() {
         // fix that the reference and email searches should be case insensitive
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
                 .withEmail("email-id@mail.com")
-                .withReference("case-Insensitive-ref")
+                .withReference(ServicePaymentReference.of("case-Insensitive-ref"))
                 .insert();
 
         DatabaseFixtures
@@ -405,12 +406,12 @@ public class ChargeDaoITest extends DaoITestBase {
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
                 .withEmail("EMAIL-ID@MAIL.COM")
-                .withReference("Case-inSENSITIVE-Ref")
+                .withReference(ServicePaymentReference.of("Case-inSENSITIVE-Ref"))
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withReferenceLike("cASe-insEnsiTIve")
+                .withReferenceLike(ServicePaymentReference.of("cASe-insEnsiTIve"))
                 .withEmailLike("EMAIL-ID@mail.com");
 
         // when
@@ -420,11 +421,11 @@ public class ChargeDaoITest extends DaoITestBase {
         assertThat(charges.size(), is(2));
 
         ChargeEntity charge = charges.get(0);
-        assertThat(charge.getReference(), is("Case-inSENSITIVE-Ref"));
+        assertThat(charge.getReference(), is(ServicePaymentReference.of("Case-inSENSITIVE-Ref")));
         assertThat(charge.getEmail(), is("EMAIL-ID@MAIL.COM"));
 
         charge = charges.get(1);
-        assertThat(charge.getReference(), is("case-Insensitive-ref"));
+        assertThat(charge.getReference(), is(ServicePaymentReference.of("case-Insensitive-ref")));
         assertThat(charge.getEmail(), is("email-id@mail.com"));
     }
 
@@ -433,14 +434,14 @@ public class ChargeDaoITest extends DaoITestBase {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
-                .withReferenceLike("reference");
+                .withReferenceLike(ServicePaymentReference.of("reference"));
         // when passed in a simple reference string
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
         // then it fetches a single result
         assertThat(charges.size(), is(1));
 
         // when passed in a non existent reference with an sql injected string
-        String sqlInjectionReferenceString = "reffff%' or 1=1 or c.reference like '%1";
+        ServicePaymentReference sqlInjectionReferenceString = ServicePaymentReference.of("reffff%' or 1=1 or c.reference like '%1");
         params = new ChargeSearchParams()
                 .withReferenceLike(sqlInjectionReferenceString);
         charges = chargeDao.findAllBy(params);
@@ -726,7 +727,7 @@ public class ChargeDaoITest extends DaoITestBase {
 
         GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
         gatewayAccount.setId(defaultTestAccount.getAccountId());
-        chargeDao.persist(aValidChargeEntity().withReference(RandomStringUtils.randomAlphanumeric(255)).build());
+        chargeDao.persist(aValidChargeEntity().withReference(ServicePaymentReference.of(RandomStringUtils.randomAlphanumeric(255))).build());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.it.dao;
 
 import org.apache.commons.lang3.RandomUtils;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.CardTypeEntity.Type;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
@@ -366,7 +367,7 @@ public class DatabaseFixtures {
         ChargeStatus chargeStatus = ChargeStatus.CREATED;
         String returnUrl = "http://service.com/success-page";
         String transactionId;
-        String reference = "Test reference";
+        ServicePaymentReference reference = ServicePaymentReference.of("Test reference");
 
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
 
@@ -388,7 +389,7 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestCharge withReference(String reference) {
+        public TestCharge withReference(ServicePaymentReference reference) {
             this.reference = reference;
             return this;
         }
@@ -432,7 +433,8 @@ public class DatabaseFixtures {
             if (testAccount == null)
                 throw new IllegalStateException("Test Account must be provided.");
 
-            databaseTestHelper.addCharge(chargeId, externalChargeId, String.valueOf(testAccount.getAccountId()), amount, chargeStatus, returnUrl, transactionId, reference, description, createdDate, email);
+            databaseTestHelper.addCharge(chargeId, externalChargeId, String.valueOf(testAccount.getAccountId()), amount, chargeStatus, returnUrl, transactionId,
+                    reference, description, createdDate, email);
 
             if (cardDetails != null) {
                 cardDetails.update();
@@ -464,7 +466,7 @@ public class DatabaseFixtures {
             return transactionId;
         }
 
-        public String getReference() {
+        public ServicePaymentReference getReference() {
             return reference;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.dao.TransactionDao;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.TransactionType;
 import uk.gov.pay.connector.model.domain.CardEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -261,7 +262,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
     @Test
     public void shouldReturnTransactions_byReference() {
-        final String expectedReference = "some random reference";
+        final ServicePaymentReference expectedReference = ServicePaymentReference.of("some random reference");
         PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
                 .withGatewayAccountEntity(gatewayAccount)
                 .withReference(expectedReference)
@@ -280,7 +281,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
     @Test
     public void shouldReturnTransactions_byReferenceWithUnderscore() {
-        final String expectedReference = "a_cedkdkwd";
+        final ServicePaymentReference expectedReference = ServicePaymentReference.of("a_cedkdkwd");
 
         PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
                 .withGatewayAccountEntity(gatewayAccount)
@@ -290,7 +291,7 @@ public class TransactionDaoITest extends DaoITestBase {
         paymentRequestDao.persist(paymentRequestEntity1);
 
         final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
-                .withGatewayAccountEntity(gatewayAccount).withReference("abcedkdkwd").build();
+                .withGatewayAccountEntity(gatewayAccount).withReference(ServicePaymentReference.of("abcedkdkwd")).build();
         paymentRequestDao.persist(paymentRequestEntity2);
 
         ChargeSearchParams searchParams = createSearchParams();
@@ -301,7 +302,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
     @Test
     public void shouldReturnTransactions_byReferenceWithPercent() {
-        final String expectedReference = "a%cedkdkwd";
+        final ServicePaymentReference expectedReference = ServicePaymentReference.of("a%cedkdkwd");
 
         PaymentRequestEntity paymentRequestEntity1 = aValidPaymentRequestEntity()
                 .withGatewayAccountEntity(gatewayAccount)
@@ -312,7 +313,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
         final PaymentRequestEntity paymentRequestEntity2 = aValidPaymentRequestEntity()
                 .withGatewayAccountEntity(gatewayAccount)
-                .withReference("abcedkdkwd")
+                .withReference(ServicePaymentReference.of("abcedkdkwd"))
                 .build();
         paymentRequestDao.persist(paymentRequestEntity2);
 
@@ -324,7 +325,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
     @Test
     public void shouldReturnTransactions_byReferenceWithUppercase() {
-        final String expectedReference = "ABCEdkdkwd";
+        final ServicePaymentReference expectedReference = ServicePaymentReference.of("ABCEdkdkwd");
 
         PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
                 .withGatewayAccountEntity(gatewayAccount)
@@ -341,7 +342,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
     @Test
     public void shouldReturnTransactions_byReferenceWithUppercaseInRequest() {
-        final String expectedReference = "dkdkwd";
+        final ServicePaymentReference expectedReference = ServicePaymentReference.of("dkdkwd");
 
         PaymentRequestEntity paymentRequestEntity = aValidPaymentRequestEntity()
                 .withGatewayAccountEntity(gatewayAccount)
@@ -351,7 +352,7 @@ public class TransactionDaoITest extends DaoITestBase {
         paymentRequestDao.persist(paymentRequestEntity);
 
         ChargeSearchParams searchParams = createSearchParams();
-        searchParams.withReferenceLike(expectedReference.toUpperCase());
+        searchParams.withReferenceLike(ServicePaymentReference.of(expectedReference.toString().toUpperCase()));
 
         assertTransactionByExternalId(paymentRequestEntity.getExternalId(), transactionDao.search(searchParams));
     }
@@ -571,8 +572,8 @@ public class TransactionDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void shouldReturnTransactions_AllParametersSet() throws Exception {
-        String ref = "ref1";
+    public void shouldReturnTransactions_AllParametersSet() {
+        ServicePaymentReference ref = ServicePaymentReference.of("ref1");
         String email = "foo@foo.com";
         String cardBrand = "visa";
 
@@ -610,7 +611,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
     @Test
     public void shouldCountTransactions_AllParametersSet() throws Exception {
-        String ref = "ref1";
+        ServicePaymentReference ref = ServicePaymentReference.of("ref1");
         String email = "foo@foo.com";
         String cardBrand = "visa";
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -6,6 +6,7 @@ import com.jayway.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.CardFixture;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.service.CardCaptureProcess;
@@ -360,8 +361,10 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .withDatabaseTestHelper(app.getDatabaseTestHelper())
                 .aMastercardCreditCardType()
                 .insert();
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, AUTHORISATION_SUCCESS, returnUrl, null, "ref", null, email);
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, testCardType.getBrand(), "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, AUTHORISATION_SUCCESS, returnUrl, null,
+                ServicePaymentReference.of("ref"), null, email);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, testCardType.getBrand(), "1234", "Mr. McPayment",
+                "03/18", "line1", null, "postcode", "city", null, "country");
 
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
@@ -380,8 +383,10 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         long chargeId = nextInt();
         String externalChargeId = "charge1";
 
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, AUTHORISATION_SUCCESS, returnUrl, null, "ref", null, email);
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "unknown-brand", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, AUTHORISATION_SUCCESS, returnUrl, null,
+                ServicePaymentReference.of("ref"), null, email);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "unknown-brand", "1234", "Mr. McPayment",
+                "03/18", "line1", null, "postcode", "city", null, "country");
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
         getChargeApi
@@ -404,14 +409,18 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         UUID card = UUID.randomUUID();
         app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
         app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null, "My reference", createdDate);
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "VISA", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null,
+                ServicePaymentReference.of("My reference"), createdDate);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "VISA", "1234", "Mr. McPayment",
+                "03/18", "line1", null, "postcode", "city", null, "country");
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
 
         String description = "Test description";
-        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, description, "My reference", createdDate, externalChargeId);
-        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, createdDate, email);
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, description,
+                ServicePaymentReference.of("My reference"), createdDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId,
+                createdDate, email);
         app.getDatabaseTestHelper().addCard(chargeId, "VISA", chargeId);
 
         getChargeApi
@@ -443,13 +452,17 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         UUID card = UUID.randomUUID();
         app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
         app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null, "My reference", createdDate);
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "visa", null, null, null, null, null, null, null, null, null);
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null,
+                ServicePaymentReference.of("My reference"), createdDate);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "visa", null, null, null,
+                null, null, null, null, null, null);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
 
-        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, "Test description", "My reference", createdDate, externalChargeId);
-        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId, createdDate, email);
+        app.getDatabaseTestHelper().addPaymentRequest(chargeId, AMOUNT, Long.valueOf(accountId), returnUrl, "Test description",
+                ServicePaymentReference.of("My reference"), createdDate, externalChargeId);
+        app.getDatabaseTestHelper().addChargeTransaction(chargeId, null, Long.valueOf(accountId), AMOUNT, chargeStatus, chargeId,
+                createdDate, email);
         app.getDatabaseTestHelper().addCard(chargeId, "visa", chargeId);
 
         getChargeApi
@@ -470,9 +483,9 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     @Test
     public void shouldFilterTransactionsBasedOnFromAndToDates() throws Exception {
 
-        addChargeAndCardDetails(CREATED, "ref-1", now());
-        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now());
-        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2));
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
         ValidatableResponse response = getChargeApi
                 .withAccountId(accountId)
@@ -519,9 +532,9 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     @Test
     public void shouldFilterTransactionsByEmail() throws Exception {
 
-        addChargeAndCardDetails(CREATED, "ref-1", now());
-        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now());
-        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2));
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
         ValidatableResponse response = getChargeApi
                 .withAccountId(accountId)
@@ -535,12 +548,12 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterTransactionsByCardBrand() throws Exception {
+    public void shouldFilterTransactionsByCardBrand() {
         String searchedCardBrand = "visa";
 
-        addChargeAndCardDetails(CREATED, "ref-1", now(), searchedCardBrand);
-        addChargeAndCardDetails(CREATED, "ref-2", now(), "master-card");
-        addChargeAndCardDetails(CREATED, "ref-3", now().minusDays(2), searchedCardBrand);
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now(), searchedCardBrand);
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-2"), now(), "master-card");
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-3"), now().minusDays(2), searchedCardBrand);
 
         getChargeApi
                 .withAccountId(accountId)
@@ -555,9 +568,9 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterTransactionsByBlankCardBrand() throws Exception {
-        addChargeAndCardDetails(CREATED, "ref-1", now(), "visa");
-        addChargeAndCardDetails(CREATED, "ref-2", now(), "master-card");
+    public void shouldFilterTransactionsByBlankCardBrand() {
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now(), "visa");
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-2"), now(), "master-card");
 
         getChargeApi
                 .withAccountId(accountId)
@@ -576,9 +589,9 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String visa = "visa";
         String mastercard = "master-card";
 
-        addChargeAndCardDetails(CREATED, "ref-1", now(), visa);
-        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now().minusHours(1), mastercard);
-        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2), "american-express");
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now(), visa);
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now().minusHours(1), mastercard);
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2), "american-express");
 
         getChargeApi
                 .withQueryParams("card_brand", asList(visa, mastercard))
@@ -592,12 +605,12 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldShowTotalCountResultsAndHalLinksForCharges() throws Exception {
-        addChargeAndCardDetails(CREATED, "ref-1", now());
-        addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now().minusDays(1));
-        addChargeAndCardDetails(CAPTURED, "ref-3", now().minusDays(2));
-        addChargeAndCardDetails(CAPTURED, "ref-4", now().minusDays(3));
-        addChargeAndCardDetails(CAPTURED, "ref-5", now().minusDays(4));
+    public void shouldShowTotalCountResultsAndHalLinksForCharges() {
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now().minusDays(1));
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-4"), now().minusDays(3));
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-5"), now().minusDays(4));
 
         assertNavigationLinksWhenNoResultFound();
         assertResultsWhenPageAndDisplaySizeNotSet();
@@ -632,11 +645,11 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldGetAllTransactionsForDefault_page_1_size_100_inCreationDateOrder() throws Exception {
-        String id_1 = addChargeAndCardDetails(CREATED, "ref-1", now());
-        String id_2 = addChargeAndCardDetails(AUTHORISATION_READY, "ref-2", now().plusHours(1));
-        String id_3 = addChargeAndCardDetails(CREATED, "ref-3", now().plusHours(2));
-        String id_4 = addChargeAndCardDetails(CREATED, "ref-4", now().plusHours(3));
-        String id_5 = addChargeAndCardDetails(CREATED, "ref-5", now().plusHours(4));
+        String id_1 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        String id_2 = addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now().plusHours(1));
+        String id_3 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-3"), now().plusHours(2));
+        String id_4 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-4"), now().plusHours(3));
+        String id_5 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-5"), now().plusHours(4));
 
         ValidatableResponse response = getChargeApi
                 .withAccountId(accountId)
@@ -653,11 +666,11 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldGetTransactionsForPageAndSizeParams_inCreationDateOrder() throws Exception {
-        String id_1 = addChargeAndCardDetails(CREATED, "ref-1", now());
-        String id_2 = addChargeAndCardDetails(CREATED, "ref-2", now().plusHours(1));
-        String id_3 = addChargeAndCardDetails(CREATED, "ref-3", now().plusHours(2));
-        String id_4 = addChargeAndCardDetails(CREATED, "ref-4", now().plusHours(3));
-        String id_5 = addChargeAndCardDetails(CREATED, "ref-5", now().plusHours(4));
+        String id_1 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        String id_2 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-2"), now().plusHours(1));
+        String id_3 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-3"), now().plusHours(2));
+        String id_4 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-4"), now().plusHours(3));
+        String id_5 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-5"), now().plusHours(4));
 
         ValidatableResponse response = getChargeApi
                 .withAccountId(accountId)
@@ -765,7 +778,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     @Test
     public void shouldGetSuccessAndFailedResponseForExpiryChargeTask() {
         //create charge
-        String extChargeId = addChargeAndCardDetails(CREATED, "ref", ZonedDateTime.now().minusMinutes(90));
+        String extChargeId = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
 
         // run expiry task
         getChargeApi
@@ -789,7 +802,8 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldGetSuccessResponseForExpiryChargeTaskFor3dsRequiredPayments() {
-        String extChargeId = addChargeAndCardDetails(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusMinutes(90));
+        String extChargeId = addChargeAndCardDetails(ChargeStatus.AUTHORISATION_3DS_REQUIRED, ServicePaymentReference.of("ref"),
+                ZonedDateTime.now().minusMinutes(90));
 
         getChargeApi
                 .postChargeExpiryTask()
@@ -994,16 +1008,16 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         return dateTimes;
     }
 
-    private String addChargeAndCardDetails(ChargeStatus status, String reference, ZonedDateTime fromDate) {
+    private String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, ZonedDateTime fromDate) {
         return addChargeAndCardDetails(status, reference, fromDate, "");
 
     }
 
-    private String addChargeAndCardDetails(ChargeStatus status, String reference, ZonedDateTime fromDate, String cardBrand) {
+    private String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, ZonedDateTime fromDate, String cardBrand) {
         return addChargeAndCardDetails(nextLong(), status, reference, fromDate, cardBrand);
     }
 
-    private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, String reference, ZonedDateTime fromDate, String cardBrand) {
+    private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, ZonedDateTime fromDate, String cardBrand) {
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null, reference, fromDate, email);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
@@ -99,8 +100,10 @@ public class ChargesFrontendResourceITest {
                 .aMastercardCreditCardType()
                 .insert();
 
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, expectedAmount, AUTHORISATION_SUCCESS, returnUrl, null, "ref", null, email);
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, testCardType.getBrand(), "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, expectedAmount, AUTHORISATION_SUCCESS, returnUrl, null,
+                ServicePaymentReference.of("ref"), null, email);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, testCardType.getBrand(), "1234", "Mr. McPayment",
+                "03/18", "line1", null, "postcode", "city", null, "country");
         validateGetCharge(expectedAmount, externalChargeId, AUTHORISATION_SUCCESS);
     }
 
@@ -109,8 +112,10 @@ public class ChargesFrontendResourceITest {
         String externalChargeId = RandomIdGenerator.newId();
         Long chargeId = 123456L;
 
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, expectedAmount, AUTHORISATION_SUCCESS, returnUrl, null, "ref", null, email);
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "unknown", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, expectedAmount, AUTHORISATION_SUCCESS, returnUrl, null,
+                ServicePaymentReference.of("ref"), null, email);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "unknown", "1234", "Mr. McPayment",
+                "03/18", "line1", null, "postcode", "city", null, "country");
         validateGetCharge(expectedAmount, externalChargeId, AUTHORISATION_SUCCESS);
     }
 
@@ -121,8 +126,10 @@ public class ChargesFrontendResourceITest {
         String issuerUrl = "https://issuer.example.com/3ds";
         String paRequest = "test-pa-request";
 
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, expectedAmount, AUTHORISATION_3DS_REQUIRED, returnUrl, null, "ref", null, email);
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "unknown", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, expectedAmount, AUTHORISATION_3DS_REQUIRED, returnUrl, null,
+                ServicePaymentReference.of("ref"), null, email);
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "unknown", "1234", "Mr. McPayment",
+                "03/18", "line1", null, "postcode", "city", null, "country");
         app.getDatabaseTestHelper().updateCharge3dsDetails(chargeId, issuerUrl, paRequest, null);
 
         connectorRestApi

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchChargesByDateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchChargesByDateResourceITest.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.util.RestAssuredClient;
@@ -211,7 +212,8 @@ public class SearchChargesByDateResourceITest {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = ChargeStatus.CREATED;
-        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, "http://return.com/1", null, "reference", createdDate);
+        app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, "http://return.com/1", null,
+                ServicePaymentReference.of("reference"), createdDate);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
         return externalChargeId;

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.it.resources;
 import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.RestAssuredClient;
@@ -71,9 +72,12 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
 
         String transactionIdCharge1 = "transaction-id-ref-3-que";
         String transactionIdCharge2 = "transaction-id-ref-3";
-        String externalChargeId1 = addChargeAndCardDetails(nextLong(), CREATED, "ref-3-que", transactionIdCharge1, now(), "", returnUrl, email);
-        addChargeAndCardDetails(nextLong(), CAPTURED, "ref-7", "transaction-id-ref-7", now(), "master-card", returnUrl, email);
-        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, "ref-3", transactionIdCharge2, now().minusDays(2), "visa", returnUrl, email);
+        String externalChargeId1 = addChargeAndCardDetails(nextLong(), CREATED, ServicePaymentReference.of("ref-3-que"), transactionIdCharge1, now(),
+                "", returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CAPTURED, ServicePaymentReference.of("ref-7"), "transaction-id-ref-7", now(), "master-card",
+                returnUrl, email);
+        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
+                "visa", returnUrl, email);
 
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
@@ -145,11 +149,13 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
 
         String transactionIdCharge2 = "transaction-id-ref-3";
         String transactionIdCharge1 = "transaction-id-ref-3-que";
-        String referenceCharge1 = "ref-3-que";
-        String referenceCharge2 = "ref-3";
+        ServicePaymentReference referenceCharge1 = ServicePaymentReference.of("ref-3-que");
+        ServicePaymentReference referenceCharge2 = ServicePaymentReference.of("ref-3");
         String externalChargeId1 = addChargeAndCardDetails(nextLong(), CREATED, referenceCharge1, transactionIdCharge1, now(), "", returnUrl, email);
-        addChargeAndCardDetails(nextLong(), CAPTURED, "ref-7", "transaction-id-ref-7", now(), "master-card", returnUrl, email);
-        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa", returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CAPTURED, ServicePaymentReference.of("ref-7"), "transaction-id-ref-7", now(), "master-card",
+                returnUrl, email);
+        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa",
+                returnUrl, email);
 
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
@@ -172,11 +178,11 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("results[0].transaction_type", is("charge"))
                 .body("results[0].gateway_transaction_id", is(transactionIdCharge1))
                 .body("results[0].charge_id", is(externalChargeId1))
-                .body("results[0].reference", is(referenceCharge1))
+                .body("results[0].reference", is(referenceCharge1.toString()))
                 .body("results[1].transaction_type", is("charge"))
                 .body("results[1].gateway_transaction_id", is(transactionIdCharge2))
                 .body("results[1].charge_id", is(externalChargeId2))
-                .body("results[1].reference", is(referenceCharge2));
+                .body("results[1].reference", is(referenceCharge2.toString()));
     }
 
     @Test
@@ -187,9 +193,12 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         long chargeId2 = nextLong();
 
         String transactionIdCharge2 = "transaction-id-ref-3";
-        addChargeAndCardDetails(nextLong(), CREATED, "ref-3-que", "transaction-id-ref-3-que", now(), "", returnUrl, email);
-        addChargeAndCardDetails(nextLong(), CAPTURED, "ref-7", "transaction-id-ref-7", now(), "master-card", returnUrl, email);
-        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, "ref-3", transactionIdCharge2, now().minusDays(2), "visa", returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CREATED, ServicePaymentReference.of("ref-3-que"), "transaction-id-ref-3-que", now(),
+                "", returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CAPTURED, ServicePaymentReference.of("ref-7"), "transaction-id-ref-7", now(),
+                "master-card", returnUrl, email);
+        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
+                "visa", returnUrl, email);
 
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
@@ -213,7 +222,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("results[0].gateway_transaction_id", is(transactionIdCharge2))
                 .body("results[0].charge_id", is(externalChargeId2));
     }
-    private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, String reference, String transactionId, ZonedDateTime fromDate, String cardBrand, String returnUrl, String email) {
+    private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, String transactionId, ZonedDateTime fromDate,
+                                           String cardBrand, String returnUrl, String email) {
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, transactionId, reference, fromDate, email);
@@ -222,7 +232,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         lastDigitsCardNumber = "1234";
         cardHolderName = "Mr. McPayment";
         expiryDate = "03/18";
-        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, cardBrand, lastDigitsCardNumber, cardHolderName, expiryDate, "line1", null, "postcode", "city", null, "country");
+        app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, cardBrand, lastDigitsCardNumber, cardHolderName, expiryDate, "line1", null,
+                "postcode", "city", null, "country");
         return externalChargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.it.resources;
 import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.RestAssuredClient;
@@ -76,9 +77,12 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
 
         String transactionIdCharge1 = "transaction-id-ref-3-que";
         String transactionIdCharge2 = "transaction-id-ref-3";
-        String externalChargeId1 = addChargeAndCardDetails(nextLong(), EXPIRED, "ref-3-que", transactionIdCharge1, now(), "", returnUrl, email);
-        addChargeAndCardDetails(nextLong(), CAPTURED, "ref-7", "transaction-id-ref-7", now(), "master-card", returnUrl, email);
-        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, "ref-3", transactionIdCharge2, now().minusDays(2), "visa", returnUrl, email);
+        String externalChargeId1 = addChargeAndCardDetails(nextLong(), EXPIRED, ServicePaymentReference.of("ref-3-que"), transactionIdCharge1, now(),
+                "", returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CAPTURED, ServicePaymentReference.of("ref-7"), "transaction-id-ref-7", now(),
+                "master-card", returnUrl, email);
+        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
+                "visa", returnUrl, email);
 
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
@@ -149,11 +153,13 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
 
         String transactionIdCharge2 = "transaction-id-ref-3";
         String transactionIdCharge1 = "transaction-id-ref-3-que";
-        String referenceCharge1 = "ref-3-que";
-        String referenceCharge2 = "ref-3";
+        ServicePaymentReference referenceCharge1 = ServicePaymentReference.of("ref-3-que");
+        ServicePaymentReference referenceCharge2 = ServicePaymentReference.of("ref-3");
         String externalChargeId1 = addChargeAndCardDetails(nextLong(), CREATED, referenceCharge1, transactionIdCharge1, now(), "", returnUrl, email);
-        addChargeAndCardDetails(nextLong(), CAPTURED, "ref-7", "transaction-id-ref-7", now(), "master-card", returnUrl, email);
-        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa", returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CAPTURED, ServicePaymentReference.of("ref-7"), "transaction-id-ref-7", now(), "master-card",
+                returnUrl, email);
+        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa",
+                returnUrl, email);
 
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
@@ -175,11 +181,11 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
                 .body("results[0].transaction_type", is("charge"))
                 .body("results[0].gateway_transaction_id", is(transactionIdCharge1))
                 .body("results[0].charge_id", is(externalChargeId1))
-                .body("results[0].reference", is(referenceCharge1))
+                .body("results[0].reference", is(referenceCharge1.toString()))
                 .body("results[1].transaction_type", is("charge"))
                 .body("results[1].gateway_transaction_id", is(transactionIdCharge2))
                 .body("results[1].charge_id", is(externalChargeId2))
-                .body("results[1].reference", is(referenceCharge2));
+                .body("results[1].reference", is(referenceCharge2.toString()));
     }
 
     @Test
@@ -190,9 +196,12 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
         long chargeId2 = nextLong();
 
         String transactionIdCharge2 = "transaction-id-ref-3";
-        addChargeAndCardDetails(nextLong(), CREATED, "ref-3-que", "transaction-id-ref-3-que", now(), "", returnUrl, email);
-        addChargeAndCardDetails(nextLong(), CAPTURED, "ref-7", "transaction-id-ref-7", now(), "master-card", returnUrl, email);
-        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, "ref-3", transactionIdCharge2, now().minusDays(2), "visa", returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CREATED, ServicePaymentReference.of("ref-3-que"), "transaction-id-ref-3-que", now(), "",
+                returnUrl, email);
+        addChargeAndCardDetails(nextLong(), CAPTURED, ServicePaymentReference.of("ref-7"), "transaction-id-ref-7", now(), "master-card",
+                returnUrl, email);
+        String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
+                "visa", returnUrl, email);
 
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
@@ -216,7 +225,8 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
                 .body("results[0].charge_id", is(externalChargeId2));
     }
 
-    private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, String reference, String transactionId, ZonedDateTime fromDate, String cardBrand, String returnUrl, String email) {
+    private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, String transactionId, ZonedDateTime fromDate,
+                                           String cardBrand, String returnUrl, String email) {
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, transactionId, reference, fromDate, email);

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
 import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.ZoneId;
@@ -19,7 +20,7 @@ public class ChargeEntityFixture {
     private String returnUrl = "http://return.com";
     private String email = "test@email.com";
     private String description = "This is a description";
-    private String reference = "This is a reference";
+    private ServicePaymentReference reference = ServicePaymentReference.of("This is a reference");
     private ChargeStatus status = ChargeStatus.CREATED;
     private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private String transactionId;
@@ -87,7 +88,7 @@ public class ChargeEntityFixture {
         return this;
     }
 
-    public ChargeEntityFixture withReference(String reference) {
+    public ChargeEntityFixture withReference(ServicePaymentReference reference) {
         this.reference = reference;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/PaymentRequestEntityFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.model.domain;
 
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.transaction.TransactionEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
@@ -19,7 +20,7 @@ public class PaymentRequestEntityFixture {
     private Long amount = 500L;
     private String returnUrl = "http://return.com";
     private String description = "This is a description";
-    private String reference = RandomIdGenerator.newId();
+    private ServicePaymentReference reference = ServicePaymentReference.of(RandomIdGenerator.newId());
     private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
     private List<TransactionEntity> transactions = asList(aChargeTransactionEntity().build());
@@ -57,7 +58,7 @@ public class PaymentRequestEntityFixture {
         return this;
     }
 
-    public PaymentRequestEntityFixture withReference(String reference) {
+    public PaymentRequestEntityFixture withReference(ServicePaymentReference reference) {
         this.reference = reference;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -11,6 +11,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import uk.gov.pay.commons.testing.pact.providers.PayPactRunner;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
@@ -52,8 +53,10 @@ public class TransactionsApiContractTest {
     private void setUpCharges(int numberOfCharges, String accountID, ZonedDateTime createdDate){
         for (int i = 0; i < numberOfCharges; i++) {
             Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
-            dbHelper.addCharge(chargeId, Long.toString(chargeId), accountID, 100L, ChargeStatus.CREATED,"aReturnUrl","aTransactionId", "aReference", createdDate, "test@test.com@");
-            dbHelper.updateChargeCardDetails(chargeId, "visa", "0001", "aName", "08/23", "aFirstAddress", "aSecondLine", "aPostCode", "aCity", "aCounty", "aCountry");
+            dbHelper.addCharge(chargeId, Long.toString(chargeId), accountID, 100L, ChargeStatus.CREATED,"aReturnUrl",
+                    "aTransactionId", ServicePaymentReference.of("aReference"), createdDate, "test@test.com@");
+            dbHelper.updateChargeCardDetails(chargeId, "visa", "0001", "aName", "08/23",
+                    "aFirstAddress", "aSecondLine", "aPostCode", "aCity", "aCounty", "aCountry");
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.dao.GatewayAccountDao;
 import uk.gov.pay.connector.dao.PaymentRequestDao;
 import uk.gov.pay.connector.dao.TokenDao;
 import uk.gov.pay.connector.model.ChargeResponse;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
@@ -154,7 +155,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getExternalId(), is(EXTERNAL_CHARGE_ID[0]));
         assertThat(createdChargeEntity.getGatewayAccount().getCredentials(), is(emptyMap()));
         assertThat(createdChargeEntity.getGatewayAccount().getGatewayName(), is("sandbox"));
-        assertThat(createdChargeEntity.getReference(), is("Pay reference"));
+        assertThat(createdChargeEntity.getReference(), is(ServicePaymentReference.of("Pay reference")));
         assertThat(createdChargeEntity.getDescription(), is("This is a description"));
         assertThat(createdChargeEntity.getAmount(), is(100L));
         assertThat(createdChargeEntity.getGatewayTransactionId(), is(nullValue()));
@@ -175,7 +176,7 @@ public class ChargeServiceTest {
         assertThat(createdPaymentRequestEntity.getExternalId(), is(EXTERNAL_CHARGE_ID[0]));
         assertThat(createdPaymentRequestEntity.getGatewayAccount().getCredentials(), is(emptyMap()));
         assertThat(createdPaymentRequestEntity.getGatewayAccount().getGatewayName(), is("sandbox"));
-        assertThat(createdPaymentRequestEntity.getReference(), is("Pay reference"));
+        assertThat(createdPaymentRequestEntity.getReference(), is(ServicePaymentReference.of("Pay reference")));
         assertThat(createdPaymentRequestEntity.getDescription(), is("This is a description"));
         assertThat(createdPaymentRequestEntity.getAmount(), is(100L));
         assertThat(createdPaymentRequestEntity.getReturnUrl(), is("http://return-service.com"));

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.postgresql.util.PGobject;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.StringColumnMapper;
+import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.AuthCardDetails;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
@@ -58,24 +59,33 @@ public class DatabaseTestHelper {
         addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId);
     }
 
-    public void addCharge(Long chargeId, String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl, String transactionId) {
-        addCharge(chargeId, externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId, "Test description", "Test reference", now(), 1, "email@fake.com");
+    public void addCharge(Long chargeId, String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl,
+                          String transactionId) {
+        addCharge(chargeId, externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId, "Test description",
+                ServicePaymentReference.of("Test reference"), now(), 1, "email@fake.com");
     }
 
     public void addCharge(String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl, String transactionId) {
-        addCharge((long) RandomUtils.nextInt(1, 9999999), externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId, "Test description", "Test reference", now(), 1, null);
+        addCharge((long) RandomUtils.nextInt(1, 9999999), externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId,
+                "Test description", ServicePaymentReference.of("Test reference"), now(), 1, null);
     }
 
-    public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl, String transactionId, String reference, ZonedDateTime createdDate) {
-        addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, "Test description", reference, createdDate == null ? now() : createdDate, 1, null);
+    public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
+                          String transactionId, ServicePaymentReference reference, ZonedDateTime createdDate) {
+        addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, "Test description", reference,
+                createdDate == null ? now() : createdDate, 1, null);
     }
 
-    public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl, String transactionId, String reference, ZonedDateTime createdDate, String email) {
-        addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, "Test description", reference, createdDate == null ? now() : createdDate, 1, email);
+    public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
+                          String transactionId, ServicePaymentReference reference, ZonedDateTime createdDate, String email) {
+        addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, "Test description", reference,
+                createdDate == null ? now() : createdDate, 1, email);
     }
 
-    public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl, String transactionId, String reference, String description, ZonedDateTime createdDate, String email) {
-        addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, description, reference, createdDate == null ? now() : createdDate, 1, email);
+    public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
+                          String transactionId, ServicePaymentReference reference, String description, ZonedDateTime createdDate, String email) {
+        addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, description, reference,
+                createdDate == null ? now() : createdDate, 1, email);
     }
 
     private void addCharge(
@@ -87,7 +97,7 @@ public class DatabaseTestHelper {
             String returnUrl,
             String transactionId,
             String description,
-            String reference,
+            ServicePaymentReference reference,
             ZonedDateTime createdDate,
             long version,
             String email
@@ -119,7 +129,7 @@ public class DatabaseTestHelper {
                         transactionId,
                         description,
                         Timestamp.from(createdDate.toInstant()),
-                        reference,
+                        reference.toString(),
                         version,
                         email
                 )
@@ -540,7 +550,7 @@ public class DatabaseTestHelper {
                                   long gatewaysAccountId,
                                   String returnUrl,
                                   String description,
-                                  String reference,
+                                  ServicePaymentReference reference,
                                   ZonedDateTime createdDate,
                                   String externalId
     ) {
@@ -564,7 +574,7 @@ public class DatabaseTestHelper {
                         gatewaysAccountId,
                         returnUrl,
                         description,
-                        reference,
+                        reference.toString(),
                         Timestamp.from(createdDate.toInstant()),
                         externalId
                 )


### PR DESCRIPTION
The new `ServicePaymentReference` is a simple immutable object that wraps a `String` containing the `reference` specified by a service when they create a payment.

Replace uses of `String`s to represent the service payment reference with the new `ServicePaymentReference` type to improve type-safety and aid comprehension.

Introduce a `ServicePaymentReferenceConverter` to convert between the new `ServicePaymentReference` type and Strings (and vice-versa) when persisting/depersisting from the database.

Use Jackson’s `ToStringSerializer` to convert between the new `ServicePaymentReference` type and Strings when serialising JSON.