### PR TITLE
PP-4178: Allow transition from CAPTURE READY

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
             <version>9.4.11.v20180605</version>

--- a/src/main/java/uk/gov/pay/connector/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PaymentGatewayStateTransitions.java
@@ -110,6 +110,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(CAPTURE_READY, CAPTURE_SUBMITTED, "");
         graph.putEdgeValue(CAPTURE_READY, CAPTURE_ERROR, "");
         graph.putEdgeValue(CAPTURE_READY, CAPTURE_APPROVED_RETRY, "");
+        graph.putEdgeValue(CAPTURE_READY, CAPTURED, "received CAPTURED notification while about to retry");
         graph.putEdgeValue(CAPTURE_SUBMITTED, CAPTURED, "");
         graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRE_CANCEL_SUBMITTED, "");
         graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRE_CANCEL_FAILED, "");

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
@@ -2,11 +2,15 @@ package uk.gov.pay.connector.it.resources.epdq;
 
 import com.google.common.collect.Lists;
 import com.jayway.restassured.response.ValidatableResponse;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.service.epdq.EpdqSha512SignatureGenerator;
 
 import java.io.IOException;
@@ -24,6 +28,7 @@ import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.model.domain.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.model.domain.RefundStatus.REFUND_SUBMITTED;
 
+@RunWith(JUnitParamsRunner.class)
 public class EpdqNotificationResourceITest extends ChargingITestBase {
 
     private static final String RESPONSE_EXPECTED_BY_EPDQ = "[OK]";
@@ -34,9 +39,14 @@ public class EpdqNotificationResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldHandleAChargeNotification() throws Exception {
+    @Parameters({
+            "CAPTURE_READY",
+            "CAPTURE_SUBMITTED",
+            "CAPTURE_APPROVED_RETRY"
+    })
+    public void shouldHandleACaptureNotification(ChargeStatus chargeStatus) throws Exception {
         String transactionId = "transaction-id";
-        String chargeId = createNewChargeWith(CAPTURE_SUBMITTED, transactionId);
+        String chargeId = createNewChargeWith(chargeStatus, transactionId);
 
         String response = notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
                 .statusCode(200)


### PR DESCRIPTION
Sometimes we receive a CAPTURED notification from epdq while the payment is in
the CAPTURE READY state (the transient state just before we attempt a capture
request). This commit allows the transition from CAPTURE_READY to CAPTURED.

@oswaldquek
