### PR TITLE
PP-4261 Change charges sweep to handle AWAITING_CAPTURE_REQUEST differently

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -48,7 +48,8 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.created;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.connector.charge.model.TransactionType.inferTransactionTypeFrom;
-import static uk.gov.pay.connector.charge.service.ChargeExpiryService.EXPIRABLE_STATUSES;
+import static uk.gov.pay.connector.charge.service.ChargeExpiryService.EXPIRABLE_REGULAR_STATUSES;
+import static uk.gov.pay.connector.charge.service.ChargeExpiryService.EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS;
 import static uk.gov.pay.connector.charge.service.SearchService.TYPE.CHARGE;
 import static uk.gov.pay.connector.charge.service.SearchService.TYPE.TRANSACTION;
 import static uk.gov.pay.connector.util.ResponseUtil.fieldsInvalidResponse;
@@ -87,7 +88,9 @@ public class ChargesApiResource {
     private static final String DISPLAY_SIZE = "display_size";
     private static final Set<String> CHARGE_REQUEST_KEYS_THAT_MAY_HAVE_PII = Collections.singleton("description");
     private static final int ONE_HOUR_AND_A_HALF = 5400;
+    private static final int FORTY_EIGHT_HOURS = 172800;
     private static final String CHARGE_EXPIRY_WINDOW = "CHARGE_EXPIRY_WINDOW_SECONDS";
+    private static final String AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW = "AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW";
     private static final Logger logger = LoggerFactory.getLogger(ChargesApiResource.class);
     public static int MIN_AMOUNT = 1;
     public static int MAX_AMOUNT = 10_000_000;
@@ -274,18 +277,34 @@ public class ChargesApiResource {
     @Path("/v1/tasks/expired-charges-sweep")
     @Produces(APPLICATION_JSON)
     public Response expireCharges(@Context UriInfo uriInfo) {
-        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(getExpiryDate(), EXPIRABLE_STATUSES);
-        logger.info("Charges found for expiry - number_of_charges={}, since_date={}", charges.size(), getExpiryDate());
+        List<ChargeEntity> charges = findAllChargesToBeExpired();
+        logger.info("Charges found for expiry - number_of_charges={}, since_date={}", charges.size(), getExpiryDateForRegularCharges());
         Map<String, Integer> resultMap = chargeExpiryService.expire(charges);
         return successResponseWithEntity(resultMap);
     }
+    
+    private List<ChargeEntity> findAllChargesToBeExpired() {
+        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(getExpiryDateForRegularCharges(), EXPIRABLE_REGULAR_STATUSES);
+        charges.addAll(chargeDao.findBeforeDateWithStatusIn(getExpiryDateForAwaitingCaptureRequest(), EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS));
+        logger.info("Charges found for expiry - number_of_charges={}, since_date={}, awaiting_capture_date{}", charges.size(), getExpiryDateForRegularCharges(), getExpiryDateForAwaitingCaptureRequest());
+        return charges;
+    }
 
-    private ZonedDateTime getExpiryDate() {
+    private ZonedDateTime getExpiryDateForRegularCharges() {
         int chargeExpiryWindowSeconds = ONE_HOUR_AND_A_HALF;
         if (StringUtils.isNotBlank(System.getenv(CHARGE_EXPIRY_WINDOW))) {
             chargeExpiryWindowSeconds = Integer.parseInt(System.getenv(CHARGE_EXPIRY_WINDOW));
         }
         logger.debug("Charge expiry window size in seconds: " + chargeExpiryWindowSeconds);
+        return ZonedDateTime.now().minusSeconds(chargeExpiryWindowSeconds);
+    }
+
+    private ZonedDateTime getExpiryDateForAwaitingCaptureRequest() {
+        int chargeExpiryWindowSeconds = FORTY_EIGHT_HOURS;
+        if (StringUtils.isNotBlank(System.getenv(AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW))) {
+            chargeExpiryWindowSeconds = Integer.parseInt(System.getenv(AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW));
+        }
+        logger.debug("Charge expiry window size for awaiting_delay_capture in seconds: " + chargeExpiryWindowSeconds);
         return ZonedDateTime.now().minusSeconds(chargeExpiryWindowSeconds);
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -45,12 +45,13 @@ public class ChargeExpiryService {
     private static final String EXPIRY_SUCCESS = "expiry-success";
     private static final String EXPIRY_FAILED = "expiry-failed";
 
-    public static final List<ChargeStatus> EXPIRABLE_STATUSES = ImmutableList.of(
+    public static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = ImmutableList.of(
             CREATED,
             ENTERING_CARD_DETAILS,
             AUTHORISATION_3DS_REQUIRED,
-            AUTHORISATION_SUCCESS,
-            AWAITING_CAPTURE_REQUEST);
+            AUTHORISATION_SUCCESS);
+
+    public static final List<ChargeStatus> EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS = ImmutableList.of(AWAITING_CAPTURE_REQUEST);
 
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.charge.service.ChargeExpiryService.EXPIRABLE_STATUSES;
+import static uk.gov.pay.connector.charge.service.ChargeExpiryService.EXPIRABLE_REGULAR_STATUSES;
 import static uk.gov.pay.connector.charge.service.ChargeExpiryService.GATEWAY_CANCELLABLE_STATUSES;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
@@ -135,7 +135,7 @@ public class ChargeExpiryServiceTest {
         GatewayResponse<WorldpayBaseResponse> gatewayResponse = gatewayResponseBuilder.withResponse(
                 mockWorldpayCancelResponse).build();
 
-        EXPIRABLE_STATUSES.stream()
+        EXPIRABLE_REGULAR_STATUSES.stream()
                 .filter(status -> !GATEWAY_CANCELLABLE_STATUSES.contains(status))
                 .forEach(status -> {
                     ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -19,8 +19,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
-import java.util.UUID;
-
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -352,7 +350,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
 
         //create charge
         String extChargeId = addChargeAndCardDetails(AWAITING_CAPTURE_REQUEST,
-                ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
+                ServicePaymentReference.of("ref"), ZonedDateTime.now().minusHours(48L));
 
         // run expiry task
         connectorRestApiClient


### PR DESCRIPTION
## WHAT
DVLA need longer than 90 minutes before they can do a capture request:
"EVL runs a clean up batch job to check the outcome of payments which have been initiated. If the payment has been authorised but EVL hasn’t been updated accordingly (e.g. the redirect back to us failed), it completes the transaction and settles the payment. I believe this batch job runs twice per day and picks up transactions that are pending payment and are more than 2 hours old.

Also our tachos service will have to go out to Tachonet to check if a card can be issued and may not get a response for up to 24 hours – so the attempt to settle the payment will be a lot more than 90 mins after the payment was created."

We agreed to change the sweep for charges in `AWAITING_CAPTURE_REQUEST` status.

See:
[JIRA story PP-4261](https://payments-platform.atlassian.net/browse/PP-4261)

## HOW
- change sweep process to expiry AWAITING_CAPTURE_REQUEST after 48 hours
- add relevant tests

with @simad 


