### PR TITLE
PP-4248 Upgrade Mockito from 2.0.54-beta to 2.22.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.0.54-beta</version>
+            <version>2.22.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/Card3dsResponseAuthServiceTest.java
@@ -196,7 +196,6 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
     @Test
     public void authoriseShouldThrowAnOperationAlreadyInProgressRuntimeExceptionWhenTimeout() throws Exception {
-        when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
@@ -297,7 +296,6 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         setupPaymentProviderMock(transactionId, authoriseStatus, null, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
-        when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.empty());
 
         return card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
     }

--- a/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardAuthoriseServiceTest.java
@@ -482,7 +482,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.AUTHORISATION_READY);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        when(mockedChargeDao.merge(any())).thenReturn(charge);
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 
         cardAuthorisationService.doAuthorise(charge.getExternalId(), aValidAuthorisationDetails());
@@ -495,7 +494,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.CREATED);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
-        when(mockedChargeDao.merge(any())).thenReturn(charge);
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
 
         cardAuthorisationService.doAuthorise(charge.getExternalId(), aValidAuthorisationDetails());

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureProcessTest.java
@@ -66,7 +66,6 @@ public class CardCaptureProcessTest {
 
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         Counter mockCounter = mock(Counter.class);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockCaptureConfiguration.getBatchSize()).thenReturn(10);
         when(mockCaptureConfiguration.getRetryFailuresEveryAsJavaDuration()).thenReturn(Duration.ofMinutes(60));

