### PR TITLE
PP-2336 Connector trace incoming requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,38 @@
             <url>https://dl.bintray.com/govuk-pay/pay-java-commons</url>
         </repository>
     </repositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-xray-recorder-sdk-bom</artifactId>
+                <version>1.3.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-apache-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-aws-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-aws-sdk-instrumentor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-sql-postgres</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -1,5 +1,9 @@
 package uk.gov.pay.connector.app;
 
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorderBuilder;
+import com.amazonaws.xray.javax.servlet.AWSXRayServletFilter;
+import com.amazonaws.xray.strategy.sampling.LocalizedSamplingStrategy;
 import com.codahale.metrics.graphite.GraphiteReporter;
 import com.codahale.metrics.graphite.GraphiteSender;
 import com.codahale.metrics.graphite.GraphiteUDP;
@@ -47,6 +51,7 @@ import uk.gov.pay.connector.util.TrustingSSLSocketFactory;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -85,6 +90,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         injector.getInstance(PersistenceServiceInitialiser.class);
 
         initialiseMetrics(configuration, environment);
+        initialiseXRay();
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(ChargeEventsResource.class));
@@ -106,6 +112,9 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         setupSmartpayBasicAuth(environment, injector.getInstance(SmartpayAccountSpecificAuthenticator.class));
 
         environment.servlets().addFilter("LoggingFilter", injector.getInstance(LoggingFilter.class))
+                .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
+
+        environment.servlets().addFilter("XRayFilter", new AWSXRayServletFilter("pay-connector"))
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
 
         environment.healthChecks().register("ping", new Ping());
@@ -139,6 +148,13 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
                 .build(graphiteUDP)
                 .start(GRAPHITE_SENDING_PERIOD_SECONDS, TimeUnit.SECONDS);
 
