### PR TITLE
PP-4122 Add corporate surcharge amount fields to payment frontend load

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
@@ -188,13 +188,13 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return requires3ds;
     }
 
-    @JsonView(Views.ApiView.class)
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_credit_card_surcharge_amount")
     public long getCorporateCreditCardSurchargeAmount() {
         return corporateCreditCardSurchargeAmount;
     }
 
-    @JsonView(Views.ApiView.class)
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_debit_card_surcharge_amount")
     public long getCorporateDebitCardSurchargeAmount() {
         return corporateDebitCardSurchargeAmount;

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -84,6 +84,10 @@ public class DatabaseTestHelper {
         addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId, 0, 0);
     }
 
+    public void addGatewayAccount(String accountId, String paymentProvider, String description, String analyticsId, long corporateCreditCardSurchargeAmount, long corporateDebitCardSurchargeAmount) {
+        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount);
+    }
+
     public void addCharge(Long chargeId, String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl,
                           String transactionId) {
         addCharge(chargeId, externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId, "Test description",


### PR DESCRIPTION
## WHAT

Add corporate surcharge fields to frontend view.

## HOW 

- tag corporate_credit_card_surcharge_amount and corporate_debit_card_surcharge_amount fields' JsonView with Views.FrontendView
- update relevant tests

with @danailminchev



