### PR TITLE
PP-4130 Remove deprecated Pact state for transactions list

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -104,13 +104,6 @@ public class TransactionsApiContractTest {
         setUpGatewayAccount(accountId);
     }
 
-    @State("User 666 exists in the database and has 4 transactions available")
-    public void account666WithTransactionsOld() {
-        long accountId = 666L;
-        setUpGatewayAccount(accountId);
-        setUpCharges(4, Long.toString(accountId), ZonedDateTime.now());
-    }
-
     @State("User 666 exists in the database and has 5 transactions available")
     public void account666WithTransactions() {
         long accountId = 666L;


### PR DESCRIPTION
## WHAT

- Remove deprecated Pact state for transactions list, because selfservice does not use it anymore.

This PR to be merged after https://github.com/alphagov/pay-selfservice/pull/928 is merged and deployed
