### PR TITLE
PP-4122 add corporate surcharge columns to gateway accounts

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1442,4 +1442,44 @@
         </update>
     </changeSet>
 
+    <changeSet id="Add corporate credit card surcharge amount column to gateway accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="corporate_credit_card_surcharge_amount" type="bigint"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="Add default value to corporate credit card surcharge amount column" author="">
+        <addDefaultValue tableName="gateway_accounts"
+                         columnName="corporate_credit_card_surcharge_amount"
+                         defaultValue="0"
+        />
+    </changeSet>
+
+    <changeSet id="Update corporate credit card surcharge amount column to default value" author="">
+        <update tableName="gateway_accounts">
+            <column name="corporate_credit_card_surcharge_amount" value="0"/>
+            <where>corporate_credit_card_surcharge_amount IS NULL</where>
+        </update>
+    </changeSet>
+
+    <changeSet id="Add corporate debit card surcharge amount column to gateway accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="corporate_debit_card_surcharge_amount" type="bigint"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="Add default value to corporate debit card surcharge amount column" author="">
+        <addDefaultValue tableName="gateway_accounts"
+                         columnName="corporate_debit_card_surcharge_amount"
+                         defaultValue="0"
+        />
+    </changeSet>
+
+    <changeSet id="Update corporate debit card surcharge amount column to default value" author="">
+        <update tableName="gateway_accounts">
+            <column name="corporate_debit_card_surcharge_amount" value="0"/>
+            <where>corporate_debit_card_surcharge_amount IS NULL</where>
+        </update>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
add corporate surcharge columns

## HOW 

- add corporate_credit_card_surcharge_amount and corporate_debit_card_surcharge_amount columns to gateway_accounts table
- set default value to 0
- back fill existing records

with @danailminchev




