### PR TITLE
PP-3928: Account list endpoint filter

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/GatewayAccountDao.java
@@ -25,7 +25,7 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
 
     @Override
     public void persist(final GatewayAccountEntity account) {
-        entityManager.get().persist(account);                                                                                                                                                                                                                                                                                                                                                                                                           
+        entityManager.get().persist(account);
         account.setEmailNotification(new EmailNotificationEntity(account));
     }
 
@@ -38,6 +38,20 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
                 .createQuery(query, GatewayAccountEntity.class)
                 .setParameter("username", username)
                 .getResultList().stream().findFirst();
+    }
+
+    public List<GatewayAccountResourceDTO> list(List<Long> accountIds) {
+        String query = "SELECT NEW uk.gov.pay.connector.model.domain.GatewayAccountResourceDTO"
+                       + " (gae.id, gae.gatewayName, gae.type, gae.description, gae.serviceName, gae.analyticsId)"
+                       + " FROM GatewayAccountEntity gae"
+                       + " WHERE gae.id IN :accountIds"
+                       + " ORDER BY gae.id";
+
+        return entityManager
+                .get()
+                .createQuery(query, GatewayAccountResourceDTO.class)
+                .setParameter("accountIds", accountIds)
+                .getResultList();
     }
 
     public List<GatewayAccountResourceDTO> listAll() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoITest.java
@@ -282,6 +282,98 @@ public class GatewayAccountDaoITest extends DaoITestBase {
     }
 
     @Test
