### PR TITLE
PP-3804 Add filtering by last digits of card number

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -115,6 +115,11 @@ public class TransactionDao {
             queryFilters = queryFilters.and(
                     field("c.cardholder_name").lower().like(buildLikeClauseContaining(params.getCardHolderName().toString().toLowerCase())));
         }
+
+        if (params.getLastDigitsCardNumber() != null && isNotBlank(params.getLastDigitsCardNumber().toString())) {
+            queryFilters = queryFilters.and(
+                    field("c.last_digits_card_number").eq(params.getLastDigitsCardNumber().toString()));
+        }
         
         if (isNotBlank(params.getEmail())) {
             queryFilters = queryFilters.and(

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -189,6 +189,7 @@ public class ChargesApiResource {
                                      @QueryParam(EMAIL_KEY) String email,
                                      @QueryParam(REFERENCE_KEY) String reference,
                                      @QueryParam(CARDHOLDER_NAME_KEY) String cardHolderName,
+                                     @QueryParam(LAST_DIGITS_CARD_NUMBER_KEY) String lastDigitsCardNumber,
                                      @QueryParam(PAYMENT_STATES_KEY) CommaDelimitedSetParameter paymentStates,
                                      @QueryParam(REFUND_STATES_KEY) CommaDelimitedSetParameter refundStates,
                                      @QueryParam(CARD_BRAND_KEY) List<String> cardBrands,
@@ -211,6 +212,7 @@ public class ChargesApiResource {
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
                             .withCardHolderNameLike(cardHolderName != null ? CardHolderName.of(cardHolderName) : null)
+                            .withLastDigitsCardNumber(lastDigitsCardNumber != null ? LastDigitsCardNumber.of(lastDigitsCardNumber) : null)
                             .withReferenceLike(reference != null ? ServicePaymentReference.of(reference) : null)
                             .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))
@@ -241,6 +243,8 @@ public class ChargesApiResource {
     public Response getTransactionsJson(@PathParam(ACCOUNT_ID) Long accountId,
                                         @QueryParam(EMAIL_KEY) String email,
                                         @QueryParam(REFERENCE_KEY) String reference,
+                                        @QueryParam(CARDHOLDER_NAME_KEY) String cardHolderName,
+                                        @QueryParam(LAST_DIGITS_CARD_NUMBER_KEY) String lastDigitsCardNumber,
                                         @QueryParam(PAYMENT_STATES_KEY) List<String> paymentStates,
                                         @QueryParam(REFUND_STATES_KEY) List<String> refundStates,
                                         @QueryParam(CARD_BRAND_KEY) List<String> cardBrands,
@@ -259,6 +263,8 @@ public class ChargesApiResource {
                     ChargeSearchParams searchParams = new ChargeSearchParams()
                             .withGatewayAccountId(accountId)
                             .withEmailLike(email)
+                            .withCardHolderNameLike(cardHolderName != null ? CardHolderName.of(cardHolderName) : null)
+                            .withLastDigitsCardNumber(lastDigitsCardNumber != null ? LastDigitsCardNumber.of(lastDigitsCardNumber) : null)
                             .withReferenceLike(reference != null ? ServicePaymentReference.of(reference) : null)
                             .withCardBrands(removeBlanks(cardBrands))
                             .withFromDate(parseDate(fromDate))

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -369,11 +369,11 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
 
     @Test
     public void shouldFilterTransactionsByCardHolderName() {
-
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
+        
         getChargeApi
                 .withAccountId(accountId)
                 .withQueryParam("cardholder_name", "McPayment")
@@ -384,6 +384,42 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
                 .body("results.size()", is(3))
                 .body("results[0].card_details.cardholder_name", is("Mr. McPayment"))
                 .body("results[0].card_details.last_digits_card_number", is("1234"));
+    }
+
+    @Test
+    public void searchChargesByFullLastFourDigits() {
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
+
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("last_digits_card_number", "1234")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(3))
+                .body("results[0].card_details.cardholder_name", is("Mr. McPayment"))
+                .body("results[0].card_details.last_digits_card_number", is("1234"));
+    }
+
+    @Test
+    public void shouldNotMatchChargesByPartialLastFourDigits() {
+        addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now());
+        addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
+        addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
+
+
+        getChargeApi
+                .withAccountId(accountId)
+                .withQueryParam("last_digits_card_number", "12")
+                .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
+                .getTransactionsAPI()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results.size()", is(0));
     }
     
     @Test


### PR DESCRIPTION
## WHAT
 - We have 3 different endpoint for search (`/v1/charges/`, `/v2/charges` and `/v1/transactions`), adding filtering (partial/full) on cardholder name and full filtering on last digits for all of these endpoints

