### PR TITLE
PP-4119 Improve capture queue reporting

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
@@ -166,15 +166,18 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
         return cb.like(cb.lower(expression), '%' + escapedReference.toLowerCase() + '%');
     }
-
-    public int countChargesForCapture(Duration notAttemptedWithin) {
-        String query = "SELECT count(c) FROM ChargeEntity c WHERE (c.status=:captureApprovedStatus OR c.status=:captureApprovedRetryStatus)"+
-                "AND NOT EXISTS (" +
-                "  SELECT ce FROM ChargeEventEntity ce WHERE " +
-                "    ce.chargeEntity = c AND " +
-                "    ce.status = :eventStatus AND " +
-                "    ce.updated >= :cutoffDate " +
-                ") ";
+    
+    private static final String FIND_CAPTURE_CHARGES_WHERE_CLAUSE = 
+            "WHERE (c.status=:captureApprovedStatus OR c.status=:captureApprovedRetryStatus)"+
+            "AND NOT EXISTS (" +
+            "  SELECT ce FROM ChargeEventEntity ce WHERE " +
+            "    ce.chargeEntity = c AND " +
+            "    ce.status = :eventStatus AND " +
+            "    ce.updated >= :cutoffDate " +
+            ") ";
+    
+    public int countChargesForImmediateCapture(Duration notAttemptedWithin) {
+        String query = "SELECT count(c) FROM ChargeEntity c " + FIND_CAPTURE_CHARGES_WHERE_CLAUSE;
 
         Number count = (Number) entityManager.get()
                 .createQuery(query)
@@ -185,36 +188,9 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .getSingleResult();
         return count.intValue();
     }
-    
-    public int countChargesAwaitingCaptureRetry(Duration notAttemptedWithin) {
-        String query = "SELECT count(c) FROM ChargeEntity c WHERE (c.status=:captureApprovedStatus OR c.status=:captureApprovedRetryStatus)"+
-                "AND EXISTS (" +
-                "  SELECT ce FROM ChargeEventEntity ce WHERE " +
-                "    ce.chargeEntity = c AND " +
-                "    ce.status = :eventStatus AND " +
-                "    ce.updated >= :cutoffDate " +
-                ") ";
 
-        Number count = (Number) entityManager.get()
-                .createQuery(query)
-                .setParameter("captureApprovedStatus", CAPTURE_APPROVED.getValue())
-                .setParameter("captureApprovedRetryStatus", CAPTURE_APPROVED_RETRY.getValue())
-                .setParameter("eventStatus", CAPTURE_APPROVED_RETRY)
-                .setParameter("cutoffDate", ZonedDateTime.now().minus(notAttemptedWithin))
-                .getSingleResult();
-        return count.intValue();
-    }
-    
     public List<ChargeEntity> findChargesForCapture(int maxNumberOfCharges, Duration notAttemptedWithin) {
-        String query = "SELECT c FROM ChargeEntity c WHERE " +
-                "(c.status=:captureApprovedStatus OR c.status=:captureApprovedRetryStatus) " +
-                "AND NOT EXISTS (" +
-                "  SELECT ce FROM ChargeEventEntity ce WHERE " +
-                "    ce.chargeEntity = c AND " +
-                "    ce.status = :eventStatus AND " +
-                "    ce.updated >= :cutoffDate " +
-                ") " +
-                "ORDER BY c.createdDate ASC";
+        String query = "SELECT c FROM ChargeEntity c " + FIND_CAPTURE_CHARGES_WHERE_CLAUSE + "ORDER BY c.createdDate ASC";
 
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)
@@ -224,6 +200,24 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setParameter("eventStatus", CAPTURE_APPROVED_RETRY)
                 .setParameter("cutoffDate", ZonedDateTime.now().minus(notAttemptedWithin))
                 .getResultList();
+    }
+    
+    public int countChargesAwaitingCaptureRetry(Duration notAttemptedWithin) {
+        String query = "SELECT count(c) FROM ChargeEntity c WHERE c.status=:captureApprovedRetryStatus "+
+                "AND EXISTS (" +
+                "  SELECT ce FROM ChargeEventEntity ce WHERE " +
+                "    ce.chargeEntity = c AND " +
+                "    ce.status = :eventStatus AND " +
+                "    ce.updated >= :cutoffDate " +
+                ") ";
+
+        Number count = (Number) entityManager.get()
+                .createQuery(query)
+                .setParameter("captureApprovedRetryStatus", CAPTURE_APPROVED_RETRY.getValue())
+                .setParameter("eventStatus", CAPTURE_APPROVED_RETRY)
+                .setParameter("cutoffDate", ZonedDateTime.now().minus(notAttemptedWithin))
+                .getSingleResult();
+        return count.intValue();
     }
 
     public int countCaptureRetriesForCharge(long chargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -1296,8 +1296,25 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withCreatedDate(now().minusHours(2))
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
                 .insert();
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(103L)
+                .withExternalChargeId("ext-id3")
+                .withCreatedDate(now())
+                .withChargeStatus(CAPTURE_APPROVED_RETRY)
+                .insert();
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestChargeEvent()
+                .withChargeId(103L)
+                .withDate(now())
+                .withChargeStatus(CAPTURE_APPROVED_RETRY)
+                .insert();
 
-        assertThat(chargeDao.countChargesForCapture(), is(2));
+        assertThat(chargeDao.countChargesForCapture(Duration.ofHours(1)), is(2));
+        assertThat(chargeDao.countChargesAwaitingCaptureRetry(Duration.ofHours(1)), is(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -1313,7 +1313,7 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
                 .insert();
 
-        assertThat(chargeDao.countChargesForCapture(Duration.ofHours(1)), is(2));
+        assertThat(chargeDao.countChargesForImmediateCapture(Duration.ofHours(1)), is(2));
         assertThat(chargeDao.countChargesAwaitingCaptureRetry(Duration.ofHours(1)), is(1));
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
@@ -56,11 +56,13 @@ public class CardCaptureProcessTest {
     
     @Mock
     MetricRegistry mockMetricRegistry;
+    
+    @Mock
+    CaptureProcessConfig mockCaptureConfiguration = mock(CaptureProcessConfig.class);
 
     @Before
     public void setup() {
         Histogram mockHistogram = mock(Histogram.class);
-        CaptureProcessConfig mockCaptureConfiguration = mock(CaptureProcessConfig.class);
 
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         Counter mockCounter = mock(Counter.class);
@@ -84,17 +86,19 @@ public class CardCaptureProcessTest {
 
     @Test
     public void shouldRecordTheQueueSizeOnEveryRun() {
-        when(mockChargeDao.countChargesForCapture(Matchers.any(Duration.class))).thenReturn(15);
-
+        when(mockCaptureConfiguration.getBatchSize()).thenReturn(0);
+        when(mockChargeDao.countChargesForImmediateCapture(Matchers.any(Duration.class))).thenReturn(15);
+        
         cardCaptureProcess.runCapture();
 
-        assertThat(cardCaptureProcess.getQueueSize(), is(15));
+        assertThat(cardCaptureProcess.getImmediateCaptureQueueSize(), is(15));
     }
 
 
     @Test
     public void shouldRegisterGaugesForChargesQueue_AndReturnCorrectSizes() {
-        when(mockChargeDao.countChargesForCapture(Matchers.any(Duration.class))).thenReturn(15);
+        when(mockCaptureConfiguration.getBatchSize()).thenReturn(0);
+        when(mockChargeDao.countChargesForImmediateCapture(Matchers.any(Duration.class))).thenReturn(15);
         when(mockChargeDao.countChargesAwaitingCaptureRetry(Matchers.any(Duration.class))).thenReturn(10);
         cardCaptureProcess.runCapture();
         ArgumentCaptor<MetricRegistry.MetricSupplier> argumentCaptor = ArgumentCaptor.forClass(MetricRegistry.MetricSupplier.class);
@@ -120,7 +124,7 @@ public class CardCaptureProcessTest {
 
         cardCaptureProcess.runCapture();
 
-        assertThat(cardCaptureProcess.getWaitingQueueSize(), is(15));
+        assertThat(cardCaptureProcess.getWaitingCaptureQueueSize(), is(15));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
@@ -7,12 +7,14 @@ import io.dropwizard.setup.Environment;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
+import uk.gov.pay.connector.model.gateway.GatewayResponse;
 
 import java.time.Duration;
 
@@ -40,6 +42,9 @@ public class CardCaptureProcessTest {
     @Mock
     private ConnectorConfiguration mockConnectorConfiguration;
 
+    @Mock
+    GatewayResponse mockGatewayResponse;
+
     @Before
     public void setup() {
         MetricRegistry mockMetricRegistry = mock(MetricRegistry.class);
@@ -55,6 +60,8 @@ public class CardCaptureProcessTest {
         when(mockCaptureConfiguration.getMaximumRetries()).thenReturn(MAXIMUM_RETRIES);
         when(mockConnectorConfiguration.getCaptureProcessConfig()).thenReturn(mockCaptureConfiguration);
         cardCaptureProcess = new CardCaptureProcess(mockEnvironment, mockChargeDao, mockCardCaptureService, mockConnectorConfiguration);
+        when(mockGatewayResponse.isSuccessful()).thenReturn(true);
+        when(mockCardCaptureService.doCapture(anyString())).thenReturn(mockGatewayResponse);
     }
 
     @Test
@@ -66,7 +73,7 @@ public class CardCaptureProcessTest {
 
     @Test
     public void shouldRecordTheQueueSizeOnEveryRun() {
-        when(mockChargeDao.countChargesForCapture()).thenReturn(15);
+        when(mockChargeDao.countChargesForCapture(Matchers.any(Duration.class))).thenReturn(15);
 
         cardCaptureProcess.runCapture();
 


### PR DESCRIPTION
Currently we only capture the total size of the charges waiting to be sent to the provider to be processed. However it is more useful to split this into two measures:
- The number of charges eligible to be processed now.
- The number of charges that are within the waiting period to be retried and so are not eligible at that moment.

Therefore the existing `gateway-operations.capture-process.queue-size` metric has been modified to count only charges which can be retried (whilst not applying the configurable batch size limit used by `findChargesForCapture`). A new metric named `gateway-operations.capture-process.waiting-queue-size` has been added to show the charges which are waiting to be retried because they were last attempted within the delay period (this is configurable but currently set to an hour).

As part of this work we have also:
- modified the metric type from `Counter` to `Gauge` which seems more appropriate.
- modified the log message at the end of the capture run to report the number of successful retries and those that failed. This introduces a check on the `GatewayResponse` and a new category in the log message `failed_capture`.

Tests have been added to confirm the registration of the gauges and that they return the correct value.


