### PR TITLE
BAU: Java 1.8.0_191 test fix

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/BaseGatewayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/BaseGatewayITest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
+import org.hamcrest.collection.IsIn;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
@@ -15,9 +16,9 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.PortFactory;
 
@@ -25,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
-import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -82,9 +82,9 @@ abstract public class BaseGatewayITest {
         root.addAppender(mockAppender);
     }
 
-    public void assertThatLastGatewayClientLoggingEventIs(String loggingEvent) {
+    public void assertThatLastGatewayClientLoggingEventIs(String... loggingEvents) {
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        Assert.assertThat(logStatement.get(logStatement.size() - 1).getFormattedMessage(), is(loggingEvent));
+        Assert.assertThat(logStatement.get(logStatement.size() - 1).getFormattedMessage(), IsIn.isIn(loggingEvents));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
@@ -19,7 +19,7 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
 
     @Rule
     public GuiceAppWithPostgresRule app = new GuiceAppWithPostgresRule(
-            config("smartpay.urls.test", "http://gobbledygook.invalid.url"));
+            config("smartpay.urls.test", "http://invalidone.invalid"));
 
 
     @Before
@@ -33,7 +33,12 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
         setupGatewayStub().respondWithUnexpectedResponseCodeWhenCapture();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
 
-        assertThatLastGatewayClientLoggingEventIs("DNS resolution error for gateway url=http://gobbledygook.invalid.url");
+        // TODO:
+        // remove "DNS resolution error for gateway url=http://invalidone.invalid" when migrated to Java >= 1.8.0_191
+        assertThatLastGatewayClientLoggingEventIs(
+                "DNS resolution error for gateway url=http://invalidone.invalid",
+                "Socket Exception for gateway url=http://invalidone.invalid"
+        );
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }


### PR DESCRIPTION
## WHAT

- When upgraded from Java `1.8.0_141` to `1.8.0_191` the messaging has changed. This PR makes sure we have the new one and we should remove the old one once we migrate to `Java >= 1.8.0_191`
