### PR TITLE
PP-3177 Escape backlashes in like statements

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
@@ -161,6 +161,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
     private Predicate likePredicate(CriteriaBuilder cb, Path<String> expression, String element) {
         String escapedReference = element
+                .replaceAll("\\\\", SQL_ESCAPE_SEQ + "\\\\")
                 .replaceAll("_", SQL_ESCAPE_SEQ + "_")
                 .replaceAll("%", SQL_ESCAPE_SEQ + "%");
 

--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -237,6 +237,7 @@ public class TransactionDao {
 
     private String buildLikeClauseContaining(String textToFind) {
         String escapedLikeClause = textToFind
+                .replaceAll("\\\\", "\\\\\\\\")
                 .replaceAll("_", "\\\\_")
                 .replaceAll("%", "\\\\%");
         return '%' + escapedLikeClause + '%';

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -391,6 +391,37 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
+    public void searchChargesByReferenceWithBackslash() {
+        // since '\' is an escape character in postgres (and java) this was resulting in undesired results
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withReference(ServicePaymentReference.of("backslash\\ref"))
+                .insert();
+
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withReference(ServicePaymentReference.of("backslashref"))
+                .insert();
+
+        ChargeSearchParams params = new ChargeSearchParams()
+                .withGatewayAccountId(defaultTestAccount.getAccountId())
+                .withReferenceLike(ServicePaymentReference.of("backslash\\ref"));
+
+        // when
+        List<ChargeEntity> charges = chargeDao.findAllBy(params);
+
+        // then
+        assertThat(charges.size(), is(1));
+
+        ChargeEntity charge = charges.get(0);
+        assertThat(charge.getReference(), is(ServicePaymentReference.of("backslash\\ref")));
+    }
+    
+    @Test
     public void searchChargesByReferenceAndEmailShouldBeCaseInsensitive() {
         // fix that the reference and email searches should be case insensitive
         DatabaseFixtures


### PR DESCRIPTION
## WHAT
 - When fields (eg. reference) contain a backslash we were unable to search
   properly because the backslash is an escape character in postgres.
   For example, for a reference of `abc\def` we were searching for `abcdef`,
   returning the wrong charge.
 - Escaping backslashes (ie. substituting `\` with `\\`) fixes this

Also, because `\` is an escape char in java, too, in the code we actually have to replace `\\\\` with `\\\\\\\\` #justjavathings 💯 

