### PR TITLE
PP-4341: Refactor Worldpay payment provider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/BasePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/BasePaymentProvider.java
@@ -30,14 +30,17 @@ abstract public class BasePaymentProvider<T extends BaseResponse, R> implements 
         this.externalRefundAvailabilityCalculator = externalRefundAvailabilityCalculator;
     }
 
-    protected <U extends GatewayRequest> GatewayResponse sendReceive(U request, Function<U, GatewayOrder> order,
+    protected <U extends GatewayRequest> GatewayResponse sendReceive(U request, 
+                                                                     Function<U, GatewayOrder> order,
                                                                      Class<? extends BaseResponse> clazz,
                                                                      Function<GatewayClient.Response, Optional<String>> responseIdentifier) {
 
         return sendReceive(null, request, order, clazz, responseIdentifier);
     }
 
-    protected <U extends GatewayRequest> GatewayResponse sendReceive(String route, U request, Function<U, GatewayOrder> order,
+    protected <U extends GatewayRequest> GatewayResponse sendReceive(String route, 
+                                                                     U request, 
+                                                                     Function<U, GatewayOrder> order,
                                                                      Class<? extends BaseResponse> clazz,
                                                                      Function<GatewayClient.Response, Optional<String>> responseIdentifier) {
         GatewayClient gatewayClient = gatewayOperationClientMap.get(request.getRequestType());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -1,16 +1,19 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import fj.data.Either;
+import io.dropwizard.setup.Environment;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.BasePaymentProvider;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
+import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -18,22 +21,27 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 
+import javax.inject.Inject;
 import javax.ws.rs.client.Invocation.Builder;
 import java.time.ZoneOffset;
-import java.util.EnumMap;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static fj.data.Either.left;
 import static fj.data.Either.right;
 import static java.util.UUID.randomUUID;
+import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.CANCEL;
+import static uk.gov.pay.connector.gateway.GatewayOperation.CAPTURE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.REFUND;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
@@ -41,18 +49,34 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
-public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, String> {
+public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, String> {
 
     public static final String WORLDPAY_MACHINE_COOKIE_NAME = "machine";
 
-    public WorldpayPaymentProvider(EnumMap<GatewayOperation, GatewayClient> clients, boolean isNotificationEndpointSecured, String notificationDomain,
-                                   ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator) {
-        super(clients, isNotificationEndpointSecured, notificationDomain, externalRefundAvailabilityCalculator);
+    private final GatewayClient authoriseClient;
+    private final GatewayClient cancelClient;
+    private final GatewayClient captureClient;
+    private final GatewayClient refundClient;
+    private final boolean isNotificationEndpointSecured;
+    private final String notificationDomain;
+    private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
+
+    @Inject
+    public WorldpayPaymentProvider(ConnectorConfiguration configuration,
+                                   GatewayClientFactory gatewayClientFactory,
+                                   Environment environment) {
+        authoriseClient = gatewayClientFactory.createGatewayClient(WORLDPAY, AUTHORISE, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
+        cancelClient = gatewayClientFactory.createGatewayClient(WORLDPAY, CANCEL, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
+        captureClient = gatewayClientFactory.createGatewayClient(WORLDPAY, CAPTURE, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
+        refundClient = gatewayClientFactory.createGatewayClient(WORLDPAY, REFUND, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
+        this.isNotificationEndpointSecured = configuration.getWorldpayConfig().isSecureNotificationEnabled();
+        this.notificationDomain = configuration.getWorldpayConfig().getNotificationDomain();
+        this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
     }
 
     @Override
     public PaymentGatewayName getPaymentGatewayName() {
-        return PaymentGatewayName.WORLDPAY;
+        return WORLDPAY;
     }
 
     @Override
@@ -62,27 +86,48 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
 
     @Override
     public GatewayResponse authorise(AuthorisationGatewayRequest request) {
-        return sendReceive(request, buildAuthoriseOrderFor(), WorldpayOrderStatusResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), buildAuthoriseOrder(request));
+        return getGatewayResponse(response, WorldpayOrderStatusResponse.class);
     }
 
     @Override
     public GatewayResponse<BaseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        return sendReceive(request, build3dsResponseAuthOrderFor(), WorldpayOrderStatusResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), build3dsResponseAuthOrder(request));
+        return getGatewayResponse(response, WorldpayOrderStatusResponse.class);
+    }
+
+    private GatewayResponse<BaseResponse> getGatewayResponse(Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
+        if (response.isLeft()) {
+            return GatewayResponse.with(response.left().value());
+        } else {
+            GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+            authoriseClient.unmarshallResponse(response.right().value(), responseClass)
+                    .bimap(
+                            responseBuilder::withGatewayError,
+                            responseBuilder::withResponse
+                    );
+            Optional.ofNullable(response.right().value().getResponseCookies().get(WORLDPAY_MACHINE_COOKIE_NAME))
+                    .ifPresent(responseBuilder::withSessionIdentifier);
+            return responseBuilder.build();
+        }
     }
 
     @Override
     public GatewayResponse capture(CaptureGatewayRequest request) {
-        return sendReceive(request, buildCaptureOrderFor(), WorldpayCaptureResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = captureClient.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrder(request));
+        return getGatewayResponse(response, WorldpayCaptureResponse.class);
     }
 
     @Override
     public GatewayResponse refund(RefundGatewayRequest request) {
-        return sendReceive(request, buildRefundOrderFor(), WorldpayRefundResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = refundClient.postRequestFor(null, request.getGatewayAccount(), buildRefundOrder(request));
+        return getGatewayResponse(response, WorldpayRefundResponse.class);
     }
 
     @Override
     public GatewayResponse cancel(CancelGatewayRequest request) {
-        return sendReceive(request, buildCancelOrderFor(), WorldpayCancelResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = cancelClient.postRequestFor(null, request.getGatewayAccount(), buildCancelOrder(request));
+        return getGatewayResponse(response, WorldpayCancelResponse.class);
 
     }
 
@@ -112,10 +157,10 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
             Notifications.Builder<String> builder = Notifications.builder();
             WorldpayNotification worldpayNotification = XMLUnmarshaller.unmarshall(payload, WorldpayNotification.class);
             builder.addNotificationFor(
-                worldpayNotification.getTransactionId(),
-                worldpayNotification.getReference(),
-                worldpayNotification.getStatus(),
-                worldpayNotification.getBookingDate().atStartOfDay(ZoneOffset.UTC),
+                    worldpayNotification.getTransactionId(),
+                    worldpayNotification.getReference(),
+                    worldpayNotification.getStatus(),
+                    worldpayNotification.getBookingDate().atStartOfDay(ZoneOffset.UTC),
                     null
             );
 
@@ -132,13 +177,13 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
 
     public static BiFunction<GatewayOrder, Builder, Builder> includeSessionIdentifier() {
         return (order, builder) ->
-            order.getProviderSessionId()
-                    .map(sessionId -> builder.cookie(WORLDPAY_MACHINE_COOKIE_NAME, sessionId))
-                    .orElseGet(() -> builder);
+                order.getProviderSessionId()
+                        .map(sessionId -> builder.cookie(WORLDPAY_MACHINE_COOKIE_NAME, sessionId))
+                        .orElseGet(() -> builder);
     }
 
-    private Function<AuthorisationGatewayRequest, GatewayOrder> buildAuthoriseOrderFor() {
-        return request -> aWorldpayAuthoriseOrderRequestBuilder()
+    private GatewayOrder buildAuthoriseOrder(AuthorisationGatewayRequest request) {
+        return aWorldpayAuthoriseOrderRequestBuilder()
                 .withSessionId(request.getChargeExternalId())
                 .with3dsRequired(request.getGatewayAccount().isRequires3ds())
                 .withTransactionId(request.getTransactionId().orElse(""))
@@ -149,8 +194,8 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
                 .build();
     }
 
-    private Function<Auth3dsResponseGatewayRequest, GatewayOrder> build3dsResponseAuthOrderFor() {
-        return request -> aWorldpay3dsResponseAuthOrderRequestBuilder()
+    private GatewayOrder build3dsResponseAuthOrder(Auth3dsResponseGatewayRequest request) {
+        return aWorldpay3dsResponseAuthOrderRequestBuilder()
                 .withPaResponse3ds(request.getAuth3DsDetails().getPaResponse())
                 .withSessionId(request.getChargeExternalId())
                 .withTransactionId(request.getTransactionId().orElse(""))
@@ -159,8 +204,8 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
                 .build();
     }
 
-    private Function<CaptureGatewayRequest, GatewayOrder> buildCaptureOrderFor() {
-        return request -> aWorldpayCaptureOrderRequestBuilder()
+    private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
+        return aWorldpayCaptureOrderRequestBuilder()
                 .withDate(DateTime.now(DateTimeZone.UTC))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withAmount(request.getAmount())
@@ -168,8 +213,8 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
                 .build();
     }
 
-    private Function<RefundGatewayRequest, GatewayOrder> buildRefundOrderFor() {
-        return request -> aWorldpayRefundOrderRequestBuilder()
+    private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
+        return aWorldpayRefundOrderRequestBuilder()
                 .withReference(request.getReference())
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withAmount(request.getAmount())
@@ -177,14 +222,10 @@ public class WorldpayPaymentProvider extends BasePaymentProvider<BaseResponse, S
                 .build();
     }
 
-    private Function<CancelGatewayRequest, GatewayOrder> buildCancelOrderFor() {
-        return request -> aWorldpayCancelOrderRequestBuilder()
+    private GatewayOrder buildCancelOrder(CancelGatewayRequest request) {
+        return aWorldpayCancelOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .build();
-    }
-
-    private Function<GatewayClient.Response, Optional<String>> extractResponseIdentifier() {
-        return response -> Optional.ofNullable(response.getResponseCookies().get(WORLDPAY_MACHINE_COOKIE_NAME));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
@@ -34,10 +34,12 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.GatewayOperation.*;
+import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.CANCEL;
+import static uk.gov.pay.connector.gateway.GatewayOperation.CAPTURE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.REFUND;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentProvidersTest {
@@ -83,18 +85,15 @@ public class PaymentProvidersTest {
     @Before
     public void setup() {
         Environment environment = mock(Environment.class);
-        when(config.getWorldpayConfig()).thenReturn(worldpayConfig);
-        when(config.getGatewayConfigFor(PaymentGatewayName.WORLDPAY)).thenReturn(worldpayConfig);
         when(config.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(smartpayConfig);
         when(config.getGatewayConfigFor(EPDQ)).thenReturn(epdqConfig);
         when(config.getLinks()).thenReturn(linksConfig);
         when(linksConfig.getFrontendUrl()).thenReturn("http://frontendUrl");
-        when(worldpayConfig.getUrls()).thenReturn(worldpayUrlMap);
         when(smartpayConfig.getUrls()).thenReturn(smartpayUrlMap);
         when(epdqConfig.getUrls()).thenReturn(epdqUrlMap);
         when(environment.metrics()).thenReturn(metricRegistry);
 
-        providers = new PaymentProviders(config, gatewayClientFactory, new ObjectMapper(), environment);
+        providers = new PaymentProviders(config, gatewayClientFactory, new ObjectMapper(), environment, mock(WorldpayPaymentProvider.class));
     }
 
     @Test
@@ -123,15 +122,6 @@ public class PaymentProvidersTest {
 
     @Test
     public void shouldSetupGatewayClientForGatewayOperations() {
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, AUTHORISE, worldpayUrlMap,
-            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, CANCEL, worldpayUrlMap,
-            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, CAPTURE, worldpayUrlMap,
-            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(WORLDPAY, REFUND, worldpayUrlMap,
-            WorldpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-
         verify(gatewayClientFactory).createGatewayClient(SMARTPAY, AUTHORISE, smartpayUrlMap,
             SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
         verify(gatewayClientFactory).createGatewayClient(SMARTPAY, CANCEL, smartpayUrlMap,


### PR DESCRIPTION
## WHAT
Makes WorldpayPaymentProvider nicer:
- It can be creating by Guice via the @Inject, which means
- It can be directly injected into PaymentProviders
- It is responsible for creating its own clients
- It implements PaymentProviders directly. In doing so,
- It doesn't extend BasePaymentProvider anymore, which means
- We can start getting rid of those `sendReceive` method in there
- Some lines of tests can be removed

@oswaldquek
