### PR TITLE
PP-4276 Code cleanup

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -65,7 +65,7 @@ public class ChargingITestBase {
     private static final String CARD_BRAND = "cardBrand";
     protected static final String RETURN_URL = "http://service.url/success-page/";
     protected static final String EMAIL = randomAlphabetic(242) + "@example.com";
-    protected RestAssuredClient connectorRestApi;
+    protected RestAssuredClient connectorRestApiClient;
     protected static final long AMOUNT = 6234L;
     protected WorldpayMockClient worldpay;
     protected SmartpayMockClient smartpay;
@@ -88,7 +88,7 @@ public class ChargingITestBase {
         this.paymentProvider = paymentProvider;
         this.accountId = String.valueOf(RandomUtils.nextInt());
 
-        connectorRestApi = new RestAssuredClient(app, accountId);
+        connectorRestApiClient = new RestAssuredClient(app, accountId);
     }
 
     @Before
@@ -155,20 +155,20 @@ public class ChargingITestBase {
     }
 
     protected ValidatableResponse getCharge(String chargeId) {
-        return connectorRestApi
+        return connectorRestApiClient
                 .withChargeId(chargeId)
                 .getCharge();
     }
 
     protected void assertFrontendChargeStatusIs(String chargeId, String status) {
-        connectorRestApi
+        connectorRestApiClient
                 .withChargeId(chargeId)
                 .getFrontendCharge()
                 .body("status", is(status));
     }
 
     protected void assertRefundStatus(String chargeId, String refundId, String status, Integer amount) {
-        connectorRestApi.withChargeId(chargeId)
+        connectorRestApiClient.withChargeId(chargeId)
                 .withRefundId(refundId)
                 .getRefund()
                 .body("status", is(status))
@@ -368,19 +368,19 @@ public class ChargingITestBase {
 
     protected String cancelChargeAndCheckApiStatus(String chargeId, ChargeStatus targetState, int targetHttpStatus) {
 
-        connectorRestApi
+        connectorRestApiClient
                 .withChargeId(chargeId)
                 .postChargeCancellation()
                 .statusCode(targetHttpStatus); //assertion
 
-        connectorRestApi
+        connectorRestApiClient
                 .withChargeId(chargeId)
                 .getCharge()
                 .body("state.status", Matchers.is("cancelled"))
                 .body("state.message", Matchers.is("Payment was cancelled by the service"))
                 .body("state.code", Matchers.is("P0040"));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withChargeId(chargeId)
                 .getFrontendCharge()
                 .body("status", Matchers.is(targetState.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthoriseResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthoriseResourceITest.java
@@ -74,7 +74,7 @@ public class CardAuthoriseResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void sanitizeCardDetails_shouldStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingMoreThan10Numbers() { 
+    public void sanitizeCardDetails_shouldStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingMoreThan10Numbers() {
         String sanitizedValue = "r-**-**-*  Ju&^****-**";
         String valueWithMoreThan10CharactersAsNumbers = "r-12-34-5  Ju&^6501-76";
         String cardHolderName = valueWithMoreThan10CharactersAsNumbers;

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardCaptureResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardCaptureResourceITest.java
@@ -8,13 +8,15 @@ import java.util.Map;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static java.util.UUID.randomUUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_ERROR_GATEWAY;
 import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRED;
 
 public class CardCaptureResourceITest extends ChargingITestBase {
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceITest.java
@@ -1,11 +1,9 @@
 package uk.gov.pay.connector.it.resources;
 
 import org.apache.commons.lang.StringUtils;
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
-import uk.gov.pay.connector.util.RestAssuredClient;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -14,23 +12,35 @@ import java.util.Map;
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.EXPIRE_CANCEL_FAILED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCELLED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCEL_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.SYSTEM_CANCEL_READY;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCELLED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_ERROR;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.USER_CANCEL_READY;
 
 public class ChargeCancelResourceITest extends ChargingITestBase {
 
-    private RestAssuredClient restApiCall;
-
     public ChargeCancelResourceITest() {
         super("worldpay");
-    }
-
-    @Before
-    public void setupGatewayAccount() {
-        restApiCall = new RestAssuredClient(app, accountId);
     }
 
     @Test
@@ -122,7 +132,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
         nonCancellableStatuses.forEach(notCancellableState -> {
             String chargeId = createNewInPastChargeWithStatus(notCancellableState);
             String expectedMessage = "Charge not in correct state to be processed, " + chargeId;
-            restApiCall
+            connectorRestApiClient
                     .withChargeId(chargeId)
                     .postChargeCancellation()
                     .statusCode(BAD_REQUEST.getStatusCode())
@@ -136,7 +146,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
     public void respondWith202_whenCancelAlreadyInProgress() {
         String chargeId = createNewInPastChargeWithStatus(SYSTEM_CANCEL_READY);
         String expectedMessage = "System Cancellation for charge already in progress, " + chargeId;
-        restApiCall
+        connectorRestApiClient
                 .withChargeId(chargeId)
                 .postChargeCancellation()
                 .statusCode(ACCEPTED.getStatusCode())
@@ -148,7 +158,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
     @Test
     public void respondWith404_whenPaymentNotFound() {
         String unknownChargeId = "2344363244";
-        restApiCall
+        connectorRestApiClient
                 .withChargeId(unknownChargeId)
                 .postChargeCancellation()
                 .statusCode(NOT_FOUND.getStatusCode())
@@ -162,7 +172,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
         String chargeId = createNewInPastChargeWithStatus(CREATED);
         String expectedMessage = "HTTP 404 Not Found";
 
-        restApiCall
+        connectorRestApiClient
                 .withAccountId("")
                 .withChargeId(chargeId)
                 .postChargeCancellation()
@@ -177,7 +187,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
         String chargeId = createNewInPastChargeWithStatus(CREATED);
         String expectedMessage = "HTTP 404 Not Found";
 
-        restApiCall
+        connectorRestApiClient
                 .withAccountId("ABSDCEFG")
                 .withChargeId(chargeId)
                 .postChargeCancellation()
@@ -192,7 +202,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
         String chargeId = createNewInPastChargeWithStatus(CREATED);
         String expectedMessage = format("Charge with id [%s] not found.", chargeId);
 
-        restApiCall
+        connectorRestApiClient
                 .withAccountId("12345")
                 .withChargeId(chargeId)
                 .postChargeCancellation()

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -64,7 +64,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .build()
         );
 
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .postCreateCharge(postBody)
                 .statusCode(Status.CREATED.getStatusCode())
                 .body(JSON_CHARGE_KEY, is(notNullValue()))
@@ -103,7 +103,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                     put("chargeTokenId", chargeTokenId);
                 }}));
 
-        ValidatableResponse getChargeResponse = connectorRestApi
+        ValidatableResponse getChargeResponse = connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(externalChargeId)
                 .getCharge()
@@ -157,7 +157,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .build()
         );
 
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .postCreateCharge(postBody)
                 .statusCode(Status.CREATED.getStatusCode())
                 .body(JSON_LANGUAGE_KEY, is("en"))
@@ -165,7 +165,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
 
         String externalChargeId = response.extract().path(JSON_CHARGE_KEY);
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(externalChargeId)
                 .getCharge()
@@ -187,7 +187,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .put(JSON_RETURN_URL_KEY, RETURN_URL).build());
 
 
-        connectorRestApi
+        connectorRestApiClient
                 .postCreateCharge(postBody)
                 .statusCode(Status.CREATED.getStatusCode())
                 .body(JSON_CHARGE_KEY, is(notNullValue()))
@@ -214,7 +214,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 JSON_GATEWAY_ACC_KEY, accountId,
                 JSON_RETURN_URL_KEY, RETURN_URL));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId("invalidAccountId")
                 .postCreateCharge(postBody)
                 .contentType(JSON)
@@ -222,7 +222,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .body("code", is(404))
                 .body("message", is("HTTP 404 Not Found"));
     }
-    
+
     @Test
     public void shouldReturn400WhenAmountIsLessThanMinAmount() {
 
@@ -236,7 +236,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .put(JSON_RETURN_URL_KEY, RETURN_URL)
                 .put(JSON_EMAIL_KEY, EMAIL).build());
 
-        connectorRestApi
+        connectorRestApiClient
                 .postCreateCharge(postBody)
                 .statusCode(Status.BAD_REQUEST.getStatusCode());
     }
@@ -254,7 +254,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .build()
         );
 
-        connectorRestApi
+        connectorRestApiClient
                 .postCreateCharge(postBody)
                 .statusCode(Status.BAD_REQUEST.getStatusCode());
 
@@ -270,7 +270,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 JSON_EMAIL_KEY, EMAIL,
                 JSON_RETURN_URL_KEY, RETURN_URL));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(missingGatewayAccount)
                 .postCreateCharge(postBody)
                 .statusCode(NOT_FOUND.getStatusCode())