+    public void shouldListASubsetOfAccountsSingle() throws Exception {
+        databaseTestHelper.addGatewayAccount(
+          "123",
+          "provider-1",
+          ImmutableMap.of(
+            "user", "fuser",
+            "password", "word"
+          ),
+          "service-name-1",
+          TEST,
+          "description-1",
+          "analytics-id-1"
+        );
+
+        databaseTestHelper.addGatewayAccount(
+          "456",
+          "provider-2",
+          null,
+          "service-name-2",
+          TEST,
+          "description-2",
+          "analytics-id-2"
+        );
+
+        List<Long> accountIds = Arrays.asList(456L);
+        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountDao.list(accountIds);
+
+        assertEquals(1, gatewayAccounts.size());
+        assertThat(gatewayAccounts.get(0).getAccountId(), is(456L));
+        assertEquals("provider-2", gatewayAccounts.get(0).getPaymentProvider());
+        assertEquals("description-2", gatewayAccounts.get(0).getDescription());
+        assertEquals("service-name-2", gatewayAccounts.get(0).getServiceName());
+        assertEquals(TEST.toString(), gatewayAccounts.get(0).getType());
+        assertEquals("analytics-id-2", gatewayAccounts.get(0).getAnalyticsId());
+    }
+
+    @Test
+    public void shouldListASubsetOfAccountsMultiple() throws Exception {
+        databaseTestHelper.addGatewayAccount(
+          "123",
+          "provider-1",
+          ImmutableMap.of(
+            "user", "fuser",
+            "password", "word"
+          ),
+          "service-name-1",
+          TEST,
+          "description-1",
+          "analytics-id-1"
+        );
+
+        databaseTestHelper.addGatewayAccount(
+          "456",
+          "provider-2",
+          null,
+          "service-name-2",
+          TEST,
+          "description-2",
+          "analytics-id-2"
+        );
+
+        databaseTestHelper.addGatewayAccount(
+          "789",
+          "provider-3",
+          null,
+          "service-name-3",
+          TEST,
+          "description-3",
+          "analytics-id-3"
+        );
+
+        List<Long> accountIds = Arrays.asList(456L, 789L);
+        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountDao.list(accountIds);
+
+        assertEquals(2, gatewayAccounts.size());
+
+        assertThat(gatewayAccounts.get(0).getAccountId(), is(456L));
+        assertEquals("provider-2", gatewayAccounts.get(0).getPaymentProvider());
+        assertEquals("description-2", gatewayAccounts.get(0).getDescription());
+        assertEquals("service-name-2", gatewayAccounts.get(0).getServiceName());
+        assertEquals(TEST.toString(), gatewayAccounts.get(0).getType());
+        assertEquals("analytics-id-2", gatewayAccounts.get(0).getAnalyticsId());
+
+        assertThat(gatewayAccounts.get(1).getAccountId(), is(789L));
+        assertEquals("provider-3", gatewayAccounts.get(1).getPaymentProvider());
+        assertEquals("description-3", gatewayAccounts.get(1).getDescription());
+        assertEquals("service-name-3", gatewayAccounts.get(1).getServiceName());
+        assertEquals(TEST.toString(), gatewayAccounts.get(1).getType());
+        assertEquals("analytics-id-3", gatewayAccounts.get(1).getAnalyticsId());
+    }
+
+    @Test
     public void shouldSaveNotifySettings() throws Exception {
         Long accountId = Long.valueOf("12345678");
         String fuser = "fuser";

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -121,7 +121,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("refund_summary.status", is("pending"))
                 .body("settlement_summary.capture_submit_time", nullValue())
                 .body("settlement_summary.captured_time", nullValue())
-                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("created_date", isWithin(10, SECONDS))
                 .contentType(JSON);
 
@@ -195,7 +195,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
 
         getCharge(chargeId)
-                .body("settlement_summary.capture_submit_time", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("settlement_summary.capture_submit_time", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("settlement_summary.capture_submit_time", isWithin(10, SECONDS))
                 .body("settlement_summary.captured_date", equalTo(expectedDayOfCapture))
         ;
@@ -225,7 +225,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body(JSON_RETURN_URL_KEY, is(returnUrl))
                 .body("containsKey('card_details')", is(false))
                 .body("containsKey('gateway_account')", is(false))
-                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("created_date", isWithin(10, SECONDS))
                 .contentType(JSON);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -429,7 +429,7 @@ public class ChargesFrontendResourceITest {
                 .body("return_url", is(returnUrl))
                 .body("email", is(email))
                 .body("created_date", is(notNullValue()))
-                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{1,3}.\\d{0,3}Z"))
                 .body("created_date", isWithin(10, SECONDS));
         validateGatewayAccount(response);
         validateCardDetails(response, chargeStatus);

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
@@ -118,7 +118,7 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("results[0].card_details.cardholder_name", is(cardHolderName))
                 .body("results[0].card_details.expiry_date", is(expiryDate))
                 .body("results[0].card_details.last_digits_card_number", is(lastDigitsCardNumber))
-                .body("results[0].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("results[0].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("results[0].created_date", isWithin(3, HOURS)) // The refund CREATED is the most recent
 
                 .body("results[1].transaction_type", is("refund"))
@@ -136,7 +136,7 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("results[1].card_details.cardholder_name", is(cardHolderName))
                 .body("results[1].card_details.expiry_date", is(expiryDate))
                 .body("results[1].card_details.last_digits_card_number", is(lastDigitsCardNumber))
-                .body("results[1].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("results[1].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("results[1].created_date", isWithin(3, HOURS)); // The refund CREATED is the most recent
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiV2ResourceITest.java
@@ -122,7 +122,7 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
                 .body("results[0].card_details.cardholder_name", is(cardHolderName))
                 .body("results[0].card_details.expiry_date", is(expiryDate))
                 .body("results[0].card_details.last_digits_card_number", is(lastDigitsCardNumber))
-                .body("results[0].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("results[0].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("results[0].created_date", isWithin(3, HOURS)) // The refund CREATED is the most recent
 
                 .body("results[1].transaction_type", is("refund"))
@@ -140,7 +140,7 @@ public class TransactionsApiV2ResourceITest extends ChargingITestBase {
                 .body("results[1].card_details.cardholder_name", is(cardHolderName))
                 .body("results[1].card_details.expiry_date", is(expiryDate))
                 .body("results[1].card_details.last_digits_card_number", is(lastDigitsCardNumber))
-                .body("results[1].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("results[1].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("results[1].created_date", isWithin(3, HOURS)); // The refund CREATED is the most recent
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
@@ -265,7 +265,7 @@ public class SandboxRefundITest extends ChargingITestBase {
                 .body("refund_id", is(notNullValue()))
                 .body("amount", is(refundAmount.intValue()))
                 .body("status", is("success"))
-                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z"))
+                .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("created_date", isWithin(10, SECONDS));
 
         String paymentUrl = format("https://localhost:%s/v1/api/accounts/%s/charges/%s",


### PR DESCRIPTION
@tlwr @brid

We return all gateway accounts from the `/v1/api/accounts` endpoint, but this PR adds the `accountIds` argument which will only retrieve those from the database.

This also adds the `/v1/frontend/accounts` endpoint, which is the same as the `api` one. This is so it can be consumed in selfservice to speed up the loading of the services page.

The same work should be replicated in dd-connector