### PR TITLE
PP-4261 Refactor ChargesApiResource, move 'sweep and expire' logic to ChargeExpiryService

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceITest.java
@@ -292,12 +292,12 @@ public class ChargeExpiryResourceITest extends ChargingITestBase {
                 .body(JSON_CHARGE_KEY, is(chargeToBeExpiredAwaitingCaptureRequest))
                 .body(JSON_STATE_KEY, is(EXPIRED.toExternal().getStatus()));
 
-        List<String> events2 = databaseTestHelper.getInternalEvents(chargeToBeExpiredCreatedStatus);
-        List<String> events3 = databaseTestHelper.getInternalEvents(chargeToBeExpiredAwaitingCaptureRequest);
+        List<String> events1 = databaseTestHelper.getInternalEvents(chargeToBeExpiredCreatedStatus);
+        List<String> events2 = databaseTestHelper.getInternalEvents(chargeToBeExpiredAwaitingCaptureRequest);
 
-        assertTrue(isEqualCollection(events2,
+        assertTrue(isEqualCollection(events1,
                 asList(CREATED.getValue(), EXPIRED.getValue())));
-        assertTrue(isEqualCollection(events3,
+        assertTrue(isEqualCollection(events2,
                 asList(AWAITING_CAPTURE_REQUEST.getValue(), EXPIRE_CANCEL_READY.getValue(), EXPIRED.getValue())));
     }
 }


### PR DESCRIPTION
## WHAT
Refactor `ChargesApiResource`. Move the 'sweep and expire' process to `ChargeExpiryService`. This is needed as the business logic has been extended [(previous PR for PP-4261)](https://github.com/alphagov/pay-connector/pull/774) and it got too complicated and too big to have it on the resource level.

## HOW 
- push logic of sweep and expiry of charges to `ChargeExpiryService`
- add relevant tests
- rearrange `ChargeExpiryServiceTest` tests, move common setups under `@Before`


