### PR TITLE
PP-4105 Add delayed_capture to payment JSON responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/dao/TransactionDao.java
@@ -67,7 +67,8 @@ public class TransactionDao {
                         field("address_line2"),
                         field("address_postcode"),
                         field("amount"),
-                        field("language"))
+                        field("language"),
+                        field("delayed_capture"))
                 .from(buildQueryFor(gatewayAccountId, QueryType.SELECT, params))
                 .orderBy(field("date_created").desc());
 
@@ -195,7 +196,8 @@ public class TransactionDao {
                 field("c.address_line2"),
                 field("c.address_postcode"),
                 field("c.amount"),
-                field("c.language"))
+                field("c.language"),
+                field("c.delayed_capture"))
                 .from(table("charges").as("c").leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))
                 .where(queryFiltersForCharges);
 
@@ -223,7 +225,8 @@ public class TransactionDao {
                 field("c.address_line2"),
                 field("c.address_postcode"),
                 field("r.amount"),
-                field("c.language"))
+                field("c.language"),
+                field("c.delayed_capture"))
                 .from(table("charges").as("c").leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))
                 .join(table("refunds").as("r"))
                 .on(field("c.id").eq(field("r.charge_id")))

--- a/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/ChargeResponse.java
@@ -249,7 +249,7 @@ public class ChargeResponse {
         public ChargeResponse build() {
             return new ChargeResponse(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
                     description, reference, providerName, createdDate, links, refundSummary, settlementSummary,
-                    cardDetails, auth3dsData, language);
+                    cardDetails, auth3dsData, language, delayedCapture);
         }
     }
 
