### PR TITLE
PP-4105 Add delayed capture flag to charge and persist to database

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/ChargeEntity.java
@@ -109,19 +109,22 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Column(name = "language", nullable = false)
     @Convert(converter = SupportedLanguageJpaConverter.class)
     private SupportedLanguage language;
+    
+    @Column(name = "delayed_capture")
+    private boolean delayedCapture;
 
     public ChargeEntity() {
         //for jpa
     }
 
     public ChargeEntity(Long amount, String returnUrl, String description, ServicePaymentReference reference,
-                        GatewayAccountEntity gatewayAccount, String email, SupportedLanguage language) {
-        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language);
+                        GatewayAccountEntity gatewayAccount, String email, SupportedLanguage language, boolean delayedCapture) {
+        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture);
     }
 
     //for fixture
     ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, ServicePaymentReference reference,
-                 GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate, SupportedLanguage language) {
+                 GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate, SupportedLanguage language, boolean delayedCapture) {
         this.amount = amount;
         this.status = status.getValue();
         this.returnUrl = returnUrl;
@@ -132,6 +135,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.externalId = RandomIdGenerator.newId();
         this.email = email;
         this.language = language;
+        this.delayedCapture = delayedCapture;
     }
 
     public Long getId() {
@@ -298,4 +302,13 @@ public class ChargeEntity extends AbstractVersionedEntity {
     public void setLanguage(SupportedLanguage language) {
         this.language = language;
     }
+
+    public boolean isDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public void setDelayedCapture(boolean delayedCapture) {
+        this.delayedCapture = delayedCapture;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -88,7 +88,8 @@ public class ChargeService {
                     ServicePaymentReference.of(chargeRequest.get("reference")),
                     gatewayAccount,
                     chargeRequest.get("email"),
-                    language);
+                    language,
+                    Boolean.valueOf(chargeRequest.getOrDefault("delayed_capture", "false")));
             chargeDao.persist(chargeEntity);
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
@@ -89,7 +89,8 @@ public class ChargeDaoCardDetailsITest extends DaoITestBase {
 
         Address billingAddress = aValidAddress().build();
         ChargeEntity chargeEntity = new ChargeEntity(2323L, "returnUrl", "description",
-                ServicePaymentReference.of("ref"), testAccount, "email@email.test", SupportedLanguage.ENGLISH);
+                ServicePaymentReference.of("ref"), testAccount, "email@email.test", SupportedLanguage.ENGLISH,
+                false);
         CardDetailsEntity cardDetailsEntity = new CardDetailsEntity();
         cardDetailsEntity.setCardBrand("VISA");
         cardDetailsEntity.setBillingAddress(new AddressEntity(billingAddress));

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -32,13 +32,15 @@ public class ChargeEntityFixture {
     private String issuerUrl;
     private String providerSessionId;
     private SupportedLanguage language = SupportedLanguage.ENGLISH;
+    private boolean delayedCapture = false;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
     }
 
     public ChargeEntity build() {
-        ChargeEntity chargeEntity = new ChargeEntity(amount, status, returnUrl, description, reference, gatewayAccountEntity, email, createdDate, language);
+        ChargeEntity chargeEntity = new ChargeEntity(amount, status, returnUrl, description, reference,
+                gatewayAccountEntity, email, createdDate, language, delayedCapture);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setGatewayTransactionId(transactionId);

--- a/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeServiceTest.java
@@ -133,7 +133,7 @@ public class ChargeServiceTest {
     }
 
     @Test
-    public void shouldCreateAChargeWithDefaultLanguage() {
+    public void shouldCreateAChargeWithDefaultLanguageAndDefaultDelayedCapture() {
         service.create(CHARGE_REQUEST, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
         ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
@@ -152,8 +152,29 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getGatewayTransactionId(), is(nullValue()));
         assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, ZonedDateTime.now(ZoneId.of("UTC")))));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
+        assertThat(createdChargeEntity.isDelayedCapture(), is(false));
 
         verify(mockedChargeEventDao).persistChargeEventOf(createdChargeEntity, Optional.empty());
+    }
+
+    @Test
+    public void shouldCreateAChargeWithDelayedCaptureTrue() {
+        Map<String, String> chargeRequestWithDelayedCapture = new HashMap<>(CHARGE_REQUEST);
+        chargeRequestWithDelayedCapture.put("delayed_capture", "true");
+        service.create(chargeRequestWithDelayedCapture, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+    }
+
+    @Test
+    public void shouldCreateAChargeWithDelayedCaptureFalse() {
+        Map<String, String> chargeRequestWithoutDelayedCapture = new HashMap<>(CHARGE_REQUEST);
+        chargeRequestWithoutDelayedCapture.put("delayed_capture", "false");
+        service.create(chargeRequestWithoutDelayedCapture, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
     }
 
     @Test


### PR DESCRIPTION
- Add delayed capture boolean flag to `ChargeEntity` such that it is persisted to the database

- When creating a payment, set the delayed capture boolean on the `ChargeEntity` based on what was in the create payment request, defaulting to false if none was supplied

with @danworth