### PR TITLE
Use single Charset instance for all ePDQ form encoding needs

### DIFF
--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqNotification.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqNotification.java
@@ -6,12 +6,12 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import uk.gov.pay.connector.model.ChargeStatusRequest;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.util.stream.Collectors.toMap;
+import static uk.gov.pay.connector.service.epdq.EpdqPaymentProvider.EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET;
 
 public class EpdqNotification implements ChargeStatusRequest {
 
@@ -31,7 +31,7 @@ public class EpdqNotification implements ChargeStatusRequest {
 
     public EpdqNotification(String payload) {
         try {
-            paramsList = URLEncodedUtils.parse(payload, Charset.forName("windows-1252"));
+            paramsList = URLEncodedUtils.parse(payload, EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET);
 
             Map<String, String> params = paramsList.stream()
                     .collect(toMap(NameValuePair::getName, NameValuePair::getValue));
@@ -41,8 +41,8 @@ public class EpdqNotification implements ChargeStatusRequest {
             payIdSub = params.get(PAYIDSUB);
             shaSign = params.get(SHASIGN);
         } catch (Exception e) {
-            throw new IllegalArgumentException(
-                    "Could not decode ePDQ notification payload as UTF-8 application/x-www-form-urlencoded");
+            throw new IllegalArgumentException("Could not decode ePDQ notification payload as "
+                    + EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET.name() + " application/x-www-form-urlencoded");
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqOrderRequestBuilder.java
@@ -8,8 +8,8 @@ import uk.gov.pay.connector.util.templates.PayloadBuilder;
 import uk.gov.pay.connector.util.templates.PayloadDefinition;
 
 import javax.ws.rs.core.MediaType;
-import java.nio.charset.Charset;
 
+import static uk.gov.pay.connector.service.epdq.EpdqPaymentProvider.EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET;
 import static uk.gov.pay.connector.service.epdq.EpdqSignedPayloadDefinition.EpdqSignedPayloadDefinitionFactory.anEpdqSignedPayloadDefinitionFactory;
 
 public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
@@ -85,8 +85,6 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
     public static final String REFUND_OPERATION_TYPE = "RFD";
     public static final String CANCEL_OPERATION_TYPE = "DES";
 
-    private static final Charset WINDOWS_1252 = Charset.forName("windows-1252");
-
     private static EpdqSignedPayloadDefinitionFactory signedPayloadDefinitionFactory = anEpdqSignedPayloadDefinitionFactory(new EpdqSha512SignatureGenerator());
 
     public static final PayloadBuilder AUTHORISE_ORDER_TEMPLATE_BUILDER = createPayloadBuilderForNewOrder();
@@ -100,22 +98,22 @@ public class EpdqOrderRequestBuilder extends OrderRequestBuilder {
 
     private static PayloadBuilder createPayloadBuilderForQueryOrder() {
         PayloadDefinition payloadDefinition = signedPayloadDefinitionFactory.create(new EpdqPayloadDefinitionForQueryOrder());
-        return new FormUrlEncodedStringBuilder(payloadDefinition, WINDOWS_1252);
+        return new FormUrlEncodedStringBuilder(payloadDefinition, EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET);
     }
 
     private static PayloadBuilder createPayloadBuilderForNewOrder() {
         PayloadDefinition payloadDefinition = signedPayloadDefinitionFactory.create(new EpdqPayloadDefinitionForNewOrder());
-        return new FormUrlEncodedStringBuilder(payloadDefinition, WINDOWS_1252);
+        return new FormUrlEncodedStringBuilder(payloadDefinition, EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET);
     }
 
     private static PayloadBuilder createPayloadBuilderForNew3dsOrder() {
         PayloadDefinition payloadDefinition = signedPayloadDefinitionFactory.create(new EpdqPayloadDefinitionForNew3dsOrder());
-        return new FormUrlEncodedStringBuilder(payloadDefinition, WINDOWS_1252);
+        return new FormUrlEncodedStringBuilder(payloadDefinition, EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET);
     }
 
     private static PayloadBuilder createPayloadBuilderForMaintenanceOrder() {
         PayloadDefinition payloadDefinition = signedPayloadDefinitionFactory.create(new EpdqPayloadDefinitionForMaintenanceOrder());
-        return new FormUrlEncodedStringBuilder(payloadDefinition, WINDOWS_1252);
+        return new FormUrlEncodedStringBuilder(payloadDefinition, EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET);
     }
 
     public static EpdqOrderRequestBuilder anEpdqAuthoriseOrderRequestBuilder() {

--- a/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.service.PaymentGatewayName;
 import uk.gov.pay.connector.service.StatusMapper;
 
 import javax.ws.rs.client.Invocation;
+import java.nio.charset.Charset;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Optional;
@@ -55,13 +56,23 @@ import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdqCa
 import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdqQueryOrderRequestBuilder;
 import static uk.gov.pay.connector.service.epdq.EpdqOrderRequestBuilder.anEpdqRefundOrderRequestBuilder;
 
-
 public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, String> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EpdqPaymentProvider.class);
 
     public static final String ROUTE_FOR_NEW_ORDER = "orderdirect.asp";
     public static final String ROUTE_FOR_MAINTENANCE_ORDER = "maintenancedirect.asp";
     public static final String ROUTE_FOR_QUERY_ORDER = "querydirect.asp";
-    private static final Logger LOGGER = LoggerFactory.getLogger(EpdqPaymentProvider.class);
+
+    /**
+     * ePDQ have never confirmed that they use Windows-1252 to decode
+     * application/x-www-form-urlencoded payloads sent by us to them and use
+     * Windows-1252 to encode application/x-www-form-urlencoded notification
+     * payloads sent from them to us but experimentation — and specifically the
+     * fact that ’ (that’s U+2019 right single quotation mark in Unicode
+     * parlance) seems to encode to %92 — makes us believe that they do
+     */
+    static final Charset EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET = Charset.forName("windows-1252");
 
     private final SignatureGenerator signatureGenerator;
     private final String frontendUrl;

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqNotificationTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqNotificationTest.java
@@ -91,13 +91,13 @@ public class EpdqNotificationTest {
 
     @Test
     public void shouldDecodeNotificationsAccordingToTheRightEpdqCharset() {
-        String cardHolderName = "mr payment%92"; //encoded value for ’ (single quote)
+        String cardHolderName = "Mr O%92Payment"; // %92 is encoded value for ’ (right single quotation mark)
         String payload = notificationPayloadForTransaction(cardHolderName, STATUS, PAY_ID, PAY_ID_SUB, SHA_SIGN);
 
         EpdqNotification epdqNotification = new EpdqNotification(payload);
 
         assertThat(epdqNotification.getParams(), hasItem(
-                new BasicNameValuePair("CN", "mr payment’")));
+                new BasicNameValuePair("CN", "Mr O’Payment")));
     }
     
     private String notificationPayloadForTransaction(String cardHolderName, String status, String payId, String payIdSub, String shaSign)


### PR DESCRIPTION
`Charset` objects are thread-safe. We already share a single instance for constructing `application/x-www-form-urlencoded` payloads to send to ePDQ. However, when decoding `application/x-www-form-urlencoded notifications` from ePDQ, we were asking (via the `Charset.forName(String)` method) for a `Charset` object every time (there’s a cache so it won’t have actually created a new object every time).

- Move the `Charset` constant from `EpdqOrderRequestBuilder` to `EpdqPaymentProvider`

- Add Javadoc to this constant to aid our future selves

- Use `Charset` constant in `EpdqNotification` for decoding

- Update outdated log line in `EpdqNotification`