### PR TITLE
PP-4094 Persist language to charge and return it in the response to API calls

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -66,7 +66,8 @@ public class TransactionDao {
                         field("address_line1"),
                         field("address_line2"),
                         field("address_postcode"),
-                        field("amount"))
+                        field("amount"),
+                        field("language"))
                 .from(buildQueryFor(gatewayAccountId, QueryType.SELECT, params))
                 .orderBy(field("date_created").desc());
 
@@ -183,7 +184,8 @@ public class TransactionDao {
                 field("c.address_line1"),
                 field("c.address_line2"),
                 field("c.address_postcode"),
-                field("c.amount"))
+                field("c.amount"),
+                field("c.language"))
                 .from(table("charges").as("c").leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))
                 .where(queryFiltersForCharges);
 
@@ -210,7 +212,8 @@ public class TransactionDao {
                 field("c.address_line1"),
                 field("c.address_line2"),
                 field("c.address_postcode"),
-                field("r.amount"))
+                field("r.amount"),
+                field("c.language"))
                 .from(table("charges").as("c").leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))
                 .join(table("refunds").as("r"))
                 .on(field("c.id").eq(field("r.charge_id")))

--- a/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.model.domain.PersistedCard;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
 import java.net.URI;
@@ -247,7 +248,8 @@ public class ChargeResponse {
         @Override
         public ChargeResponse build() {
             return new ChargeResponse(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
-                    description, reference, providerName, createdDate, links, refundSummary, settlementSummary, cardDetails, auth3dsData);
+                    description, reference, providerName, createdDate, links, refundSummary, settlementSummary,
+                    cardDetails, auth3dsData, language);
         }
     }
 
