### PR TITLE
PP-4041 only skip a charge on ConflictRuntimeException

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
@@ -6,11 +6,13 @@ import com.google.common.base.Stopwatch;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.inject.Inject;
 import java.util.Collections;
@@ -18,6 +20,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
+import static uk.gov.pay.connector.filters.LoggingFilter.HEADER_REQUEST_ID;
 
 public class CardCaptureProcess {
 
@@ -40,6 +43,8 @@ public class CardCaptureProcess {
     }
 
     public void runCapture() {
+        MDC.put(HEADER_REQUEST_ID, format("runCapture-%s", RandomIdGenerator.newId()));
+
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
         long captured = 0, skipped = 0, error = 0, total = 0;
 
@@ -78,6 +83,7 @@ public class CardCaptureProcess {
             metricRegistry.histogram("gateway-operations.capture-process.running_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
             logger.info(format("Capture complete [captured=%d] [skipped=%d] [capture_error=%d] [total=%d]", captured, skipped, error, queueSize));
         }
+        MDC.remove(HEADER_REQUEST_ID);
     }
 
     private boolean shouldRetry(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardCaptureProcess.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.dao.ChargeDao;
+import uk.gov.pay.connector.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 
 import javax.inject.Inject;
@@ -54,8 +55,8 @@ public class CardCaptureProcess {
                 if (shouldRetry(charge)) {
                     try {
                         captureService.doCapture(charge.getExternalId());
-                    } catch (Exception e) {
-                        logger.error("Exception when running capture for [" + charge.getExternalId() + "]", e);
+                    } catch (ConflictRuntimeException e) {
+                        logger.info("Another process has already attempted to capture [chargeId=" + charge.getExternalId() + "]. Skipping.");
                     }
                 } else {
                     captureService.markChargeAsCaptureError(charge.getExternalId());


### PR DESCRIPTION
`ConflictRuntimeException` indicates that another process has tried to
modify the same charge. Any other exception is unexpected and should be
logged as an error and the batch aborted.

Also improved the logging output of the process.

## How to review/test

I haven't written a unit test for the exception handling behaviour, the implementation seems simple enough to not warrant it, but I'm open to feedback on this point.

I manually tested the log output generated by modifying the `src/test/resources/logback.xml` to:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<configuration>

	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
		<layout class="ch.qos.logback.classic.PatternLayout">
			<Pattern>
				"[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
			</Pattern>
		</layout>
	</appender>

	<root level="debug">
		<appender-ref ref="STDOUT" />
	</root>

</configuration>
```

and then running `CardCaptureProcessTest`. 