### PR TITLE
PP-4293 Refactor validation of search params 

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/TransactionsPaginationServiceConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/TransactionsPaginationServiceConfig.java
@@ -4,9 +4,9 @@ import io.dropwizard.Configuration;
 
 public class TransactionsPaginationServiceConfig extends Configuration {
 
-    private int displayPageSize;
+    private long displayPageSize;
 
-    public int getDisplayPageSize() {
+    public long getDisplayPageSize() {
         return displayPageSize;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.charge.dao;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.charge.model.FromDate;
+import uk.gov.pay.connector.charge.model.ToDate;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.dao.JpaDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -93,7 +95,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
     public List<ChargeEntity> findBeforeDateWithStatusIn(ZonedDateTime date, List<ChargeStatus> statuses) {
         SearchParams params = new SearchParams()
-                .withToDate(date)
+                .withToDate(ToDate.of(date))
                 .withInternalStates(statuses);
         return findAllBy(params);
     }
@@ -103,8 +105,8 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                                                                     List<ChargeStatus> statuses) {
         SearchParams params = new SearchParams()
                 .withGatewayAccountId(gatewayAccountId)
-                .withFromDate(from)
-                .withToDate(to)
+                .withFromDate(FromDate.of(from))
+                .withToDate(ToDate.of(to))
                 .withInternalStates(statuses);
         return findAllBy(params);
     }
@@ -121,9 +123,9 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
         Query query = entityManager.get().createQuery(cq);
 
         if (params.getPage() != null && params.getDisplaySize() != null) {
-            Long firstResult = (params.getPage() - 1) * params.getDisplaySize(); // page coming from params is 1 based, so -1
+            Long firstResult = (params.getPage().getRawValue() - 1) * params.getDisplaySize().getRawValue(); // page coming from params is 1 based, so -1
             query.setFirstResult(firstResult.intValue());
-            query.setMaxResults(params.getDisplaySize().intValue());
+            query.setMaxResults(params.getDisplaySize().getRawValue().intValue());
         }
         return query.getResultList();
     }
@@ -159,9 +161,9 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
             predicates.add(charge.get(CARD_DETAILS).get("cardBrand").in(params.getCardBrands()));
         }
         if (params.getFromDate() != null)
-            predicates.add(cb.greaterThanOrEqualTo(charge.get(CREATED_DATE), params.getFromDate()));
+            predicates.add(cb.greaterThanOrEqualTo(charge.get(CREATED_DATE), params.getFromDate().getRawValue()));
         if (params.getToDate() != null)
-            predicates.add(cb.lessThan(charge.get(CREATED_DATE), params.getToDate()));
+            predicates.add(cb.lessThan(charge.get(CREATED_DATE), params.getToDate().getRawValue()));
 
         return predicates;
     }

--- a/src/main/java/uk/gov/pay/connector/charge/dao/SearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/SearchParams.java
@@ -1,16 +1,21 @@
 package uk.gov.pay.connector.charge.dao;
 
