### PR TITLE
PP-4319 Use string constructor for big decimal

### DIFF
--- a/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoITest.java
@@ -9,11 +9,11 @@ import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.report.model.domain.GatewayAccountPerformanceReportEntity;
 import uk.gov.pay.connector.report.model.domain.PerformanceReportEntity;
 
+import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.List;
 
 import static java.math.BigDecimal.ZERO;
-import static java.math.BigDecimal.valueOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.number.BigDecimalCloseTo.closeTo;
 import static org.junit.Assert.assertThat;
@@ -50,8 +50,8 @@ public class PerformanceReportDaoITest extends DaoITestBase {
         insertCharge(testAccountFixture, 10L, ZonedDateTime.now());
         insertCharge(testAccountFixture, 2L, ZonedDateTime.now());
         PerformanceReportEntity performanceReportEntity = performanceReportDao.aggregateNumberAndValueOfPayments();
-        assertThat(performanceReportEntity.getAverageAmount(), is(closeTo(valueOf(6L), ZERO)));
-        assertThat(performanceReportEntity.getTotalAmount(), is(closeTo(valueOf(12L), ZERO)));
+        assertThat(performanceReportEntity.getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
+        assertThat(performanceReportEntity.getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
         assertThat(performanceReportEntity.getTotalVolume(), is(2L));
     }
 
@@ -76,11 +76,11 @@ public class PerformanceReportDaoITest extends DaoITestBase {
         insertCharge(anotherGatewayAccount, 6L, ZonedDateTime.now());
         List<GatewayAccountPerformanceReportEntity> gatewayAccountPerformanceReportEntities = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount();
         assertThat(gatewayAccountPerformanceReportEntities.size(), is(2));
-        assertThat(gatewayAccountPerformanceReportEntities.get(0).getAverageAmount(), is(closeTo(valueOf(6L), ZERO)));
-        assertThat(gatewayAccountPerformanceReportEntities.get(0).getTotalAmount(), is(closeTo(valueOf(12L), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(0).getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(0).getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
         assertThat(gatewayAccountPerformanceReportEntities.get(0).getTotalVolume(), is(2L));
-        assertThat(gatewayAccountPerformanceReportEntities.get(1).getAverageAmount(), is(closeTo(valueOf(5L), ZERO)));
-        assertThat(gatewayAccountPerformanceReportEntities.get(1).getTotalAmount(), is(closeTo(valueOf(15L), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(1).getAverageAmount(), is(closeTo(new BigDecimal("5"), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(1).getTotalAmount(), is(closeTo(new BigDecimal("15"), ZERO)));
         assertThat(gatewayAccountPerformanceReportEntities.get(1).getTotalVolume(), is(3L));
     }
 
@@ -93,8 +93,8 @@ public class PerformanceReportDaoITest extends DaoITestBase {
         insertCharge(testAccountFixture, 2L, validDate1);
         insertCharge(testAccountFixture, 10L, validDate2);
         PerformanceReportEntity performanceReportEntity = performanceReportDao.aggregateNumberAndValueOfPaymentsForAGivenDay(validDate1);
-        assertThat(performanceReportEntity.getAverageAmount(), is(closeTo(valueOf(6L), ZERO)));
-        assertThat(performanceReportEntity.getTotalAmount(), is(closeTo(valueOf(12L), ZERO)));
+        assertThat(performanceReportEntity.getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
+        assertThat(performanceReportEntity.getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
         assertThat(performanceReportEntity.getTotalVolume(), is(2L));
     }
 }


### PR DESCRIPTION
## WHAT
Apparently, bigdecimal is a bit tricky when instantiating one via long / double

