### PR TITLE
PP-4196 Fix PayersCardType enum

### DIFF
--- a/src/main/java/uk/gov/pay/connector/model/domain/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/AuthCardDetails.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import static uk.gov.pay.connector.model.domain.PayersCardType.DEBIT_OR_CREDIT;
+import static uk.gov.pay.connector.model.domain.PayersCardType.CREDIT_OR_DEBIT;
 
 public class AuthCardDetails implements AuthorisationDetails {
 
@@ -108,6 +108,6 @@ public class AuthCardDetails implements AuthorisationDetails {
     }
 
     public PayersCardType getPayersCardType() {
-        return payersCardType == null ? DEBIT_OR_CREDIT : payersCardType;
+        return payersCardType == null ? CREDIT_OR_DEBIT : payersCardType;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/model/domain/PayersCardType.java
+++ b/src/main/java/uk/gov/pay/connector/model/domain/PayersCardType.java
@@ -13,5 +13,5 @@ package uk.gov.pay.connector.model.domain;
 public enum PayersCardType {
     DEBIT,
     CREDIT,
-    DEBIT_OR_CREDIT
+    CREDIT_OR_DEBIT
 }

--- a/src/test/java/uk/gov/pay/connector/util/charge/CorporateSurchargeCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/charge/CorporateSurchargeCalculatorTest.java
@@ -94,7 +94,7 @@ public class CorporateSurchargeCalculatorTest {
     @Test
     public void shouldNotGetCorporateSurchargeForCreditOrDebitCardType() {
         AuthCardDetails creditOrDebit = AuthCardDetailsBuilder.anAuthCardDetails()
-                .withCardType(PayersCardType.DEBIT_OR_CREDIT)
+                .withCardType(PayersCardType.CREDIT_OR_DEBIT)
                 .withCorporateCard(Boolean.TRUE)
                 .build();
 
@@ -112,7 +112,7 @@ public class CorporateSurchargeCalculatorTest {
     @Test
     public void shouldNotGetCorporateSurchargeForConsumerCreditOrDebitCardType() {
         AuthCardDetails creditOrDebit = AuthCardDetailsBuilder.anAuthCardDetails()
-                .withCardType(PayersCardType.DEBIT_OR_CREDIT)
+                .withCardType(PayersCardType.CREDIT_OR_DEBIT)
                 .withCorporateCard(Boolean.FALSE)
                 .build();
 


### PR DESCRIPTION
## WHAT

- Fix PayersCardType enum to have `CREDIT_OR_DEBIT` instead of `DEBIT_OR_CREDIT` value as frontend is converting `CD` type to `CREDIT_OR_DEBIT`

with @stephencdaly
