### PR TITLE
PP-4054: Adding index to refunds on status

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1360,4 +1360,15 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add index to status column on refunds table" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_refunds_status ON refunds (status);
+        </sql>
+    </changeSet>
+
+    <changeSet id="Drop trigram index to refunds.reference" runInTransaction="false" author="">
+        <sql>
+            DROP INDEX idx_refunds_reference_gin_idx;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
The requests to get transactions for a certain payment and status
are still taking a long time. I noticed there was no index on status for
refunds.

This shows up as a sequence scan.
```
connector=> explain analyze select * from charges as c join  refunds as r on r.charge_id = c.id where r.status='success' and c.reference like '%asasa%';
                                                 QUERY PLAN
------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.42..21.70 rows=1 width=1263) (actual time=0.002..0.002 rows=0 loops=1)
   ->  Seq Scan on refunds r  (cost=0.00..13.25 rows=1 width=280) (actual time=0.002..0.002 rows=0 loops=1)
         Filter: ((status)::text = 'success'::text)
   ->  Index Scan using pk_charges on charges c  (cost=0.42..8.44 rows=1 width=983) (never executed)
         Index Cond: (id = r.charge_id)
         Filter: ((reference)::text ~~ '%asasa%'::text)
 Planning time: 0.272 ms
 Execution time: 0.038 ms
(8 rows)
```

Adding an index reduces the variance.
```
connector=>             CREATE INDEX CONCURRENTLY idx_refunds_status ON refunds (status);
CREATE INDEX
connector=> explain analyze select * from charges as c join  refunds as r on r.charge_id = c.id where c.reference like '%asasa%' AND r.status='success';
                                                              QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.57..16.62 rows=1 width=1263) (actual time=0.002..0.002 rows=0 loops=1)
   ->  Index Scan using idx_refunds_status on refunds r  (cost=0.15..8.17 rows=1 width=280) (actual time=0.002..0.002 rows=0 loops=1)
         Index Cond: ((status)::text = 'success'::text)
   ->  Index Scan using pk_charges on charges c  (cost=0.42..8.44 rows=1 width=983) (never executed)
         Index Cond: (id = r.charge_id)
         Filter: ((reference)::text ~~ '%asasa%'::text)
 Planning time: 0.322 ms
 Execution time: 0.050 ms
(8 rows)
```

If the queries work the same in production, it should help some.

Looking into the connector code base a bit more I found out we don't query by reference for refund at all, so dropping this index for now.



