### PR TITLE
PP-4094 Change `language` column type from `char` to `varchar`

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1398,7 +1398,7 @@
 
     <changeSet id="Add language column to charges table" author="">
         <addColumn tableName="charges">
-            <column name="language" type="char(2)"/>
+            <column name="language" type="varchar(2)"/>
         </addColumn>
     </changeSet>
 


### PR DESCRIPTION
## WHAT

- We haven't run the migrations yet, that is why we are changing the type directly in the old change set.
- `char` will initialise the rows immediately and add blank space as a value - this will lock the tables which we are trying to avoid.
- also, when using `char` it will temporary double the size of the table in the database which may cause problems with smaller databases (for example on `test` environment).

with @whpearson and @alexbishop1
