### PR TITLE
PP-4280 New validation pattern and validation testing

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/NewChargeStatusRequest.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.charge.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.validation.ValidationMethod;
+import org.hibernate.validator.constraints.NotEmpty;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+
+
+public class NewChargeStatusRequest {
+    @NotEmpty
+    private final String newStatus;
+    
+    NewChargeStatusRequest(@JsonProperty("new_status") String newStatus) {
+        this.newStatus = newStatus;
+    }
+
+    @JsonProperty("new_status")
+    public String getNewStatus() {
+        return newStatus;
+    }
+
+    @ValidationMethod(message="invalid new status")
+    @JsonIgnore
+    public boolean isValidNewStatus() {
+        return ChargeStatus.ENTERING_CARD_DETAILS.toString().equals(newStatus);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/exception/ConstraintViolationExceptionMapper.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.exception;
+
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+
+public class ConstraintViolationExceptionMapper implements ExceptionMapper<ConstraintViolationException> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConstraintViolationExceptionMapper.class);
+
+    @Override
+    public Response toResponse(ConstraintViolationException exception) {
+        LOGGER.error(exception.getMessage());
+        List<String> constraintViolationMessages = exception
+                .getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.toList());
+
+        return Response.status(400)
+                .entity(ImmutableMap.of("message", constraintViolationMessages))
+                .type(APPLICATION_JSON).build();
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -5,6 +5,7 @@ server:
   adminConnectors:
     - type: http
       port: ${ADMIN_PORT:-0}
+  registerDefaultExceptionMappers: false
 
 logging:
     level: INFO

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.connector.charge.resource;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.dao.CardTypeDao;
+import uk.gov.pay.connector.rules.ResourceTestRuleWithCustomExceptionMappersBuilder;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChargesFrontendResourceTest {
+    @Mock
+    private static ChargeService chargeService;
+    @Mock
+    private static  ChargeDao chargeDao;
+    @Mock
+    private static  CardTypeDao cardTypeDao;
+    
+    @ClassRule
+    public static ResourceTestRule resources = ResourceTestRuleWithCustomExceptionMappersBuilder.getBuilder()
+            .addResource(new ChargesFrontendResource(chargeDao, chargeService, cardTypeDao))
+            .build();
+
+    @Test
+    public void shouldReturn400_whenPutToChargeStatus_emptyPayload() {
+        Response response = resources.client()
+                .target("/v1/frontend/charges/irrelevant_charge_id/status")
+                .request()
+                .put(Entity.json(""));
+
+        assertThat(response.getStatus(), is(400));
+        
+        List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
+        assertThat(listOfErrors.size(), is(1));
+        assertThat(listOfErrors, hasItem("may not be null"));
+    }
+
+    @Test
+    public void shouldReturn400_whenPutToChargeStatus_emptyNewStatus() {
+        Response response = resources.client()
+                .target("/v1/frontend/charges/irrelevant_charge_id/status")
+                .request()
+                .put(Entity.json(Collections.singletonMap("new_status", "")));
+
+        assertEquals( 400, response.getStatus());
+        
+        List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
+        assertThat(listOfErrors.size(), is(2));
+        assertThat(listOfErrors, hasItem("invalid new status"));
+        assertThat(listOfErrors, hasItem("may not be empty"));
+
+    }
+
+    @Test
+    public void shouldReturn400_whenPutToChargeStatus_invalidNewStatus() {
+        Response response = resources.client()
+                .target("/v1/frontend/charges/irrelevant_charge_id/status")
+                .request()
+                .put(Entity.json(Collections.singletonMap("new_status", "invalid_status")));
+
+        assertEquals(400, response.getStatus());
+
+        List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
+        assertThat(listOfErrors.size(), is(1));
+        assertThat(listOfErrors, hasItem("invalid new status"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -191,37 +191,6 @@ public class ChargesFrontendResourceITest {
     }
 
     @Test
-    public void shouldBeBadRequestForUpdateStatusWithEmptyBody() {
-        String chargeId = postToCreateACharge(expectedAmount);
-        String putBody = "";
-
-        connectorRestApi
-                .withChargeId(chargeId)
-                .putChargeStatus(putBody)
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body(is("{\"message\":\"Field(s) missing: [new_status]\"}"));
-
-        //charge status should remain CREATED
-        validateGetCharge(expectedAmount, chargeId, CREATED, true);
-    }
-
-    @Test
-    public void shouldBeBadRequestForUpdateStatusForUnrecognisedStatus() {
-        String chargeId = postToCreateACharge(expectedAmount);
-        String putBody = toJson(ImmutableMap.of("new_status", "junk"));
-
-        connectorRestApi
-                .withAccountId(accountId)
-                .withChargeId(chargeId)
-                .putChargeStatus(putBody)
-                .statusCode(BAD_REQUEST.getStatusCode())
-                .body(is("{\"message\":\"charge status not recognized: junk\"}"));
-
-        //charge status should remain CREATED
-        validateGetCharge(expectedAmount, chargeId, CREATED, true);
-    }
-
-    @Test
     public void cannotGetCharge_WhenInvalidChargeId() {
         String chargeId = "23235124";
         connectorRestApi

--- a/src/test/java/uk/gov/pay/connector/rules/ResourceTestRuleWithCustomExceptionMappersBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/rules/ResourceTestRuleWithCustomExceptionMappersBuilder.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.connector.rules;
+
+import io.dropwizard.jersey.errors.EarlyEofExceptionMapper;
+import io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper;
+import io.dropwizard.testing.junit.ResourceTestRule;
+import uk.gov.pay.connector.exception.ConstraintViolationExceptionMapper;
+import uk.gov.pay.connector.exception.ValidationExceptionMapper;
+
+public class ResourceTestRuleWithCustomExceptionMappersBuilder {
+    public static ResourceTestRule.Builder getBuilder() {
+        return ResourceTestRule.builder()
+                .setRegisterDefaultExceptionMappers(false)
+                .addProvider(ConstraintViolationExceptionMapper.class)
+                .addProvider(ValidationExceptionMapper.class)
+                .addProvider(JsonProcessingExceptionMapper.class)
+                .addProvider(EarlyEofExceptionMapper.class);
+    }
+}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -5,6 +5,7 @@ server:
   adminConnectors:
     - type: http
       port: 0
+  registerDefaultExceptionMappers: false
 
 logging:
     level: INFO

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -5,6 +5,7 @@ server:
   adminConnectors:
     - type: http
       port: 0
+  registerDefaultExceptionMappers: false
 
 logging:
     level: INFO

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -5,6 +5,7 @@ server:
   adminConnectors:
     - type: http
       port: 0
+  registerDefaultExceptionMappers: false
 
 logging:
     level: INFO

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -5,6 +5,7 @@ server:
   adminConnectors:
     - type: http
       port: 0
+  registerDefaultExceptionMappers: false
 
 logging:
     level: WARN

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -5,6 +5,7 @@ server:
   adminConnectors:
     - type: http
       port: 0
+  registerDefaultExceptionMappers: false
 
 logging:
     level: WARN


### PR DESCRIPTION
This commit illustrates how to use Dropwizard's built in validation
functionality to validate incoming requests. It is quite powerful, and
can do most of (probably all) the things we require of it.

In this commit I have taken one example endpoint
`/v1/frontend/charges/{chargeId}/status`, and refactored
validation for the PUT method.

I do not necessarily think that the validation logic is right
(in particular the constraint on the value of `new_status`),
but I have not changed it at this stage, just the implementation.

In order to change as little as possible, I have overridden the
dropwizard default exception mapper (see https://www.dropwizard.io/0.9.2/docs/manual/validation.html)
, so as  to be able to add my own `ConstraintViolationExceptionMapper`,
which allows me to map ConstraintViolationExceptions to 400 status
code. The returned message is slightly different from before, but
is not any worse IMHO.

In tandem with this change to the validation, I have changed how it
is tested. Instead of spinning up a whole application and db, I have
used the ResourceTestRule that provides a testable resource which can be
interacted with as if it is an http server, whilst allowing mocking
of it's dependencies. This allows tests to complete in ~400 ms as opposed to
~16 seconds before.

To do this I again had to do some fiddling with the exception mapper config,
(see https://www.dropwizard.io/1.3.5/docs/manual/testing.html)
which is the reason for the brillaintly named
`ResourceTestRuleWithCustomExceptionMappersBuilder`, which encapsulates the needed
changes.