@@ -304,10 +306,14 @@ public class ChargeResponse {
     @JsonProperty("card_details")
     protected PersistedCard cardDetails;
 
+    @JsonProperty
+    @JsonSerialize(using = ToStringSerializer.class)
+    private SupportedLanguage language;
+
     protected ChargeResponse(String chargeId, Long amount, ExternalTransactionState state, String cardBrand, String gatewayTransactionId, String returnUrl,
                              String email, String description, ServicePaymentReference reference, String providerName, String createdDate,
                              List<Map<String, Object>> dataLinks, RefundSummary refundSummary, SettlementSummary settlementSummary, PersistedCard cardDetails,
-                             Auth3dsData auth3dsData) {
+                             Auth3dsData auth3dsData, SupportedLanguage language) {
         this.dataLinks = dataLinks;
         this.chargeId = chargeId;
         this.amount = amount;
@@ -324,6 +330,7 @@ public class ChargeResponse {
         this.settlementSummary = settlementSummary;
         this.cardDetails = cardDetails;
         this.auth3dsData = auth3dsData;
+        this.language = language;
     }
 
     public List<Map<String, Object>> getDataLinks() {
@@ -386,6 +393,10 @@ public class ChargeResponse {
         return cardDetails;
     }
 
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
     public URI getLink(String rel) {
         return dataLinks.stream()
                 .filter(map -> rel.equals(map.get("rel")))
@@ -428,8 +439,9 @@ public class ChargeResponse {
             return false;
         if (auth3dsData != null ? !auth3dsData.equals(that.auth3dsData) : that.auth3dsData != null)
             return false;
-        return cardDetails != null ? cardDetails.equals(that.cardDetails) : that.cardDetails == null;
-
+        if (cardDetails != null ? !cardDetails.equals(that.cardDetails) : that.cardDetails != null)
+            return false;
+        return language.equals(that.language);
     }
 
     @Override
@@ -450,6 +462,7 @@ public class ChargeResponse {
         result = 31 * result + (settlementSummary != null ? settlementSummary.hashCode() : 0);
         result = 31 * result + (auth3dsData != null ? auth3dsData.hashCode() : 0);
         result = 31 * result + (cardDetails != null ? cardDetails.hashCode() : 0);
+        result = 31 * result + language.hashCode();
         return result;
     }
 
@@ -470,6 +483,7 @@ public class ChargeResponse {
                 ", refundSummary=" + refundSummary +
                 ", settlementSummary=" + settlementSummary +
                 ", auth3dsData=" + auth3dsData +
+                ", language=" + language +
                 '}';
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/FrontendChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/FrontendChargeResponse.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.PersistedCard;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 
 import java.util.List;
 import java.util.Map;
@@ -44,7 +45,7 @@ public class FrontendChargeResponse extends ChargeResponse {
         public FrontendChargeResponse build() {
             return new FrontendChargeResponse(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl,
                     email, description, reference, providerName, createdDate, links, status, refundSummary,
-                    settlementSummary, persistedCard, auth3dsData, gatewayAccount);
+                    settlementSummary, persistedCard, auth3dsData, gatewayAccount, language);
         }
     }
 
@@ -62,10 +63,12 @@ public class FrontendChargeResponse extends ChargeResponse {
                                    String gatewayTransactionId, String returnUrl, String email, String description,
                                    ServicePaymentReference reference, String providerName, String createdDate,
                                    List<Map<String, Object>> dataLinks, String status, RefundSummary refundSummary,
-                                   SettlementSummary settlementSummary, PersistedCard chargeCardDetails, Auth3dsData auth3dsData,
-                                   GatewayAccountEntity gatewayAccount) {
+                                   SettlementSummary settlementSummary, PersistedCard chargeCardDetails,
+                                   Auth3dsData auth3dsData, GatewayAccountEntity gatewayAccount,
+                                   SupportedLanguage language) {
         super(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email, description, reference,
-                providerName, createdDate, dataLinks, refundSummary, settlementSummary, chargeCardDetails, auth3dsData);
+                providerName, createdDate, dataLinks, refundSummary, settlementSummary, chargeCardDetails, auth3dsData,
+                language);
         this.status = status;
         this.gatewayAccount = gatewayAccount;
     }

--- a/src/main/java/uk/gov/pay/connector/model/TransactionResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/TransactionResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.model.domain.PersistedCard;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 
 import java.util.List;
 import java.util.Map;
@@ -26,8 +27,9 @@ public class TransactionResponse extends ChargeResponse {
 
         @Override
         public TransactionResponse build() {
-            return new TransactionResponse(transactionType, chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
-                    description, reference, providerName, createdDate, links, refundSummary, settlementSummary, cardDetails, auth3dsData);
+            return new TransactionResponse(transactionType, chargeId, amount, state, cardBrand, gatewayTransactionId,
+                    returnUrl, email, description, reference, providerName, createdDate, links, refundSummary,
+                    settlementSummary, cardDetails, auth3dsData, language);
         }
 
     }
@@ -41,11 +43,12 @@ public class TransactionResponse extends ChargeResponse {
 
     protected TransactionResponse(String transactionType, String chargeId, Long amount, ExternalTransactionState state,
                                   String cardBrand, String gatewayTransactionId, String returnUrl, String email,
-                                  String description, ServicePaymentReference reference, String providerName, String createdDate,
-                                  List<Map<String, Object>> dataLinks, RefundSummary refundSummary,
-                                  SettlementSummary settlementSummary, PersistedCard cardDetails, Auth3dsData auth3dsData) {
+                                  String description, ServicePaymentReference reference, String providerName,
+                                  String createdDate, List<Map<String, Object>> dataLinks, RefundSummary refundSummary,
+                                  SettlementSummary settlementSummary, PersistedCard cardDetails,
+                                  Auth3dsData auth3dsData, SupportedLanguage language) {
         super(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email, description, reference,
-                providerName, createdDate, dataLinks, refundSummary, settlementSummary, cardDetails, auth3dsData);
+                providerName, createdDate, dataLinks, refundSummary, settlementSummary, cardDetails, auth3dsData, language);
         this.transactionType = transactionType;
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/model/builder/AbstractChargeResponseBuilder.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.model.ChargeResponse;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.model.domain.PersistedCard;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -28,6 +29,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected ChargeResponse.SettlementSummary settlementSummary;
     protected PersistedCard cardDetails;
     protected ChargeResponse.Auth3dsData auth3dsData;
+    protected SupportedLanguage language;
 
     protected abstract T thisObject();
 
@@ -119,6 +121,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public T withAuth3dsData(ChargeResponse.Auth3dsData auth3dsData) {
         this.auth3dsData = auth3dsData;
+        return thisObject();
+    }
+
+    public T withLanguage(SupportedLanguage language) {
+        this.language = language;
         return thisObject();
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
@@ -104,18 +104,22 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime createdDate;
 
+    @Column(name = "language", nullable = false)
+    @Convert(converter = SupportedLanguageConverter.class)
+    private SupportedLanguage language;
+
     public ChargeEntity() {
         //for jpa
     }
 
     public ChargeEntity(Long amount, String returnUrl, String description, ServicePaymentReference reference,
-                        GatewayAccountEntity gatewayAccount, String email) {
-        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")));
+                        GatewayAccountEntity gatewayAccount, String email, SupportedLanguage language) {
+        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language);
     }
 
     //for fixture
     ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, ServicePaymentReference reference,
-                 GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate) {
+                 GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate, SupportedLanguage language) {
         this.amount = amount;
         this.status = status.getValue();
         this.returnUrl = returnUrl;
@@ -125,6 +129,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.createdDate = createdDate;
         this.externalId = RandomIdGenerator.newId();
         this.email = email;
+        this.language = language;
     }
 
     public Long getId() {
@@ -282,5 +287,13 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void set3dsDetails(Auth3dsDetailsEntity auth3dsDetails) {
         this.auth3dsDetails = auth3dsDetails;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(SupportedLanguage language) {
+        this.language = language;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/SupportedLanguage.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/SupportedLanguage.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.model.domain;
+
+public enum SupportedLanguage {
+
+    ENGLISH("en"),
+    WELSH("cy");
+
+    private final String iso639AlphaTwoCode;
+
+    SupportedLanguage(String iso639AlphaTwoCode) {
+        this.iso639AlphaTwoCode = iso639AlphaTwoCode;
+    }
+
+    @Override
+    public String toString() {
+        return iso639AlphaTwoCode;
+    }
+
+    public static SupportedLanguage fromIso639AlphaTwoCode(String iso639AlphaTwoCode) {
+        for (SupportedLanguage supportedLanguage : SupportedLanguage.values()) {
+            if (supportedLanguage.iso639AlphaTwoCode.equals(iso639AlphaTwoCode)) {
+                return supportedLanguage;
+            }
+        }
+        throw new IllegalArgumentException(iso639AlphaTwoCode + " is not a supported ISO 639-1 code");
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/SupportedLanguageConverter.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/SupportedLanguageConverter.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.connector.model.domain;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class SupportedLanguageConverter implements AttributeConverter<SupportedLanguage, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SupportedLanguage supportedLanguage) {
+        return supportedLanguage.toString();
+    }
+
+    @Override
+    public SupportedLanguage convertToEntityAttribute(String supportedLanguage) {
+        return SupportedLanguage.fromIso639AlphaTwoCode(supportedLanguage);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
@@ -38,7 +38,8 @@ import java.time.ZonedDateTime;
                         @ColumnResult(name = "address_line1", type = String.class),
                         @ColumnResult(name = "address_line2", type = String.class),
                         @ColumnResult(name = "address_postcode", type = String.class),
-                        @ColumnResult(name = "amount", type = Long.class)}))
+                        @ColumnResult(name = "amount", type = Long.class),
+                        @ColumnResult(name = "language", type = String.class)}))
 @Entity
 @ReadOnly
 public class Transaction {
@@ -53,6 +54,7 @@ public class Transaction {
     private long gatewayAccountId;
     private String gatewayTransactionId;
     private ZonedDateTime createdDate;
+    private SupportedLanguage language;
 
     @Id
     private String transactionType;
@@ -95,8 +97,9 @@ public class Transaction {
                        String addressLine1,
                        String addressLine2,
                        String addressPostcode,
-                       long amount) {
-        this.chargeId= chargeId;
+                       long amount,
+                       String language) {
+        this.chargeId = chargeId;
         this.externalId = externalId;
         this.reference = reference;
         this.description = description;
@@ -119,6 +122,7 @@ public class Transaction {
         this.addressLine2 = addressLine2;
         this.addressPostcode = addressPostcode;
         this.amount = amount;
+        this.language = SupportedLanguage.fromIso639AlphaTwoCode(language);
     }
 
     public Long getChargeId() {
@@ -207,6 +211,10 @@ public class Transaction {
 
     public long getAmount() {
         return amount;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
     }
 
     public String getUserExternalId() {

--- a/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
@@ -4,9 +4,11 @@ import fj.data.Either;
 import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.connector.dao.GatewayAccountDao;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +48,8 @@ class ApiValidators {
         LANGUAGE(LANGUAGE_KEY) {
             @Override
             boolean validate(String iso639AlphaTwoCode) {
-                return "en".equals(iso639AlphaTwoCode) || "cy".equals(iso639AlphaTwoCode);
+                return Arrays.stream(SupportedLanguage.values())
+                        .anyMatch(supportedLanguage -> supportedLanguage.toString().equals(iso639AlphaTwoCode));
             }
         };
 

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
@@ -178,6 +178,7 @@ public class ChargesFrontendResource {
                 .withChargeCardDetails(persistedCard)
                 .withAuth3dsData(auth3dsData)
                 .withGatewayAccount(charge.getGatewayAccount())
+                .withLanguage(charge.getLanguage())
                 .withLink("self", GET, locationUriFor("/v1/frontend/charges/{chargeId}", uriInfo, chargeId))
                 .withLink("cardAuth", POST, locationUriFor("/v1/frontend/charges/{chargeId}/cards", uriInfo, chargeId))
                 .withLink("cardCapture", POST, locationUriFor("/v1/frontend/charges/{chargeId}/capture", uriInfo, chargeId)).build();

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -158,6 +158,7 @@ public class ChargeService {
                 .withCreatedDate(DateTimeUtils.toUTCDateTimeString(chargeEntity.getCreatedDate()))
                 .withReturnUrl(chargeEntity.getReturnUrl())
                 .withEmail(chargeEntity.getEmail())
+                .withLanguage(chargeEntity.getLanguage())
                 .withRefunds(buildRefundSummary(chargeEntity))
                 .withSettlement(buildSettlementSummary(chargeEntity))
                 .withCardDetails(persistedCard)

--- a/src/main/java/uk/gov/pay/connector/service/search/TransactionSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/TransactionSearchStrategy.java
@@ -1,9 +1,5 @@
 package uk.gov.pay.connector.service.search;
 
-import java.util.List;
-import java.util.Map;
-import javax.ws.rs.core.UriInfo;
-
 import com.google.inject.Inject;
 import uk.gov.pay.connector.dao.CardTypeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
@@ -21,6 +17,10 @@ import uk.gov.pay.connector.model.domain.RefundStatus;
 import uk.gov.pay.connector.model.domain.Transaction;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
+import javax.ws.rs.core.UriInfo;
+import java.util.List;
+import java.util.Map;
+
 import static javax.ws.rs.HttpMethod.GET;
 import static uk.gov.pay.connector.model.TransactionResponse.aTransactionResponseBuilder;
 
@@ -31,7 +31,7 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
     @Inject
     public TransactionSearchStrategy(TransactionDao transactionDao, CardTypeDao cardTypeDao) {
         super(cardTypeDao);
-        this.transactionDao=transactionDao;
+        this.transactionDao = transactionDao;
     }
 
     @Override
@@ -74,6 +74,7 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
                 .withReference(transaction.getReference())
                 .withEmail(transaction.getEmail())
                 .withGatewayTransactionId(transaction.getGatewayTransactionId())
+                .withLanguage(transaction.getLanguage())
                 .withLink("self", GET, uriInfo.getBaseUriBuilder()
                         .path("/v1/api/accounts/{accountId}/charges/{chargeId}")
                         .build(transaction.getGatewayAccountId(), transaction.getExternalId()))

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.model.domain.CardDetailsEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -87,8 +88,8 @@ public class ChargeDaoCardDetailsITest extends DaoITestBase {
         gatewayAccountDao.persist(testAccount);
 
         Address billingAddress = aValidAddress().build();
-        ChargeEntity chargeEntity = new ChargeEntity(2323L, "returnUrl", "description", 
-                ServicePaymentReference.of("ref"), testAccount, "email@email.com");
+        ChargeEntity chargeEntity = new ChargeEntity(2323L, "returnUrl", "description",
+                ServicePaymentReference.of("ref"), testAccount, "email@email.test", SupportedLanguage.ENGLISH);
         CardDetailsEntity cardDetailsEntity = new CardDetailsEntity();
         cardDetailsEntity.setCardBrand("VISA");
         cardDetailsEntity.setBillingAddress(new AddressEntity(billingAddress));

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.model.domain.CardTypeEntity.Type;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
@@ -361,13 +362,14 @@ public class DatabaseFixtures {
     public class TestCharge {
         Long chargeId = RandomUtils.nextLong(1, 99999);
         private String description = "Test description";
-        String email = "alice.111@mail.fake";
+        String email = "alice.111@mail.test";
         String externalChargeId = RandomIdGenerator.newId();
         long amount = 101L;
         ChargeStatus chargeStatus = ChargeStatus.CREATED;
         String returnUrl = "http://service.com/success-page";
         String transactionId;
         ServicePaymentReference reference = ServicePaymentReference.of("Test reference");
+        SupportedLanguage language = SupportedLanguage.ENGLISH;
 
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
 
@@ -428,13 +430,18 @@ public class DatabaseFixtures {
             this.description = description;
             return this;
         }
+        
+        public TestCharge withLanguage(SupportedLanguage language) {
+            this.language = language;
+            return this;
+        }
 
         public TestCharge insert() {
             if (testAccount == null)
                 throw new IllegalStateException("Test Account must be provided.");
 
             databaseTestHelper.addCharge(chargeId, externalChargeId, String.valueOf(testAccount.getAccountId()), amount, chargeStatus, returnUrl, transactionId,
-                    reference, description, createdDate, email);
+                    reference, description, createdDate, email, language);
 
             if (cardDetails != null) {
                 cardDetails.update();
@@ -480,6 +487,10 @@ public class DatabaseFixtures {
 
         public String getDescription() {
             return description;
+        }
+        
+        public SupportedLanguage getLanguage() {
+            return language;
         }
 
         public TestAccount getTestAccount() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.dao.TransactionDao;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 import uk.gov.pay.connector.model.domain.Transaction;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
@@ -79,6 +80,7 @@ public class TransactionDaoITest extends DaoITestBase {
         assertThat(transactionRefund.getCardBrand(), is(testCardDetails.getCardBrand()));
         assertThat(transactionRefund.getUserExternalId(), is(REFUND_USER_EXTERNAL_ID));
         assertThat(transactionRefund.getCardBrandLabel(), is("Visa")); // read from card types table which is populated by the card_types.csv seed data
+        assertThat(transactionRefund.getLanguage(), is(testCharge.getLanguage()));
         assertDateMatch(transactionRefund.getCreatedDate().toString());
 
         Transaction transactionCharge = transactions.get(1);
@@ -90,6 +92,7 @@ public class TransactionDaoITest extends DaoITestBase {
         assertThat(transactionCharge.getStatus(), is(testCharge.getChargeStatus().toString()));
         assertThat(transactionCharge.getCardBrand(), is(testCardDetails.getCardBrand()));
         assertThat(transactionCharge.getUserExternalId(), is(nullValue()));
+        assertThat(transactionCharge.getLanguage(), is(testCharge.getLanguage()));
         assertDateMatch(transactionCharge.getCreatedDate().toString());
     }
 
@@ -429,14 +432,14 @@ public class TransactionDaoITest extends DaoITestBase {
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
                 .withReference(ServicePaymentReference.of("under_score_ref"))
-                .withEmail("under_score@mail.com")
+                .withEmail("under_score@mail.test")
                 .insert();
 
         withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
                 .withReference(ServicePaymentReference.of("understand"))
-                .withEmail("undertaker@mail.com")
+                .withEmail("undertaker@mail.test")
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
@@ -451,7 +454,7 @@ public class TransactionDaoITest extends DaoITestBase {
 
         Transaction transaction = transactions.get(0);
         assertThat(transaction.getReference(), is(ServicePaymentReference.of("under_score_ref")));
-        assertThat(transaction.getEmail(), is("under_score@mail.com"));
+        assertThat(transaction.getEmail(), is("under_score@mail.test"));
     }
 
     @Test
@@ -488,20 +491,20 @@ public class TransactionDaoITest extends DaoITestBase {
         withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withEmail("email-id@mail.com")
+                .withEmail("email-id@mail.test")
                 .withReference(ServicePaymentReference.of("case-Insensitive-ref"))
                 .insert();
 
         withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withEmail("EMAIL-ID@MAIL.COM")
+                .withEmail("EMAIL-ID@MAIL.TEST")
                 .withReference(ServicePaymentReference.of("Case-inSENSITIVE-Ref"))
                 .insert();
 
         ChargeSearchParams params = new ChargeSearchParams()
                 .withReferenceLike(ServicePaymentReference.of("cASe-insEnsiTIve"))
-                .withEmailLike("EMAIL-ID@mail.com");
+                .withEmailLike("EMAIL-ID@mail.test");
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -511,11 +514,11 @@ public class TransactionDaoITest extends DaoITestBase {
 
         Transaction transaction = transactions.get(0);
         assertThat(transaction.getReference(), is(ServicePaymentReference.of("Case-inSENSITIVE-Ref")));
-        assertThat(transaction.getEmail(), is("EMAIL-ID@MAIL.COM"));
+        assertThat(transaction.getEmail(), is("EMAIL-ID@MAIL.TEST"));
 
         transaction = transactions.get(1);
         assertThat(transaction.getReference(), is(ServicePaymentReference.of("case-Insensitive-ref")));
-        assertThat(transaction.getEmail(), is("email-id@mail.com"));
+        assertThat(transaction.getEmail(), is("email-id@mail.test"));
     }
 
     @Test
@@ -1165,6 +1168,7 @@ public class TransactionDaoITest extends DaoITestBase {
                         .withAmount(amount)
                         .withTestAccount(defaultTestAccount)
                         .withCreatedDate(creationDate)
+                        .withLanguage(SupportedLanguage.ENGLISH)
                         .insert();
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.SupportedLanguage;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.util.RestAssuredClient;
 
@@ -85,7 +86,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
         app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null,
-                ServicePaymentReference.of("My reference"), createdDate);
+                ServicePaymentReference.of("My reference"), createdDate, SupportedLanguage.WELSH);
         app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "VISA", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
@@ -109,7 +110,8 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
                 .body("results[0].gateway_account", nullValue())
                 .body("results[0].reference", is("My reference"))
                 .body("results[0].description", is(description))
-                .body("results[0].created_date", is("2016-01-26T13:45:32Z"));
+                .body("results[0].created_date", is("2016-01-26T13:45:32Z"))
+                .body("results[0].language", is(SupportedLanguage.WELSH.toString()));
     }
 
     @Test
@@ -186,7 +188,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
                 .body("results[0].card_details.card_brand", endsWith("Mastercard"))
                 .body("results[1].card_details.card_brand", endsWith("Visa"));
     }
-    
+
     @Test
     public void shouldFilterTransactionsByMultipleCardBrand() {
         String visa = "visa";
@@ -437,7 +439,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
         assertThat(references, containsInAnyOrder("ref-1"));
         assertThat(references, not(contains("ref-1", "ref-3", "ref-4", "ref-5")));
     }
-    
+
     private void assertNavigationLinksWhenNoResultFound() {
         ValidatableResponse response = getChargeApi
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -410,6 +410,7 @@ public class ChargesFrontendResourceITest {
                 .body("return_url", is(returnUrl))
                 .body("email", is(email))
                 .body("created_date", is(notNullValue()))
+                .body("language", is("en"))
                 .contentType(JSON);
 
         return response.extract().path("charge_id");
@@ -430,7 +431,8 @@ public class ChargesFrontendResourceITest {
                 .body("email", is(email))
                 .body("created_date", is(notNullValue()))
                 .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{1,3}.\\d{0,3}Z"))
-                .body("created_date", isWithin(10, SECONDS));
+                .body("created_date", isWithin(10, SECONDS))
+                .body("language", is("en"));
         validateGatewayAccount(response);
         validateCardDetails(response, chargeStatus);
         return response;

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -30,20 +30,21 @@ public class ChargeEntityFixture {
     private String paRequest;
     private String issuerUrl;
     private String providerSessionId;
+    private SupportedLanguage language = SupportedLanguage.ENGLISH;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
     }
 
     public ChargeEntity build() {
-        ChargeEntity chargeEntity = new ChargeEntity(amount, status ,returnUrl, description, reference, gatewayAccountEntity, email, createdDate);
+        ChargeEntity chargeEntity = new ChargeEntity(amount, status, returnUrl, description, reference, gatewayAccountEntity, email, createdDate, language);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setGatewayTransactionId(transactionId);
         chargeEntity.getEvents().addAll(events);
         chargeEntity.getRefunds().addAll(refunds);
         chargeEntity.setProviderSessionId(providerSessionId);
-        if(paRequest != null && issuerUrl != null) {
+        if (paRequest != null && issuerUrl != null) {
             Auth3dsDetailsEntity auth3dsDetailsEntity = new Auth3dsDetailsEntity();
             auth3dsDetailsEntity.setIssuerUrl(issuerUrl);
             auth3dsDetailsEntity.setPaRequest(paRequest);

--- a/src/test/java/uk/gov/pay/connector/model/domain/SupportedLanguageTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/SupportedLanguageTest.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.model.domain;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class SupportedLanguageTest {
+
+    @Test
+    public void enMapsToEnglish() {
+        SupportedLanguage result = SupportedLanguage.fromIso639AlphaTwoCode("en");
+        assertThat(result, is(SupportedLanguage.ENGLISH));
+    }
+
+    @Test
+    public void cyMapsToWelsh() {
+        SupportedLanguage result = SupportedLanguage.fromIso639AlphaTwoCode("cy");
+        assertThat(result, is(SupportedLanguage.WELSH));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void frThrowsException() {
+        SupportedLanguage.fromIso639AlphaTwoCode("fr");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void enUpperCaseThrowsException() {
+        SupportedLanguage.fromIso639AlphaTwoCode("EN");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void englishUpperCaseThrowsException() {
+        SupportedLanguage.fromIso639AlphaTwoCode("ENGLISH");
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -397,7 +397,8 @@ public class ChargeServiceTest {
                 .withEmail(chargeEntity.getEmail())
                 .withRefunds(refunds)
                 .withSettlement(settlement)
-                .withReturnUrl(chargeEntity.getReturnUrl());
+                .withReturnUrl(chargeEntity.getReturnUrl())
+                .withLanguage(chargeEntity.getLanguage());
     }
 
 }


### PR DESCRIPTION
## WHAT

Make connector accept a optional `language` field in the create payment request containing either `"en"` (English) or `"cy"` (Welsh), persist the language to the database when saving the charge and return the `language` when the payment is retrieved via the API endpoints (including in response to the initial create payment request).

Commits:
1. Accept `language` in the create payment request, persist to the database and add to model
2. Return `language` inside payment in response to API calls
3. Update integration tests for resources to check for the presence of `language`
4. Make create payment request validation use new enum rather than repeating the list of supported languages

## HOW 

1. Creating payments with either `language: "en"`, `language: "cy"` or no `language` creates payment in database with appropriate value in the `language` column (defaulting to `"en"`) and returns appropriate `language` in JSON response (defaulting to `"en"`).
2. Retrieving the payment from the `/v1/api/accounts/ACCOUNT_ID/charges`, `/v2/api/accounts/ACCOUNT_ID/charges`, `/v1/api/accounts/ACCOUNT_ID/transactions` or `/v1/frontend/charges` endpoints returns object including appropriate `language` (defaulting to `"en"` if none was specified when the payment was created).

with @alexbishop1
