### PR TITLE
PP-4205 Detect docker host dynamically

### DIFF
--- a/src/test/java/uk/gov/pay/connector/rules/PostgresDockerRule.java
+++ b/src/test/java/uk/gov/pay/connector/rules/PostgresDockerRule.java
@@ -10,34 +10,10 @@ import org.junit.runners.model.Statement;
 import uk.gov.pay.connector.util.PostgresContainer;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Optional;
-
-import static org.junit.Assert.assertNotNull;
 
 public class PostgresDockerRule implements TestRule {
 
-    private static String host;
     private static PostgresContainer container;
-
-    private static final String DOCKER_HOST = "DOCKER_HOST";
-    private static final String DOCKER_CERT_PATH = "DOCKER_CERT_PATH";
-
-    static {
-        try {
-            String dockerHost = Optional.ofNullable(System.getenv(DOCKER_HOST)).
-                    orElseThrow(() -> new RuntimeException(DOCKER_HOST + " environment variable not set. It has to be set to the docker daemon location."));
-            URI dockerHostURI = new URI(dockerHost);
-            boolean isDockerDaemonLocal = "unix".equals(dockerHostURI.getScheme());
-            if (!isDockerDaemonLocal) {
-                assertNotNull(DOCKER_CERT_PATH + " environment variable not set.", System.getenv(DOCKER_CERT_PATH));
-            }
-            host = isDockerDaemonLocal ? "localhost" : dockerHostURI.getHost();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
 
     public PostgresDockerRule() throws DockerException {
         startPostgresIfNecessary();
@@ -56,7 +32,7 @@ public class PostgresDockerRule implements TestRule {
         try {
             if (container == null) {
                 DockerClient docker = DefaultDockerClient.fromEnv().build();
-                container = new PostgresContainer(docker, host);
+                container = new PostgresContainer(docker);
             }
         } catch (DockerCertificateException | InterruptedException | IOException | ClassNotFoundException e) {
             throw new RuntimeException(e);

--- a/src/test/java/uk/gov/pay/connector/util/PostgresContainer.java
+++ b/src/test/java/uk/gov/pay/connector/util/PostgresContainer.java
@@ -4,7 +4,11 @@ import com.google.common.base.Stopwatch;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.LogStream;
 import com.spotify.docker.client.exceptions.DockerException;
-import com.spotify.docker.client.messages.*;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerInfo;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.LogConfig;
+import com.spotify.docker.client.messages.PortBinding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +29,6 @@ public class PostgresContainer {
     private final String containerId;
     private final int port;
     private DockerClient docker;
-    private String host;
     private volatile boolean stopped = false;
 
     private static final String DB_PASSWORD = "mysecretpassword";
@@ -34,11 +37,10 @@ public class PostgresContainer {
     private static final String GOVUK_POSTGRES_IMAGE = "govukpay/postgres:9.6.6";
     private static final String INTERNAL_PORT = "5432";
 
-    public PostgresContainer(DockerClient docker, String host) throws DockerException, InterruptedException, IOException, ClassNotFoundException {
+    public PostgresContainer(DockerClient docker) throws DockerException, InterruptedException, IOException, ClassNotFoundException {
         Class.forName("org.postgresql.Driver");
 
         this.docker = docker;
-        this.host = host;
 
         failsafeDockerPull(docker, GOVUK_POSTGRES_IMAGE);
         docker.listImages(DockerClient.ListImagesParam.create("name", GOVUK_POSTGRES_IMAGE));
@@ -65,7 +67,7 @@ public class PostgresContainer {
     }
 
     public String getConnectionUrl() {
-        return "jdbc:postgresql://" + host + ":" + port + "/";
+        return "jdbc:postgresql://" + docker.getHost() + ":" + port + "/";
     }
 
     private void failsafeDockerPull(DockerClient docker, String image) {


### PR DESCRIPTION
We were requiring `DOCKER_HOST` and `DOCKER_CERT_PATH`
to be set to run unit tests. Turns out we don't need them
at all. They were used to figure out a host string, which
was then not used. Deleted all the offending stuff.🤓