### PR TITLE
PP-4248 Stop using internal JDK NotImplementedException

### DIFF
--- a/src/test/java/uk/gov/pay/connector/rules/GuiceAppRule.java
+++ b/src/test/java/uk/gov/pay/connector/rules/GuiceAppRule.java
@@ -10,7 +10,6 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.ConfigOverride;
 import net.sourceforge.argparse4j.inf.Namespace;
 import org.junit.rules.ExternalResource;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 import uk.gov.pay.connector.app.InjectorLookup;
 
 import javax.annotation.Nullable;
@@ -51,17 +50,17 @@ public class GuiceAppRule<C extends Configuration> extends ExternalResource impl
 
     @Override
     public int getLocalPort() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int getPort(int connectorIndex) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public int getAdminPort() {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Make GuiceAppRule stop using `sun.reflect.generics.reflectiveObjects.NotImplementedException` because it’s an JDK internal thing and not available out of the box with Java 11.

The intention was probably to use the Apache Commons `NotImplementedException` but Java’s own `UnsupportedOperationException` is a better fit (we never plan to implement those methods) so switch to that instead.