### PR TITLE
PP-4105 Add delayed_capture validation to create payment request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
@@ -24,6 +24,7 @@ import static uk.gov.pay.connector.resources.ChargesApiResource.AMOUNT_KEY;
 import static uk.gov.pay.connector.resources.ChargesApiResource.EMAIL_KEY;
 import static uk.gov.pay.connector.resources.ChargesApiResource.LANGUAGE_KEY;
 import static uk.gov.pay.connector.resources.ChargesApiResource.MAXIMUM_FIELDS_SIZE;
+import static uk.gov.pay.connector.resources.ChargesApiResource.DELAYED_CAPTURE_KEY;
 import static uk.gov.pay.connector.resources.ChargesApiResource.MAX_AMOUNT;
 import static uk.gov.pay.connector.resources.ChargesApiResource.MIN_AMOUNT;
 
@@ -40,8 +41,20 @@ class ApiValidators {
         AMOUNT(AMOUNT_KEY) {
             @Override
             boolean validate(String amount) {
-                Integer amountValue = Integer.valueOf(amount);
+                Integer amountValue;
+                try {
+                    amountValue  = Integer.valueOf(amount);
+                } catch (NumberFormatException e) {
+                    return false;
+                }
                 return MIN_AMOUNT <= amountValue && MAX_AMOUNT >= amountValue;
+            }
+        },
+        
+        DELAYED_CAPTURE(DELAYED_CAPTURE_KEY) {
+            @Override
+            boolean validate(String delayedCapture) {
+                return Boolean.TRUE.toString().equals(delayedCapture) || Boolean.FALSE.toString().equals(delayedCapture);
             }
         },
 

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesApiResource.java
@@ -61,6 +61,7 @@ public class ChargesApiResource {
     public static final String EMAIL_KEY = "email";
     static final String AMOUNT_KEY = "amount";
     static final String LANGUAGE_KEY = "language";
+    static final String DELAYED_CAPTURE_KEY = "delayed_capture";
     private static final String DESCRIPTION_KEY = "description";
     private static final String RETURN_URL_KEY = "return_url";
     private static final String REFERENCE_KEY = "reference";

--- a/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/ApiValidatorsTest.java
@@ -24,6 +24,7 @@ import static uk.gov.pay.connector.resources.ApiValidators.validateChargeParams;
 import static uk.gov.pay.connector.resources.ApiValidators.validateChargePatchParams;
 import static uk.gov.pay.connector.resources.ApiValidators.validateFromDateIsBeforeToDate;
 import static uk.gov.pay.connector.resources.ChargesApiResource.AMOUNT_KEY;
+import static uk.gov.pay.connector.resources.ChargesApiResource.DELAYED_CAPTURE_KEY;
 import static uk.gov.pay.connector.resources.ChargesApiResource.EMAIL_KEY;
 import static uk.gov.pay.connector.resources.ChargesApiResource.LANGUAGE_KEY;
 import static uk.gov.pay.connector.resources.ChargesApiResource.MAX_AMOUNT;
@@ -169,6 +170,16 @@ public class ApiValidatorsTest {
     }
 
     @Test
+    public void validateChargeParams_shouldRejectAmount_whenNotParsableAsLong() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(AMOUNT_KEY, "this is not a number");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList(AMOUNT_KEY))));
+    }
+
+    @Test
     public void validateChargeParams_shouldAcceptLanguage_whenEn() {
         Map<String, String> inputData = new HashMap<>();
         inputData.put(LANGUAGE_KEY, "en");
@@ -218,6 +229,36 @@ public class ApiValidatorsTest {
         assertThat(result, is(Optional.of(Collections.singletonList("language"))));
     }
 
+    @Test
+    public void validateChargeParams_shouldAcceptDelayedCapture_whenTrue() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(DELAYED_CAPTURE_KEY, "true");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.empty()));
+    }
+
+    @Test
+    public void validateChargeParams_shouldAcceptDelayedCapture_whenFalse() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(DELAYED_CAPTURE_KEY, "false");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.empty()));
+    }
+
+    @Test
+    public void validateChargeParams_shouldAcceptDelayedCapture_whenNotTrueOrFalse() {
+        Map<String, String> inputData = new HashMap<>();
+        inputData.put(DELAYED_CAPTURE_KEY, "maybe");
+
+        Optional<List<String>> result = validateChargeParams(inputData);
+
+        assertThat(result, is(Optional.of(Collections.singletonList("delayed_capture"))));
+    }
+    
     @Test
     public void validateChargeParams_shouldRejectEmailAndAmount_whenBothInvalid() {
         Map<String, String> inputData = new HashMap<>();


### PR DESCRIPTION
- The validation accepts `true` and `false` as values
- Even if valid, the `delayed_capture` is still ignored for now
- Correct validation for `amount` so it no longer throws an exception if input cannot be parsed into long (returns `false` instead, which ultimately makes connector return a more sensible error response)
- Doesn’t actually do anything with `delayed_capture` yet after validating it

with @danworth