### PR TITLE
PP-4248 Upgrade EclipseLink from 2.6.4 to 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
     <properties>
         <dropwizard.version>1.3.5</dropwizard.version>
         <wiremock.version>1.57</wiremock.version>
-        <jpa.version>2.6.4</jpa.version>
+        <eclipselink.version>2.7.3</eclipselink.version>
         <guice.version>4.1.0</guice.version>
         <docker-client.version>8.9.2</docker-client.version>
         <jackson.version>2.9.6</jackson.version>
-        <pay-java-commons.version>1.0.0-a6b07e0c4c5e19e38c19ea7b181592a1c4f07a2f</pay-java-commons.version>
+        <pay-java-commons.version>1.0.0-7d88c91ee08a7129d00cb08716a1801b10bc4df2</pay-java-commons.version>
     </properties>
     <repositories>
         <repository>
@@ -115,11 +115,6 @@
             <version>21.0</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>eclipselink</artifactId>
-            <version>${jpa.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.functionaljava</groupId>
             <artifactId>functionaljava-java8</artifactId>
             <version>4.6</version>
@@ -127,8 +122,38 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>org.eclipse.persistence.jpa</artifactId>
-            <version>${jpa.version}</version>
+            <version>${eclipselink.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.moxy</artifactId>
+            <version>${eclipselink.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <!--
+            The dependency below is required because the javax.persistence 2.2.x JAR is signed but
+            the rest of the EclipseLink JAR isn’t, which causes a “signer information does not
+            match signer information of other classes in the same package” error. The
+            javax.persistence 2.1.1 JAR below isn’t signed so it doesn’t have the problem. See
+            https://stackoverflow.com/q/45870753 for more information.
+
+            Note that the below is JPA 2.1.1 whereas EclipseLink 2.7.x supports JPA 2.2. However,
+            https://projects.eclipse.org/projects/ee4j.eclipselink/releases/2.7.3/review says
+            EclipseLink 2.7.3 still supports pre-2.2 versions of JPA (though deprecated). We
+            survived with JPA 2.1.1 when we were using EclipseLink 2.6.4 because that’s all it
+            supported. (We’ve never used JPA 2.2: the upgrade from EclipseLink 2.6.4 to 2.7.3
+            introduced the signing problem and is when we added the extra dependency below as a
+            mitigation).
+
+            If https://bugs.eclipse.org/bugs/show_bug.cgi?id=525457 is anything to go by, a future
+            EclipseLink release should resolve this problem and we should be able to remove the
+            below dependency.
+        -->
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -446,6 +446,12 @@
             <artifactId>jetty-util</artifactId>
             <version>9.4.11.v20180605</version>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
Upgrade EclipseLink from 2.6.4 to 2.7.3 because 2.6.x versions do not support Java 11.

Rather than bringing in all of EclipseLink, just depend on the JPA and MOXy (XML) features because we don’t use the rest.

Rename the POM property `jpa.version` to `eclipselink.version` because it represents the EclipseLink version, not the JPA version.

Update the versions of our Java commons libraries to a newer release: the only change is that the `utils` submodule has had its EclipseLink dependency upgraded from 2.6.4 to 2.7.3.

Add test dependency on `javax.json` from `org.glassfish` because we seem to need this to get some of the Pact tests to work now.

Nothing on https://www.eclipse.org/eclipselink/releases/2.7.php or https://projects.eclipse.org/projects/ee4j.eclipselink/releases/2.7.3/review indicates any backwards-compatibility issues that affect us: the former page mentions that “Behavior of `@XmlID` and `@XmlValue` annotations has been updated to be JAXB 2.2 RI compatible” but we never use `@XmlID` and only use `@XmlValue` in a single test.

EclipseLink 2.7.3 supports JPA 2.2 (EclipseLink 2.6.4 supports JPA 2.1.1) but a perusal of the JPA documentation indicates no changes to be concerned about.

Due to a signing issue, we now need to explicitly depend on JPA 2.1.1. See the comment in the POM file for the justification and why this should cause any problems.