-import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.CardHolderName;
+import uk.gov.pay.connector.charge.model.DisplaySize;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.FromDate;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.PageNumber;
+import uk.gov.pay.connector.charge.model.PositiveLong;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.model.ToDate;
 import uk.gov.pay.connector.charge.model.TransactionType;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.exception.ValidationException;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 import uk.gov.pay.connector.model.api.ExternalRefundStatus;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,10 +37,10 @@ public class SearchParams {
     private Long gatewayAccountId;
     private ServicePaymentReference reference;
     private String email;
-    private ZonedDateTime fromDate;
-    private ZonedDateTime toDate;
-    private Long page;
-    private Long displaySize;
+    private FromDate fromDate;
+    private ToDate toDate;
+    private PageNumber page;
+    private DisplaySize displaySize;
     private List<String> cardBrands = new ArrayList<>();
     private Set<ChargeStatus> internalStates = new HashSet<>();
     private Set<String> externalChargeStates = new HashSet<>();
@@ -199,42 +204,38 @@ public class SearchParams {
         return this;
     }
 
-    public ZonedDateTime getFromDate() {
+    public FromDate getFromDate() {
         return fromDate;
     }
 
-    public SearchParams withFromDate(ZonedDateTime fromDate) {
+    public SearchParams withFromDate(FromDate fromDate) {
         this.fromDate = fromDate;
         return this;
     }
 
-    public ZonedDateTime getToDate() {
+    public ToDate getToDate() {
         return toDate;
     }
 
-    public SearchParams withToDate(ZonedDateTime toDate) {
+    public SearchParams withToDate(ToDate toDate) {
         this.toDate = toDate;
         return this;
     }
 
-    public Long getPage() {
+    public PositiveLong getPage() {
         return page;
     }
 
-    public SearchParams withPage(Long page) {
+    public SearchParams withPage(PageNumber page) {
         this.page = page;
         return this;
     }
 
-    public Long getDisplaySize() {
+    public DisplaySize getDisplaySize() {
         return displaySize;
     }
 
-    public SearchParams withDisplaySize(Long displaySize) {
-        if (displaySize <= 0) {
-            throw new IllegalArgumentException("displaySize must be a positive integer");
-        }
-
+    public SearchParams withDisplaySize(DisplaySize displaySize) {
         this.displaySize = displaySize;
         return this;
     }
@@ -301,7 +302,7 @@ public class SearchParams {
         }
         return builder.toString().replaceFirst("&", "");
     }
-
+    
     private List<ExternalChargeState> parseChargeState(String state) {
         if (isBlank(state)) {
             return new ArrayList<>();

--- a/src/main/java/uk/gov/pay/connector/charge/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/TransactionDao.java
@@ -9,12 +9,12 @@ import org.jooq.SelectJoinStep;
 import org.jooq.SelectOrderByStep;
 import org.jooq.SelectSeekStep1;
 import org.jooq.impl.DSL;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumberConverter;
 import uk.gov.pay.connector.charge.model.TransactionType;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.charge.model.LastDigitsCardNumberConverter;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.charge.model.domain.Transaction;
 import uk.gov.pay.connector.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -78,8 +78,8 @@ public class TransactionDao {
                 .orderBy(field("date_created").desc());
 
         if (params.getPage() != null && params.getDisplaySize() != null) {
-            int offset = Long.valueOf((params.getPage() - 1) * params.getDisplaySize()).intValue();
-            int limit = params.getDisplaySize().intValue();
+            int offset = Long.valueOf((params.getPage().getRawValue() - 1) * params.getDisplaySize().getRawValue()).intValue();
+            int limit = params.getDisplaySize().getRawValue().intValue();
 
             query.offset(offset).limit(limit);
         }
@@ -163,15 +163,16 @@ public class TransactionDao {
         }
         if (params.getFromDate() != null) {
             queryFiltersForCharges = queryFiltersForCharges.and(
-                    field("c.created_date").greaterOrEqual(utcDateTimeConverter.convertToDatabaseColumn(params.getFromDate())));
+                    field("c.created_date").greaterOrEqual(utcDateTimeConverter.convertToDatabaseColumn(params.getFromDate().getRawValue())));
             queryFiltersForRefunds = queryFiltersForRefunds.and(
-                    field("r.created_date").greaterOrEqual(utcDateTimeConverter.convertToDatabaseColumn(params.getFromDate())));
+                    field("r.created_date").greaterOrEqual(utcDateTimeConverter.convertToDatabaseColumn(params.getFromDate().getRawValue())));
         }
         if (params.getToDate() != null) {
             queryFiltersForCharges = queryFiltersForCharges.and(
-                    field("c.created_date").lessThan(utcDateTimeConverter.convertToDatabaseColumn(params.getToDate())));
+                    field("c.created_date").lessThan(utcDateTimeConverter.convertToDatabaseColumn(params.getToDate().getRawValue()
+                    )));
             queryFiltersForRefunds = queryFiltersForRefunds.and(
-                    field("r.created_date").lessThan(utcDateTimeConverter.convertToDatabaseColumn(params.getToDate())));
+                    field("r.created_date").lessThan(utcDateTimeConverter.convertToDatabaseColumn(params.getToDate().getRawValue())));
         }
         if (params.getExternalChargeStates() != null && !params.getExternalChargeStates().isEmpty()) {
             queryFiltersForCharges = queryFiltersForCharges.and(
@@ -251,8 +252,8 @@ public class TransactionDao {
             queryForRefunds.orderBy(field("r.created_date").desc());
 
             if (params.getPage() != null && params.getDisplaySize() != null) {
-                int offset = Long.valueOf((params.getPage() - 1) * params.getDisplaySize()).intValue();
-                int limit = params.getDisplaySize().intValue();
+                int offset = Long.valueOf((params.getPage().getRawValue() - 1) * params.getDisplaySize().getRawValue()).intValue();
+                int limit = params.getDisplaySize().getRawValue().intValue();
 
                 queryForCharges.limit(offset + limit);
                 queryForRefunds.limit(offset + limit);

--- a/src/main/java/uk/gov/pay/connector/charge/model/CardHolderName.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardHolderName.java
@@ -1,6 +1,10 @@
 package uk.gov.pay.connector.charge.model;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class CardHolderName {
 
@@ -14,6 +18,13 @@ public class CardHolderName {
         return new CardHolderName(cardHolderName);
     }
 
+    public static CardHolderName ofNullable(String cardHolderName) {
+        if (isBlank(cardHolderName)) {
+            return null;
+        }
+        return new CardHolderName(cardHolderName);
+    }
+    
     @Override
     public boolean equals(Object other) {
         if (other != null && other.getClass() == CardHolderName.class) {

--- a/src/main/java/uk/gov/pay/connector/charge/model/DateParam.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/DateParam.java
@@ -5,28 +5,24 @@ import uk.gov.pay.connector.exception.ValidationException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 
-public class DateParam {
+public abstract class DateParam {
     
     private ZonedDateTime date;
 
-    public DateParam(ZonedDateTime date) {
+    DateParam(ZonedDateTime date) {
         this.date = date;
     }
     
-    public static DateParam of(String date) {
+    DateParam(String date) {
         try {
-            ZonedDateTime parsedDate = ZonedDateTime.parse(date);
-            return new DateParam(parsedDate);
+            this.date = ZonedDateTime.parse(date);
         } catch (DateTimeParseException exc) {
-            throw new ValidationException("DateParam is invalid");
+            throw new ValidationException("Date is invalid");
         }
     }
 
-    public static DateParam ofNullable(String date) {
-        if (date == null) {
-            return null;
-        }
-        return DateParam.of(date);
+    public ZonedDateTime getRawValue() {
+        return date;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/charge/model/DateParam.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/DateParam.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.charge.model;
+
+import uk.gov.pay.connector.exception.ValidationException;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+
+public class DateParam {
+    
+    private ZonedDateTime date;
+
+    public DateParam(ZonedDateTime date) {
+        this.date = date;
+    }
+    
+    public static DateParam of(String date) {
+        try {
+            ZonedDateTime parsedDate = ZonedDateTime.parse(date);
+            return new DateParam(parsedDate);
+        } catch (DateTimeParseException exc) {
+            throw new ValidationException("DateParam is invalid");
+        }
+    }
+
+    public static DateParam ofNullable(String date) {
+        if (date == null) {
+            return null;
+        }
+        return DateParam.of(date);
+    }
+
+    @Override
+    public String toString() {
+        return date.toString();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/DisplaySize.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/DisplaySize.java
@@ -1,47 +1,20 @@
 package uk.gov.pay.connector.charge.model;
 
-import uk.gov.pay.connector.exception.ValidationException;
+public class DisplaySize extends PositiveLong {
 
-public class DisplaySize {
-    
-    private Long displaySize;
-
-    public DisplaySize(Long displaySize) {
-        this.displaySize = displaySize;
+    private DisplaySize(Long pageNumber) {
+        super(pageNumber);
     }
 
-    private static boolean isValid(Long displaySize) {
-        return displaySize > 0;
+    private DisplaySize(Long pageNumber, Long defaultValue) {
+        super(pageNumber, defaultValue);
     }
 
-    public static DisplaySize of(Long displaySize) {
-        if (!(isValid(displaySize))) {
-            throw new ValidationException("DisplaySize is invalid");
-        }
-        return new DisplaySize(displaySize);
+    public static DisplaySize of(Long pageNumber) {
+        return new DisplaySize(pageNumber);
     }
 
-    public Long getDisplaySize() {
-        return displaySize;
-    }
-
-    @Override
-    public String toString() {
-        return String.valueOf(displaySize);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        DisplaySize that = (DisplaySize) o;
-
-        return displaySize != null ? displaySize.equals(that.displaySize) : that.displaySize == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return displaySize != null ? displaySize.hashCode() : 0;
+    public static DisplaySize ofDefault(Long positiveLong, Long defaultValue) {
+        return new DisplaySize(positiveLong, defaultValue);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/DisplaySize.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/DisplaySize.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.charge.model;
+
+import uk.gov.pay.connector.exception.ValidationException;
+
+public class DisplaySize {
+    
+    private Long displaySize;
+
+    public DisplaySize(Long displaySize) {
+        this.displaySize = displaySize;
+    }
+
+    private static boolean isValid(Long displaySize) {
+        return displaySize > 0;
+    }
+
+    public static DisplaySize of(Long displaySize) {
+        if (!(isValid(displaySize))) {
+            throw new ValidationException("DisplaySize is invalid");
+        }
+        return new DisplaySize(displaySize);
+    }
+
+    public Long getDisplaySize() {
+        return displaySize;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(displaySize);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DisplaySize that = (DisplaySize) o;
+
+        return displaySize != null ? displaySize.equals(that.displaySize) : that.displaySize == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return displaySize != null ? displaySize.hashCode() : 0;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/FromDate.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/FromDate.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.charge.model;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.ZonedDateTime;
+
+public class FromDate extends DateParam {
+    private FromDate(ZonedDateTime date) {
+        super(date);
+    }
+
+    private FromDate(String date) {
+        super(date);
+    }
+
+    public static FromDate of(String date) {
+        return new FromDate(date);
+    }
+
+    public static FromDate of(ZonedDateTime date) {
+        return new FromDate(date);
+    }
+
+    public static FromDate ofNullable(String date) {
+        if (StringUtils.isBlank(date)) {
+            return null;
+        }
+        return new FromDate(date);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/PageNumber.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/PageNumber.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.connector.charge.model;
+
+import uk.gov.pay.connector.exception.ValidationException;
+
+public class PageNumber {
+
+    private Long pageNumber;
+
+    public PageNumber(Long pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+
+    public Long getPageNumber() {
+        return pageNumber;
+    }
+
+    private static boolean isValid(Long pageNumber) {
+        return pageNumber > 0;
+    }
+
+    public static PageNumber of(Long pageNumber) {
+        if (!(isValid(pageNumber))) {
+            throw new ValidationException("PageNumber is invalid");
+
+        }
+        return new PageNumber(pageNumber);
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(pageNumber);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PageNumber that = (PageNumber) o;
+
+        return pageNumber != null ? pageNumber.equals(that.pageNumber) : that.pageNumber == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return pageNumber != null ? pageNumber.hashCode() : 0;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/PageNumber.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/PageNumber.java
@@ -1,48 +1,21 @@
 package uk.gov.pay.connector.charge.model;
 
-import uk.gov.pay.connector.exception.ValidationException;
+public class PageNumber extends PositiveLong {
 
-public class PageNumber {
-
-    private Long pageNumber;
-
-    public PageNumber(Long pageNumber) {
-        this.pageNumber = pageNumber;
+    private PageNumber(Long pageNumber) {
+        super(pageNumber);
     }
 
-    public Long getPageNumber() {
-        return pageNumber;
-    }
-
-    private static boolean isValid(Long pageNumber) {
-        return pageNumber > 0;
+    private PageNumber(Long pageNumber, Long defaultValue) {
+        super(pageNumber, defaultValue);
     }
 
     public static PageNumber of(Long pageNumber) {
-        if (!(isValid(pageNumber))) {
-            throw new ValidationException("PageNumber is invalid");
-
-        }
         return new PageNumber(pageNumber);
     }
 
-    @Override
-    public String toString() {
-        return String.valueOf(pageNumber);
+    public static PageNumber ofDefault(Long positiveLong, Long defaultValue) {
+        return new PageNumber(positiveLong, defaultValue);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        PageNumber that = (PageNumber) o;
-
-        return pageNumber != null ? pageNumber.equals(that.pageNumber) : that.pageNumber == null;
-    }
-
-    @Override
-    public int hashCode() {
-        return pageNumber != null ? pageNumber.hashCode() : 0;
-    }
+    
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/PositiveLong.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/PositiveLong.java
@@ -1,0 +1,48 @@
+package uk.gov.pay.connector.charge.model;
+
+import uk.gov.pay.connector.exception.ValidationException;
+
+public abstract class PositiveLong {
+
+    private Long positiveLong;
+
+    PositiveLong(Long positiveLong) {
+        if (positiveLong <= 0) {
+            throw new ValidationException("DisplaySize must be a positive integer");
+        }
+        this.positiveLong = positiveLong;
+    }
+
+    PositiveLong(Long positiveLong, Long defaultValue) {
+        if (positiveLong == null) {
+            this.positiveLong = defaultValue;
+        } else {
+            this.positiveLong = positiveLong;
+        }
+    }
+
+    public Long getRawValue() {
+        return positiveLong;
+    }
+
+    
+    @Override
+    public String toString() {
+        return String.valueOf(positiveLong);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PositiveLong that = (PositiveLong) o;
+
+        return positiveLong != null ? positiveLong.equals(that.positiveLong) : that.positiveLong == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return positiveLong != null ? positiveLong.hashCode() : 0;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/ServicePaymentReference.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ServicePaymentReference.java
@@ -1,6 +1,10 @@
 package uk.gov.pay.connector.charge.model;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class ServicePaymentReference {
 
@@ -10,6 +14,13 @@ public class ServicePaymentReference {
         this.servicePaymentReference = Objects.requireNonNull(servicePaymentReference);
     }
 
+    public static ServicePaymentReference ofNullable(String servicePaymentReference) {
+        if (isBlank(servicePaymentReference)) {
+            return null;
+        }
+        return new ServicePaymentReference(servicePaymentReference);
+    }
+    
     public static ServicePaymentReference of(String servicePaymentReference) {
         return new ServicePaymentReference(servicePaymentReference);
     }

--- a/src/main/java/uk/gov/pay/connector/charge/model/ToDate.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ToDate.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.charge.model;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.ZonedDateTime;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class ToDate extends DateParam {
+
+    private ToDate(ZonedDateTime date) {
+        super(date);
+    }
+
+    private ToDate(String date) {
+        super(date);
+    }
+
+    public static ToDate of(String date) {
+        return new ToDate(date);
+    }
+
+    public static ToDate of(ZonedDateTime date) {
+        return new ToDate(date);
+    }
+
+    public static ToDate ofNullable(String date) {
+        if (isBlank(date)) {
+            return null;
+        }
+        return new ToDate(date);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/exception/ValidationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/exception/ValidationExceptionMapper.java
@@ -18,7 +18,7 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
     @Override
     public Response toResponse(ValidationException exception) {
         LOGGER.error(exception.getMessage());
-        Map<String, List<String>> entity = ImmutableMap.of("errors", exception.getErrors());
+        Map<String, List<String>> entity = ImmutableMap.of("message", exception.getErrors());
         return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -125,9 +125,9 @@ public class RefundDao extends JpaDao<RefundEntity> {
         if (params.getGatewayAccountId() != null)
             predicates.add(cb.equal(refundEntityRoot.get(CHARGE_ENTITY).get(GATEWAY_ACCOUNT).get("id"), params.getGatewayAccountId()));
         if (params.getFromDate() != null)
-            predicates.add(cb.greaterThanOrEqualTo(refundEntityRoot.get(CREATED_DATE), params.getFromDate()));
+            predicates.add(cb.greaterThanOrEqualTo(refundEntityRoot.get(CREATED_DATE), params.getFromDate().getRawValue()));
         if (params.getToDate() != null)
-            predicates.add(cb.lessThan(refundEntityRoot.get(CREATED_DATE), params.getToDate()));
+            predicates.add(cb.lessThan(refundEntityRoot.get(CREATED_DATE), params.getToDate().getRawValue()));
 
         return predicates;
     }
@@ -145,9 +145,9 @@ public class RefundDao extends JpaDao<RefundEntity> {
         Query query = entityManager.get().createQuery(cq);
 
         if (params.getPage() != null && params.getDisplaySize() != null) {
-            Long firstResult = (params.getPage() - 1) * params.getDisplaySize();
+            Long firstResult = (params.getPage().getRawValue() - 1) * params.getDisplaySize().getRawValue();
             query.setFirstResult(firstResult.intValue());
-            query.setMaxResults(params.getDisplaySize().intValue());
+            query.setMaxResults(params.getDisplaySize().getRawValue().intValue());
         }
         return query.getResultList();
     }

--- a/src/main/java/uk/gov/pay/connector/refund/resource/SearchRefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/SearchRefundsResource.java
@@ -4,6 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.dao.SearchParams;
+import uk.gov.pay.connector.charge.model.DisplaySize;
+import uk.gov.pay.connector.charge.model.FromDate;
+import uk.gov.pay.connector.charge.model.PageNumber;
+import uk.gov.pay.connector.charge.model.ToDate;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.refund.service.SearchRefundsService;
 
@@ -16,11 +20,9 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-import java.time.ZonedDateTime;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 
 @Path("/")
@@ -53,10 +55,10 @@ public class SearchRefundsResource {
                                           @Context UriInfo uriInfo) {
         logger.info("Getting all refunds for account id {}", accountId);
         SearchParams refundSearchParams = new SearchParams()
-                .withFromDate(parseDate(fromDate))
-                .withToDate(parseDate(toDate))
-                .withDisplaySize(displaySize != null ? displaySize : configuration.getTransactionsPaginationConfig().getDisplayPageSize())
-                .withPage(pageNumber != null ? pageNumber : 1);
+                .withFromDate(FromDate.ofNullable(fromDate))
+                .withToDate(ToDate.ofNullable(toDate))
+                .withDisplaySize(DisplaySize.ofDefault(displaySize, configuration.getTransactionsPaginationConfig().getDisplayPageSize()))
+                .withPage(PageNumber.ofDefault(pageNumber, 1L));
 
         
         return gatewayAccountDao.findById(accountId)
@@ -66,12 +68,4 @@ public class SearchRefundsResource {
 
     }
 
-    //todo do not do this
-    private ZonedDateTime parseDate(String date) {
-        ZonedDateTime parse = null;
-        if (isNotBlank(date)) {
-            parse = ZonedDateTime.parse(date);
-        }
-        return parse;
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/SearchRefundsService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/SearchRefundsService.java
@@ -8,10 +8,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 public class SearchRefundsService {
-
-    private static final Long MAX_DISPLAY_SIZE = 500L;
+    
     private RefundDao refundDao;
-    private RefundSearchStrategy refundSearchStrategy;
 
     @Inject
     public SearchRefundsService(RefundDao refundDao) {
@@ -19,10 +17,7 @@ public class SearchRefundsService {
     }
 
     public Response getAllRefunds(UriInfo uriInfo, SearchParams searchParams) {
-        refundSearchStrategy = new RefundSearchStrategy(refundDao);
-        
-        //todo defaults?
-        return refundSearchStrategy.search(searchParams, uriInfo);
+        return new RefundSearchStrategy(refundDao).search(searchParams, uriInfo);
     }
 }
 

--- a/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
+++ b/src/main/java/uk/gov/pay/connector/resources/ApiValidators.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.resources;
 import fj.data.Either;
 import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.connector.exception.ValidationException;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.model.builder.PatchRequestBuilder;
 
@@ -90,33 +91,6 @@ public class ApiValidators {
         public static Optional<ChargeParamValidator> fromString(String type) {
             return Optional.ofNullable(stringToEnum.get(type));
         }
-    }
-
-    public static Optional<List> validateQueryParams(List<Pair<String, String>> dateParams, List<Pair<String, Long>> nonNegativePairMap) {
-        Map<String, String> invalidQueryParams = new HashMap<>();
-
-        dateParams.forEach(param -> {
-            String dateString = param.getRight();
-            if (isNotBlank(dateString) && !parseZonedDateTime(dateString).isPresent()) {
-                invalidQueryParams.put(param.getLeft(), "query param '%s' not in correct format");
-            }
-        });
-
-        nonNegativePairMap.forEach(param -> {
-            if (param.getRight() != null && param.getRight() < 1) {
-                invalidQueryParams.put(param.getLeft(), "query param '%s' should be a non zero positive integer");
-            }
-        });
-
-        if (!invalidQueryParams.isEmpty()) {
-            List<String> invalidResponse = newArrayList();
-            invalidResponse.addAll(invalidQueryParams.keySet()
-                    .stream()
-                    .map(param -> String.format(invalidQueryParams.get(param), param))
-                    .collect(Collectors.toList()));
-            return Optional.of(invalidResponse);
-        }
-        return Optional.empty();
     }
 
     public static Either<String, Boolean> validateGatewayAccountReference(GatewayAccountDao gatewayAccountDao, Long gatewayAccountId) {

--- a/src/main/java/uk/gov/pay/connector/resources/PaginationResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/resources/PaginationResponseBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.resources;
 
 import black.door.hate.HalRepresentation;
 import uk.gov.pay.connector.charge.dao.SearchParams;
+import uk.gov.pay.connector.charge.model.PageNumber;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -26,7 +27,7 @@ public class PaginationResponseBuilder<T> {
     public PaginationResponseBuilder(SearchParams searchParams, UriInfo uriInfo) {
         this.searchParams = searchParams;
         this.uriInfo = uriInfo;
-        selfPageNum = searchParams.getPage();
+        selfPageNum = searchParams.getPage().getRawValue();
         selfLink = uriWithParams(searchParams.buildQueryParams());
     }
 
@@ -41,7 +42,7 @@ public class PaginationResponseBuilder<T> {
     }
 
     public Response buildResponse() {
-        Long size = searchParams.getDisplaySize();
+        Long size = searchParams.getDisplaySize().getRawValue();
         long lastPage = totalCount > 0 ? (totalCount + size - 1) / size : 1;
         buildLinks(lastPage);
 
@@ -67,17 +68,17 @@ public class PaginationResponseBuilder<T> {
     }
 
     private void buildLinks(long lastPage) {
-        searchParams.withPage(1L);
+        searchParams.withPage(PageNumber.of(1L));
         firstLink = uriWithParams(searchParams.buildQueryParams());
 
-        searchParams.withPage(lastPage);
+        searchParams.withPage(PageNumber.of(lastPage));
         lastLink = uriWithParams(searchParams.buildQueryParams());
 
-        searchParams.withPage(selfPageNum - 1);
-        prevLink = selfPageNum == 1L ? null : uriWithParams(searchParams.buildQueryParams());
+        prevLink = selfPageNum == 1L ? null : uriWithParams(searchParams.withPage(
+                PageNumber.of(selfPageNum - 1)).buildQueryParams());
 
-        searchParams.withPage(selfPageNum + 1);
-        nextLink = selfPageNum == lastPage ? null : uriWithParams(searchParams.buildQueryParams());
+        nextLink = selfPageNum == lastPage ? null : uriWithParams(searchParams.withPage(
+                PageNumber.of(selfPageNum + 1)).buildQueryParams());
     }
 
     private URI uriWithParams(String params) {

--- a/src/main/java/uk/gov/pay/connector/service/search/AbstractSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/service/search/AbstractSearchStrategy.java
@@ -17,10 +17,10 @@ public abstract class AbstractSearchStrategy<T, R> implements SearchStrategy, Bu
     @Override
     public Response search(SearchParams searchParams, UriInfo uriInfo) {
         Long totalCount = getTotalFor(searchParams);
-        Long size = searchParams.getDisplaySize();
+        Long size = searchParams.getDisplaySize().getRawValue();
         if (totalCount > 0 && size > 0) {
             long lastPage = (totalCount + size - 1) / size;
-            if (searchParams.getPage() > lastPage || searchParams.getPage() < 1) {
+            if (searchParams.getPage().getRawValue() > lastPage || searchParams.getPage().getRawValue() < 1) {
                 return notFoundResponse("the requested page not found");
             }
         }

--- a/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
@@ -1,6 +1,9 @@
 package uk.gov.pay.connector.util;
 
-import java.time.*;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
@@ -65,8 +68,7 @@ public class DateTimeUtils {
     public static String toUTCDateString(ZonedDateTime zonedDateTime) {
         return zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toLocalDate().format(localDateFormatter);
     }
-
-
+    
     public static String toUserFriendlyDate(ZonedDateTime zonedDateTime) {
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy - HH:mm:ss");
 

--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -51,13 +51,13 @@ public class ResponseUtil {
         return responseWith(BAD_REQUEST, message, code);
     }
 
-    public static Response badRequestResponse(List message) {
+    public static Response badRequestResponse(List<String> message) {
         logger.error(message.toString());
         return responseWithMessageMap(BAD_REQUEST, message);
     }
 
     public static Response preconditionFailedResponse(String message) {
-        logger.info(message.toString());
+        logger.info(message);
         return responseWithMessageMap(PRECONDITION_FAILED, message);
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/model/CardHolderNameTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/CardHolderNameTest.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.charge.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class CardHolderNameTest {
+    
+    @Test
+    public void shouldSerialiseValidString() {
+        assertThat(CardHolderName.of("bla").toString(), is("bla"));
+    }
+
+    @Test
+    public void shouldSerialiseValidString_ifNullable() {
+        assertThat(CardHolderName.ofNullable("bla bla").toString(), is("bla bla"));
+    }
+
+    @Test
+    public void shouldReturnNullIfStringIsNull_ifNullable() {
+        assertThat(CardHolderName.ofNullable(null), is(nullValue()));
+    }
+    
+    @Test
+    public void shouldReturnNullIfStringIsBlank_ifNullable() {
+        assertThat(CardHolderName.ofNullable(""), is(nullValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/FromDateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/FromDateTest.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.charge.model;
+
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class FromDateTest {
+
+
+    @Test
+    public void shouldSerialiseValidDate() {
+        assertThat(FromDate.of("2012-06-30T12:30:40Z[UTC]").getRawValue(), is(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]")));
+    }
+
+    @Test
+    public void shouldSerialiseValidDate_ifNullable() {
+        assertThat(FromDate.ofNullable("2012-06-30T12:30:40Z[UTC]").getRawValue(), is(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]")));
+    }
+
+    @Test
+    public void shouldReturnNullIfDateIsNull_ifNullable() {
+        assertThat(FromDate.ofNullable(null), is(nullValue()));
+    }
+    
+    @Test
+    public void shouldReturnNullIfDateIsBlank_ifNullable() {
+        assertThat(FromDate.ofNullable(""), is(nullValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/ServicePaymentReferenceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ServicePaymentReferenceTest.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.charge.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+public class ServicePaymentReferenceTest {
+    @Test
+    public void shouldSerialiseValidString() {
+        assertThat(ServicePaymentReference.of("bla").toString(), is("bla"));
+    }
+
+    @Test
+    public void shouldSerialiseValidString_ifNullable() {
+        assertThat(ServicePaymentReference.ofNullable("bla bla").toString(), is("bla bla"));
+    }
+
+    @Test
+    public void shouldReturnNullIfStringIsNull_ifNullable() {
+        assertThat(ServicePaymentReference.ofNullable(null), is(nullValue()));
+    }
+
+    @Test
+    public void shouldReturnNullIfStringIsBlank_ifNullable() {
+        assertThat(ServicePaymentReference.ofNullable(""), is(nullValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/ToDateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ToDateTest.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.charge.model;
+
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class ToDateTest {
+
+
+    @Test
+    public void shouldSerialiseValidDate() {
+        assertThat(ToDate.of("2012-06-30T12:30:40Z[UTC]").getRawValue(), is(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]")));
+    }
+
+    @Test
+    public void shouldSerialiseValidDate_ifNullable() {
+        assertThat(ToDate.ofNullable("2012-06-30T12:30:40Z[UTC]").getRawValue(), is(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]")));
+    }
+
+    @Test
+    public void shouldReturnNullIfDateIsNull_ifNullable() {
+        assertThat(ToDate.ofNullable(null), is(nullValue()));
+    }
+    
+    @Test
+    public void shouldReturnNullIfDateIsBlank_ifNullable() {
+        assertThat(ToDate.ofNullable(""), is(nullValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -27,7 +27,7 @@ public class ChargesFrontendResourceTest {
     @Mock
     private static ChargeService chargeService;
     @Mock
-    private static  ChargeDao chargeDao;
+    private static ChargeDao chargeDao;
     @Mock
     private static CardTypeDao cardTypeDao;
     

--- a/src/test/java/uk/gov/pay/connector/dao/SearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/SearchParamsTest.java
@@ -2,13 +2,15 @@ package uk.gov.pay.connector.dao;
 
 import org.junit.Test;
 import uk.gov.pay.connector.charge.dao.SearchParams;
-import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.CardHolderName;
+import uk.gov.pay.connector.charge.model.DisplaySize;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.FromDate;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.PageNumber;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.model.ToDate;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
-
-import java.time.ZonedDateTime;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -17,7 +19,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.TransactionType.PAYMENT;
-import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ABORTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
@@ -38,6 +39,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCELL
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_CREATED;
 
 public class SearchParamsTest {
 
@@ -59,23 +61,23 @@ public class SearchParamsTest {
           
 
         SearchParams params = new SearchParams()
-                .withDisplaySize(5L)
+                .withDisplaySize(DisplaySize.of(5L))
                 .withExternalState(EXTERNAL_CREATED.getStatus())
                 .withCardBrand("visa")
                 .withGatewayAccountId(111L)
-                .withPage(2L)
+                .withPage(PageNumber.of(2L))
                 .withLastDigitsCardNumber(LastDigitsCardNumber.of("1234"))
                 .withFirstDigitsCardNumber(FirstDigitsCardNumber.of("123456"))
                 .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user")
                 .withCardHolderNameLike(CardHolderName.of("bla"))
-                .withFromDate(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]"))
-                .withToDate(ZonedDateTime.parse("2012-07-30T12:30:40Z[UTC]"));
+                .withFromDate(FromDate.of("2012-06-30T12:30:40Z[UTC]"))
+                .withToDate(ToDate.of("2012-07-30T12:30:40Z[UTC]"));
 
         assertThat(params.buildQueryParams(), is(expectedQueryString));
         assertThat(params.getGatewayAccountId(), is(111L));
-        assertThat(params.getDisplaySize(), is(5L));
-        assertThat(params.getPage(), is(2L));
+        assertThat(params.getDisplaySize().getRawValue(), is(5L));
+        assertThat(params.getPage().getRawValue(), is(2L));
     }
 
     @Test
@@ -92,15 +94,15 @@ public class SearchParamsTest {
                         "&card_brand=visa";
 
         SearchParams params = new SearchParams()
-                .withDisplaySize(5L)
+                .withDisplaySize(DisplaySize.of(5L))
                 .withExternalState(EXTERNAL_CREATED.getStatus())
                 .withCardBrand("visa")
                 .withGatewayAccountId(111L)
-                .withPage(2L)
+                .withPage(PageNumber.of(2L))
                 .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user")
-                .withFromDate(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]"))
-                .withToDate(ZonedDateTime.parse("2012-07-30T12:30:40Z[UTC]"));
+                .withFromDate(FromDate.of("2012-06-30T12:30:40Z[UTC]"))
+                .withToDate(ToDate.of("2012-07-30T12:30:40Z[UTC]"));
 
         assertThat(params.buildQueryParamsWithPiiRedaction(), is(expectedQueryString));
     }
@@ -150,7 +152,7 @@ public class SearchParamsTest {
                         "&card_brand=master-card";
 
         SearchParams params = new SearchParams()
-                .withDisplaySize(5L)
+                .withDisplaySize(DisplaySize.of(5L))
                 .withTransactionType(PAYMENT)
                 .withFirstDigitsCardNumber(FirstDigitsCardNumber.of("695943"))
                 .withLastDigitsCardNumber(LastDigitsCardNumber.of("6749"))
@@ -159,11 +161,11 @@ public class SearchParamsTest {
                 .addExternalRefundStates(singletonList("submitted"))
                 .withCardBrands(asList("visa", "master-card"))
                 .withGatewayAccountId(111L)
-                .withPage(2L)
+                .withPage(PageNumber.of(2L))
                 .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user@example.com")
-                .withFromDate(ZonedDateTime.parse("2012-06-30T12:30:40Z[UTC]"))
-                .withToDate(ZonedDateTime.parse("2012-07-30T12:30:40Z[UTC]"));
+                .withFromDate(FromDate.of("2012-06-30T12:30:40Z[UTC]"))
+                .withToDate(ToDate.of("2012-07-30T12:30:40Z[UTC]"));
 
         assertThat(params.buildQueryParams(), is(expectedQueryString));
     }
@@ -182,7 +184,7 @@ public class SearchParamsTest {
                 .addExternalChargeStates(singletonList("success"))
                 .addExternalRefundStates(singletonList("success"))
                 .withGatewayAccountId(111L)
-                .withPage(2L)
+                .withPage(PageNumber.of(2L))
                 .withReferenceLike(ServicePaymentReference.of("ref"))
                 .withEmailLike("user@example.com");
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -7,15 +7,19 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
-import uk.gov.pay.connector.charge.model.ServicePaymentReference;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.dao.SearchParams;
+import uk.gov.pay.connector.charge.model.CardHolderName;
+import uk.gov.pay.connector.charge.model.DisplaySize;
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.FromDate;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.PageNumber;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.model.ToDate;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures.TestCharge;
-import uk.gov.pay.connector.charge.model.CardHolderName;
-import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
-import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
@@ -39,10 +43,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
-import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_CREATED;
-import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_STARTED;
-import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
@@ -55,6 +55,10 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBM
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCELLED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_CREATED;
+import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_STARTED;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 
 public class ChargeDaoITest extends DaoITestBase {
 
@@ -322,8 +326,8 @@ public class ChargeDaoITest extends DaoITestBase {
         // when
         SearchParams params = new SearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withPage(1L)
-                .withDisplaySize(3L);
+                .withPage(PageNumber.of(1L))
+                .withDisplaySize(DisplaySize.of(3L));
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
         // then
         assertThat(charges.size(), is(3));
@@ -334,8 +338,8 @@ public class ChargeDaoITest extends DaoITestBase {
         // when
         params = new SearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withPage(2L)
-                .withDisplaySize(3L);
+                .withPage(PageNumber.of(2L))
+                .withDisplaySize(DisplaySize.of(3L));
         charges = chargeDao.findAllBy(params);
         // then
         assertThat(charges.size(), is(3));
@@ -346,8 +350,8 @@ public class ChargeDaoITest extends DaoITestBase {
         // when
         params = new SearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withPage(3L)
-                .withDisplaySize(3L);
+                .withPage(PageNumber.of(3L))
+                .withDisplaySize(DisplaySize.of(3L));
         charges = chargeDao.findAllBy(params);
         // then
         assertThat(charges.size(), is(2));
@@ -366,7 +370,7 @@ public class ChargeDaoITest extends DaoITestBase {
         SearchParams params = new SearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withExternalState(EXTERNAL_CREATED.getStatus())
-                .withDisplaySize(2L);
+                .withDisplaySize(DisplaySize.of(2L));
 
         // when
         Long count = chargeDao.getTotalFor(params);
@@ -633,8 +637,8 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withReferenceLike(defaultTestCharge.getReference())
                 .withExternalState(EXTERNAL_CREATED.getStatus())
-                .withFromDate(ZonedDateTime.parse(FROM_DATE))
-                .withToDate(ZonedDateTime.parse(TO_DATE));
+                .withFromDate(FromDate.of(FROM_DATE))
+                .withToDate(ToDate.of(TO_DATE));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -661,7 +665,7 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withReferenceLike(defaultTestCharge.getReference())
                 .withExternalState(EXTERNAL_CREATED.getStatus())
-                .withFromDate(ZonedDateTime.parse(FROM_DATE));
+                .withFromDate(FromDate.of(FROM_DATE));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -705,7 +709,7 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withReferenceLike(defaultTestCharge.getReference())
                 .withExternalState(EXTERNAL_STARTED.getStatus())
-                .withFromDate(ZonedDateTime.parse(FROM_DATE));
+                .withFromDate(FromDate.of(FROM_DATE));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -763,8 +767,8 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withExternalState(EXTERNAL_CREATED.getStatus())
                 .withCardBrand(defaultTestCardDetails.getCardBrand())
                 .withEmailLike(defaultTestCharge.getEmail())
-                .withFromDate(ZonedDateTime.parse(FROM_DATE))
-                .withToDate(ZonedDateTime.parse(TO_DATE));
+                .withFromDate(FromDate.of(FROM_DATE))
+                .withToDate(ToDate.of(TO_DATE));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -791,7 +795,7 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withReferenceLike(defaultTestCharge.getReference())
                 .withExternalState(EXTERNAL_CREATED.getStatus())
-                .withToDate(ZonedDateTime.parse(TO_DATE));
+                .withToDate(ToDate.of(TO_DATE));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -817,7 +821,7 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withReferenceLike(defaultTestCharge.getReference())
                 .withExternalState(EXTERNAL_CREATED.getStatus())
-                .withFromDate(ZonedDateTime.parse(TO_DATE));
+                .withFromDate(FromDate.of(TO_DATE));
 
         // when
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
@@ -832,7 +836,7 @@ public class ChargeDaoITest extends DaoITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withReferenceLike(defaultTestCharge.getReference())
                 .withExternalState(EXTERNAL_CREATED.getStatus())
-                .withToDate(ZonedDateTime.parse(FROM_DATE));
+                .withToDate(ToDate.of(FROM_DATE));
 
         List<ChargeEntity> charges = chargeDao.findAllBy(params);
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaITest.java
@@ -4,6 +4,8 @@ import com.google.common.collect.Lists;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.dao.SearchParams;
+import uk.gov.pay.connector.charge.model.FromDate;
+import uk.gov.pay.connector.charge.model.ToDate;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.refund.dao.RefundDao;
@@ -134,12 +136,12 @@ public class RefundDaoJpaITest extends DaoITestBase {
 
     @Test
     public void findAllBy_shouldFindByDateRange() {
-        ZonedDateTime fromDate = ZonedDateTime.parse("2016-01-02T01:00:00Z");
-        ZonedDateTime toDate = ZonedDateTime.parse("2016-01-03T01:00:00Z");
-        addSuccessfulRefundsToAccount("oldRefund", fromDate.minusMinutes(1L));
-        addSuccessfulRefundsToAccount("inRangeRefund1", toDate.minusMinutes(1L));
-        addSuccessfulRefundsToAccount("inRangeRefund2", fromDate.plusMinutes(1L));
-        addSuccessfulRefundsToAccount("futureRefund", toDate.plusMinutes(1L));
+        FromDate fromDate = FromDate.of("2016-01-02T01:00:00Z");
+        ToDate toDate = ToDate.of("2016-01-03T01:00:00Z");
+        addSuccessfulRefundsToAccount("oldRefund", fromDate.getRawValue().minusMinutes(1L));
+        addSuccessfulRefundsToAccount("inRangeRefund1", toDate.getRawValue().minusMinutes(1L));
+        addSuccessfulRefundsToAccount("inRangeRefund2", fromDate.getRawValue().plusMinutes(1L));
+        addSuccessfulRefundsToAccount("futureRefund", toDate.getRawValue().plusMinutes(1L));
         SearchParams searchParams = new SearchParams()
                 .withGatewayAccountId(sandboxAccount.getAccountId())
                 .withFromDate(fromDate)

--- a/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
@@ -3,16 +3,20 @@ package uk.gov.pay.connector.it.dao;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.commons.model.SupportedLanguage;
-import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.dao.SearchParams;
 import uk.gov.pay.connector.charge.dao.TransactionDao;
-import uk.gov.pay.connector.it.dao.DatabaseFixtures.TestCharge;
 import uk.gov.pay.connector.charge.model.CardHolderName;
+import uk.gov.pay.connector.charge.model.DisplaySize;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.FromDate;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.PageNumber;
+import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.model.ToDate;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.charge.model.domain.Transaction;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures.TestCharge;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
 import java.time.ZonedDateTime;
@@ -27,15 +31,15 @@ import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
 import static uk.gov.pay.connector.charge.model.TransactionType.PAYMENT;
 import static uk.gov.pay.connector.charge.model.TransactionType.REFUND;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
 import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_CREATED;
 import static uk.gov.pay.connector.model.api.ExternalChargeState.EXTERNAL_STARTED;
 import static uk.gov.pay.connector.model.api.ExternalRefundStatus.EXTERNAL_SUBMITTED;
 import static uk.gov.pay.connector.model.api.ExternalRefundStatus.EXTERNAL_SUCCESS;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 
@@ -304,8 +308,8 @@ public class TransactionDaoITest extends DaoITestBase {
 
         // when
         SearchParams params = new SearchParams()
-                .withPage(1L)
-                .withDisplaySize(3L);
+                .withPage(PageNumber.of(1L))
+                .withDisplaySize(DisplaySize.of(3L));
 
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
         // then
@@ -326,8 +330,8 @@ public class TransactionDaoITest extends DaoITestBase {
         // when
         params = new SearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withPage(2L)
-                .withDisplaySize(3L);
+                .withPage(PageNumber.of(2L))
+                .withDisplaySize(DisplaySize.of(3L));
 
         transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
 
@@ -352,8 +356,8 @@ public class TransactionDaoITest extends DaoITestBase {
         // when
         params = new SearchParams()
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
-                .withPage(3L)
-                .withDisplaySize(3L);
+                .withPage(PageNumber.of(3L))
+                .withDisplaySize(DisplaySize.of(3L));
 
         transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
 
@@ -384,8 +388,8 @@ public class TransactionDaoITest extends DaoITestBase {
         insertNewRefundForCharge(charge3, REFUND_USER_EXTERNAL_ID, 5L, now().plusHours(8));
 
         SearchParams params = new SearchParams()
-                .withPage(1L)
-                .withDisplaySize(2L);
+                .withPage(PageNumber.of(1L))
+                .withDisplaySize(DisplaySize.of(2L));
 
         // when
         Long count = transactionDao.getTotalFor(defaultTestAccount.getAccountId(), params);
@@ -809,8 +813,8 @@ public class TransactionDaoITest extends DaoITestBase {
         SearchParams params = new SearchParams()
                 .withReferenceLike(testCharge.getReference())
                 .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
-                .withFromDate(ZonedDateTime.parse(FROM_DATE))
-                .withToDate(ZonedDateTime.parse(TO_DATE));
+                .withFromDate(FromDate.of(FROM_DATE))
+                .withToDate(ToDate.of(TO_DATE));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -851,7 +855,7 @@ public class TransactionDaoITest extends DaoITestBase {
                 .withTransactionType(PAYMENT)
                 .withReferenceLike(testCharge.getReference())
                 .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
-                .withFromDate(ZonedDateTime.parse(FROM_DATE));
+                .withFromDate(FromDate.of(FROM_DATE));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -882,7 +886,7 @@ public class TransactionDaoITest extends DaoITestBase {
                 .withTransactionType(REFUND)
                 .withReferenceLike(testCharge.getReference())
                 .addExternalRefundStates(singletonList(EXTERNAL_SUBMITTED.getStatus()))
-                .withFromDate(ZonedDateTime.parse(FROM_DATE));
+                .withFromDate(FromDate.of(FROM_DATE));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -1270,8 +1274,8 @@ public class TransactionDaoITest extends DaoITestBase {
                 .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
                 .withCardBrand(testCardDetails.getCardBrand())
                 .withEmailLike(testCharge.getEmail())
-                .withFromDate(ZonedDateTime.parse(FROM_DATE))
-                .withToDate(ZonedDateTime.parse(TO_DATE));
+                .withFromDate(FromDate.of(FROM_DATE))
+                .withToDate(ToDate.of(TO_DATE));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -1303,7 +1307,7 @@ public class TransactionDaoITest extends DaoITestBase {
                 .withTransactionType(PAYMENT)
                 .withReferenceLike(testCharge.getReference())
                 .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
-                .withToDate(ZonedDateTime.parse(TO_DATE));
+                .withToDate(ToDate.of(TO_DATE));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -1334,7 +1338,7 @@ public class TransactionDaoITest extends DaoITestBase {
         SearchParams params = new SearchParams()
                 .withReferenceLike(testCharge.getReference())
                 .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
-                .withFromDate(ZonedDateTime.parse(TO_DATE));
+                .withFromDate(FromDate.of(TO_DATE));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);
@@ -1353,7 +1357,7 @@ public class TransactionDaoITest extends DaoITestBase {
         SearchParams params = new SearchParams()
                 .withReferenceLike(testCharge.getReference())
                 .addExternalChargeStates(singletonList(EXTERNAL_CREATED.getStatus()))
-                .withToDate(ZonedDateTime.parse(FROM_DATE));
+                .withToDate(ToDate.of(FROM_DATE));
 
         // when
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), params);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiFilterChargesITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiFilterChargesITest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.it.resources;
 
 import com.google.common.collect.ImmutableList;
 import com.jayway.restassured.response.ValidatableResponse;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -12,6 +13,7 @@ import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.HttpHeaders;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -193,24 +195,17 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldShowValidationsForDateAndPageDisplaySize() {
-        ImmutableList<String> expectedList = ImmutableList.of(
-                "query param 'from_date' not in correct format",
-                "query param 'to_date' not in correct format",
-                "query param 'display_size' should be a non zero positive integer",
-                "query param 'page' should be a non zero positive integer");
-
+    public void shouldShowValidationErrorForInvalidQueryParam() {
         connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("to_date", "-1")
-                .withQueryParam("from_date", "-1")
-                .withQueryParam("page", "-1")
-                .withQueryParam("display_size", "-2")
+                .withQueryParam("page", "1")
+                .withQueryParam("display_size", "2")
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getChargesV1()
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is(expectedList));
+                .body("message", is(Collections.singletonList("Date is invalid")));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
@@ -16,15 +16,14 @@ import java.time.ZonedDateTime;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static java.time.ZonedDateTime.now;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 
 @RunWith(DropwizardJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
@@ -11,7 +11,6 @@ import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.ws.rs.core.HttpHeaders;
-
 import java.time.ZonedDateTime;
 
 import static com.jayway.restassured.http.ContentType.JSON;

--- a/src/test/java/uk/gov/pay/connector/resources/PaginationResponseBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/PaginationResponseBuilderTest.java
@@ -6,6 +6,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.dao.SearchParams;
+import uk.gov.pay.connector.charge.model.DisplaySize;
+import uk.gov.pay.connector.charge.model.PageNumber;
 import uk.gov.pay.connector.model.api.ExternalChargeState;
 
 import javax.ws.rs.core.Response;
@@ -33,8 +35,8 @@ public class PaginationResponseBuilderTest {
         SearchParams searchParams = new SearchParams()
                 .withGatewayAccountId(1L)
                 .withExternalState(ExternalChargeState.EXTERNAL_STARTED.getStatus())
-                .withDisplaySize(100L)
-                .withPage(2L);
+                .withDisplaySize(DisplaySize.of(100L))
+                .withPage(PageNumber.of(2L));
 
         when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://app.com"),
                 UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"),

--- a/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
@@ -62,7 +62,7 @@ public class SearchRefundsServiceTest {
         searchRefundsService = new SearchRefundsService(refundDao);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getAllRefunds_shouldReturnBadRequestResponse_whenQueryParamsAreInvalid() {
         Long pageNumber = -1L;
         Long displaySize = -2L;


### PR DESCRIPTION
## WHAT
- Refactored existing search params, adding type objects `FromDate`, `ToDate`, `PageNumber` and `DisplaySize`. These are "implicitly" validated, so that it's been possible to remove the (quite ugly) validation we had before.
- The semantics of validation have changed a bit: we were collecting all errors and returning them in a bad request response, now we "fail fast" and let the dropwizard exception mapper return a bad request as soon as any validation fails

