### PR TITLE
PP-4341: Refactor EpdqPaymentProvider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -10,6 +10,8 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
+import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
@@ -82,5 +84,10 @@ public class ConnectorModule extends AbstractModule {
     @Singleton
     public XrayUtils xrayUtils(ConnectorConfiguration connectorConfiguration) {
         return new XrayUtils(connectorConfiguration.isXrayEnabled());
+    }
+    
+    @Provides
+    public SignatureGenerator signatureGenerator() {
+        return new EpdqSha512SignatureGenerator();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
@@ -42,7 +42,8 @@ public class PaymentProviders<T extends BaseResponse> {
                             GatewayClientFactory gatewayClientFactory, 
                             ObjectMapper objectMapper, 
                             Environment environment,
-                            WorldpayPaymentProvider worldpayPaymentProvider) {
+                            WorldpayPaymentProvider worldpayPaymentProvider,
+                            EpdqPaymentProvider epdqPaymentProvider) {
         this.gatewayClientFactory = gatewayClientFactory;
         this.environment = environment;
         this.config = config;
@@ -50,7 +51,7 @@ public class PaymentProviders<T extends BaseResponse> {
         this.paymentProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
         this.paymentProviders.put(PaymentGatewayName.SMARTPAY, createSmartPayProvider(objectMapper));
         this.paymentProviders.put(PaymentGatewayName.SANDBOX, new SandboxPaymentProvider(defaultExternalRefundAvailabilityCalculator));
-        this.paymentProviders.put(PaymentGatewayName.EPDQ, createEpdqProvider());
+        this.paymentProviders.put(PaymentGatewayName.EPDQ, epdqPaymentProvider);
     }
 
     private GatewayClient gatewayClientForOperation(PaymentGatewayName gateway,
@@ -75,17 +76,6 @@ public class PaymentProviders<T extends BaseResponse> {
                 objectMapper,
                 defaultExternalRefundAvailabilityCalculator
         );
-    }
-
-    private PaymentProvider createEpdqProvider() {
-        EnumMap<GatewayOperation, GatewayClient> gatewayClientEnumMap = GatewayOperationClientBuilder.builder()
-                .authClient(gatewayClientForOperation(PaymentGatewayName.EPDQ, GatewayOperation.AUTHORISE, EpdqPaymentProvider.includeSessionIdentifier()))
-                .cancelClient(gatewayClientForOperation(PaymentGatewayName.EPDQ, GatewayOperation.CANCEL, EpdqPaymentProvider.includeSessionIdentifier()))
-                .captureClient(gatewayClientForOperation(PaymentGatewayName.EPDQ, GatewayOperation.CAPTURE, EpdqPaymentProvider.includeSessionIdentifier()))
-                .refundClient(gatewayClientForOperation(PaymentGatewayName.EPDQ, GatewayOperation.REFUND, EpdqPaymentProvider.includeSessionIdentifier()))
-                .build();
-
-        return new EpdqPaymentProvider(gatewayClientEnumMap, new EpdqSha512SignatureGenerator(), epdqExternalRefundAvailabilityCalculator, config.getLinks().getFrontendUrl(), environment.metrics());
     }
 
     public PaymentProvider<T, ?> byName(PaymentGatewayName gateway) {

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -2,16 +2,18 @@ package uk.gov.pay.connector.gateway.epdq;
 
 import com.codahale.metrics.MetricRegistry;
 import fj.data.Either;
+import io.dropwizard.setup.Environment;
 import org.apache.http.NameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.BasePaymentProvider;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCancelResponse;
@@ -27,23 +29,30 @@ import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 
+import javax.inject.Inject;
 import javax.ws.rs.client.Invocation;
 import java.nio.charset.Charset;
-import java.util.EnumMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import static fj.data.Either.left;
+import static fj.data.Either.reduce;
 import static fj.data.Either.right;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
+import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.CANCEL;
+import static uk.gov.pay.connector.gateway.GatewayOperation.CAPTURE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.REFUND;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.SHASIGN_KEY;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdq3DsAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqAuthoriseOrderRequestBuilder;
@@ -57,7 +66,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 
-public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, String> {
+public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EpdqPaymentProvider.class);
 
@@ -78,13 +87,25 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
     private final SignatureGenerator signatureGenerator;
     private final String frontendUrl;
     private final MetricRegistry metricRegistry;
+    private final GatewayClient authoriseClient;
+    private final GatewayClient cancelClient;
+    private final GatewayClient captureClient;
+    private final GatewayClient refundClient;
+    private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 
-    public EpdqPaymentProvider(EnumMap<GatewayOperation, GatewayClient> clients, SignatureGenerator signatureGenerator,
-                               ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator, String frontendUrl, MetricRegistry metricRegistry) {
-        super(clients, externalRefundAvailabilityCalculator);
+    @Inject
+    public EpdqPaymentProvider(ConnectorConfiguration configuration,
+                               GatewayClientFactory gatewayClientFactory,
+                               Environment environment,
+                               SignatureGenerator signatureGenerator) {
+        authoriseClient = gatewayClientFactory.createGatewayClient(EPDQ, AUTHORISE, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
+        cancelClient = gatewayClientFactory.createGatewayClient(EPDQ, CANCEL, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
+        captureClient = gatewayClientFactory.createGatewayClient(EPDQ, CAPTURE, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
+        refundClient = gatewayClientFactory.createGatewayClient(EPDQ, REFUND, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
         this.signatureGenerator = signatureGenerator;
-        this.frontendUrl = frontendUrl;
-        this.metricRegistry = metricRegistry;
+        this.frontendUrl = configuration.getLinks().getFrontendUrl();
+        this.metricRegistry = environment.metrics();
+        this.externalRefundAvailabilityCalculator = new EpdqExternalRefundAvailabilityCalculator();
     }
 
     @Override
@@ -99,29 +120,48 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
 
     @Override
     public GatewayResponse authorise(AuthorisationGatewayRequest request) {
-        return sendReceive(ROUTE_FOR_NEW_ORDER, request, buildAuthoriseOrderFor(frontendUrl), EpdqAuthorisationResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_NEW_ORDER, request.getGatewayAccount(), buildAuthoriseOrder(request, frontendUrl));
+        return getGatewayResponse(response, EpdqAuthorisationResponse.class);
+    }
+
+    private GatewayResponse<BaseResponse> getGatewayResponse(Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
+        if (response.isLeft()) {
+            return GatewayResponse.with(response.left().value());
+        } else {
+            GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+            authoriseClient.unmarshallResponse(response.right().value(), responseClass)
+                    .bimap(
+                            responseBuilder::withGatewayError,
+                            responseBuilder::withResponse
+                    );
+            return responseBuilder.build();
+        }
     }
 
     @Override
     public GatewayResponse capture(CaptureGatewayRequest request) {
-        return sendReceive(ROUTE_FOR_MAINTENANCE_ORDER, request, buildCaptureOrderFor(), EpdqCaptureResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = captureClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCaptureOrder(request));
+        return getGatewayResponse(response, EpdqCaptureResponse.class);
     }
 
     @Override
     public GatewayResponse refund(RefundGatewayRequest request) {
-        return sendReceive(ROUTE_FOR_MAINTENANCE_ORDER, request, buildRefundOrderFor(), EpdqRefundResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = refundClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildRefundOrder(request));
+        return getGatewayResponse(response, EpdqRefundResponse.class);
     }
 
     @Override
     public GatewayResponse cancel(CancelGatewayRequest request) {
-        return sendReceive(ROUTE_FOR_MAINTENANCE_ORDER, request, buildCancelOrderFor(), EpdqCancelResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = cancelClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCancelOrder(request));
+        return getGatewayResponse(response, EpdqCancelResponse.class);
     }
 
     @Override
     public GatewayResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        GatewayResponse<EpdqAuthorisationResponse> gatewayResponse = sendReceive(ROUTE_FOR_QUERY_ORDER, request, buildQueryOrderRequestFor(), EpdqAuthorisationResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_QUERY_ORDER, request.getGatewayAccount(), buildQueryOrderRequestFor().apply(request));
+        GatewayResponse<BaseResponse> gatewayResponse = getGatewayResponse(response, EpdqAuthorisationResponse.class);
 
-        BaseAuthoriseResponse.AuthoriseStatus authoriseStatus = gatewayResponse.getBaseResponse().map(epdqStatus -> epdqStatus.authoriseStatus()).orElse(BaseAuthoriseResponse.AuthoriseStatus.ERROR);
+        BaseAuthoriseResponse.AuthoriseStatus authoriseStatus = gatewayResponse.getBaseResponse().map(epdqStatus -> ((EpdqAuthorisationResponse) epdqStatus).authoriseStatus()).orElse(BaseAuthoriseResponse.AuthoriseStatus.ERROR);
         final Auth3dsDetails.Auth3dsResult auth3DResult = request.getAuth3DsDetails().getAuth3DsResult() == null ?
                 Auth3dsDetails.Auth3dsResult.ERROR : // we treat no result from frontend as an error
                 request.getAuth3DsDetails().getAuth3DsResult();
@@ -198,7 +238,7 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
      * The outgoing response is error biased. Meaning, we have to make sure that the authorisation success can only happen if both frontend as well as epdq confirms its a success.
      * In all other combinations it is not authorised and the frontend error state take precedence followed by gateway error state for the resulting status.
      */
-    private GatewayResponse reconstructErrorBiasedGatewayResponse(GatewayResponse<EpdqAuthorisationResponse> gatewayResponse, BaseAuthoriseResponse.AuthoriseStatus authoriseStatus, Auth3dsDetails.Auth3dsResult auth3DResult) {
+    private GatewayResponse reconstructErrorBiasedGatewayResponse(GatewayResponse<BaseResponse> gatewayResponse, BaseAuthoriseResponse.AuthoriseStatus authoriseStatus, Auth3dsDetails.Auth3dsResult auth3DResult) {
         GatewayResponse.GatewayResponseBuilder<EpdqAuthorisationResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         if (auth3DResult.equals(Auth3dsDetails.Auth3dsResult.ERROR)) {
             return responseBuilder.withGatewayError(GatewayError.baseError(format("epdq.authorise-3ds.result.mismatch expected=%s, actual=%s", Auth3dsDetails.Auth3dsResult.ERROR, authoriseStatus.name())))
@@ -232,30 +272,27 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
                 .build();
     }
 
-    private Function<AuthorisationGatewayRequest, GatewayOrder> buildAuthoriseOrderFor(String frontendUrl) {
-        return request -> {
-            EpdqOrderRequestBuilder epdqOrderRequestBuilder =
-                    request.getGatewayAccount().isRequires3ds() ?
-                            anEpdq3DsAuthoriseOrderRequestBuilder(frontendUrl) :
-                            anEpdqAuthoriseOrderRequestBuilder();
+    private GatewayOrder buildAuthoriseOrder(AuthorisationGatewayRequest request, String frontendUrl) {
+        EpdqOrderRequestBuilder epdqOrderRequestBuilder =
+                request.getGatewayAccount().isRequires3ds() ?
+                        anEpdq3DsAuthoriseOrderRequestBuilder(frontendUrl) :
+                        anEpdqAuthoriseOrderRequestBuilder();
 
-
-            return epdqOrderRequestBuilder
-                    .withOrderId(request.getChargeExternalId())
-                    .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
-                    .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
-                            CREDENTIALS_SHA_IN_PASSPHRASE))
-                    .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
-                    .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                    .withDescription(request.getDescription())
-                    .withAmount(request.getAmount())
-                    .withAuthorisationDetails(request.getAuthCardDetails())
-                    .build();
-        };
+        return epdqOrderRequestBuilder
+                .withOrderId(request.getChargeExternalId())
+                .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
+                .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
+                        CREDENTIALS_SHA_IN_PASSPHRASE))
+                .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withDescription(request.getDescription())
+                .withAmount(request.getAmount())
+                .withAuthorisationDetails(request.getAuthCardDetails())
+                .build();
     }
 
-    private Function<CaptureGatewayRequest, GatewayOrder> buildCaptureOrderFor() {
-        return request -> anEpdqCaptureOrderRequestBuilder()
+    private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
+        return anEpdqCaptureOrderRequestBuilder()
                 .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
                 .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
                 .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
@@ -265,8 +302,8 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
                 .build();
     }
 
-    private Function<CancelGatewayRequest, GatewayOrder> buildCancelOrderFor() {
-        return request -> anEpdqCancelOrderRequestBuilder()
+    private GatewayOrder buildCancelOrder(CancelGatewayRequest request) {
+        return anEpdqCancelOrderRequestBuilder()
                 .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
                 .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
                 .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
@@ -276,8 +313,8 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
                 .build();
     }
 
-    private Function<RefundGatewayRequest, GatewayOrder> buildRefundOrderFor() {
-        return request -> anEpdqRefundOrderRequestBuilder()
+    private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
+        return anEpdqRefundOrderRequestBuilder()
                 .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
                 .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
                 .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
@@ -286,13 +323,6 @@ public class EpdqPaymentProvider extends BasePaymentProvider<BaseResponse, Strin
                 .withTransactionId(request.getTransactionId())
                 .withAmount(request.getAmount())
                 .build();
-    }
-
-    private Function<GatewayClient.Response, Optional<String>> extractResponseIdentifier() {
-        return response -> {
-            Optional<String> emptyResponseIdentifierForEpdq = Optional.empty();
-            return emptyResponseIdentifierForEpdq;
-        };
     }
 
     public static BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> includeSessionIdentifier() {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -206,7 +206,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
 
         assertThat(provider.verifyNotification(mockNotification, mockGatewayAccountEntity), is(false));
     }
-
+    
     @Test
     public void shouldNotVerifyNotificationIfEmptyPayload() {
         when(mockNotification.getPayload()).thenReturn(Optional.empty());
@@ -232,12 +232,4 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         assertThat(notification.getStatus(), is(NOTIFICATION_STATUS));
         assertThat(notification.getGatewayEventDate(), IsNull.nullValue());
     }
-
-    @Test
-    public void shouldReturnExternalRefundAvailability() {
-        ChargeEntity mockChargeEntity = mock(ChargeEntity.class);
-        when(mockExternalRefundAvailabilityCalculator.calculate(mockChargeEntity)).thenReturn(EXTERNAL_AVAILABLE);
-        assertThat(provider.getExternalChargeRefundAvailability(mockChargeEntity), is(EXTERNAL_AVAILABLE));
-    }
-
 }

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -4,47 +4,53 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
 import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.LinksConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
-import uk.gov.pay.connector.gateway.GatewayOperationClientBuilder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
 import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
+import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
+import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
-import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.TestClientFactory;
 
 import javax.ws.rs.client.Client;
 import java.io.IOException;
 import java.net.URL;
-import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 import static java.util.UUID.randomUUID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,6 +74,8 @@ public class EpdqPaymentProviderTest {
     private MetricRegistry mockMetricRegistry;
     private Histogram mockHistogram;
     private Counter mockCounter;
+    @Mock
+    private Environment environment;
 
     @Test
     public void shouldAuthoriseSuccessfully() {
@@ -171,13 +179,17 @@ public class EpdqPaymentProviderTest {
         Client client = TestClientFactory.createJerseyClient();
         GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
                 EpdqPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
-        EnumMap<GatewayOperation, GatewayClient> gatewayClients = GatewayOperationClientBuilder.builder()
-                .authClient(gatewayClient)
-                .captureClient(gatewayClient)
-                .cancelClient(gatewayClient)
-                .refundClient(gatewayClient)
-                .build();
-        return new EpdqPaymentProvider(gatewayClients, new EpdqSha512SignatureGenerator(), new EpdqExternalRefundAvailabilityCalculator(), "http://frontendUrl", mockMetricRegistry);
+        ConnectorConfiguration configuration = mock(ConnectorConfiguration.class);
+        LinksConfig linksConfig = mock(LinksConfig.class);
+        when(configuration.getLinks()).thenReturn(linksConfig);
+        when(linksConfig.getFrontendUrl()).thenReturn("http://frontendUrl");
+        
+        GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any(BiFunction.class), any())).thenReturn(gatewayClient);
+        
+        when(environment.metrics()).thenReturn(mockMetricRegistry);
+        
+        return new EpdqPaymentProvider(configuration, gatewayClientFactory, environment, mock(SignatureGenerator.class));
     }
 
     private static AuthorisationGatewayRequest buildAuthorisationRequest(ChargeEntity chargeEntity) {

--- a/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
@@ -12,10 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.GatewayConfig;
-import uk.gov.pay.connector.app.LinksConfig;
-import uk.gov.pay.connector.app.WorldpayConfig;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -24,9 +21,7 @@ import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 
-import javax.ws.rs.client.Invocation.Builder;
 import java.util.Map;
-import java.util.function.BiFunction;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -56,29 +51,11 @@ public class PaymentProvidersTest {
     ConnectorConfiguration config;
 
     @Mock
-    LinksConfig linksConfig;
-
-    @Mock
-    WorldpayConfig worldpayConfig;
-
-    @Mock
     GatewayConfig smartpayConfig;
 
     @Mock
-    GatewayConfig epdqConfig;
-
-    @Mock
-    Map<String, String> worldpayUrlMap;
-
-    @Mock
     Map<String, String> smartpayUrlMap;
-
-    @Mock
-    Map<String, String> epdqUrlMap;
-
-    @Mock
-    BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier;
-
+    
     @Mock
     MetricRegistry metricRegistry;
 
@@ -86,36 +63,32 @@ public class PaymentProvidersTest {
     public void setup() {
         Environment environment = mock(Environment.class);
         when(config.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(smartpayConfig);
-        when(config.getGatewayConfigFor(EPDQ)).thenReturn(epdqConfig);
-        when(config.getLinks()).thenReturn(linksConfig);
-        when(linksConfig.getFrontendUrl()).thenReturn("http://frontendUrl");
         when(smartpayConfig.getUrls()).thenReturn(smartpayUrlMap);
-        when(epdqConfig.getUrls()).thenReturn(epdqUrlMap);
         when(environment.metrics()).thenReturn(metricRegistry);
 
-        providers = new PaymentProviders(config, gatewayClientFactory, new ObjectMapper(), environment, mock(WorldpayPaymentProvider.class));
+        providers = new PaymentProviders(config, gatewayClientFactory, new ObjectMapper(), environment, mock(WorldpayPaymentProvider.class), mock(EpdqPaymentProvider.class));
     }
 
     @Test
-    public void shouldResolveSandboxPaymentProvider() throws Exception {
+    public void shouldResolveSandboxPaymentProvider() {
         PaymentProvider sandbox = providers.byName(PaymentGatewayName.SANDBOX);
         assertThat(sandbox, is(instanceOf(SandboxPaymentProvider.class)));
     }
 
     @Test
-    public void shouldResolveWorldpayPaymentProvider() throws Exception {
+    public void shouldResolveWorldpayPaymentProvider() {
         PaymentProvider worldpay = providers.byName(PaymentGatewayName.WORLDPAY);
         assertThat(worldpay, is(instanceOf(WorldpayPaymentProvider.class)));
     }
 
     @Test
-    public void shouldResolveSmartpayPaymentProvider() throws Exception {
+    public void shouldResolveSmartpayPaymentProvider() {
         PaymentProvider smartpay = providers.byName(PaymentGatewayName.SMARTPAY);
         assertThat(smartpay, is(instanceOf(SmartpayPaymentProvider.class)));
     }
 
     @Test
-    public void shouldResolveEpdqPaymentProvider() throws Exception {
+    public void shouldResolveEpdqPaymentProvider() {
         PaymentProvider epdq = providers.byName(EPDQ);
         assertThat(epdq, is(instanceOf(EpdqPaymentProvider.class)));
     }
@@ -130,15 +103,6 @@ public class PaymentProvidersTest {
             SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
         verify(gatewayClientFactory).createGatewayClient(SMARTPAY, REFUND, smartpayUrlMap,
             SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, AUTHORISE, epdqUrlMap,
-            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, CANCEL, epdqUrlMap,
-            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, CAPTURE, epdqUrlMap,
-            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(EPDQ, REFUND, epdqUrlMap,
-            EpdqPaymentProvider.includeSessionIdentifier(), metricRegistry);
 
     }
 }


### PR DESCRIPTION
Similar to
https://github.com/alphagov/pay-connector/commit/dfef04523e22d78980cefa55d0a7015c4766e5ff
this PR makes EpdqPaymentProvider nicer:
- It can be creating by Guice via the @Inject, which means
- It can be directly injected into PaymentProviders
- It is responsible for creating its own clients
- It implements PaymentProviders directly. In doing so,
- It doesn't extend BasePaymentProvider anymore, which means
- We can start getting rid of those `sendReceive` method in there
- Some lines of tests can be removed

We are a step closer to getting rid of BasePaymentProvider and its ugly
`EnumMap<GatewayOperation, GatewayClient> clients` field.

@oswaldquek

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


