### PR TITLE
PP-3493 Add user_external_id to RefundSummary

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/OldTransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/OldTransactionDao.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jooq.impl.DSL.count;
 import static org.jooq.impl.DSL.field;
+import static org.jooq.impl.DSL.inline;
 import static org.jooq.impl.DSL.selectDistinct;
 import static org.jooq.impl.DSL.table;
 
@@ -59,6 +60,7 @@ public class OldTransactionDao {
                         field("cardholder_name"),
                         field("expiry_date"),
                         field("last_digits_card_number"),
+                        field("user_external_id"),
                         field("address_city"),
                         field("address_country"),
                         field("address_county"),
@@ -168,6 +170,7 @@ public class OldTransactionDao {
                 field("c.status"),
                 field("c.email"),
                 field("c.gateway_account_id"),
+                inline((String) null).as("user_external_id"),
                 field("c.gateway_transaction_id"),
                 field("c.created_date").as("date_created"),
                 field("c.card_brand"),
@@ -194,6 +197,7 @@ public class OldTransactionDao {
                 field("r.status"),
                 field("c.email"),
                 field("c.gateway_account_id"),
+                field("r.user_external_id").as("user_external_id"),
                 field("c.gateway_transaction_id"),
                 field("r.created_date").as("date_created"),
                 field("c.card_brand"),

--- a/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
@@ -28,6 +28,8 @@ public class ChargeResponse {
 
         @JsonProperty("status")
         private String status;
+        @JsonProperty("user_external_id")
+        private String userExternalId;
         @JsonProperty("amount_available")
         private Long amountAvailable;
         @JsonProperty("amount_submitted")
@@ -45,6 +47,14 @@ public class ChargeResponse {
             this.amountSubmitted = amountSubmitted;
         }
 
+        public String getUserExternalId() {
+            return userExternalId;
+        }
+
+        public void setUserExternalId(String userExternalId) {
+            this.userExternalId = userExternalId;
+        }
+
         public Long getAmountAvailable() {
             return amountAvailable;
         }
@@ -59,21 +69,36 @@ public class ChargeResponse {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
 
             RefundSummary that = (RefundSummary) o;
 
-            if (!status.equals(that.status)) return false;
-            if (!amountAvailable.equals(that.amountAvailable)) return false;
-            return amountSubmitted.equals(that.amountSubmitted);
+            if (!status.equals(that.status)) {
+                return false;
+            }
+            if (userExternalId != null ? !userExternalId.equals(that.userExternalId)
+                    : that.userExternalId != null) {
+                return false;
+            }
+            if (amountAvailable != null ? !amountAvailable.equals(that.amountAvailable)
+                    : that.amountAvailable != null) {
+                return false;
+            }
+            return amountSubmitted != null ? amountSubmitted.equals(that.amountSubmitted)
+                    : that.amountSubmitted == null;
         }
 
         @Override
         public int hashCode() {
             int result = status.hashCode();
-            result = 31 * result + amountAvailable.hashCode();
-            result = 31 * result + amountSubmitted.hashCode();
+            result = 31 * result + (userExternalId != null ? userExternalId.hashCode() : 0);
+            result = 31 * result + (amountAvailable != null ? amountAvailable.hashCode() : 0);
+            result = 31 * result + (amountSubmitted != null ? amountSubmitted.hashCode() : 0);
             return result;
         }
 
@@ -81,6 +106,7 @@ public class ChargeResponse {
         public String toString() {
             return "RefundSummary{" +
                     "status='" + status + '\'' +
+                    "userExternalId='" + userExternalId + '\'' +
                     ", amountAvailable=" + amountAvailable +
                     ", amountSubmitted=" + amountSubmitted +
                     '}';

--- a/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
@@ -31,6 +31,7 @@ import java.time.ZonedDateTime;
                         @ColumnResult(name = "cardholder_name", type = String.class),
                         @ColumnResult(name = "expiry_date", type = String.class),
                         @ColumnResult(name = "last_digits_card_number", type = String.class),
+                        @ColumnResult(name = "user_external_id", type = String.class),
                         @ColumnResult(name = "address_city", type = String.class),
                         @ColumnResult(name = "address_country", type = String.class),
                         @ColumnResult(name = "address_county", type = String.class),
@@ -60,6 +61,7 @@ public class Transaction {
     private String cardHolderName;
     private String expiryDate;
     private String lastDigitsCardNumber;
+    private String userExternalId;
     private String addressCity;
     private String addressCountry;
     private String addressCounty;
@@ -86,6 +88,7 @@ public class Transaction {
                        String cardHolderName,
                        String expiryDate,
                        String lastDigitsCardNumber,
+                       String userExternalId,
                        String addressCity,
                        String addressCountry,
                        String addressCounty,
@@ -104,6 +107,7 @@ public class Transaction {
         this.createdDate = new UTCDateTimeConverter().convertToEntityAttribute(createdDate);
         this.transactionType = transactionType;
         this.cardBrand = cardBrand;
+        this.userExternalId = userExternalId;
         this.cardBrandLabel = cardBrandLabel;
         this.cardHolderName = cardHolderName;
         this.expiryDate = expiryDate;
@@ -203,5 +207,9 @@ public class Transaction {
 
     public long getAmount() {
         return amount;
+    }
+
+    public String getUserExternalId() {
+        return userExternalId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/transaction/TransactionEntity.java
@@ -52,6 +52,9 @@ public abstract class TransactionEntity<S extends Status, T extends TransactionE
     // This just needs to be set when we save the transaction. It is then used to optimise
     // transaction search don't access in Java code.
     private Long gatewayAccountId;
+    @Column(name = "user_external_id")
+    // This is the user external id of whoever issued a refund.
+    private String userExternalId;
 
     TransactionEntity(TransactionOperation operation) {
         this.operation = operation;


### PR DESCRIPTION
## WHAT
 - We need to display the issuer of a refund in the transaction list (csv file) in selfservice
   This specific section of code in connector is in a bit of a flux; this is probably not the
   nicest way to get the job done, but it will be reworked pretty soon (tm).