--- a/src/test/java/uk/gov/pay/connector/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/CardCaptureServiceTest.java
@@ -208,8 +208,6 @@ public class CardCaptureServiceTest extends CardServiceTest {
         ChargeEntity charge = createNewChargeWith(chargeId, ChargeStatus.CAPTURE_READY);
         when(mockedChargeDao.findByExternalId(charge.getExternalId()))
                 .thenReturn(Optional.of(charge));
-        when(mockedChargeDao.merge(any()))
-                .thenReturn(charge);
         exception.expect(OperationAlreadyInProgressRuntimeException.class);
         cardCaptureService.doCapture(charge.getExternalId());
         assertThat(charge.getStatus(), is(ChargeStatus.CAPTURE_READY.getValue()));
@@ -223,8 +221,6 @@ public class CardCaptureServiceTest extends CardServiceTest {
         ChargeEntity charge = createNewChargeWith(chargeId, ChargeStatus.ENTERING_CARD_DETAILS);
         when(mockedChargeDao.findByExternalId(charge.getExternalId()))
                 .thenReturn(Optional.of(charge));
-        when(mockedChargeDao.merge(any()))
-                .thenReturn(charge);
 
         exception.expect(IllegalStateRuntimeException.class);
         cardCaptureService.doCapture(charge.getExternalId());

--- a/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeExpiryServiceTest.java
@@ -130,8 +130,6 @@ public class ChargeExpiryServiceTest {
         GatewayResponseBuilder<WorldpayBaseResponse> gatewayResponseBuilder = responseBuilder();
         GatewayResponse<WorldpayBaseResponse> gatewayResponse = gatewayResponseBuilder.withResponse(
                 mockWorldpayCancelResponse).build();
-        when(mockPaymentProviders.byName(PaymentGatewayName.WORLDPAY)).thenReturn(mockPaymentProvider);
-        when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
 
         EXPIRABLE_STATUSES.stream()
                 .filter(status -> !GATEWAY_CANCELLABLE_STATUSES.contains(status))

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -174,9 +174,7 @@ public class ChargeRefundServiceTest {
 
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, accountId))
                 .thenReturn(Optional.of(charge));
-
-        when(mockChargeDao.merge(charge)).thenReturn(charge);
-
+ 
         when(mockProviders.byName(SMARTPAY)).thenReturn(mockProvider);
         String reference = "refund-pspReference";
         setupSmartpayMock(reference, null);

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountNotificationCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountNotificationCredentialsServiceTest.java
@@ -109,17 +109,13 @@ public class GatewayAccountNotificationCredentialsServiceTest {
     }
 
     @Test
-    public void shouldValidateThatPasswordisAtLeaset10Characters() throws CredentialsException {
+    public void shouldValidateThatPasswordisAtLeast10Characters() throws CredentialsException {
         expectedException.expect(CredentialsException.class);
         expectedException.expectMessage("Invalid password length");
 
         GatewayAccountEntity gatewayAccount = mock(GatewayAccountEntity.class);
         NotificationCredentials notificationCredentials = mock(NotificationCredentials.class);
         Map<String, String> credentials = ImmutableMap.of("username", "bob", "password", "bobsecret");
-
-        when(gatewayAccount.getNotificationCredentials()).thenReturn(null);
-        when(entityBuilder.newNotificationCredentials(gatewayAccount)).thenReturn(notificationCredentials);
-        when(hashUtil.hash("bobsecret")).thenReturn("bobshashedsecret");
 
         gatewayAccountNotificationCredentialsService.setCredentialsForAccount(credentials, gatewayAccount);
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -75,7 +75,6 @@ public class GatewayClientTest {
             mockSessionIdentifier, mockMetricRegistry);
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
-        doAnswer(invocationOnMock -> null).when(mockHistogram).update(anyInt());
         doAnswer(invocationOnMock -> null).when(mockCounter).inc();
 
         WebTarget mockWebTarget = mock(WebTarget.class);
@@ -92,7 +91,6 @@ public class GatewayClientTest {
 
         when(mockGatewayOrder.getOrderRequestType()).thenReturn(OrderRequestType.AUTHORISE);
         when(mockGatewayOrder.getPayload()).thenReturn(orderPayload);
-        when(mockGatewayOrder.getProviderSessionId()).thenReturn(Optional.empty());
         when(mockGatewayOrder.getMediaType()).thenReturn(mediaType);
     }
 
@@ -132,7 +130,6 @@ public class GatewayClientTest {
     public void shouldIncludeCookieIfSessionIdentifierAvailableInOrder() {
         String providerSessionid = "provider-session-id";
 
-        when(mockGatewayOrder.getProviderSessionId()).thenReturn(Optional.of(providerSessionid));
         when(mockResponse.getStatus()).thenReturn(200);
 
         gatewayClient.postRequestFor(null, mockGatewayAccountEntity, mockGatewayOrder);

--- a/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/NotificationServiceTest.java
@@ -120,7 +120,6 @@ public class NotificationServiceTest {
                 IgnoredStatus mockedIgnoredStatus = mock(IgnoredStatus.class);
                 when(mockedIgnoredStatus.getType()).thenReturn(type);
                 when(mockedStatusMapper.from(any())).thenReturn(mockedIgnoredStatus);
-                when(mockedStatusMapper.from(any(), any(ChargeStatus.class))).thenReturn(mockedIgnoredStatus);
                 return mockedStatusMapper;
             case UNKNOWN:
             default:
@@ -364,7 +363,6 @@ public class NotificationServiceTest {
         when(mockedPaymentProviders.byName(WORLDPAY)).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.isNotificationEndpointSecured()).thenReturn(true);
         when(mockedPaymentProvider.getNotificationDomain()).thenReturn("something.com");
-        when(mockDnsUtils.reverseDnsLookup(anyString())).thenReturn(Optional.empty());
 
         assertThat(notificationService.handleNotificationFor("", WORLDPAY, "payload"), is(false));
         verifyZeroInteractions(mockedChargeDao);

--- a/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
@@ -78,9 +78,7 @@ public class PaymentProvidersTest {
     @Before
     public void setup() {
         Environment environment = mock(Environment.class);
-        when(config.getSmartpayConfig()).thenReturn(smartpayConfig);
         when(config.getWorldpayConfig()).thenReturn(worldpayConfig);
-        when(config.getEpdqConfig()).thenReturn(epdqConfig);
         when(config.getGatewayConfigFor(PaymentGatewayName.WORLDPAY)).thenReturn(worldpayConfig);
         when(config.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(smartpayConfig);
         when(config.getGatewayConfigFor(EPDQ)).thenReturn(epdqConfig);

--- a/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
@@ -86,7 +86,6 @@ public class SearchRefundsServiceTest {
         List<RefundEntity> refundEntities = getRefundEntity(1, gatewayAccount);
 
         when(refundDao.getTotalFor(any(SearchParams.class))).thenReturn(Long.valueOf(refundEntities.size()));
-        when(refundDao.findAllBy(any(SearchParams.class))).thenReturn(refundEntities);
 
         Response response = searchRefundsService.getAllRefunds(uriInfo, ACCOUNT_ID, pageNumber, displaySize);
 

--- a/src/test/java/uk/gov/pay/connector/service/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/UserNotificationServiceTest.java
@@ -96,7 +96,6 @@ public class UserNotificationServiceTest {
         when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
         when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(notificationId);
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
@@ -126,7 +125,6 @@ public class UserNotificationServiceTest {
         when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
         when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(notificationId);
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
@@ -180,10 +178,6 @@ public class UserNotificationServiceTest {
     @Test
     public void shouldNotSendPaymentConfirmedEmail_IfNotifyIsDisabled() throws Exception {
         when(mockNotifyConfiguration.isEmailNotifyEnabled()).thenReturn(false);
-        when(mockNotifyClientFactoryProvider.clientFactory()).thenReturn(mockNotifyClientFactory);
-        when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
-        when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
-        when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
 
         userNotificationService = new UserNotificationService(mockNotifyClientFactoryProvider, mockConfig, mockEnvironment);
         Future<Optional<String>> idF = userNotificationService.sendPaymentConfirmedEmail(ChargeEntityFixture.aValidChargeEntity().build());
@@ -195,10 +189,6 @@ public class UserNotificationServiceTest {
     @Test
     public void shouldNotSendRefundIssuedEmail_IfNotifyIsDisabled() throws Exception {
         when(mockNotifyConfiguration.isEmailNotifyEnabled()).thenReturn(false);
-        when(mockNotifyClientFactoryProvider.clientFactory()).thenReturn(mockNotifyClientFactory);
-        when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
-        when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
-        when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
 
         userNotificationService = new UserNotificationService(mockNotifyClientFactoryProvider, mockConfig, mockEnvironment);
         Future<Optional<String>> idF = userNotificationService.sendRefundIssuedEmail(RefundEntityFixture.aValidRefundEntity().build());
@@ -210,10 +200,6 @@ public class UserNotificationServiceTest {
     @Test
     public void shouldNotSendPaymentConfirmedEmail_whenConfirmationEmailNotificationsAreDisabledForService() throws Exception {
         when(mockNotifyConfiguration.isEmailNotifyEnabled()).thenReturn(true);
-        when(mockNotifyClientFactoryProvider.clientFactory()).thenReturn(mockNotifyClientFactory);
-        when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
-        when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
-        when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
         chargeEntity.getGatewayAccount()
@@ -233,7 +219,6 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
         when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
@@ -250,10 +235,6 @@ public class UserNotificationServiceTest {
     @Test
     public void shouldNotSendRefundIssuedEmail_whenConfirmationEmailNotificationsAreDisabledForService() throws Exception {
         when(mockNotifyConfiguration.isEmailNotifyEnabled()).thenReturn(true);
-        when(mockNotifyClientFactoryProvider.clientFactory()).thenReturn(mockNotifyClientFactory);
-        when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
-        when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
-        when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
         chargeEntity.getGatewayAccount()
@@ -276,7 +257,6 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
         when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
@@ -299,7 +279,6 @@ public class UserNotificationServiceTest {
         when(mockNotifyClientFactoryProvider.clientFactory()).thenReturn(mockNotifyClientFactory);
         when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenThrow(NotificationClientException.class);
-        when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
@@ -320,7 +299,6 @@ public class UserNotificationServiceTest {
         when(mockNotifyClientFactoryProvider.clientFactory()).thenReturn(mockNotifyClientFactory);
         when(mockNotifyClientFactory.getInstance()).thenReturn(mockNotifyClient);
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenThrow(NotificationClientException.class);
-        when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
@@ -348,7 +326,6 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
         when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(randomUUID());
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProvider3dsTest.java
@@ -24,7 +24,6 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
 
     @Test
     public void shouldRequire3dsAuthoriseRequest() {
-        when(mockGatewayAccountEntity.isRequires3ds()).thenReturn(true);
         mockPaymentProviderResponse(200, successAuth3dResponse());
         GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise(buildTestAuthorisationRequest());
         verifyPaymentProviderRequest(successAuthRequest());

--- a/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/epdq/EpdqPaymentProviderTest.java
@@ -205,8 +205,6 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
 
     @Test
     public void shouldNotVerifyNotificationIfEmptyPayload() {
-        when(mockGatewayAccountEntity.getCredentials()).thenReturn(Collections.singletonMap(CREDENTIALS_SHA_OUT_PASSPHRASE, "passphrase"));
-
         when(mockNotification.getPayload()).thenReturn(Optional.empty());
 
         assertThat(provider.verifyNotification(mockNotification, mockGatewayAccountEntity), is(false));

--- a/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/smartpay/SmartpayPaymentProviderTest.java
@@ -106,7 +106,6 @@ public class SmartpayPaymentProviderTest {
         gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
 
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockClientFactory.createWithDropwizardClient(eq(PaymentGatewayName.SMARTPAY), any(GatewayOperation.class), any(MetricRegistry.class)))
                 .thenReturn(mockClient);
 

--- a/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/worldpay/WorldpayPaymentProviderTest.java
@@ -208,9 +208,8 @@ public class WorldpayPaymentProviderTest {
 
         verify(mockGatewayClient).postRequestFor(eq(null), eq(mockGatewayAccountEntity), argThat(new ArgumentMatcher<GatewayOrder>() {
             @Override
-            public boolean matches(Object argument) {
-                return ((GatewayOrder) argument).getPayload().equals(expectedRefundRequest) &&
-                        ((GatewayOrder) argument).getOrderRequestType().equals(OrderRequestType.REFUND);
+            public boolean matches(GatewayOrder argument) {
+                return argument.getPayload().equals(expectedRefundRequest) && argument.getOrderRequestType().equals(OrderRequestType.REFUND);
             }
         }));
     }
@@ -297,13 +296,10 @@ public class WorldpayPaymentProviderTest {
 
         when(mockChargeEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
         when(mockChargeEntity.getExternalId()).thenReturn("uniqueSessionId");
-        when(mockChargeEntity.getAmount()).thenReturn(500L);
-        when(mockChargeEntity.getDescription()).thenReturn("This is a description");
         when(mockChargeEntity.getGatewayTransactionId()).thenReturn("MyUniqueTransactionId!");
 
         Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
         when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
-        when(mockGatewayAccountEntity.isRequires3ds()).thenReturn(true);
         when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
                 .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 401 from gateway")));
 
@@ -333,14 +329,11 @@ public class WorldpayPaymentProviderTest {
 
         when(mockChargeEntity.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
         when(mockChargeEntity.getExternalId()).thenReturn("uniqueSessionId");
-        when(mockChargeEntity.getAmount()).thenReturn(500L);
-        when(mockChargeEntity.getDescription()).thenReturn("This is a description");
         when(mockChargeEntity.getGatewayTransactionId()).thenReturn("MyUniqueTransactionId!");
         when(mockChargeEntity.getProviderSessionId()).thenReturn(providerSessionId);
 
         Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
         when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
-        when(mockGatewayAccountEntity.isRequires3ds()).thenReturn(true);
         when(mockGatewayClient.postRequestFor(isNull(String.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
                 .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway")));
 


### PR DESCRIPTION
Upgrade Mockito from 2.0.54-beta to 2.22.0 for Java 11 compatibility.

Newer Mockito versions fail if they detect unnecessary stubbing, so also remove all the stubbing lines that Mockito indicates are unused.

When stubbing, newer Mockito releases seem to not consider `null` to match `any(Long.class)`. Some tests in `ChargeRefundServiceTest` stub returning a `RefundEntity` from the (mocked) `RefundDao` by an ID that turns out to actually be `null`, due to a `RefundEntity` only getting an ID when the `RefundDao` persists it (the mock `RefundDao` does not set an ID). Fix this by using a Mockito `Answer` to set the ID on the `RefundEntity` (and in one test, on its spy double) to an arbitrary (but non-`null`) value that can then be used in stubbing. This is not great and `ChargeRefundServiceTest` could do with some love but we want to minimise the number of changes we make at once.

(There is a version 2.22.1 but it’s not in Maven Central.)