### PR TITLE
[WIP] PP-4183 Multiple threads - CardCaptureProcess

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
@@ -7,6 +7,7 @@ public class CaptureProcessConfig extends Configuration {
     private long schedulerInitialDelayInSeconds;
     private long schedulerRandomIntervalMinimumInSeconds;
     private long schedulerRandomIntervalMaximumInSeconds;
+    private int schedulerThreads;
 
     private int batchSize;
     private Duration retryFailuresEvery;
@@ -38,5 +39,9 @@ public class CaptureProcessConfig extends Configuration {
 
     public int getMaximumRetries() {
         return maximumRetries;
+    }
+
+    public int getSchedulerThreads() {
+        return schedulerThreads;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class CaptureProcessScheduler implements Managed {
-    final Logger logger = LoggerFactory.getLogger(CaptureProcessScheduler.class);
+    private final Logger logger = LoggerFactory.getLogger(CaptureProcessScheduler.class);
 
     static final String CAPTURE_PROCESS_SCHEDULER_NAME = "capture-process";
     static final int SCHEDULER_THREADS = 1;
@@ -25,13 +25,14 @@ public class CaptureProcessScheduler implements Managed {
     private long initialDelayInSeconds = INITIAL_DELAY_IN_SECONDS;
     private long randomIntervalMinimumInSeconds = RANDOM_INTERVAL_MINIMUM_IN_SECONDS;
     private long randomIntervalMaximumInSeconds = RANDOM_INTERVAL_MAXIMUM_IN_SECONDS;
+    private int schedulerThreads = SCHEDULER_THREADS;
 
     private final CardCaptureProcess cardCaptureProcess;
     private final ScheduledExecutorService scheduledExecutorService;
     private final XrayUtils xrayUtils;
 
-    public CaptureProcessScheduler(ConnectorConfiguration configuration, 
-                                   Environment environment, 
+    public CaptureProcessScheduler(ConnectorConfiguration configuration,
+                                   Environment environment,
                                    CardCaptureProcess cardCaptureProcess,
                                    XrayUtils xrayUtils) {
         this.cardCaptureProcess = cardCaptureProcess;
@@ -42,12 +43,13 @@ public class CaptureProcessScheduler implements Managed {
             initialDelayInSeconds = captureProcessConfig.getSchedulerInitialDelayInSeconds();
             randomIntervalMinimumInSeconds = captureProcessConfig.getSchedulerRandomIntervalMinimumInSeconds();
             randomIntervalMaximumInSeconds = captureProcessConfig.getSchedulerRandomIntervalMaximumInSeconds();
+            schedulerThreads = captureProcessConfig.getSchedulerThreads();
         }
 
         scheduledExecutorService = environment
                 .lifecycle()
                 .scheduledExecutorService(CAPTURE_PROCESS_SCHEDULER_NAME)
-                .threads(SCHEDULER_THREADS)
+                .threads(schedulerThreads + 1)
                 .build();
     }
 
@@ -56,13 +58,21 @@ public class CaptureProcessScheduler implements Managed {
         logger.info("Scheduling CardCaptureProcess to run every {} seconds (will start in {} seconds)", interval, initialDelayInSeconds);
 
         scheduledExecutorService.scheduleAtFixedRate(() -> {
-            try {
-                xrayUtils.beginSegment();
-                cardCaptureProcess.runCapture();
-            } catch (Exception e) {
-                logger.error("Unexpected error running capture operations", e);
-            } finally {
-                xrayUtils.endSegment();
+            for (int threadNumber = 1; threadNumber <= schedulerThreads; threadNumber++) {
+                final int finalThreadNumber = threadNumber;
+
+                cardCaptureProcess.loadCaptureQueue();
+
+                scheduledExecutorService.schedule(() -> {
+                    try {
+                        xrayUtils.beginSegment();
+                        cardCaptureProcess.runCapture(finalThreadNumber);
+                    } catch (Exception e) {
+                        logger.error("Unexpected error running capture operations", e);
+                    } finally {
+                        xrayUtils.endSegment();
+                    }
+                }, 0, TimeUnit.SECONDS);
             }
         }, initialDelayInSeconds, interval, TimeUnit.SECONDS);
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcess.java
@@ -15,8 +15,8 @@ import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.inject.Inject;
-import java.util.Collections;
 import java.util.List;
+import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
@@ -29,44 +29,31 @@ public class CardCaptureProcess {
     private final CardCaptureService captureService;
     private final MetricRegistry metricRegistry;
     private final CaptureProcessConfig captureConfig;
+    private Queue<ChargeEntity> captureQueue;
     private volatile int readyCaptureQueueSize;
     private volatile int waitingCaptureQueueSize;
+    private volatile int chargesToCaptureSize;
 
     @Inject
-    public CardCaptureProcess(Environment environment, ChargeDao chargeDao, CardCaptureService cardCaptureService, ConnectorConfiguration connectorConfiguration) {
+    public CardCaptureProcess(Environment environment, ChargeDao chargeDao, CardCaptureService cardCaptureService,
+                              ConnectorConfiguration connectorConfiguration, Queue<ChargeEntity> captureQueue) {
         this.chargeDao = chargeDao;
         this.captureService = cardCaptureService;
         this.captureConfig = connectorConfiguration.getCaptureProcessConfig();
+        this.captureQueue = captureQueue;
         metricRegistry = environment.metrics();
         metricRegistry.gauge("gateway-operations.capture-process.queue-size.ready_capture_queue_size", () -> () -> readyCaptureQueueSize);
         metricRegistry.gauge("gateway-operations.capture-process.queue-size.waiting_capture_queue_size", () -> () -> waitingCaptureQueueSize);
     }
 
-    public void runCapture() {
-        MDC.put(HEADER_REQUEST_ID, format("runCapture-%s", RandomIdGenerator.newId()));
+    public void runCapture(int threadNumber) {
+        MDC.put(HEADER_REQUEST_ID, format("runCapture-%s, thread %d", RandomIdGenerator.newId(), threadNumber));
 
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
-        int captured = 0, skipped = 0, error = 0, failedCapture = 0, total = 0, chargesToCaptureSize = 0;
-
+        int captured = 0, skipped = 0, error = 0, failedCapture = 0, total = 0;
         try {
-            waitingCaptureQueueSize = chargeDao.countChargesAwaitingCaptureRetry(captureConfig.getRetryFailuresEveryAsJavaDuration());
-
-            List<ChargeEntity> chargesToCapture = chargeDao.findChargesForCapture(captureConfig.getBatchSize(),
-                    captureConfig.getRetryFailuresEveryAsJavaDuration());
-            chargesToCaptureSize = chargesToCapture.size();
-
-            if (chargesToCaptureSize < captureConfig.getBatchSize()) {
-                readyCaptureQueueSize = chargesToCaptureSize;
-            } else {
-                readyCaptureQueueSize = chargeDao.countChargesForImmediateCapture(captureConfig.getRetryFailuresEveryAsJavaDuration());
-            }
-
-            if (chargesToCaptureSize > 0) {
-                logger.info("Capturing: {} of {} charges", chargesToCaptureSize, (waitingCaptureQueueSize + readyCaptureQueueSize));
-            }
-
-            Collections.shuffle(chargesToCapture);
-            for (ChargeEntity charge : chargesToCapture) {
+            ChargeEntity charge;
+            while ((charge = getChargeToCapture()) != null) {
                 total++;
                 if (shouldRetry(charge)) {
                     try {
@@ -75,12 +62,15 @@ public class CardCaptureProcess {
                         if (gatewayResponse.isSuccessful()) {
                             captured++;
                         } else {
-                            logger.info("Failed to capture [chargeId={}] due to: {}", charge.getExternalId(), 
+                            logger.info("Failed to capture [chargeId={}] due to: {}", charge.getExternalId(),
                                     gatewayResponse.getError().get().getMessage());
                             failedCapture++;
                         }
                     } catch (ConflictRuntimeException e) {
                         logger.info("Another process has already attempted to capture [chargeId={}]. Skipping.", charge.getExternalId());
+                        skipped++;
+                    } catch (Exception e) {
+                        logger.info("Exception capturing charge [chargeId={}]. Skipping.", charge.getExternalId());
                         skipped++;
                     }
                 } else {
@@ -99,6 +89,33 @@ public class CardCaptureProcess {
             }
         }
         MDC.remove(HEADER_REQUEST_ID);
+    }
+
+    public synchronized void loadCaptureQueue() {
+        if (captureQueue.isEmpty()) {
+            waitingCaptureQueueSize = chargeDao.countChargesAwaitingCaptureRetry(captureConfig.getRetryFailuresEveryAsJavaDuration());
+
+            List<ChargeEntity> chargesToCapture = chargeDao.findChargesForCapture(captureConfig.getBatchSize(),
+                    captureConfig.getRetryFailuresEveryAsJavaDuration());
+
+            chargesToCaptureSize = chargesToCapture.size();
+
+            if (chargesToCaptureSize < captureConfig.getBatchSize()) {
+                readyCaptureQueueSize = chargesToCaptureSize;
+            } else {
+                readyCaptureQueueSize = chargeDao.countChargesForImmediateCapture(captureConfig.getRetryFailuresEveryAsJavaDuration());
+            }
+
+            if (chargesToCaptureSize > 0) {
+                logger.info("Capturing: {} of {} charges", chargesToCaptureSize, (waitingCaptureQueueSize + readyCaptureQueueSize));
+            }
+
+            captureQueue.addAll(chargesToCapture);
+        }
+    }
+
+    private synchronized ChargeEntity getChargeToCapture() {
+        return captureQueue.poll();
     }
 
     private boolean shouldRetry(ChargeEntity charge) {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -86,9 +86,10 @@ executorServiceConfig:
 captureProcessConfig:
   schedulerInitialDelayInSeconds: ${CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS:-20}
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-10}
-  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-20}
+  schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-30}
 
   batchSize: ${CAPTURE_PROCESS_BATCH_SIZE:-10}
+  schedulerThreads: ${SCHEDULER_THREADS:-10}
 
   # The below effectively get multiplied together. In order to handle how
   # certain payment gateways do things, it is extremely desirable to keep these
@@ -120,7 +121,7 @@ jerseyClient:
   proxy:
     host: ${HTTP_PROXY_HOST:-0}
     port: ${HTTP_PROXY_PORT:-0}
-    scheme : ${HTTP_PROXY_SCHEME:-https}
+    scheme: ${HTTP_PROXY_SCHEME:-https}
     nonProxyHosts:
       - localhost
 

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayCaptureFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayCaptureFailuresITest.java
@@ -31,7 +31,8 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenUnexpectedResponseCodeFromGateway() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithUnexpectedResponseCodeWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs(
                 String.format("Gateway returned unexpected status code: 999, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", port));
@@ -42,7 +43,8 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenMalformedResponseFromGateway() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithMalformedBody_WhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs("Could not unmarshall response >>>|<malformed xml/>|<<<.");
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
@@ -52,7 +54,8 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
     public void shouldSucceedCapture() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithSuccessWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
@@ -31,7 +31,8 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenInvalidConnectorUrl() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithUnexpectedResponseCodeWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs("DNS resolution error for gateway url=http://gobbledygook.invalid.url");
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -13,12 +12,10 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.dropwizard.testing.ConfigOverride.config;
-import static java.lang.String.format;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -39,9 +36,10 @@ public class GatewaySocketErrorITest extends BaseGatewayITest {
                 post(urlPathEqualTo("/pal/servlet/soap/Payment"))
                         .willReturn(aResponse().withStatus(404))
         );
-        
+
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs(
                 String.format("Gateway returned unexpected status code: 404, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", port));

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
@@ -31,7 +31,8 @@ public class GatewaySocketReadTimeoutITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenConnectionTimeoutFromGateway() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithTimeoutWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs(
                 String.format("Connection timed out error for gateway url=http://localhost:%s/pal/servlet/soap/Payment", port));

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -75,7 +75,8 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .statusCode(204);
 
         // Trigger the capture process programmatically which normally would be invoked by the scheduler.
-        testContext.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        testContext.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        testContext.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         getCharge(chargeId)
                 .body("settlement_summary.capture_submit_time", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))

--- a/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new EpdqMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
@@ -36,7 +37,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new EpdqMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +48,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new EpdqMockClient().mockCaptureError();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +59,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new EpdqMockClient().mockCaptureError();
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
@@ -24,7 +24,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
     }
@@ -34,7 +35,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }

--- a/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new SmartpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
@@ -36,7 +37,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new SmartpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +47,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new SmartpayMockClient().mockCaptureError();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +58,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new SmartpayMockClient().mockCaptureError();
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
     }
@@ -36,7 +37,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +47,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureError(testCharge.getTransactionId());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +58,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureError(testCharge.getTransactionId());
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
@@ -36,7 +37,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +47,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureError();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +58,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureError();
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-    level: INFO
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %nß"
+  level: INFO
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %nß"
 
 worldpay:
   urls:
@@ -75,11 +75,11 @@ jerseyClient:
   userAgent: connector
   gzipEnabledForRequests: false
   proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
+    host: localhost
+    port: 1234
+    scheme: http
+    nonProxyHosts:
+      - localhost
 
 customJerseyClient:
   readTimeout: 50000ms
@@ -94,6 +94,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-    level: INFO
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+  level: INFO
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 worldpay:
   urls:
@@ -74,11 +74,11 @@ jerseyClient:
   userAgent: connector
   gzipEnabledForRequests: false
   proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
+    host: localhost
+    port: 1234
+    scheme: http
+    nonProxyHosts:
+      - localhost
 
 customJerseyClient:
   readTimeout: 50000ms
@@ -93,6 +93,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-    level: INFO
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+  level: INFO
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 worldpay:
   urls:
@@ -64,11 +64,11 @@ jerseyClient:
   userAgent: connector
   gzipEnabledForRequests: false
   proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
+    host: localhost
+    port: 1234
+    scheme: http
+    nonProxyHosts:
+      - localhost
 
 customJerseyClient:
   readTimeout: 500ms
@@ -83,6 +83,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-    level: WARN
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+  level: WARN
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 links:
   frontendUrl: http://Frontend/
@@ -67,6 +67,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
@@ -85,11 +86,11 @@ jerseyClient:
   userAgent: connector
   gzipEnabledForRequests: false
   proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
+    host: localhost
+    port: 1234
+    scheme: http
+    nonProxyHosts:
+      - localhost
 
 customJerseyClient:
   readTimeout: 90000ms

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-    level: WARN
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+  level: WARN
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
 
 links:
   frontendUrl: http://Frontend/
@@ -64,6 +64,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 
@@ -82,11 +83,11 @@ jerseyClient:
   userAgent: connector
   gzipEnabledForRequests: false
   proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
+    host: localhost
+    port: 1234
+    scheme: http
+    nonProxyHosts:
+      - localhost
 
 customJerseyClient:
   readTimeout: 90000ms


### PR DESCRIPTION
## WHAT
### `Background`

The capture process (captures charges asynchronously in the background) in connector is a single threaded job that takes a number of charges (based on batch size) and captures them one by one. Potential issues with this approach:

1. If there are multiple connector nodes running, could potentially end up with overlap of charges being captured.
2. The average response time (live) to capture charges is ~100ms. So a batch size of 50 will take ~5 seconds to process a batch. So a single connector capture job scheduled every 10 seconds can only capture ~17k charges/day.
3. Increasing number of connector nodes doesn't necessarilty multiply the number of charges the can be captured as charges can overlap with other connector jobs

So given a high volume of transactions (~1 million/day), capture processes can take weeks to clear charges for a single day and may end up with expiring authorisations.

### `Solution`

Proposed solution is to introduce a queue (within connector node) and run multi-threaded capture process so that charges can be captured parallely and quickly. For a batch size of 50 charges and 10 capture threads we can clear the batch with in ~500ms. It can also likely to mitigate the issue of overlapping charges between connector nodes.

### `Changes`

- CaptureProcessScheduler now schedules multiple threads to capture charges
- Scheduler first loads shared queue (with charges awaiting capture)
- Each thread reads (removes charge from head of the queue - if queue is not empty) a charge from queue to further process it.
        - `ArrayBlockingQueue` is used as a queue which seemed most suitable to use as it is a fixed size queue that can hold charges equivalent to batch size, thread safe and size() method is constant-time operation. Although it is blocking queue, operations used (poll(), isEmpty()) are not blocking. So a thread can exit from operation without being blocked.


