### PR TITLE
PP-4261 Refactor charges sweep to use config file

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -2,6 +2,7 @@
 ## POST /v1/tasks/expired-charges-sweep
 
 This starts a task to expire the charges with a default window of 90 minutes. The default value can be overridden by setting an environment variable CHARGE_EXPIRY_WINDOW_SECONDS in seconds. Response of the call will tell you how many charges were successfully expired and how many of them failed for some reason.
+This endpoint also expires charges in AWAITING_CAPTURE_REQUEST status. The default window is 48 hours. It can be overriden by setting an environment variable AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW in seconds.
 
 ### Request example
 

--- a/src/main/java/uk/gov/pay/connector/app/ChargeSweepConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/ChargeSweepConfig.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.app;
+
+import io.dropwizard.Configuration;
+
+public class ChargeSweepConfig extends Configuration {
+
+    private int defaultChargeExpiryThreshold;
+    private int awaitingCaptureExpiryThreshold;
+
+    public int getDefaultChargeExpiryThreshold() {
+        return defaultChargeExpiryThreshold;
+    }
+
+    public int getAwaitingCaptureExpiryThreshold() {
+        return awaitingCaptureExpiryThreshold;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -9,7 +9,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-public class    ConnectorConfiguration extends Configuration {
+public class ConnectorConfiguration extends Configuration {
 
     @Valid
     @NotNull
@@ -62,6 +62,11 @@ public class    ConnectorConfiguration extends Configuration {
     @NotNull
     @JsonProperty("customJerseyClient")
     private CustomJerseyClientConfiguration customJerseyClient;
+    
+    @Valid
+    @NotNull
+    @JsonProperty("chargesSweepConfig")
+    private ChargeSweepConfig chargeSweepConfig;
 
     @NotNull
     private String graphiteHost;
@@ -151,5 +156,9 @@ public class    ConnectorConfiguration extends Configuration {
 
     public Boolean isXrayEnabled() {
         return xrayEnabled;
+    }
+    
+    public ChargeSweepConfig getChargeSweepConfig() {
+        return chargeSweepConfig;
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -179,3 +179,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: ${XRAY_ENABLED:-false}
+
+chargesSweepConfig:
+  defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
+  awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -6,6 +6,8 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ChargeSweepConfig;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -62,12 +64,19 @@ public class ChargeExpiryServiceTest {
     @Mock
     private WorldpayCancelResponse mockWorldpayCancelResponse;
     
+    @Mock
+    private ChargeSweepConfig mockedChargeSweepConfig;
+
+    @Mock
+    private ConnectorConfiguration mockedConfig;
+    
     private GatewayResponse<BaseCancelResponse> gatewayResponse;
     private GatewayAccountEntity gatewayAccount;
 
     @Before
     public void setup() {
-        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, TransactionFlow::new);
+        when(mockedConfig.getChargeSweepConfig()).thenReturn(mockedChargeSweepConfig);
+        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, TransactionFlow::new, mockedConfig);
         when(mockPaymentProviders.byName(PaymentGatewayName.WORLDPAY)).thenReturn(mockPaymentProvider);
         GatewayResponseBuilder<BaseCancelResponse> gatewayResponseBuilder = responseBuilder();
         gatewayResponse = gatewayResponseBuilder.withResponse(mockWorldpayCancelResponse).build();

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -139,3 +139,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+
+chargesSweepConfig:
+  defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
+  awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -138,3 +138,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+
+chargesSweepConfig:
+  defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
+  awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -128,3 +128,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+
+chargesSweepConfig:
+  defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
+  awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -134,3 +134,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+
+chargesSweepConfig:
+  defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
+  awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -132,3 +132,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+
+chargesSweepConfig:
+  defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
+  awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}


### PR DESCRIPTION
## WHAT
Use config file for charge expiry windows instead of hard coded values.

## HOW 
- refactor ChargeExpiryService to use config file for expiry windows


