### PR TITLE
PP-4248 Add Maven dependency on JAXB API 2.3.0 (latest stable)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>


### PR DESCRIPTION
JAXB was deprecrated in Java 9 SE and removed in Java 11 SE.