### PR TITLE
PP-4054: Adding GIN index to reference and emails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
         script {
           def long stepBuildTime = System.currentTimeMillis()
 
-          sh 'docker pull govukpay/postgres:9.4.4'
+          sh 'docker pull govukpay/postgres:9.6.6'
           sh 'mvn clean package'
 
           postSuccessfulMetrics("connector.maven-build", stepBuildTime)
@@ -50,7 +50,7 @@ pipeline {
         branch 'master'
       }
       steps {
-        sh 'docker pull govukpay/postgres:9.4.4'
+        sh 'docker pull govukpay/postgres:9.6.6'
         sh 'mvn -Dmaven.test.skip=true clean package'
       }
     }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1340,5 +1340,18 @@
             CREATE INDEX CONCURRENTLY idx_tokens_secure_redirect_token ON tokens (secure_redirect_token);
         </sql>
     </changeSet>
-    
+
+    <changeSet id="add trigram index to charges.reference" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_charges_references_gin_idx  ON charges USING GIN (reference gin_trgm_ops);
+        </sql>
+    </changeSet>
+
+
+    <changeSet id="add trigram index to charges.email" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_charges_email_gin_idx ON charges USING GIN (email gin_trgm_ops);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/connector/util/PostgresContainer.java
+++ b/src/test/java/uk/gov/pay/connector/util/PostgresContainer.java
@@ -31,7 +31,7 @@ public class PostgresContainer {
     private static final String DB_PASSWORD = "mysecretpassword";
     private static final String DB_USERNAME = "postgres";
     private static final int DB_TIMEOUT_SEC = 15;
-    private static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.4.4";
+    private static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.6.6";
     private static final String INTERNAL_PORT = "5432";
 
     public PostgresContainer(DockerClient docker, String host) throws DockerException, InterruptedException, IOException, ClassNotFoundException {


### PR DESCRIPTION
We were still getting a connector CPU usage spike every hour. It looked like people
were doing queries of the type

```18.30.213 - [25/Jul/2018:11:05:04 +0000] \"GET /v1/payments?reference=EVW-XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX&state=success HTTP/1.1\" 200 1780 0.978 https \"\" \"curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.27.1 zlib/1.2.3 libidn/1.18 libssh2/1.4.2\"}" ```

While we have an index on reference, we do `like` queries on references (because we are using the same api for user queries)
so this is unoptimized.

Try adding a GIN index on reference (and email for good measure) so that these become quicker.

Information about GIN indexes here

https://www.postgresql.org/docs/9.6/static/textsearch-indexes.html



