### PR TITLE
PP-3840 Allow searching by cardholder name and last digits of card number

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
@@ -140,6 +140,10 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
     private List<Predicate> buildParamPredicates(ChargeSearchParams params, CriteriaBuilder cb, Root<ChargeEntity> charge) {
         List<Predicate> predicates = new ArrayList<>();
+        if (params.getCardHolderName() != null && StringUtils.isNotBlank(params.getCardHolderName().toString()))
+            predicates.add(likePredicate(cb, charge.get(CARD_DETAILS).get("cardHolderName"), params.getCardHolderName().toString().toLowerCase()));
+        if (params.getLastDigitsCardNumber() != null && StringUtils.isNotBlank(params.getLastDigitsCardNumber().toString()))
+            predicates.add(cb.equal(charge.get(CARD_DETAILS).get("lastDigitsCardNumber"), params.getLastDigitsCardNumber().toString()));
         if (params.getGatewayAccountId() != null)
             predicates.add(cb.equal(charge.get(GATEWAY_ACCOUNT).get("id"), params.getGatewayAccountId()));
         if (params.getReference() != null && StringUtils.isNotBlank(params.getReference().toString()))

--- a/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeDao.java
@@ -141,7 +141,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
     private List<Predicate> buildParamPredicates(ChargeSearchParams params, CriteriaBuilder cb, Root<ChargeEntity> charge) {
         List<Predicate> predicates = new ArrayList<>();
         if (params.getCardHolderName() != null && StringUtils.isNotBlank(params.getCardHolderName().toString()))
-            predicates.add(likePredicate(cb, charge.get(CARD_DETAILS).get("cardHolderName"), params.getCardHolderName().toString().toLowerCase()));
+            predicates.add(likePredicate(cb, charge.get(CARD_DETAILS).get("cardHolderName"), params.getCardHolderName().toString()));
         if (params.getLastDigitsCardNumber() != null && StringUtils.isNotBlank(params.getLastDigitsCardNumber().toString()))
             predicates.add(cb.equal(charge.get(CARD_DETAILS).get("lastDigitsCardNumber"), params.getLastDigitsCardNumber().toString()));
         if (params.getGatewayAccountId() != null)

--- a/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/dao/ChargeSearchParams.java
@@ -1,12 +1,5 @@
 package uk.gov.pay.connector.dao;
 
-import uk.gov.pay.connector.model.ServicePaymentReference;
-import uk.gov.pay.connector.model.TransactionType;
-import uk.gov.pay.connector.model.api.ExternalChargeState;
-import uk.gov.pay.connector.model.api.ExternalRefundStatus;
-import uk.gov.pay.connector.model.domain.ChargeStatus;
-import uk.gov.pay.connector.model.domain.RefundStatus;
-
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -15,6 +8,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import uk.gov.pay.connector.model.CardHolderName;
+import uk.gov.pay.connector.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.model.ServicePaymentReference;
+import uk.gov.pay.connector.model.TransactionType;
+import uk.gov.pay.connector.model.api.ExternalChargeState;
+import uk.gov.pay.connector.model.api.ExternalRefundStatus;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.RefundStatus;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -23,6 +24,8 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 public class ChargeSearchParams {
 
     private TransactionType transactionType;
+    private LastDigitsCardNumber lastDigitsCardNumber;
+    private CardHolderName cardHolderName;
     private Long gatewayAccountId;
     private ServicePaymentReference reference;
     private String email;
@@ -56,6 +59,16 @@ public class ChargeSearchParams {
         return this;
     }
 
+    public ChargeSearchParams withLastDigitsCardNumber(LastDigitsCardNumber lastDigitsCardNumber) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        return this;
+    }
+
+    public ChargeSearchParams withCardHolderNameLike(CardHolderName cardHolderName) {
+        this.cardHolderName = cardHolderName;
+        return this;
+    }
+    
     public Set<String> getExternalChargeStates() {
         return this.internalChargeStatuses.stream()
                 .map(s -> s.toExternal().getStatus())
@@ -74,6 +87,14 @@ public class ChargeSearchParams {
                 .map(s -> s.toExternal().getStatus())
                 .sorted()
                 .collect(Collectors.toSet());
+    }
+
+    public LastDigitsCardNumber getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public CardHolderName getCardHolderName() {
+        return cardHolderName;
     }
 
     public Set<ChargeStatus> getInternalChargeStatuses() {

--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -111,6 +111,11 @@ public class TransactionDao {
     private SelectOrderByStep buildQueryFor(Long gatewayAccountId, QueryType queryType, ChargeSearchParams params) {
         Condition queryFilters = field("c.gateway_account_id").eq(gatewayAccountId);
 
+        if (params.getCardHolderName() != null && isNotBlank(params.getCardHolderName().toString())) {
+            queryFilters = queryFilters.and(
+                    field("c.cardholder_name").lower().like(buildLikeClauseContaining(params.getCardHolderName().toString().toLowerCase())));
+        }
+        
         if (isNotBlank(params.getEmail())) {
             queryFilters = queryFilters.and(
                     field("c.email").lower().like(buildLikeClauseContaining(params.getEmail().toLowerCase())));
@@ -245,13 +250,13 @@ public class TransactionDao {
 
     private Set<String> mapChargeStatuses(Set<ChargeStatus> status) {
         return status.stream()
-                .map(s -> s.getValue())
+                .map(ChargeStatus::getValue)
                 .collect(Collectors.toSet());
     }
 
     private Set<String> mapRefundStatuses(Set<RefundStatus> status) {
         return status.stream()
-                .map(s -> s.getValue())
+                .map(RefundStatus::getValue)
                 .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/CardHolderName.java
+++ b/src/main/java/uk/gov/pay/connector/model/CardHolderName.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.model;
+
+import java.util.Objects;
+
+public class CardHolderName {
+
+    private final String cardHolderName;
+
+    private CardHolderName(String cardHolderName) {
+        this.cardHolderName = Objects.requireNonNull(cardHolderName);
+    }
+
+    public static CardHolderName of(String cardHolderName) {
+        return new CardHolderName(cardHolderName);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == CardHolderName.class) {
+            CardHolderName that = (CardHolderName) other;
+            return this.cardHolderName.equals(that.cardHolderName);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return cardHolderName.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return cardHolderName;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/model/LastDigitsCardNumber.java
+++ b/src/main/java/uk/gov/pay/connector/model/LastDigitsCardNumber.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.model;
+
+import java.util.Objects;
+
+public class LastDigitsCardNumber {
+
+    private final String lastDigitsCardNumber;
+
+    private LastDigitsCardNumber(String lastDigitsCardNumber) {
+        this.lastDigitsCardNumber = Objects.requireNonNull(lastDigitsCardNumber);
+    }
+
+    public static LastDigitsCardNumber of(String lastDigitsCardNumber) {
+        return new LastDigitsCardNumber(lastDigitsCardNumber);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other != null && other.getClass() == LastDigitsCardNumber.class) {
+            LastDigitsCardNumber that = (LastDigitsCardNumber) other;
+            return this.lastDigitsCardNumber.equals(that.lastDigitsCardNumber);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return lastDigitsCardNumber.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(lastDigitsCardNumber);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -11,6 +11,8 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
 import uk.gov.pay.connector.dao.GatewayAccountDao;
+import uk.gov.pay.connector.model.CardHolderName;
+import uk.gov.pay.connector.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.service.ChargeExpiryService;
@@ -62,6 +64,8 @@ public class ChargesApiResource {
     private static final String DESCRIPTION_KEY = "description";
     private static final String RETURN_URL_KEY = "return_url";
     private static final String REFERENCE_KEY = "reference";
+    private static final String CARDHOLDER_NAME_KEY = "cardholder_name";
+    public static final String LAST_DIGITS_CARD_NUMBER_KEY = "last_digits_card_number";
     static final Map<String, Integer> MAXIMUM_FIELDS_SIZE = ImmutableMap.of(
             DESCRIPTION_KEY, 255,
             REFERENCE_KEY, 255,
@@ -128,6 +132,8 @@ public class ChargesApiResource {
     public Response getChargesJson(@PathParam(ACCOUNT_ID) Long accountId,
                                    @QueryParam(EMAIL_KEY) String email,
                                    @QueryParam(REFERENCE_KEY) String reference,
+                                   @QueryParam(CARDHOLDER_NAME_KEY) String cardHolderName,
+                                   @QueryParam(LAST_DIGITS_CARD_NUMBER_KEY) String lastDigitsCardNumber,
                                    @QueryParam(STATE_KEY) String state,
                                    @QueryParam(PAYMENT_STATES_KEY) CommaDelimitedSetParameter paymentStates,
                                    @QueryParam(REFUND_STATES_KEY) CommaDelimitedSetParameter refundStates,
@@ -151,6 +157,9 @@ public class ChargesApiResource {
                     ChargeSearchParams searchParams = new ChargeSearchParams()
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
+                            .withCardHolderNameLike(cardHolderName != null ? CardHolderName.of(cardHolderName) : null)
+                            .withLastDigitsCardNumber(lastDigitsCardNumber != null ? LastDigitsCardNumber
+                                    .of(lastDigitsCardNumber) : null)
                             .withReferenceLike(reference != null ? ServicePaymentReference.of(reference) : null)
                             .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))
@@ -179,6 +188,7 @@ public class ChargesApiResource {
     public Response getChargesJsonV2(@PathParam(ACCOUNT_ID) Long accountId,
                                      @QueryParam(EMAIL_KEY) String email,
                                      @QueryParam(REFERENCE_KEY) String reference,
+                                     @QueryParam(CARDHOLDER_NAME_KEY) String cardHolderName,
                                      @QueryParam(PAYMENT_STATES_KEY) CommaDelimitedSetParameter paymentStates,
                                      @QueryParam(REFUND_STATES_KEY) CommaDelimitedSetParameter refundStates,
                                      @QueryParam(CARD_BRAND_KEY) List<String> cardBrands,
@@ -200,6 +210,7 @@ public class ChargesApiResource {
                     ChargeSearchParams searchParams = new ChargeSearchParams()
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
+                            .withCardHolderNameLike(cardHolderName != null ? CardHolderName.of(cardHolderName) : null)
                             .withReferenceLike(reference != null ? ServicePaymentReference.of(reference) : null)
                             .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -152,18 +152,24 @@ public class ChargeDaoITest extends DaoITestBase {
 
         // then
         assertThat(charges.size(), is(1));
-        assertCharge("visa", testCharge, charges.get(0));
+        ChargeEntity charge = charges.get(0);
+        assertCharge("visa", testCharge, charge);
+        assertThat(charge.getCardDetails().getCardHolderName(), is(testCharge.cardDetails.getCardHolderName()));
+        assertThat(charge.getCardDetails().getLastDigitsCardNumber(), is(testCharge.cardDetails.getLastDigitsCardNumber()));
     }
 
     @Test
     public void searchChargesByPartialCardHolderNameMatch() {
         // given
+        String cardHolderName = "Mr. McPayment";
         Long chargeId = 12L;
         TestCharge testCharge = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCardDetails(defaultTestCardDetails.withChargeId(chargeId))
+                .withCardDetails(defaultTestCardDetails
+                        .withChargeId(chargeId)
+                        .withCardHolderName(cardHolderName))
                 .withChargeId(chargeId)
                 .insert();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -174,18 +180,26 @@ public class ChargeDaoITest extends DaoITestBase {
 
         // then
         assertThat(charges.size(), is(1));
-        assertCharge("visa", testCharge, charges.get(0));
+        ChargeEntity charge = charges.get(0);
+        assertCharge("visa", testCharge, charge);
+        assertThat(charge.getCardDetails().getCardHolderName(), is(cardHolderName));
+        assertThat(charge.getCardDetails().getLastDigitsCardNumber(), is(testCharge.cardDetails.getLastDigitsCardNumber()));
     }
 
     @Test
     public void searchChargesByFullLastFourDigits() {
         // given
+        String cardHolderName = "Mr. McPayment";
+        String lastDigits = "4321";
         Long chargeId = 12L;
         TestCharge testCharge = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCardDetails(defaultTestCardDetails.withChargeId(chargeId))
+                .withCardDetails(defaultTestCardDetails
+                        .withChargeId(chargeId)
+                        .withCardHolderName(cardHolderName)
+                        .withLastDigitsOfCardNumber(lastDigits))
                 .withChargeId(chargeId)
                 .insert();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -196,22 +210,28 @@ public class ChargeDaoITest extends DaoITestBase {
 
         // then
         assertThat(charges.size(), is(1));
-        assertCharge("visa", testCharge, charges.get(0));
+        ChargeEntity charge = charges.get(0);
+        assertCharge("visa", testCharge, charge);
+        assertThat(charge.getCardDetails().getCardHolderName(), is(cardHolderName));
+        assertThat(charge.getCardDetails().getLastDigitsCardNumber(), is(lastDigits));
     }
 
     @Test
     public void shouldNotMatchChargesByPartialLastFourDigits() {
         // given
+        String lastDigits = "4321";
         Long chargeId = 12L;
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCardDetails(defaultTestCardDetails.withChargeId(chargeId))
+                .withCardDetails(defaultTestCardDetails
+                        .withChargeId(chargeId)
+                .withLastDigitsOfCardNumber(lastDigits))
                 .withChargeId(chargeId)
                 .insert();
         ChargeSearchParams params = new ChargeSearchParams()
-                .withLastDigitsCardNumber(LastDigitsCardNumber.of("123"));
+                .withLastDigitsCardNumber(LastDigitsCardNumber.of("432"));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -8,6 +8,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.dao.ChargeDao;
 import uk.gov.pay.connector.dao.ChargeSearchParams;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures.TestCharge;
+import uk.gov.pay.connector.model.CardHolderName;
+import uk.gov.pay.connector.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeEntity;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
@@ -69,14 +72,14 @@ public class ChargeDaoITest extends DaoITestBase {
     private DatabaseFixtures.TestCardDetails defaultTestCardDetails;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         chargeDao = env.getInstance(ChargeDao.class);
         defaultTestCardDetails = new DatabaseFixtures(databaseTestHelper).validTestCardDetails();
         insertTestAccount();
     }
 
     @Test
-    public void searchChargesByGatewayAccountIdOnly() throws Exception {
+    public void searchChargesByGatewayAccountIdOnly() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -99,7 +102,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByFullEmailMatch() throws Exception {
+    public void searchChargesByFullEmailMatch() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -115,7 +118,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByPartialEmailMatch() throws Exception {
+    public void searchChargesByPartialEmailMatch() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -131,7 +134,94 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByCardBrandOnly() throws Exception {
+    public void searchChargesByFullCardHolderNameMatch() {
+        // given
+        Long chargeId = 12L;
+        TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withCardDetails(defaultTestCardDetails.withChargeId(chargeId))
+                .withChargeId(chargeId)
+                .insert();
+        ChargeSearchParams params = new ChargeSearchParams()
+                .withCardHolderNameLike(CardHolderName.of(testCharge.cardDetails.getCardHolderName()));
+
+        // when
+        List<ChargeEntity> charges = chargeDao.findAllBy(params);
+
+        // then
+        assertThat(charges.size(), is(1));
+        assertCharge("visa", testCharge, charges.get(0));
+    }
+
+    @Test
+    public void searchChargesByPartialCardHolderNameMatch() {
+        // given
+        Long chargeId = 12L;
+        TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withCardDetails(defaultTestCardDetails.withChargeId(chargeId))
+                .withChargeId(chargeId)
+                .insert();
+        ChargeSearchParams params = new ChargeSearchParams()
+                .withCardHolderNameLike(CardHolderName.of("pay"));
+
+        // when
+        List<ChargeEntity> charges = chargeDao.findAllBy(params);
+
+        // then
+        assertThat(charges.size(), is(1));
+        assertCharge("visa", testCharge, charges.get(0));
+    }
+
+    @Test
+    public void searchChargesByFullLastFourDigits() {
+        // given
+        Long chargeId = 12L;
+        TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withCardDetails(defaultTestCardDetails.withChargeId(chargeId))
+                .withChargeId(chargeId)
+                .insert();
+        ChargeSearchParams params = new ChargeSearchParams()
+                .withLastDigitsCardNumber(LastDigitsCardNumber.of(testCharge.cardDetails.getLastDigitsCardNumber()));
+
+        // when
+        List<ChargeEntity> charges = chargeDao.findAllBy(params);
+
+        // then
+        assertThat(charges.size(), is(1));
+        assertCharge("visa", testCharge, charges.get(0));
+    }
+
+    @Test
+    public void shouldNotMatchChargesByPartialLastFourDigits() {
+        // given
+        Long chargeId = 12L;
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withCardDetails(defaultTestCardDetails.withChargeId(chargeId))
+                .withChargeId(chargeId)
+                .insert();
+        ChargeSearchParams params = new ChargeSearchParams()
+                .withLastDigitsCardNumber(LastDigitsCardNumber.of("123"));
+
+        // when
+        List<ChargeEntity> charges = chargeDao.findAllBy(params);
+
+        // then
+        assertThat(charges.size(), is(0));
+    }
+    
+    @Test
+    public void searchChargesByCardBrandOnly() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -147,7 +237,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByMultipleCardBrandOnly() throws Exception {
+    public void searchChargesByMultipleCardBrandOnly() {
         // given
         String visa = "visa";
         String masterCard = "master-card";
@@ -168,7 +258,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesWithDefaultSizeAndPage_shouldGetChargesInCreationDateOrder() throws Exception {
+    public void searchChargesWithDefaultSizeAndPage_shouldGetChargesInCreationDateOrder() {
         // given
         insertNewChargeWithId(700L, now().plusHours(1));
         insertNewChargeWithId(800L, now().plusHours(2));
@@ -191,7 +281,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesWithSizeAndPageSetshouldGetChargesInCreationDateOrder() throws Exception {
+    public void searchChargesWithSizeAndPageSetshouldGetChargesInCreationDateOrder() {
         // given
         insertNewChargeWithId(900L, now().plusHours(1));
         insertNewChargeWithId(800L, now().plusHours(2));
@@ -259,7 +349,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByFullReferenceOnly() throws Exception {
+    public void searchChargesByFullReferenceOnly() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -284,7 +374,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByPartialReferenceOnly() throws Exception {
+    public void searchChargesByPartialReferenceOnly() {
         // given
         insertTestCharge();
         ServicePaymentReference paymentReference = ServicePaymentReference.of("Council Tax Payment reference 2");
@@ -360,7 +450,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargesByReferenceWithPercentSign() throws Exception {
+    public void searchChargesByReferenceWithPercentSign() {
         // since '%' have special meaning in like queries of postgres this was resulting in undesired results
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
@@ -461,7 +551,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void aBasicTestAgainstSqlInjection() throws Exception {
+    public void aBasicTestAgainstSqlInjection() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -483,7 +573,7 @@ public class ChargeDaoITest extends DaoITestBase {
 
 
     @Test
-    public void searchChargeByReferenceAndLegacyStatusOnly() throws Exception {
+    public void searchChargeByReferenceAndLegacyStatusOnly() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -508,7 +598,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargeByReferenceAndStatusAndFromDateAndToDate() throws Exception {
+    public void searchChargeByReferenceAndStatusAndFromDateAndToDate() {
 
         // given
         insertTestCharge();
@@ -536,7 +626,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargeByReferenceAndStatusAndFromDate() throws Exception {
+    public void searchChargeByReferenceAndStatusAndFromDate() {
 
         // given
         insertTestCharge();
@@ -637,7 +727,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargeByReferenceAndStatusAndEmailAndCardBrandAndFromDateAndToDate() throws Exception {
+    public void searchChargeByReferenceAndStatusAndEmailAndCardBrandAndFromDateAndToDate() {
         // given
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
@@ -666,7 +756,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargeByReferenceAndStatusAndToDate() throws Exception {
+    public void searchChargeByReferenceAndStatusAndToDate() {
 
         // given
         insertTestCharge();
@@ -693,7 +783,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargeByReferenceAndStatusAndFromDate_ShouldReturnZeroIfDateIsNotInRange() throws Exception {
+    public void searchChargeByReferenceAndStatusAndFromDate_ShouldReturnZeroIfDateIsNotInRange() {
         insertTestCharge();
 
         ChargeSearchParams params = new ChargeSearchParams()
@@ -709,7 +799,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void searchChargeByReferenceAndStatusAndToDate_ShouldReturnZeroIfToDateIsNotInRange() throws Exception {
+    public void searchChargeByReferenceAndStatusAndToDate_ShouldReturnZeroIfToDateIsNotInRange() {
         insertTestCharge();
         ChargeSearchParams params = new ChargeSearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
@@ -731,7 +821,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void chargeEvents_shouldRecordTransactionIdWithEachStatusChange() throws Exception {
+    public void chargeEvents_shouldRecordTransactionIdWithEachStatusChange() {
         Long chargeId = 56735L;
         String externalChargeId = "charge456";
 
@@ -753,7 +843,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void invalidSizeOfReference() throws Exception {
+    public void invalidSizeOfReference() {
         expectedEx.expect(RuntimeException.class);
 
         GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
@@ -944,7 +1034,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void findById_shouldFindChargeEntity() throws Exception {
+    public void findById_shouldFindChargeEntity() {
 
         // given
         insertTestCharge();
@@ -988,7 +1078,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void testFindByDate_status_findsValidChargeForStatus() throws Exception {
+    public void testFindByDate_status_findsValidChargeForStatus() {
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -1007,7 +1097,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void testFindByDateStatus_findsNoneForValidStatus() throws Exception {
+    public void testFindByDateStatus_findsNoneForValidStatus() {
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -1025,7 +1115,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void testFindByDateStatus_findsNoneForExpiredDate() throws Exception {
+    public void testFindByDateStatus_findsNoneForExpiredDate() {
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -1176,7 +1266,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void findChargesForCapture_shouldReturnChargesInCaptureApprovedState() throws Exception {
+    public void findChargesForCapture_shouldReturnChargesInCaptureApprovedState() {
         final long chargeId1 = 101L;
 
         DatabaseFixtures
@@ -1234,7 +1324,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void findChargesForCapture_shouldNotReturnAChargeForWhichCaptureHasBeenAttemptedRecently() throws Exception {
+    public void findChargesForCapture_shouldNotReturnAChargeForWhichCaptureHasBeenAttemptedRecently() {
         final long chargeId1 = 101L;
         final long chargeId2 = 102L;
 
@@ -1308,7 +1398,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void countChargesForCapture_shouldReturnNumberOfChargesInCaptureApprovedState() throws Exception {
+    public void countChargesForCapture_shouldReturnNumberOfChargesInCaptureApprovedState() {
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -1349,7 +1439,7 @@ public class ChargeDaoITest extends DaoITestBase {
     }
 
     @Test
-    public void countCaptureRetriesForCharge_shouldReturnNumberOfRetries() throws Exception {
+    public void countCaptureRetriesForCharge_shouldReturnNumberOfRetries() {
         long chargeId = 101L;
 
         DatabaseFixtures

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -376,6 +376,10 @@ public class DatabaseFixtures {
         TestAccount testAccount;
         TestCardDetails cardDetails;
 
+        public TestCardDetails getCardDetails() {
+            return cardDetails;
+        }
+
         public TestCharge withTestAccount(TestAccount account) {
             this.testAccount = account;
             return this;

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -76,7 +76,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetChargeTransactionsForJSONAcceptHeader() throws Exception {
+    public void shouldGetChargeTransactionsForJSONAcceptHeader() {
         long chargeId = nextInt();
         String externalChargeId = "charge3";
 
@@ -115,7 +115,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetChargeLegacyTransactions() throws Exception {
+    public void shouldGetChargeLegacyTransactions() {
 
         long chargeId = nextInt();
         String externalChargeId = "charge3";
@@ -153,7 +153,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterTransactionsByCardBrand() throws Exception {
+    public void shouldFilterTransactionsByCardBrand() {
         String searchedCardBrand = "visa";
 
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now(), searchedCardBrand);
@@ -234,7 +234,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetTransactionsForPageAndSizeParams_inCreationDateOrder2() throws Exception {
+    public void shouldGetTransactionsForPageAndSizeParams_inCreationDateOrder2() {
         String id_1 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
         String id_2 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-2"), now().plusHours(1));
         String id_3 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-3"), now().plusHours(2));
@@ -350,7 +350,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterTransactionsByEmail() throws Exception {
+    public void shouldFilterTransactionsByEmail() {
 
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
@@ -367,6 +367,24 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
                 .body("results[0].email", endsWith("example.com"));
     }
 
+    @Test
+    public void shouldFilterTransactionsByCardHolderName() {
+
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("cardholder_name", "McPayment")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(3))
+                .body("results[0].card_details.cardholder_name", is("Mr. McPayment"));
+    }
+    
     @Test
     public void shouldShowTotalCountResultsAndHalLinksForCharges() {
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
@@ -584,7 +602,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
                 "query param 'display_size' should be a non zero positive integer",
                 "query param 'page' should be a non zero positive integer");
 
-        ValidatableResponse response = getChargeApi
+        getChargeApi
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "-1")

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -382,7 +382,8 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
                 .body("results.size()", is(3))
-                .body("results[0].card_details.cardholder_name", is("Mr. McPayment"));
+                .body("results[0].card_details.cardholder_name", is("Mr. McPayment"))
+                .body("results[0].card_details.last_digits_card_number", is("1234"));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -236,7 +236,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void makeChargeNoEmailField_shouldReturnOK() throws Exception {
+    public void makeChargeNoEmailField_shouldReturnOK() {
         String expectedReference = "Test reference";
         String expectedDescription = "Test description";
         String postBody = toJson(ImmutableMap.builder()
@@ -366,7 +366,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetCardDetails_ifStatusIsBeyondAuthorised() throws Exception {
+    public void shouldGetCardDetails_ifStatusIsBeyondAuthorised() {
         long chargeId = nextInt();
         String externalChargeId = "charge1";
 
@@ -385,7 +385,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterChargeStatusToReturnInProgressIfInternalStatusIsAuthorised() throws Exception {
+    public void shouldFilterChargeStatusToReturnInProgressIfInternalStatusIsAuthorised() {
 
         long chargeId = nextInt();
         String externalChargeId = "charge1";
@@ -404,7 +404,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturnCardBrandLabelWhenChargeIsAuthorised() throws Exception {
+    public void shouldReturnCardBrandLabelWhenChargeIsAuthorised() {
 
         long chargeId = nextInt();
         String externalChargeId = "charge1";
@@ -430,7 +430,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturnEmptyCardBrandLabelWhenChargeIsAuthorisedAndBrandUnknown() throws Exception {
+    public void shouldReturnEmptyCardBrandLabelWhenChargeIsAuthorisedAndBrandUnknown() {
 
         long chargeId = nextInt();
         String externalChargeId = "charge1";
@@ -451,7 +451,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetChargeTransactionsForJSONAcceptHeader() throws Exception {
+    public void shouldGetChargeTransactionsForJSONAcceptHeader() {
 
         long chargeId = nextInt();
         String externalChargeId = "charge3";
@@ -494,7 +494,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetChargeLegacyTransactions() throws Exception {
+    public void shouldGetChargeLegacyTransactions() {
 
         long chargeId = nextInt();
         String externalChargeId = "charge3";
@@ -533,7 +533,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterTransactionsBasedOnFromAndToDates() throws Exception {
+    public void shouldFilterTransactionsBasedOnFromAndToDates() {
 
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
@@ -582,13 +582,13 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterTransactionsByEmail() throws Exception {
+    public void shouldFilterTransactionsByEmail() {
 
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        ValidatableResponse response = getChargeApi
+        getChargeApi
                 .withAccountId(accountId)
                 .withQueryParam("email", "@example.com")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -599,6 +599,42 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("results[0].email", endsWith("example.com"));
     }
 
+    @Test
+    public void shouldFilterTransactionsByCardHolderName() {
+        
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("cardholder_name", "McPayment")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactions()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(3))
+                .body("results[0].card_details.cardholder_name", is("Mr. McPayment"));
+    }
+
+    @Test
+    public void shouldFilterTransactionsByLastDigitsCardNumber() {
+        
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("last_digits_card_number", "1234")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactions()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(3))
+                .body("results[0].card_details.last_digits_card_number", is("1234"));
+    }
+    
     @Test
     public void shouldFilterTransactionsByCardBrand() {
         String searchedCardBrand = "visa";
@@ -637,7 +673,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldFilterTransactionsByMultipleCardBrand() throws Exception {
+    public void shouldFilterTransactionsByMultipleCardBrand() {
         String visa = "visa";
         String mastercard = "master-card";
 
@@ -675,7 +711,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldShowValidationsForDateAndPageDisplaySize() throws Exception {
+    public void shouldShowValidationsForDateAndPageDisplaySize() {
         ImmutableList<String> expectedList = ImmutableList.of(
                 "query param 'from_date' not in correct format",
                 "query param 'to_date' not in correct format",
@@ -696,7 +732,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetAllTransactionsForDefault_page_1_size_100_inCreationDateOrder() throws Exception {
+    public void shouldGetAllTransactionsForDefault_page_1_size_100_inCreationDateOrder() {
         String id_1 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
         String id_2 = addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now().plusHours(1));
         String id_3 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-3"), now().plusHours(2));
@@ -717,7 +753,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldGetTransactionsForPageAndSizeParams_inCreationDateOrder() throws Exception {
+    public void shouldGetTransactionsForPageAndSizeParams_inCreationDateOrder() {
         String id_1 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
         String id_2 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-2"), now().plusHours(1));
         String id_3 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-3"), now().plusHours(2));
@@ -768,7 +804,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void cannotMakeChargeForMissingGatewayAccount() throws Exception {
+    public void cannotMakeChargeForMissingGatewayAccount() {
         String missingGatewayAccount = "1234123";
         String postBody = toJson(ImmutableMap.of(
                 JSON_AMOUNT_KEY, AMOUNT,
@@ -788,7 +824,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void cannotMakeChargeForInvalidSizeOfFields() throws Exception {
+    public void cannotMakeChargeForInvalidSizeOfFields() {
         String postBody = toJson(ImmutableMap.builder()
                 .put(JSON_AMOUNT_KEY, AMOUNT)
                 .put(JSON_REFERENCE_KEY, randomAlphabetic(256))
@@ -806,7 +842,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void cannotMakeChargeForMissingFields() throws Exception {
+    public void cannotMakeChargeForMissingFields() {
         createChargeApi.postCreateCharge("{}")
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
@@ -816,7 +852,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void cannotGetCharge_WhenInvalidChargeId() throws Exception {
+    public void cannotGetCharge_WhenInvalidChargeId() {
         String chargeId = "23235124";
         getChargeApi
                 .withAccountId(accountId)
@@ -893,7 +929,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 "query param 'display_size' should be a non zero positive integer",
                 "query param 'page' should be a non zero positive integer");
 
-        ValidatableResponse response = getChargeApi
+        getChargeApi
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "-1")
@@ -972,7 +1008,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("_links.self.href", is(expectedChargesLocationFor(accountId, "?reference=junk-yard&page=1&display_size=500")));
 
         List<Map<String, Object>> results = response.extract().body().jsonPath().getList("results");
-        List<String> references = collect(results, "reference");
+        collect(results, "reference");
         assertTrue(results.isEmpty());
     }
 


### PR DESCRIPTION
## WHAT
- Adding both query params for searching payments via publicapi (old `/v1/charges` endpoint)
- Adding just the cardholder name query param for searching via selfservice (new `/v2/charges` endpoint)
- Cardholder name will match on partial search, eg. searching for `Jane` will match both `Jane Doe` and `Bob Somejane`, while last digit of card number must be provided in full, as in searching for `12` won't match `1234`

