### PR TITLE
PP-4094 Add language column to charges table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1396,4 +1396,24 @@
         </sql>
     </changeSet>
 
+    <changeSet id="Add language column to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="language" type="char(2)"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="Add default value to language column" author="">
+        <addDefaultValue tableName="charges"
+                         columnName="language"
+                         defaultValue="en"
+        />
+    </changeSet>
+
+    <changeSet id="Update language column to default value" author="">
+        <update tableName="charges">
+            <column name="language" value="en"/>
+            <where>language IS NULL</where>
+        </update>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT

- Add language column to charges table with `char(2)`, because it contains only `ISO-639-1`
- Add default value and update the existing rows

Don’t add the default in the same statement as adding the column because this will lock the table while updating all the existing rows.

with @alexbishop1
