### PR TITLE
PP-4111 Add email collection mode and email notifications to pact and frontend

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/GatewayAccountEntity.java
@@ -183,11 +183,16 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return cardTypes;
     }
 
-    @JsonView(Views.ApiView.class)
+    @JsonProperty("email_notifications")
     public Map<EmailNotificationType, EmailNotificationEntity> getEmailNotifications() {
         return emailNotifications;
     }
 
+    @JsonProperty("email_collection_mode")
+    public EmailCollectionMode getEmailCollectionMode() {
+        return emailCollectionMode;
+    }
+    
     @JsonView(Views.ApiView.class)
     public NotificationCredentials getNotificationCredentials() {
         return notificationCredentials;
@@ -294,10 +299,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public boolean isLive() {
         return Type.LIVE.equals(type);
-    }
-
-    public EmailCollectionMode getEmailCollectionMode() {
-        return emailCollectionMode;
     }
 
     public void setCorporateCreditCardSurchargeAmount(long corporateCreditCardSurchargeAmount) {

--- a/src/main/java/uk/gov/pay/connector/resources/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/resources/GatewayAccountResource.java
@@ -77,7 +77,6 @@ public class GatewayAccountResource {
     private static final String PAYMENT_PROVIDER_KEY = "payment_provider";
     private static final String USERNAME_KEY = "username";
     private static final String PASSWORD_KEY = "password";
-
     private final GatewayAccountDao gatewayDao;
     private final CardTypeDao cardTypeDao;
     private final Map<String, List<String>> providerCredentialFields;
@@ -184,7 +183,7 @@ public class GatewayAccountResource {
     @Path("/v1/frontend/accounts/{accountId}")
     @Produces(APPLICATION_JSON)
     @JsonView(GatewayAccountEntity.Views.ApiView.class)
-    public Response getGatewayAccountWithCredentials(@PathParam("accountId") Long gatewayAccountId) throws IOException {
+    public Response getGatewayAccountWithCredentials(@PathParam("accountId") Long gatewayAccountId) {
 
         return gatewayDao.findById(gatewayAccountId)
                 .map(serviceAccount ->

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -376,6 +376,16 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestAccount withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public TestAccount withAnalyticsId(String analyticsId) {
+            this.analyticsId = analyticsId;
+            return this;
+        }
+        
         public TestAccount withType(GatewayAccountEntity.Type type) {
             this.type = type;
             return this;
@@ -405,6 +415,7 @@ public class DatabaseFixtures {
                     type,
                     description,
                     analyticsId,
+                    emailCollectionMode,
                     corporateCreditCardSurchargeAmount,
                     corporateDebitCardSurchargeAmount);
             for (TestCardType cardType : cardTypes) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -20,13 +20,13 @@ import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -131,6 +131,11 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .body("credentials.username", is(gatewayAccountPayload.getUserName()))
                 .body("credentials.password", is(nullValue()))
                 .body("credentials.merchant_id", is(gatewayAccountPayload.getMerchantId()))
+                .body("email_collection_mode", is("MANDATORY"))
+                .body("email_notifications.PAYMENT_CONFIRMED.template_body", is(nullValue()))
+                .body("email_notifications.PAYMENT_CONFIRMED.enabled", is(true))
+                .body("email_notifications.REFUND_ISSUED.template_body", is(nullValue()))
+                .body("email_notifications.REFUND_ISSUED.enabled", is(true))
                 .body("description", is(nullValue()))
                 .body("analytics_id", is(nullValue()))
                 .body("service_name", is(gatewayAccountPayload.getServiceName()))
@@ -196,7 +201,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .body(format("card_types.find { it.brand == '%s' }.id", brand), is(notNullValue()))
                 .body(format("card_types.find { it.brand == '%s' }.label", brand), is(label))
                 .body(format("card_types.find { it.brand == '%s' }.requires3ds", brand), is(false))
-                .body(format("card_types.findAll { it.brand == '%s' }.type", brand), Matchers.hasItems(type));
+                .body(format("card_types.findAll { it.brand == '%s' }.type", brand), hasItems(type));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -122,7 +122,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .body("type", is(TEST.toString()))
                 .body("description", is("a description"))
                 .body("analytics_id", is("an analytics id"))
-                .body("email_collection_mode", is("MANDATORY"))
+                .body("email_collection_mode", is("OPTIONAL"))
                 .body("email_notifications.PAYMENT_CONFIRMED.template_body", is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
                 .body("email_notifications.PAYMENT_CONFIRMED.enabled", is(true))
                 .body("email_notifications.REFUND_ISSUED.template_body", is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -12,6 +12,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import uk.gov.pay.commons.testing.pact.providers.PayPactRunner;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
@@ -51,7 +52,15 @@ public class TransactionsApiContractTest {
 
     private void setUpGatewayAccount(long accountId) {
         if (dbHelper.getAccountCredentials(accountId) == null) {
-            dbHelper.addGatewayAccount(Long.toString(accountId), "sandbox", "aDescription", "8b02c7e542e74423aa9e6d0f0628fd58");
+                    DatabaseFixtures
+                            .withDatabaseTestHelper(dbHelper)
+                    .aTestAccount()
+                    .withAccountId(accountId)
+                    .withPaymentProvider("sandbox")
+                    .withDescription("aDescription")
+                    .withAnalyticsId("8b02c7e542e74423aa9e6d0f0628fd58")
+                    .withServiceName("a cool service")
+                    .insert();
         } else {
             dbHelper.deleteAllChargesOnAccount(accountId);
         }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -10,6 +10,7 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.AuthCardDetails;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
+import uk.gov.pay.connector.model.domain.EmailCollectionMode;
 import uk.gov.pay.connector.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.model.domain.GatewayAccountEntity;
 
@@ -38,6 +39,7 @@ public class DatabaseTestHelper {
                                   GatewayAccountEntity.Type providerUrlType,
                                   String description,
                                   String analyticsId,
+                                  EmailCollectionMode emailCollectionMode,
                                   long corporateCreditCardSurchargeAmount,
                                   long corporateDebitCardSurchargeAmount) {
         try {
@@ -56,9 +58,10 @@ public class DatabaseTestHelper {
                                     "                              type,\n" +
                                     "                              description,\n" +
                                     "                              analytics_id,\n" +
+                                    "                              email_collection_mode,\n" +
                                     "                              corporate_credit_card_surcharge_amount,\n" +
                                     "                              corporate_debit_card_surcharge_amount)\n" +
-                                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                             Long.valueOf(accountId),
                             paymentGateway,
                             jsonObject,
@@ -66,6 +69,7 @@ public class DatabaseTestHelper {
                             providerUrlType,
                             description,
                             analyticsId,
+                            emailCollectionMode,
                             corporateCreditCardSurchargeAmount,
                             corporateDebitCardSurchargeAmount)
             );
@@ -75,23 +79,23 @@ public class DatabaseTestHelper {
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider, Map<String, String> credentials) {
-        addGatewayAccount(accountId, paymentProvider, credentials, null, TEST, null, null, 0, 0);
+        addGatewayAccount(accountId, paymentProvider, credentials, null, TEST, null, null, EmailCollectionMode.MANDATORY, 0, 0);
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider) {
-        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, null, null, 0, 0);
+        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, null, null,  EmailCollectionMode.MANDATORY, 0, 0);
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider, String description, String analyticsId) {
-        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId, 0, 0);
+        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId,  EmailCollectionMode.MANDATORY, 0, 0);
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider, String description, String analyticsId, long corporateCreditCardSurchargeAmount, long corporateDebitCardSurchargeAmount) {
-        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount);
+        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId,  EmailCollectionMode.MANDATORY, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount);
     }
 
-    public void addGatewayAccount(String accountId, String paymentProvider, Map<String, String> credentials, long corporateCreditCardSurchargeAmount, long corporateDebitCardSurchargeAmount) {
-        addGatewayAccount(accountId, paymentProvider, credentials, "a cool service", TEST, "aDescription", "8b02c7e542e74423aa9e6d0f0628fd58", corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount);
+    public void addGatewayAccount(String accountId, String paymentProvider, Map<String, String> credentials, String serviceName, GatewayAccountEntity.Type type, String description, String analyticsId, long corporateCreditCardSurchargeAmount, long corporateDebitCardSurchargeAmount) {
+        addGatewayAccount(accountId, paymentProvider, credentials, serviceName, type, description, analyticsId,  EmailCollectionMode.MANDATORY, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount);
     }
 
     public void addCharge(Long chargeId, String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl,


### PR DESCRIPTION
Apparently, we were using a `/frontend` endpoint for self service, which gets the data in a different way from the `/v1/accounts` endpoint. 
This PR updates connector to return the right data.