### PR TITLE
PP-4111 Add type to notifications and email_collection_mode to gateway accounts

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1482,4 +1482,36 @@
         </update>
     </changeSet>
 
+    <changeSet id="add type column to email notifications table" author="">
+        <addColumn tableName="email_notifications">
+            <column name="type" type="VARCHAR(36)" >
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="backfill existing notifications with PAYMENT_CONFIRMED value" author="">
+        <sql>
+            UPDATE email_notifications SET type = 'PAYMENT_CONFIRMED';
+        </sql>
+    </changeSet>
+
+    <changeSet id="add email_collection_mode column to gateway accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="email_collection_mode" type="VARCHAR(36)">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add default value to email_collection_mode in gateway accounts table" author="">
+        <addDefaultValue tableName="gateway_accounts" columnName="email_collection_mode" defaultValue="MANDATORY"/>
+    </changeSet>
+
+    <changeSet id="backfill existing gateway accounts with MANDATORY default value" author="">
+        <sql>
+            UPDATE gateway_accounts SET email_collection_mode = 'MANDATORY';
+        </sql>
+    </changeSet>
+    
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
 - Notifications can be, for now, of type `REFUND_ISSUED` or `PAYMENT_CONFIRMED`. We used to only
   have confirmation notifications, so we are going to backfill existing values.
 - `email_collection_mode` is at a Gateway Account level and needs to be backfilled as
   mandatory.