@@ -290,7 +290,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .put(JSON_GATEWAY_ACC_KEY, accountId)
                 .put(JSON_RETURN_URL_KEY, RETURN_URL).build());
 
-        connectorRestApi.postCreateCharge(postBody)
+        connectorRestApiClient.postCreateCharge(postBody)
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
                 .header("Location", is(nullValue()))
@@ -300,14 +300,14 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
 
     @Test
     public void cannotMakeChargeForMissingFields() {
-        connectorRestApi.postCreateCharge("{}")
+        connectorRestApiClient.postCreateCharge("{}")
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
                 .header("Location", is(nullValue()))
                 .body(JSON_CHARGE_KEY, is(nullValue()))
                 .body(JSON_MESSAGE_KEY, is("Field(s) missing: [amount, description, reference, return_url]"));
     }
-    
+
     private String expectedChargeLocationFor(String accountId, String chargeId) {
         return "https://localhost:" + app.getLocalPort() + "/v1/api/accounts/{accountId}/charges/{chargeId}"
                 .replace("{accountId}", accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiFilterChargesITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiFilterChargesITest.java
@@ -51,7 +51,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("from_date", DateTimeUtils.toUTCDateTimeString(now().minusDays(1)))
                 .withQueryParam("to_date", DateTimeUtils.toUTCDateTimeString(now().plusDays(1)))
@@ -100,7 +100,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("email", "@example.com")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -118,7 +118,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("cardholder_name", "McPayment")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -137,7 +137,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-2"), now(), "master-card");
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-3"), now().minusDays(2), searchedCardBrand);
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("card_brand", searchedCardBrand)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -154,7 +154,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-1"), now(), "visa");
         addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-2"), now(), "master-card");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("card_brand", "")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -175,7 +175,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now().minusHours(1), mastercard);
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2), "american-express");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withQueryParams("card_brand", asList(visa, mastercard))
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getChargesV1()
@@ -194,7 +194,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
                 "query param 'display_size' should be a non zero positive integer",
                 "query param 'page' should be a non zero positive integer");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("to_date", "-1")
                 .withQueryParam("from_date", "-1")
