### PR TITLE
Pp 4165 create capture resource

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -1064,6 +1064,48 @@ Content-Type: application/json
     "message": "Cannot capture a charge with status AUTHORISATION REJECTED."
 }
 ```
+
+-----------------------------------------------------------------------------------------------------------
+
+## POST /v1/api/accounts/{accountId}/charges/{chargeId}/capture
+
+* This endpoint should be called to capture a delayed capture charge. The charge needs to have been previously marked as 
+`AWAITING CAPTURE REQUEST` for this call to succeed.
+
+* When a charge is in any of the states `CAPTURED, CAPTURE APPROVED, CAPTURE APPROVED RETRY, CAPTURE READY,
+ CAPTURE SUBMITTED` then nothing happens and the response will be a 204.
+
+* When a charge is in a status that cannot transition (eg. none of the above) then we return 409
+
+* When a charge doesn't exist then we return 404
+
+### Request example
+
+```
+POST /v1/api/accounts/1/charges/abc/capture
+Content-Type: application/json
+```
+
+#### The request body is empty
+
+
+### Response example
+
+#### Authorisation success
+
+```
+204 No content
+Content-Type: application/json
+```
+#### Error
+```
+404 Not Found
+Content-Type: application/json
+
+{
+    "message": "Charge with id [abc] not found."
+}
+```
 -----------------------------------------------------------------------------------------------------------
 ## GET /v1/frontend/charges?gatewayAccountId={gatewayAccountId}
 

--- a/src/main/java/uk/gov/pay/connector/resources/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/CardResource.java
@@ -7,13 +7,24 @@ import uk.gov.pay.connector.model.GatewayError;
 import uk.gov.pay.connector.model.domain.Auth3dsDetails;
 import uk.gov.pay.connector.model.domain.AuthCardDetails;
 import uk.gov.pay.connector.model.gateway.GatewayResponse;
-import uk.gov.pay.connector.service.*;
+import uk.gov.pay.connector.service.BaseAuthoriseResponse;
 import uk.gov.pay.connector.service.BaseAuthoriseResponse.AuthoriseStatus;
+import uk.gov.pay.connector.service.BaseCancelResponse;
+import uk.gov.pay.connector.service.Card3dsResponseAuthService;
+import uk.gov.pay.connector.service.CardAuthoriseService;
+import uk.gov.pay.connector.service.CardCaptureService;
+import uk.gov.pay.connector.service.ChargeCancelService;
 import uk.gov.pay.connector.util.ResponseUtil;
 
 import javax.inject.Inject;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -73,6 +84,17 @@ public class CardResource {
     public Response captureCharge(@PathParam("chargeId") String chargeId) {
         logger.info("Capture of charge asynchronously [charge_external_id={}]", chargeId);
         cardCaptureService.markChargeAsEligibleForCapture(chargeId);
+        return ResponseUtil.noContentResponse();
+    }
+
+    @POST
+    @Path("/v1/api/accounts/{accountId}/charges/{chargeId}/capture")
+    @Produces(APPLICATION_JSON)
+    public Response markChargeAsCaptureApproved(@PathParam("accountId") Long accountId,
+                                  @PathParam("chargeId") String chargeId,
+                                  @Context UriInfo uriInfo) {
+        logger.info("Mark charge as CAPTURE APPROVED [charge_external_id={}]", chargeId);
+        cardCaptureService.markChargeAsCaptureApproved(chargeId);
         return ResponseUtil.noContentResponse();
     }
 

--- a/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/service/CardAuthoriseBaseService.java
@@ -31,7 +31,7 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
         this.cardExecutorService = cardExecutorService;
     }
 
-    public GatewayResponse doAuthorise(String chargeId, T gatewayAuthRequest) {
+    public GatewayResponse<BaseAuthoriseResponse> doAuthorise(String chargeId, T gatewayAuthRequest) {
         Supplier authorisationSupplier = () -> {
             ChargeEntity charge;
 
@@ -41,9 +41,9 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> e
                     throw new ConflictRuntimeException(chargeId, "configuration mismatch");
                 }
             } catch (OptimisticLockException e) {
-                LOG.info("OptimisticLockException in doAuthorise for charge external_id=" + chargeId);
+                LOG.info("OptimisticLockException in doAuthorise for charge external_id={}", chargeId);
                 throw new ConflictRuntimeException(chargeId);
-            } 
+            }
 
             GatewayResponse<BaseAuthoriseResponse> operationResponse = operation(charge, gatewayAuthRequest);
             return postOperation(chargeId, gatewayAuthRequest, operationResponse);

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -221,7 +221,7 @@ public class ChargingITestBase {
     }
 
     protected static String buildJsonAuthorisationDetailsFor(String cardHolderName, String cardNumber, String cvc, String expiryDate, String cardBrand,
-                                                      String line1, String line2, String city, String county, String postCode, String countryCode) {
+                                                             String line1, String line2, String city, String county, String postCode, String countryCode) {
         JsonObject addressObject = new JsonObject();
 
         addressObject.addProperty("line1", line1);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -1022,7 +1022,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     private void assert404WhenRequestingInvalidPage() {
         // when 5 charges are there, page is 10, display-size is 2
-        ValidatableResponse response = getChargeApi
+        getChargeApi
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "10")
@@ -1201,7 +1201,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     private List<ZonedDateTime> datesFrom(List<String> createdDateStrings) {
         List<ZonedDateTime> dateTimes = newArrayList();
-        createdDateStrings.stream().forEach(aDateString -> dateTimes.add(toUTCZonedDateTime(aDateString).get()));
+        createdDateStrings.forEach(aDateString -> dateTimes.add(toUTCZonedDateTime(aDateString).get()));
         return dateTimes;
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -208,4 +208,13 @@ public class RestAssuredClient {
         this.refundId = refundId;
         return this;
     }
+
+    public ValidatableResponse postMarkChargeAsCaptureApproved() {
+        final String path = "/v1/api/accounts/{accountId}/charges/{chargeId}/capture"
+                .replace("{accountId}", accountId)
+                .replace("{chargeId}", chargeId);
+        return given().port(app.getLocalPort())
+                .post(path)
+                .then();
+    }
 }


### PR DESCRIPTION
## WHAT

* Added a new POST resource in `CardResource` that will be called on
`"/v1/api/accounts/{accountId}/charges/{chargeId}/capture"` when a service
will want to mark a delayed charge as `CAPTURE APPROVED`.

* When a charge is in status `AWAITING CAPTURE REQUEST` then we transition
to status `CAPTURE APPROVED`, we record an event and we return 204

* When a charge is in statuses `CAPTURED, CAPTURE APPROVED,
CAPTURE APPROVED RETRY, CAPTURE READY, CAPTURE SUBMITTED` then we
do not transition and we return 204

* When a charge is in a status that cannot transition to (none of the above)
then we return 409

* When a charge it doesn't exist then we return 404

* Updated documentation

with @danworth


