### PR TITLE
PP-4293 Add created date of refund as a pact param

### DIFF
--- a/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
@@ -43,8 +43,8 @@ public class SearchRefundsServiceTest {
     private SearchRefundsService searchRefundsService;
     private GatewayAccountEntity gatewayAccount;
     private static final String EXT_CHARGE_ID = "someExternalId";
-    static final String EXT_REFUND_ID = "someExternalRefundId";
-    static final Long PAGE_NUMBER = 1L;
+    private static final String EXT_REFUND_ID = "someExternalRefundId";
+    private static final Long PAGE_NUMBER = 1L;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();


### PR DESCRIPTION
## WHAT
- We need to be able to control the refund created date to successfully write a pact test between connector and publicapi, checking the filtering by date in the refunds endpoint

