### PR TITLE
BAU: remove colourised log output from default log config

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -14,7 +14,7 @@ logging:
         threshold: ALL
         timeZone: UTC
         target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id}] - %msg%n"
 
 links:
   frontendUrl: ${FRONTEND_URL}


### PR DESCRIPTION
The colourised output is not handled well by our log aggregation tool.
This results in log lines containing ANSI terminal escape codes (`#033`
etc) like this:

```
2018-07-21T13:26:42+00:00 ip6-localhost ecs-production-2_connector-24-connector-bcbef7bdc9ad80e35900[7501]:
[2018-07-21 13:26:42.822] [dw-57511] #033[34mINFO #033[0;39m #033[36mu.g.p.c.f.LoggingFilter#033[0;39m
[requestID=7cf7a88b-b9f0-470b-c7c0-fc451c47eb49] ...
```

These are not easy to view or read. They're also not easy to search for
because `34mINFO` is treated as a word by the log aggregation tool.

This changes the log configuration to produce a line like:

```
[2018-07-21 14:17:24.805] [thread=main] [level=INFO ] [logger=u.g.p.c.s.CardCaptureProcess] [requestID=runCapture-q7hvk26l5831p1hkerru3ncf6b] - <message>
```

the `[thread=x]` syntax can be used with [`keyvalue`](https://help.sumologic.com/Search/Search-Query-Language/01-Parse-Operators/04-Parse-Keyvalue-Formatted-Logs) operator