### PR TITLE
PP-4054: Add index for gateway_transaction_id to charges

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1328,4 +1328,17 @@
             columnName="password"
             newDataType="varchar(255)"/>
     </changeSet>
+
+    <changeSet id="add index to charges.gateway_transaction_id" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_charges_gateway_transaction_id ON charges (gateway_transaction_id);
+        </sql>
+    </changeSet>
+
+    <changeSet id="add index to tokens.secure_redirect_token" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_tokens_secure_redirect_token ON tokens (secure_redirect_token);
+        </sql>
+    </changeSet>
+    
 </databaseChangeLog>


### PR DESCRIPTION
We currently look it up when we get notifications. This is
consuming a fair amount of compute time on our db.

We don't have an index. So add one.

https://github.com/alphagov/pay-connector/blob/4096a80aeae533dcd59f75aaf9bda28a807a401c/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java

Also add an index for looking up tokens by the secure_redirect_token. We do that a lot.