@@ -215,7 +215,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         String id_4 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-4"), now().plusHours(3));
         String id_5 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-5"), now().plusHours(4));
 
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("display_size", "2")
                 .withQueryParam("page", "1")
@@ -229,7 +229,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         List<String> charge_ids = collect(results, "charge_id");
         assertThat(charge_ids, is(ImmutableList.of(id_5, id_4)));
 
-        response = connectorRestApi
+        response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("display_size", "2")
                 .withQueryParam("page", "2")
@@ -243,7 +243,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         charge_ids = collect(results, "charge_id");
         assertThat(charge_ids, is(ImmutableList.of(id_3, id_2)));
 
-        response = connectorRestApi
+        response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("display_size", "2")
                 .withQueryParam("page", "3")
@@ -265,7 +265,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("last_digits_card_number", "1234")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -284,7 +284,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("last_digits_card_number", "12")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -303,7 +303,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("first_digits_card_number", "123456")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -322,7 +322,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("first_digits_card_number", "1234")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -341,7 +341,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("first_digits_card_number", "")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -362,7 +362,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addCharge(chargeId, externalChargeId, accountId, AMOUNT, AUTHORISATION_SUCCESS, RETURN_URL, null);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(externalChargeId)
                 .getCharge()
@@ -379,7 +379,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("first_digits_card_number", "123456")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -397,7 +397,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("first_digits_card_number", "")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -415,7 +415,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("first_digits_card_number", "12")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -433,7 +433,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("last_digits_card_number", "1234")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -451,7 +451,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("last_digits_card_number", "")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -469,7 +469,7 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
         addChargeAndCardDetails(AUTHORISATION_READY, ServicePaymentReference.of("ref-2"), now());
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("first_digits_card_number", "12")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceGetChargesJsonITest.java
@@ -31,7 +31,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
 
     @Test
     public void shouldReturn404OnGetTransactionsWhenAccountIdIsNonNumeric() {
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId("invalidAccountId")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getTransactionsAPI()
@@ -59,7 +59,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
 
         String description = "Test description";
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getTransactionsAPI()
@@ -98,7 +98,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
 
         String description = "Test description";
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getTransactionsAPI()
@@ -136,7 +136,7 @@ public class ChargesApiResourceGetChargesJsonITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getTransactionsAPI()

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -45,7 +45,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     private static final String JSON_CORPORATE_SURCHARGE_KEY = "corporate_surcharge";
     private static final String JSON_TOTAL_AMOUNT_KEY = "total_amount";
     private static final String PROVIDER_NAME = "sandbox";
-    
+
     public ChargesApiResourceITest() {
         super(PROVIDER_NAME);
     }
@@ -74,7 +74,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldReturn404OnGetCharge_whenAccountIdIsNonNumeric() {
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId("wrongAccount")
                 .withChargeId("123")
                 .withHeader(HttpHeaders.ACCEPT, JSON.getAcceptHeader())
@@ -87,7 +87,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldReturn404_whenAccountIdIsNonNumeric() {
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId("invalidAccountId")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getChargesV1()
@@ -106,7 +106,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, CardFixture.aValidCard().withCardNo("12345678").build());
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(externalChargeId)
                 .getCharge()
@@ -134,7 +134,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(externalChargeId)
                 .getCharge()
@@ -155,7 +155,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 "03/18", "line1", null, "postcode", "city", null, "country");
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(externalChargeId)
                 .getCharge()
@@ -177,7 +177,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().updateCorporateSurcharge(chargeId, 50L);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .getChargesV1()
                 .statusCode(OK.getStatusCode())
@@ -200,7 +200,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().updateCorporateSurcharge(chargeId, 150L);
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .getChargesV2()
                 .statusCode(OK.getStatusCode())
@@ -230,7 +230,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
         String description = "Test description";
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getChargesV1()
@@ -266,7 +266,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
         app.getDatabaseTestHelper().addEvent(chargeId, chargeStatus.getValue());
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getChargesV1()
@@ -281,11 +281,11 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("results[0].card_details.first_digits_card_number", nullValue())
                 .body("results[0].card_details.expiry_date", nullValue());
     }