@@ -309,11 +309,15 @@ public class ChargeResponse {
     @JsonProperty
     @JsonSerialize(using = ToStringSerializer.class)
     private SupportedLanguage language;
+    
+    @JsonProperty("delayed_capture")
+    private boolean delayedCapture;
+    
 
     protected ChargeResponse(String chargeId, Long amount, ExternalTransactionState state, String cardBrand, String gatewayTransactionId, String returnUrl,
                              String email, String description, ServicePaymentReference reference, String providerName, String createdDate,
                              List<Map<String, Object>> dataLinks, RefundSummary refundSummary, SettlementSummary settlementSummary, PersistedCard cardDetails,
-                             Auth3dsData auth3dsData, SupportedLanguage language) {
+                             Auth3dsData auth3dsData, SupportedLanguage language, boolean delayedCapture) {
         this.dataLinks = dataLinks;
         this.chargeId = chargeId;
         this.amount = amount;
@@ -331,6 +335,7 @@ public class ChargeResponse {
         this.cardDetails = cardDetails;
         this.auth3dsData = auth3dsData;
         this.language = language;
+        this.delayedCapture = delayedCapture;
     }
 
     public List<Map<String, Object>> getDataLinks() {
@@ -396,6 +401,10 @@ public class ChargeResponse {
     public SupportedLanguage getLanguage() {
         return language;
     }
+    
+    public boolean getDelayedCapture() {
+        return delayedCapture;
+    }
 
     public URI getLink(String rel) {
         return dataLinks.stream()
@@ -409,61 +418,32 @@ public class ChargeResponse {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         ChargeResponse that = (ChargeResponse) o;
-
-        if (dataLinks != null ? !dataLinks.equals(that.dataLinks) : that.dataLinks != null)
-            return false;
-        if (chargeId != null ? !chargeId.equals(that.chargeId) : that.chargeId != null)
-            return false;
-        if (amount != null ? !amount.equals(that.amount) : that.amount != null) return false;
-        if (state != null ? !state.equals(that.state) : that.state != null) return false;
-        if (cardBrand != null ? !cardBrand.equals(that.cardBrand) : that.cardBrand != null)
-            return false;
-        if (gatewayTransactionId != null ? !gatewayTransactionId.equals(that.gatewayTransactionId) : that.gatewayTransactionId != null)
-            return false;
-        if (returnUrl != null ? !returnUrl.equals(that.returnUrl) : that.returnUrl != null)
-            return false;
-        if (email != null ? !email.equals(that.email) : that.email != null) return false;
-        if (description != null ? !description.equals(that.description) : that.description != null)
-            return false;
-        if (reference != null ? !reference.equals(that.reference) : that.reference != null)
-            return false;
-        if (providerName != null ? !providerName.equals(that.providerName) : that.providerName != null)
-            return false;
-        if (createdDate != null ? !createdDate.equals(that.createdDate) : that.createdDate != null)
-            return false;
-        if (refundSummary != null ? !refundSummary.equals(that.refundSummary) : that.refundSummary != null)
-            return false;
-        if (settlementSummary != null ? !settlementSummary.equals(that.settlementSummary) : that.settlementSummary != null)
-            return false;
-        if (auth3dsData != null ? !auth3dsData.equals(that.auth3dsData) : that.auth3dsData != null)
-            return false;
-        if (cardDetails != null ? !cardDetails.equals(that.cardDetails) : that.cardDetails != null)
-            return false;
-        return language.equals(that.language);
+        return delayedCapture == that.delayedCapture &&
+                Objects.equals(dataLinks, that.dataLinks) &&
+                Objects.equals(chargeId, that.chargeId) &&
+                Objects.equals(amount, that.amount) &&
+                Objects.equals(state, that.state) &&
+                Objects.equals(cardBrand, that.cardBrand) &&
+                Objects.equals(gatewayTransactionId, that.gatewayTransactionId) &&
+                Objects.equals(returnUrl, that.returnUrl) &&
+                Objects.equals(email, that.email) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(reference, that.reference) &&
+                Objects.equals(providerName, that.providerName) &&
+                Objects.equals(createdDate, that.createdDate) &&
+                Objects.equals(refundSummary, that.refundSummary) &&
+                Objects.equals(settlementSummary, that.settlementSummary) &&
+                Objects.equals(auth3dsData, that.auth3dsData) &&
+                Objects.equals(cardDetails, that.cardDetails) &&
+                language == that.language;
     }
 
     @Override
     public int hashCode() {
-        int result = dataLinks != null ? dataLinks.hashCode() : 0;
-        result = 31 * result + (chargeId != null ? chargeId.hashCode() : 0);
-        result = 31 * result + (amount != null ? amount.hashCode() : 0);
-        result = 31 * result + (state != null ? state.hashCode() : 0);
-        result = 31 * result + (cardBrand != null ? cardBrand.hashCode() : 0);
-        result = 31 * result + (gatewayTransactionId != null ? gatewayTransactionId.hashCode() : 0);
-        result = 31 * result + (returnUrl != null ? returnUrl.hashCode() : 0);
-        result = 31 * result + (email != null ? email.hashCode() : 0);
-        result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (reference != null ? reference.hashCode() : 0);
-        result = 31 * result + (providerName != null ? providerName.hashCode() : 0);
-        result = 31 * result + (createdDate != null ? createdDate.hashCode() : 0);
-        result = 31 * result + (refundSummary != null ? refundSummary.hashCode() : 0);
-        result = 31 * result + (settlementSummary != null ? settlementSummary.hashCode() : 0);
-        result = 31 * result + (auth3dsData != null ? auth3dsData.hashCode() : 0);
-        result = 31 * result + (cardDetails != null ? cardDetails.hashCode() : 0);
-        result = 31 * result + language.hashCode();
-        return result;
+        return Objects.hash(dataLinks, chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
+                description, reference, providerName, createdDate, refundSummary, settlementSummary, auth3dsData,
+                cardDetails, language, delayedCapture);
     }
 
     @Override
@@ -484,6 +464,7 @@ public class ChargeResponse {
                 ", settlementSummary=" + settlementSummary +
                 ", auth3dsData=" + auth3dsData +
                 ", language=" + language +
+                ", delayedCapture=" + delayedCapture +
                 '}';
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/FrontendChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/FrontendChargeResponse.java
@@ -45,7 +45,7 @@ public class FrontendChargeResponse extends ChargeResponse {
         public FrontendChargeResponse build() {
             return new FrontendChargeResponse(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl,
                     email, description, reference, providerName, createdDate, links, status, refundSummary,
-                    settlementSummary, persistedCard, auth3dsData, gatewayAccount, language);
+                    settlementSummary, persistedCard, auth3dsData, gatewayAccount, language, delayedCapture);
         }
     }
 
@@ -65,10 +65,10 @@ public class FrontendChargeResponse extends ChargeResponse {
                                    List<Map<String, Object>> dataLinks, String status, RefundSummary refundSummary,
                                    SettlementSummary settlementSummary, PersistedCard chargeCardDetails,
                                    Auth3dsData auth3dsData, GatewayAccountEntity gatewayAccount,
-                                   SupportedLanguage language) {
+                                   SupportedLanguage language, boolean delayedCapture) {
         super(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email, description, reference,
                 providerName, createdDate, dataLinks, refundSummary, settlementSummary, chargeCardDetails, auth3dsData,
-                language);
+                language, delayedCapture);
         this.status = status;
         this.gatewayAccount = gatewayAccount;
     }

--- a/src/main/java/uk/gov/pay/connector/model/TransactionResponse.java
+++ b/src/main/java/uk/gov/pay/connector/model/TransactionResponse.java
@@ -29,7 +29,7 @@ public class TransactionResponse extends ChargeResponse {
         public TransactionResponse build() {
             return new TransactionResponse(transactionType, chargeId, amount, state, cardBrand, gatewayTransactionId,
                     returnUrl, email, description, reference, providerName, createdDate, links, refundSummary,
-                    settlementSummary, cardDetails, auth3dsData, language);
+                    settlementSummary, cardDetails, auth3dsData, language, delayedCapture);
         }
 
     }
@@ -46,9 +46,9 @@ public class TransactionResponse extends ChargeResponse {
                                   String description, ServicePaymentReference reference, String providerName,
                                   String createdDate, List<Map<String, Object>> dataLinks, RefundSummary refundSummary,
                                   SettlementSummary settlementSummary, PersistedCard cardDetails,
-                                  Auth3dsData auth3dsData, SupportedLanguage language) {
+                                  Auth3dsData auth3dsData, SupportedLanguage language, boolean delayedCapture) {
         super(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email, description, reference,
-                providerName, createdDate, dataLinks, refundSummary, settlementSummary, cardDetails, auth3dsData, language);
+                providerName, createdDate, dataLinks, refundSummary, settlementSummary, cardDetails, auth3dsData, language, delayedCapture);
         this.transactionType = transactionType;
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/model/builder/AbstractChargeResponseBuilder.java
@@ -30,6 +30,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected PersistedCard cardDetails;
     protected ChargeResponse.Auth3dsData auth3dsData;
     protected SupportedLanguage language;
+    protected boolean delayedCapture;
 
     protected abstract T thisObject();
 
@@ -126,6 +127,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public T withLanguage(SupportedLanguage language) {
         this.language = language;
+        return thisObject();
+    }
+    
+    public T withDelayedCapture(boolean delayedCapture) {
+        this.delayedCapture = delayedCapture;
         return thisObject();
     }
 

--- a/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/Transaction.java
@@ -40,7 +40,8 @@ import java.time.ZonedDateTime;
                         @ColumnResult(name = "address_line2", type = String.class),
                         @ColumnResult(name = "address_postcode", type = String.class),
                         @ColumnResult(name = "amount", type = Long.class),
-                        @ColumnResult(name = "language", type = String.class)}))
+                        @ColumnResult(name = "language", type = String.class),
+                        @ColumnResult(name = "delayed_capture", type = Boolean.class)}))
 @Entity
 @ReadOnly
 public class Transaction {
@@ -56,6 +57,7 @@ public class Transaction {
     private String gatewayTransactionId;
     private ZonedDateTime createdDate;
     private SupportedLanguage language;
+    private boolean delayedCapture;
 
     @Id
     private String transactionType;
@@ -99,7 +101,8 @@ public class Transaction {
                        String addressLine2,
                        String addressPostcode,
                        long amount,
-                       String language) {
+                       String language,
+                       boolean delayedCapture) {
         this.chargeId = chargeId;
         this.externalId = externalId;
         this.reference = reference;
@@ -124,6 +127,7 @@ public class Transaction {
         this.addressPostcode = addressPostcode;
         this.amount = amount;
         this.language = SupportedLanguage.fromIso639AlphaTwoCode(language);
+        this.delayedCapture = delayedCapture;
     }
 
     public Long getChargeId() {
@@ -216,6 +220,10 @@ public class Transaction {
 
     public SupportedLanguage getLanguage() {
         return language;
+    }
+    
+    public boolean isDelayedCapture() {
+        return delayedCapture;
     }
 
     public String getUserExternalId() {

--- a/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ChargesFrontendResource.java
@@ -179,6 +179,7 @@ public class ChargesFrontendResource {
                 .withAuth3dsData(auth3dsData)
                 .withGatewayAccount(charge.getGatewayAccount())
                 .withLanguage(charge.getLanguage())
+                .withDelayedCapture(charge.isDelayedCapture())
                 .withLink("self", GET, locationUriFor("/v1/frontend/charges/{chargeId}", uriInfo, chargeId))
                 .withLink("cardAuth", POST, locationUriFor("/v1/frontend/charges/{chargeId}/cards", uriInfo, chargeId))
                 .withLink("cardCapture", POST, locationUriFor("/v1/frontend/charges/{chargeId}/capture", uriInfo, chargeId)).build();

--- a/src/main/java/uk/gov/pay/connector/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/service/ChargeService.java
@@ -160,6 +160,7 @@ public class ChargeService {
                 .withReturnUrl(chargeEntity.getReturnUrl())
                 .withEmail(chargeEntity.getEmail())
                 .withLanguage(chargeEntity.getLanguage())
+                .withDelayedCapture(chargeEntity.isDelayedCapture())
                 .withRefunds(buildRefundSummary(chargeEntity))
                 .withSettlement(buildSettlementSummary(chargeEntity))
                 .withCardDetails(persistedCard)

--- a/src/main/java/uk/gov/pay/connector/service/search/TransactionSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/TransactionSearchStrategy.java
@@ -75,6 +75,7 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
                 .withEmail(transaction.getEmail())
                 .withGatewayTransactionId(transaction.getGatewayTransactionId())
                 .withLanguage(transaction.getLanguage())
+                .withDelayedCapture(transaction.isDelayedCapture())
                 .withLink("self", GET, uriInfo.getBaseUriBuilder()
                         .path("/v1/api/accounts/{accountId}/charges/{chargeId}")
                         .build(transaction.getGatewayAccountId(), transaction.getExternalId()))

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -370,6 +370,7 @@ public class DatabaseFixtures {
         String transactionId;
         ServicePaymentReference reference = ServicePaymentReference.of("Test reference");
         SupportedLanguage language = SupportedLanguage.ENGLISH;
+        boolean delayedCapture = false;
 
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
 
@@ -439,7 +440,12 @@ public class DatabaseFixtures {
             this.language = language;
             return this;
         }
-
+        
+        public TestCharge withDelayedCapture(boolean delayedCapture) {
+            this.delayedCapture = delayedCapture;
+            return this;
+        }
+        
         public TestCharge insert() {
             if (testAccount == null)
                 throw new IllegalStateException("Test Account must be provided.");
@@ -495,6 +501,10 @@ public class DatabaseFixtures {
         
         public SupportedLanguage getLanguage() {
             return language;
+        }
+        
+        public boolean isDelayedCapture() {
+            return delayedCapture;
         }
 
         public TestAccount getTestAccount() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
@@ -84,6 +84,7 @@ public class TransactionDaoITest extends DaoITestBase {
         assertThat(transactionRefund.getUserExternalId(), is(REFUND_USER_EXTERNAL_ID));
         assertThat(transactionRefund.getCardBrandLabel(), is("Visa")); // read from card types table which is populated by the card_types.csv seed data
         assertThat(transactionRefund.getLanguage(), is(testCharge.getLanguage()));
+        assertThat(transactionRefund.isDelayedCapture(), is(testCharge.isDelayedCapture()));
         assertDateMatch(transactionRefund.getCreatedDate().toString());
 
         Transaction transactionCharge = transactions.get(1);
@@ -96,6 +97,7 @@ public class TransactionDaoITest extends DaoITestBase {
         assertThat(transactionCharge.getCardBrand(), is(testCardDetails.getCardBrand()));
         assertThat(transactionCharge.getUserExternalId(), is(nullValue()));
         assertThat(transactionCharge.getLanguage(), is(testCharge.getLanguage()));
+        assertThat(transactionCharge.isDelayedCapture(), is(testCharge.isDelayedCapture()));
         assertDateMatch(transactionCharge.getCreatedDate().toString());
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -86,7 +86,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addCardType(card, "label", "CREDIT", "brand", false);
         app.getDatabaseTestHelper().addAcceptedCardType(Long.valueOf(accountId), card);
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, chargeStatus, returnUrl, null,
-                ServicePaymentReference.of("My reference"), createdDate, SupportedLanguage.WELSH);
+                ServicePaymentReference.of("My reference"), createdDate, SupportedLanguage.WELSH, true);
         app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, "VISA", "1234", "Mr. McPayment", "03/18", "line1", null, "postcode", "city", null, "country");
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
@@ -111,7 +111,8 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
                 .body("results[0].reference", is("My reference"))
                 .body("results[0].description", is(description))
                 .body("results[0].created_date", is("2016-01-26T13:45:32Z"))
-                .body("results[0].language", is(SupportedLanguage.WELSH.toString()));
+                .body("results[0].language", is(SupportedLanguage.WELSH.toString()))
+                .body("results[0].delayed_capture", is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -79,6 +79,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     private static final String JSON_EMAIL_KEY = "email";
     private static final String JSON_PROVIDER_KEY = "payment_provider";
     private static final String JSON_LANGUAGE_KEY = "language";
+    private static final String JSON_DELAYED_CAPTURE_KEY = "delayed_capture";
     private static final String PROVIDER_NAME = "sandbox";
     private static final long AMOUNT = 6234L;
 
@@ -118,6 +119,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body(JSON_RETURN_URL_KEY, is(returnUrl))
                 .body(JSON_EMAIL_KEY, is(email))
                 .body(JSON_LANGUAGE_KEY, is("cy"))
+                .body(JSON_DELAYED_CAPTURE_KEY, is(false))
                 .body("containsKey('card_details')", is(false))
                 .body("containsKey('gateway_account')", is(false))
                 .body("refund_summary.amount_submitted", is(0))
@@ -159,6 +161,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body(JSON_RETURN_URL_KEY, is(returnUrl))
                 .body(JSON_EMAIL_KEY, is(email))
                 .body(JSON_LANGUAGE_KEY, is("cy"))
+                .body(JSON_DELAYED_CAPTURE_KEY, is(false))
                 .body("containsKey('card_details')", is(false))
                 .body("containsKey('gateway_account')", is(false))
                 .body("settlement_summary.capture_submit_time", nullValue())

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
@@ -120,6 +120,7 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("results[0].card_details.last_digits_card_number", is(lastDigitsCardNumber))
                 .body("results[0].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("results[0].created_date", isWithin(3, HOURS)) // The refund CREATED is the most recent
+                .body("results[0].delayed_capture", is(false))
 
                 .body("results[1].transaction_type", is("refund"))
                 .body("results[1].gateway_transaction_id", is(transactionIdCharge2))
@@ -137,7 +138,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("results[1].card_details.expiry_date", is(expiryDate))
                 .body("results[1].card_details.last_digits_card_number", is(lastDigitsCardNumber))
                 .body("results[1].created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
-                .body("results[1].created_date", isWithin(3, HOURS)); // The refund CREATED is the most recent
+                .body("results[1].created_date", isWithin(3, HOURS))
+                .body("results[0].delayed_capture", is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -10,7 +10,6 @@ import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.AuthCardDetails;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
-import uk.gov.pay.connector.model.domain.RefundStatus;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -63,43 +62,44 @@ public class DatabaseTestHelper {
     public void addCharge(Long chargeId, String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl,
                           String transactionId) {
         addCharge(chargeId, externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId, "Test description",
-                ServicePaymentReference.of("Test reference"), now(), 1, "email@fake.test", SupportedLanguage.ENGLISH);
+                ServicePaymentReference.of("Test reference"), now(), 1, "email@fake.test", SupportedLanguage.ENGLISH, false);
     }
 
     public void addCharge(String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl, String transactionId) {
         addCharge((long) RandomUtils.nextInt(1, 9999999), externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId,
-                "Test description", ServicePaymentReference.of("Test reference"), now(), 1, null, SupportedLanguage.ENGLISH);
+                "Test description", ServicePaymentReference.of("Test reference"), now(), 1, null, SupportedLanguage.ENGLISH, false);
     }
 
     public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
                           String transactionId, ServicePaymentReference reference, ZonedDateTime createdDate) {
         addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, "Test description", reference,
-                createdDate == null ? now() : createdDate, 1, null, SupportedLanguage.ENGLISH);
+                createdDate == null ? now() : createdDate, 1, null, SupportedLanguage.ENGLISH, false);
     }
 
     public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
-                          String transactionId, ServicePaymentReference reference, ZonedDateTime createdDate, SupportedLanguage language) {
+                          String transactionId, ServicePaymentReference reference, ZonedDateTime createdDate, SupportedLanguage language,
+                          boolean delayedCapture) {
         addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, "Test description", reference,
-                createdDate == null ? now() : createdDate, 1, null, language);
+                createdDate == null ? now() : createdDate, 1, null, language, delayedCapture);
     }
 
     public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
                           String transactionId, ServicePaymentReference reference, ZonedDateTime createdDate, String email) {
         addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, "Test description", reference,
-                createdDate == null ? now() : createdDate, 1, email, SupportedLanguage.ENGLISH);
+                createdDate == null ? now() : createdDate, 1, email, SupportedLanguage.ENGLISH, false);
     }
 
     public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
                           String transactionId, ServicePaymentReference reference, String description, ZonedDateTime createdDate, String email) {
         addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, description, reference,
-                createdDate == null ? now() : createdDate, 1, email, SupportedLanguage.ENGLISH);
+                createdDate == null ? now() : createdDate, 1, email, SupportedLanguage.ENGLISH, false);
     }
 
     public void addCharge(Long chargeId, String externalChargeId, String accountId, long amount, ChargeStatus chargeStatus, String returnUrl,
                           String transactionId, ServicePaymentReference reference, String description, ZonedDateTime createdDate, String email,
                           SupportedLanguage language) {
         addCharge(chargeId, externalChargeId, accountId, amount, chargeStatus, returnUrl, transactionId, description, reference,
-                createdDate == null ? now() : createdDate, 1, email, language);
+                createdDate == null ? now() : createdDate, 1, email, language, false);
     }
 
     private void addCharge(
@@ -115,7 +115,8 @@ public class DatabaseTestHelper {
             ZonedDateTime createdDate,
             long version,
             String email,
-            SupportedLanguage language
+            SupportedLanguage language,
+            boolean delayedCapture
     ) {
         jdbi.withHandle(h ->
                 h.update(
@@ -133,9 +134,10 @@ public class DatabaseTestHelper {
                                 "        reference,\n" +
                                 "        version,\n" +
                                 "        email,\n" +
-                                "        language\n" +
+                                "        language,\n" +
+                                "        delayed_capture\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
                         chargeId,
                         externalChargeId,
                         amount,
@@ -148,7 +150,8 @@ public class DatabaseTestHelper {
                         reference.toString(),
                         version,
                         email,
-                        language.toString()
+                        language.toString(),
+                        delayedCapture
                 )
         );
     }


### PR DESCRIPTION
Add `delayed_capture` property to JSON returned when getting a charge from an API endpoint (including charges, transactions and frontend charges endpoints)