+    }
+
+    private void initialiseXRay(){
+        AWSXRayRecorderBuilder builder = AWSXRayRecorderBuilder.standard();
+        URL ruleFile = ConnectorApp.class.getResource("/sampling-rules.json");
+        builder.withSamplingStrategy(new LocalizedSamplingStrategy(ruleFile));
+        AWSXRay.setGlobalRecorder(builder.build());
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/uk/gov/pay/connector/filters/XRayHttpClientFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/XRayHttpClientFilter.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.connector.filters;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorder;
+import com.amazonaws.xray.entities.Namespace;
+import com.amazonaws.xray.entities.Segment;
+import com.amazonaws.xray.entities.Subsegment;
+import com.amazonaws.xray.entities.TraceHeader;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.util.HashMap;
+
+
+@Provider
+public class XRayHttpClientFilter implements ClientRequestFilter, ClientResponseFilter {
+    private static final String AWS_TRACE_HEADER = "X-Amzn-Trace-Id";
+    private static final int TOO_MANY_REQUESTS = 429;
+
+    private final AWSXRayRecorder recorder = AWSXRay.getGlobalRecorder();
+
+    @Override
+    public void filter(ClientRequestContext requestContext)
+            throws IOException {
+
+        Subsegment subsegment = recorder.beginSubsegment(requestContext.getUri().getHost());
+        try {
+            if (subsegment != null) {
+                subsegment.setNamespace(Namespace.REMOTE.toString());
+                requestContext.getHeaders().add(AWS_TRACE_HEADER, generateTraceHeader(subsegment));
+                HashMap requestInformation = new HashMap();
+                requestInformation.put("url", requestContext.getUri());
+                requestInformation.put("method", requestContext.getMethod());
+                subsegment.putHttp("request", requestInformation);
+            }
+        } catch (Exception exception) {
+            if (subsegment != null) {
+                subsegment.addException(exception);
+            }
+        } finally {
+            if (subsegment != null) {
+                subsegment.end();
+            }
+        }
+
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext,
+                       ClientResponseContext responseContext) throws IOException {
+
+        Subsegment subsegment = recorder.getCurrentSubsegment();
+        try {
+            if (subsegment != null) {
+                int responseCode = responseContext.getStatus();
+                switch (responseCode / 100) {
+                    case 4:
+                        subsegment.setError(true);
+                        if (responseCode == TOO_MANY_REQUESTS) {
+                            subsegment.setThrottle(true);
+                        }
+                        break;
+                    case 5:
+                        subsegment.setFault(true);
+                }
+                HashMap responseInformation = new HashMap();
+                responseInformation.put("status", Integer.valueOf(responseCode));
+                responseInformation.put("content_length", Long.valueOf(responseContext.getLength()));
+                subsegment.putHttp("response", responseInformation);
+            }
+        } catch (Exception exception) {
+            if (subsegment != null) {
+                subsegment.addException(exception);
+            }
+        } finally {
+            if (subsegment != null) {
+                subsegment.end();
+            }
+        }
+    }
+
+    private String generateTraceHeader(Subsegment subsegment) {
+        Segment parentSegment = subsegment.getParentSegment();
+        return new TraceHeader(
+                parentSegment.getTraceId(),
+                parentSegment.isSampled() ?
+                        subsegment.getId() :
+                        null,
+                parentSegment.isSampled() ?
+                        TraceHeader.SampleDecision.SAMPLED :
+                        TraceHeader.SampleDecision.NOT_SAMPLED
+        ).toString();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/XRaySessionProfiler.java
+++ b/src/main/java/uk/gov/pay/connector/util/XRaySessionProfiler.java
@@ -1,0 +1,114 @@
+package uk.gov.pay.connector.util;
+
+import com.amazonaws.xray.AWSXRay;
+import com.amazonaws.xray.AWSXRayRecorder;
+import com.amazonaws.xray.entities.Namespace;
+import com.amazonaws.xray.entities.Subsegment;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.internal.sessions.AbstractRecord;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.queries.DatabaseQuery;
+import org.eclipse.persistence.sessions.Record;
+import org.eclipse.persistence.sessions.Session;
+import org.eclipse.persistence.sessions.SessionProfiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.HashMap;
+
+public class XRaySessionProfiler implements SessionProfiler {
+    private int profileWeight = SessionProfiler.ALL;
+    private static final Logger logger = LoggerFactory.getLogger(XRaySessionProfiler.class);
+    private final AWSXRayRecorder recorder = AWSXRay.getGlobalRecorder();
+
+    @Override
+    public void endOperationProfile(String operationName) {
+    }
+
+    @Override
+    public void endOperationProfile(String operationName, DatabaseQuery databaseQuery, int weight) {
+    }
+
+    @Override
+    public Object profileExecutionOfQuery(DatabaseQuery databaseQuery, Record record, AbstractSession abstractSession) {
+
+        HashMap additionalParams = new HashMap();
+        DatabaseMetaData metadata;
+        String hostname = "database";
+        try {
+            Connection connection = abstractSession.getAccessor().getConnection();
+            metadata = connection.getMetaData();
+            additionalParams.put("url", metadata.getURL());
+            additionalParams.put("user", metadata.getUserName());
+            additionalParams.put("driver_version", metadata.getDriverVersion());
+            additionalParams.put("database_type", metadata.getDatabaseProductName());
+            additionalParams.put("database_version", metadata.getDatabaseProductVersion());
+            additionalParams.put("preparation", databaseQuery.isCallQuery() ? "call" : "statement");
+            additionalParams.put("sanitized_query", StringUtils.isEmpty(databaseQuery.getSQLString()) ? "" : databaseQuery.getSQLString());
+
+            try {
+                hostname = new URI((new URI(metadata.getURL())).getSchemeSpecificPart()).getHost();
+                hostname = connection.getCatalog() + "@" + hostname;
+            } catch (URISyntaxException exception) {
+                logger.warn("Error parsing database host name.");
+            }
+        } catch (SQLException exception) {
+            logger.warn("Error getting database connection details.");
+        }
+
+        Subsegment subsegment = recorder.beginSubsegment(hostname);
+        subsegment.putMetadata("monitor_name", databaseQuery.getMonitorName());
+        subsegment.putMetadata("calling_class", databaseQuery.getClass().getSimpleName());
+        subsegment.setNamespace(Namespace.REMOTE.toString());
+        subsegment.putAllSql(additionalParams);
+
+        try {
+            return abstractSession.internalExecuteQuery(databaseQuery, (AbstractRecord) record);
+        } finally {
+            subsegment.end();
+        }
+    }
+
+    @Override
+    public void setSession(Session session) {
+    }
+
+    @Override
+    public void startOperationProfile(String operationName) {
+    }
+
+    @Override
+    public void startOperationProfile(String operationName, DatabaseQuery databaseQuery, int weight) {
+    }
+
+    @Override
+    public void update(String operationName, Object value) {
+    }
+
+    @Override
+    public void occurred(String operationName, AbstractSession abstractSession) {
+    }
+
+    @Override
+    public void occurred(String operationName, DatabaseQuery databaseQuery, AbstractSession abstractSession) {
+    }
+
+    @Override
+    public void setProfileWeight(int profileWeight) {
+        this.profileWeight = profileWeight;
+    }
+
+    @Override
+    public int getProfileWeight() {
+        return this.profileWeight;
+    }
+
+    @Override
+    public void initialize() {
+    }
+}

--- a/src/main/resources/sampling-rules.json
+++ b/src/main/resources/sampling-rules.json
@@ -1,0 +1,17 @@
+{
+  "rules": [
+    {
+      "description": "Exclude healthchecks",
+      "service_name": "*",
+      "http_method": "*",
+      "url_path": "/healthcheck",
+      "fixed_target": 0,
+      "rate": 0.0
+    }
+  ],
+  "default": {
+    "fixed_target": 1,
+    "rate": 0.05
+  },
+  "version": 1
+}


### PR DESCRIPTION
Adds incoming request tracing/segmenting. This allows the flowing of traces from upstream services (self-service) into connector, which can then be visualised using the aws console, or called via the API.

Outbound http requests to any downstream services is a WIP and was previously failing build/test, so we are splitting the work up in order to get the quick win/advantages above.