-    
+
     @Test
     public void cannotGetCharge_WhenInvalidChargeId() {
         String chargeId = "23235124";
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(chargeId)
                 .getCharge()
@@ -300,7 +300,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String extChargeId = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
 
         // run expiry task
-        connectorRestApi
+        connectorRestApiClient
                 .postChargeExpiryTask()
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
@@ -308,7 +308,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("expiry-failed", is(0));
 
         // get the charge back and assert its status is expired
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .getCharge()
@@ -324,14 +324,14 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String extChargeId = addChargeAndCardDetails(ChargeStatus.AUTHORISATION_3DS_REQUIRED, ServicePaymentReference.of("ref"),
                 ZonedDateTime.now().minusMinutes(90));
 
-        connectorRestApi
+        connectorRestApiClient
                 .postChargeExpiryTask()
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
                 .body("expiry-success", is(1))
                 .body("expiry-failed", is(0));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .getCharge()
@@ -349,7 +349,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
 
         // run expiry task
-        connectorRestApi
+        connectorRestApiClient
                 .postChargeExpiryTask()
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
@@ -357,7 +357,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("expiry-failed", is(0));
 
         // get the charge back and assert its status is expired
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .getCharge()
@@ -374,14 +374,14 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String extChargeId = addChargeAndCardDetails(AWAITING_CAPTURE_REQUEST,
                 ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .postMarkChargeAsCaptureApproved()
                 .statusCode(NO_CONTENT.getStatusCode());
 
         // get the charge back and assert its status is expired
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .getCharge()
@@ -398,14 +398,14 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String extChargeId = addChargeAndCardDetails(CAPTURE_APPROVED,
                 ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .postMarkChargeAsCaptureApproved()
                 .statusCode(NO_CONTENT.getStatusCode());
 
         // get the charge back and assert its status is expired
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .getCharge()
@@ -419,7 +419,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     @Test
     public void shouldGetNotFoundFor_markChargeAsCaptureApproved_whenNoChargeExists() {
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId("i-do-not-exist")
                 .postMarkChargeAsCaptureApproved()
@@ -435,7 +435,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
 
         final String expectedErrorMessage = format("Operation for charge conflicting, %s, attempt to perform delayed capture on charge not in AWAITING CAPTURE REQUEST state.", extChargeId);
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(extChargeId)
                 .postMarkChargeAsCaptureApproved()

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceJsonPaginationITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceJsonPaginationITest.java
@@ -38,7 +38,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
 
     @Test
     public void shouldReturn404OnGetTransactionsWhenAccountIdIsNonNumeric() {
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId("invalidAccountId")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getTransactionsAPI()
@@ -81,7 +81,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
         String id_5 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-5"), now().plusHours(4));
         int expectedTotalRows = 5;
 
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("display_size", "2")
                 .withQueryParam("page", "1")
@@ -97,7 +97,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
         List<String> charge_ids = collect(results, "charge_id");
         assertThat(charge_ids, is(ImmutableList.of(id_5, id_4)));
 
-        response = connectorRestApi
+        response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("display_size", "2")
                 .withQueryParam("page", "2")
@@ -112,7 +112,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
         charge_ids = collect(results, "charge_id");
         assertThat(charge_ids, is(ImmutableList.of(id_3, id_2)));
 
-        response = connectorRestApi
+        response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("display_size", "2")
                 .withQueryParam("page", "3")
@@ -136,7 +136,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
                 "query param 'display_size' should be a non zero positive integer",
                 "query param 'page' should be a non zero positive integer");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("to_date", "-1")
                 .withQueryParam("from_date", "-1")
@@ -157,7 +157,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
         String id_4 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-4"), now().plusHours(3));
         String id_5 = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref-5"), now().plusHours(4));
 
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getChargesV1()
@@ -176,7 +176,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
                 "query param 'display_size' should be a non zero positive integer",
                 "query param 'page' should be a non zero positive integer");
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "-1")
@@ -195,7 +195,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-3"), now().minusDays(2));
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-4"), now().minusDays(3));
         addChargeAndCardDetails(CAPTURED, ServicePaymentReference.of("ref-5"), now().minusDays(4));
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-1")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -219,7 +219,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
 
     @Test
     public void shouldGetNoNavigationLinks_whenNoResultFound() {
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "junk-yard")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -243,7 +243,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
     public void shouldGetResultsAndNoPrevLink_whenOnFirstPage() {
         setUpChargeAndCardDetails();
         // when 5 charges are there, page is 1, display-size is 2
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "1")
@@ -271,7 +271,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
     public void shouldGetResultsAndAllLinks_whenOnMiddlePage() {
         // when 5 charges are there, page is 2, display-size is 2
         setUpChargeAndCardDetails();
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "2")
@@ -299,7 +299,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
     public void shouldGetResultsAndNoNextLinks_whenOnLastPage() {
         // when 5 charges are there, page is 3, display-size is 2
         setUpChargeAndCardDetails();
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "3")
@@ -327,7 +327,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
     public void shouldGetJustSelfLink_whenJustOneResult() {
         // when 5 charges are there, page is 1, display-size is 2
         setUpChargeAndCardDetails();
-        ValidatableResponse response = connectorRestApi
+        ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-1")
                 .withQueryParam("page", "1")
@@ -355,7 +355,7 @@ public class ChargesApiResourceJsonPaginationITest extends ChargingITestBase {
     public void shouldReceive404_whenRequestingInvalidPage() {
         // when 5 charges are there, page is 10, display-size is 2
         setUpChargeAndCardDetails();
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref")
                 .withQueryParam("page", "10")

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
@@ -6,7 +6,6 @@ import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
-import uk.gov.pay.connector.util.RestAssuredClient;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.time.ZonedDateTime;
@@ -87,7 +86,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-3")
                 .withQueryParam("page", "1")
@@ -165,7 +164,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-3")
                 .withQueryParam("page", "1")
@@ -189,12 +188,12 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
                 .body("results[1].reference", is(referenceCharge2.toString()));
     }
 
-        @Test
+    @Test
     public void shouldFilterTransactionsByCardHolderName() {
         String cardHolderName = "Mr. PayMcPayment";
         addChargeAndCardDetails(nextLong(), CREATED, ServicePaymentReference.of("ref-1"), "ref", now(), "", "http://service.url/success-page/", "aaa@bbb.test", cardHolderName, "1234");
         addChargeAndCardDetails(nextLong(), AUTHORISATION_SUCCESS, ServicePaymentReference.of("ref-1"), "ref", now(), "", "http://service.url/success-page/", "aaa@bbb.test", cardHolderName, "1234");
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("cardholder_name", "PayMc")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -212,7 +211,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         addChargeAndCardDetails(nextLong(), CREATED, ServicePaymentReference.of("ref-1"), "ref", now(), "", "http://service.url/success-page/", "aaa@bbb.test", cardHolderName, lastFourDigits);
         addChargeAndCardDetails(nextLong(), AUTHORISATION_SUCCESS, ServicePaymentReference.of("ref-1"), "ref", now(), "", "http://service.url/success-page/", "aaa@bbb.test", cardHolderName, lastFourDigits);
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("last_digits_card_number", "3943")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -226,7 +225,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldNotMatchChargesByPartialLastFourDigits() {
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("last_digits_card_number", "12")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -235,7 +234,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
                 .contentType(JSON)
                 .body("results.size()", is(0));
     }
-    
+
     @Test
     public void shouldGetExpectedCharge_whenOnlySpecifiedRefundStates() {
 
@@ -254,7 +253,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
 
-        connectorRestApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-3")
                 .withQueryParam("page", "1")
@@ -284,7 +283,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().updateChargeCardDetails(chargeId, cardBrand, lastDigitsCardNumber, firstDigitsCardNumber, cardHolderName, expiryDate, "line1", null, "postcode", "city", null, "country");
         return externalChargeId;
     }
-    
+
     private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, String transactionId, ZonedDateTime fromDate,
                                            String cardBrand, String returnUrl, String email,
                                            String cardHolderName, String lastDigitsCardNumber) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.RefundStatus;
-import uk.gov.pay.connector.util.RestAssuredClient;
 
 import javax.ws.rs.core.HttpHeaders;
 
@@ -26,13 +25,11 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
 
     private static final String PROVIDER_NAME = "sandbox";
 
-    private RestAssuredClient api = new RestAssuredClient(app, accountId);
     private static final String INVALID_ACCOUNT_ID = "999999999";
 
     public SearchRefundsResourceITest() {
         super(PROVIDER_NAME);
     }
-
 
     @Test
     public void shouldReturnAllRefundsForGetRefundsByAccountId() {
@@ -47,7 +44,7 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId, now().minusHours(3));
         app.getDatabaseTestHelper().addToken(chargeId, "tokenId");
 
-        api.withAccountId(accountId)
+        connectorRestApiClient.withAccountId(accountId)
                 .withQueryParam("page", "1")
                 .withQueryParam("display_size", "2")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -70,7 +67,7 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addCharge(chargeId, "charge2", accountId, AMOUNT, AUTHORISATION_SUCCESS, returnUrl, null,
                 ServicePaymentReference.of("ref"), null, email);
 
-        api.withAccountId(accountId)
+        connectorRestApiClient.withAccountId(accountId)
                 .withQueryParam("page", "1")
                 .withQueryParam("display_size", "2")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
@@ -86,7 +83,7 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
 
     @Test
     public void shouldReturnNotFoundResponseWhenAccountDoesNotExist() {
-        api.withAccountId(INVALID_ACCOUNT_ID)
+        connectorRestApiClient.withAccountId(INVALID_ACCOUNT_ID)
                 .withQueryParam("page", "1")
                 .withQueryParam("display_size", "2")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
@@ -6,7 +6,6 @@ import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.model.ServicePaymentReference;
 import uk.gov.pay.connector.model.domain.ChargeStatus;
 import uk.gov.pay.connector.model.domain.RefundStatus;
-import uk.gov.pay.connector.util.RestAssuredClient;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.time.ZonedDateTime;
@@ -32,7 +31,6 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
 
     private static final String PROVIDER_NAME = "sandbox";
 
-    private RestAssuredClient getChargeApi = new RestAssuredClient(app, accountId);
     private String lastDigitsCardNumber;
     private String firstDigitsCardNumber;
     private String cardHolderName;
@@ -83,7 +81,7 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
 
-        getChargeApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-3")
                 .withQueryParam("page", "1")
@@ -164,7 +162,7 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
 
-        getChargeApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-3")
                 .withQueryParam("page", "1")
@@ -207,7 +205,7 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
         app.getDatabaseTestHelper().addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
 
-        getChargeApi
+        connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("reference", "ref-3")
                 .withQueryParam("page", "1")
@@ -226,6 +224,7 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
                 .body("results[0].gateway_transaction_id", is(transactionIdCharge2))
                 .body("results[0].charge_id", is(externalChargeId2));
     }
+
     private String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, String transactionId, ZonedDateTime fromDate,
                                            String cardBrand, String returnUrl, String email) {
         String externalChargeId = "charge" + chargeId;

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqChargeApiResourceITest.java
@@ -18,7 +18,7 @@ public class EpdqChargeApiResourceITest extends ChargingITestBase {
         String expectedHtml = "someHtml";
         app.getDatabaseTestHelper().updateCharge3dsDetails(Long.valueOf(chargeId), null, null, expectedHtml);
 
-        connectorRestApi.withChargeId(externalChargeId).getFrontendCharge()
+        connectorRestApiClient.withChargeId(externalChargeId).getFrontendCharge()
                 .statusCode(200)
                 .body("status", is(AUTHORISATION_3DS_REQUIRED.toString()))
                 .body("auth_3ds_data.htmlOut", is(expectedHtml));

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
@@ -67,7 +67,7 @@ public class EpdqNotificationResourceITest extends ChargingITestBase {
 
         String externalChargeId = createNewChargeWithRefund(transactionId, refundExternalId, payIdSub, refundAmount);
 
-        String response = notifyConnector(transactionId, payIdSub,"8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+        String response = notifyConnector(transactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
                 .statusCode(200)
                 .extract().body()
                 .asString();

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
@@ -49,7 +49,8 @@ public class EpdqRefundITest extends ChargingITestBase {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setup() {
+        super.setup();
         databaseTestHelper = app.getDatabaseTestHelper();
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxNotificationResourceITest.java
@@ -3,12 +3,8 @@ package uk.gov.pay.connector.it.resources.sandbox;
 import org.junit.Test;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 
-import static com.google.common.io.Resources.getResource;
 import static com.jayway.restassured.RestAssured.given;
-import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 
 public class SandboxNotificationResourceITest extends ChargingITestBase {
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
@@ -16,7 +16,9 @@ import java.util.Map;
 
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
@@ -39,8 +41,8 @@ public class SandboxRefundITest extends ChargingITestBase {
     }
 
     @Before
-    public void setUp() throws Exception {
-
+    public void setup() {
+        super.setup();
         databaseTestHelper = app.getDatabaseTestHelper();
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthITest.java
@@ -22,7 +22,10 @@ import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.model.domain.ChargeStatus.*;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.model.domain.RefundStatus.REFUND_SUBMITTED;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_MULTIPLE_NOTIFICATIONS;
@@ -38,7 +41,8 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthITest extends Ch
     }
 
     @Before
-    public void setUpAuthForEndpoint() {
+    public void setup() {
+        super.setup();
         givenSetup()
                 .body(toJson(ImmutableMap.of("username", "bob", "password", "bobsbigsecret")))
                 .post("/v1/api/accounts/" + accountId + "/notification-credentials")

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
@@ -47,7 +47,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setup() {
+        super.setup();
         databaseTestHelper = app.getDatabaseTestHelper();
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
@@ -48,7 +48,8 @@ public class WorldpayRefundITest extends ChargingITestBase {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setup() {
+        super.setup();
         databaseTestHelper = app.getDatabaseTestHelper();
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)


### PR DESCRIPTION
## WHAT

- All classes that inherit from `ChargingITestBase` call `super.setup()`
when they have a method annotated with `@Before`
- The methods annotated with `@Before` have been renamed to `setup` so it
will override the method in the parent class. In some cases, the parent
method annotated with `@Before` was not called and some of the clients
were not instantiated, throwing NPE. JUnit uses Reflection for methods
annotated with `@Before` and when overriding it in a child class, the
parent functionality was not called. In some cases it was working because
it was called `setUp` or something else (mind the upper case `U`)
- Optimised imports and code style
- Removed locally instantiated client objects, as there's an `connectorRestApi`
object that gets created every time when a test is run. As we only use this
client objects to call the resources, it seems perfectly fine to use the
object that gets created anyway
- This change might help in the future in adding all the generic setup
required in the base class and test behaviour in the child classes that
also have the tests


