### PR TITLE
PP-4248 Add Maven dependency on GlassFish JAXB runtime 2.3.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
             <version>2.3.0</version>
         </dependency>
         <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
             <version>${dropwizard.version}</version>


### PR DESCRIPTION
JAXB was deprecrated in Java 9 SE and removed in Java 11 SE, so add a dependency on the GlassFish JAXB runtime (GlassFish is the reference implementation of Java EE, which is in the process of being transferred from Oracle to the Eclipse Foundation).

Maven dependency added per the documentation (we already added the dependency on the JAXB API in commit e08ef77745a14e744695c3d12d3d895d8d6039e9):

https://javaee.github.io/jaxb-v2/doc/user-guide/ch03.html#deployment-maven-coordinates

We’re adding version 2.3.0.1, which is newer than the version that ships with Java 8 SE but nothing in the changelog looks scary:

https://javaee.github.io/jaxb-v2/doc/user-guide/release-documentation.html#jaxb-2-0-changelog