### PR TITLE
PP-4094 Add language validation to create payment request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -15,8 +15,8 @@ import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.service.ChargeExpiryService;
 import uk.gov.pay.connector.service.ChargeService;
-import uk.gov.pay.connector.service.search.TransactionSearchStrategy;
 import uk.gov.pay.connector.service.search.SearchService;
+import uk.gov.pay.connector.service.search.TransactionSearchStrategy;
 import uk.gov.pay.connector.util.ResponseUtil;
 
 import javax.inject.Inject;
@@ -58,6 +58,7 @@ import static uk.gov.pay.connector.util.ResponseUtil.successResponseWithEntity;
 public class ChargesApiResource {
     public static final String EMAIL_KEY = "email";
     static final String AMOUNT_KEY = "amount";
+    static final String LANGUAGE_KEY = "language";
     private static final String DESCRIPTION_KEY = "description";
     private static final String RETURN_URL_KEY = "return_url";
     private static final String REFERENCE_KEY = "reference";
@@ -81,7 +82,7 @@ public class ChargesApiResource {
     private static final String CHARGE_EXPIRY_WINDOW = "CHARGE_EXPIRY_WINDOW_SECONDS";
     private static final Logger logger = LoggerFactory.getLogger(ChargesApiResource.class);
     static int MIN_AMOUNT = 1;
-    static int MAX_AMOUNT = 10000000;
+    static int MAX_AMOUNT = 10_000_000;
     private final ChargeDao chargeDao;
     private final GatewayAccountDao gatewayAccountDao;
     private final ChargeService chargeService;
@@ -176,16 +177,16 @@ public class ChargesApiResource {
     @Timed
     @Produces(APPLICATION_JSON)
     public Response getChargesJsonV2(@PathParam(ACCOUNT_ID) Long accountId,
-                                   @QueryParam(EMAIL_KEY) String email,
-                                   @QueryParam(REFERENCE_KEY) String reference,
-                                   @QueryParam(PAYMENT_STATES_KEY) CommaDelimitedSetParameter paymentStates,
-                                   @QueryParam(REFUND_STATES_KEY) CommaDelimitedSetParameter refundStates,
-                                   @QueryParam(CARD_BRAND_KEY) List<String> cardBrands,
-                                   @QueryParam(FROM_DATE_KEY) String fromDate,
-                                   @QueryParam(TO_DATE_KEY) String toDate,
-                                   @QueryParam(PAGE) Long pageNumber,
-                                   @QueryParam(DISPLAY_SIZE) Long displaySize,
-                                   @Context UriInfo uriInfo) {
+                                     @QueryParam(EMAIL_KEY) String email,
+                                     @QueryParam(REFERENCE_KEY) String reference,
+                                     @QueryParam(PAYMENT_STATES_KEY) CommaDelimitedSetParameter paymentStates,
+                                     @QueryParam(REFUND_STATES_KEY) CommaDelimitedSetParameter refundStates,
+                                     @QueryParam(CARD_BRAND_KEY) List<String> cardBrands,
+                                     @QueryParam(FROM_DATE_KEY) String fromDate,
+                                     @QueryParam(TO_DATE_KEY) String toDate,
+                                     @QueryParam(PAGE) Long pageNumber,
+                                     @QueryParam(DISPLAY_SIZE) Long displaySize,
+                                     @Context UriInfo uriInfo) {
 
         List<Pair<String, String>> inputDatePairMap = ImmutableList.of(Pair.of(FROM_DATE_KEY, fromDate), Pair.of(TO_DATE_KEY, toDate));
         List<Pair<String, Long>> nonNegativePairMap = ImmutableList.of(Pair.of(PAGE, pageNumber), Pair.of(DISPLAY_SIZE, displaySize));

--- a/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
@@ -2,21 +2,33 @@ package uk.gov.pay.connector.resources;
 
 import com.google.common.collect.ImmutableMap;
 import fj.data.Either;
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 
 import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.resources.ApiValidators.parseZonedDateTime;
+import static uk.gov.pay.connector.resources.ApiValidators.validateChargeParams;
 import static uk.gov.pay.connector.resources.ApiValidators.validateChargePatchParams;
 import static uk.gov.pay.connector.resources.ApiValidators.validateFromDateIsBeforeToDate;
-import static uk.gov.pay.connector.resources.ApiValidators.parseZonedDateTime;
+import static uk.gov.pay.connector.resources.ChargesApiResource.AMOUNT_KEY;
+import static uk.gov.pay.connector.resources.ChargesApiResource.EMAIL_KEY;
+import static uk.gov.pay.connector.resources.ChargesApiResource.LANGUAGE_KEY;
+import static uk.gov.pay.connector.resources.ChargesApiResource.MAX_AMOUNT;
+import static uk.gov.pay.connector.resources.ChargesApiResource.MIN_AMOUNT;
+
 
 public class ApiValidatorsTest {
 
@@ -27,7 +39,7 @@ public class ApiValidatorsTest {
                 ImmutableMap.of(
                         "op", "replace",
                         "path", "email",
-                        "value","test@examplecom"))
+                        "value", "test@example.com"))
                 .withValidOps(singletonList("replace"))
                 .withValidPaths(singletonList("email"))
                 .build();
@@ -41,7 +53,7 @@ public class ApiValidatorsTest {
                 ImmutableMap.of(
                         "op", "replace",
                         "path", "email",
-                        "value",randomAlphanumeric(255) +"@examplecom"))
+                        "value", randomAlphanumeric(255) + "@example.com"))
                 .withValidOps(singletonList("replace"))
                 .withValidPaths(singletonList("email"))
                 .build();
@@ -50,7 +62,7 @@ public class ApiValidatorsTest {
 
     @Test
     public void validateFromDateIsBeforeToDate_fromDateBeforeToDate() {
-        Either<List<String>, Pair<ZonedDateTime, ZonedDateTime>> result = validateFromDateIsBeforeToDate("from_date",  "2017-11-23T12:00:00Z",
+        Either<List<String>, Pair<ZonedDateTime, ZonedDateTime>> result = validateFromDateIsBeforeToDate("from_date", "2017-11-23T12:00:00Z",
                 "to_date", "2017-11-23T15:00:00Z");
 
         assertThat(result.isRight(), is(true));
@@ -59,7 +71,7 @@ public class ApiValidatorsTest {
 
     @Test
     public void validateFromDateIsBeforeToDate_fromDateAfterToDate() {
-        Either<List<String>, Pair<ZonedDateTime, ZonedDateTime>> result =  validateFromDateIsBeforeToDate("from_date", "2017-11-23T15:00:00Z",
+        Either<List<String>, Pair<ZonedDateTime, ZonedDateTime>> result = validateFromDateIsBeforeToDate("from_date", "2017-11-23T15:00:00Z",
                 "to_date", "2017-11-23T12:00:00Z");
 
         assertThat(result.isLeft(), is(true));
@@ -107,11 +119,113 @@ public class ApiValidatorsTest {
         String rawDate = "2018-06-20T00:00:00Z";
         Optional<ZonedDateTime> maybeDate = parseZonedDateTime(rawDate);
 
-        assert(maybeDate.isPresent());
+        assertThat(maybeDate.isPresent(), is(true));
 
         ZonedDateTime date = maybeDate.get();
         assertThat(date.getDayOfMonth(), is(20));
         assertThat(date.getMonthValue(), is(06));
-        assertThat(date.getYear(),       is(2018));
+        assertThat(date.getYear(), is(2018));
+    }
+
+    @Test
+    public void validateChargeParams_shouldAccept_whenEmailAndAmountValid() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(EMAIL_KEY, "anonymous@example.com");
+        inputData.put(AMOUNT_KEY, "500");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.empty()));
+    }
+
+    @Test
+    public void validateChargeParams_shouldRejectEmail_when255Characters() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(EMAIL_KEY, RandomStringUtils.randomAlphanumeric(255));
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList(EMAIL_KEY))));
+    }
+
+    @Test
+    public void validateChargeParams_shouldRejectAmount_whenBelowMinAmount() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(AMOUNT_KEY, String.valueOf(MIN_AMOUNT - 1));
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList(AMOUNT_KEY))));
+    }
+
+    @Test
+    public void validateChargeParams_shouldRejectAmount_whenAboveMaxAmount() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(AMOUNT_KEY, String.valueOf(MAX_AMOUNT + 1));
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList(AMOUNT_KEY))));
+    }
+
+    @Test
+    public void validateChargeParams_shouldAcceptLanguage_whenEn() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(LANGUAGE_KEY, "en");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.empty()));
+    }
+
+    @Test
+    public void validateChargeParams_shouldAcceptLanguage_whenCy() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(LANGUAGE_KEY, "cy");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.empty()));
+    }
+
+    @Test
+    public void validateChargeParams_shouldRejectLanguage_whenEmptyString() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(LANGUAGE_KEY, "");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList("language"))));
+    }
+
+    @Test
+    public void validateChargeParams_shouldRejectLanguage_whenNull() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(LANGUAGE_KEY, null);
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList("language"))));
+    }
+
+    @Test
+    public void validateChargeParams_shouldRejectLanguage_whenIsFr() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(LANGUAGE_KEY, "fr");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList("language"))));
+    }
+
+    @Test
+    public void validateChargeParams_shouldRejectEmailAndAmount_whenBothInvalid() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(EMAIL_KEY, RandomStringUtils.randomAlphanumeric(255));
+        inputData.put(AMOUNT_KEY, String.valueOf(MAX_AMOUNT + 1));
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result.get().containsAll(Arrays.asList(AMOUNT_KEY, EMAIL_KEY)), is(true));
     }
 }


### PR DESCRIPTION
## WHAT

Add `language` validation to create payment request

- The validation accepts `en` and `cy` as values.
- Even if valid, the `language` is still ignored for now.
- Add some tests for `email` and `amount` validation.

with @alexbishop1
