### PR TITLE
PP-4341: Refactor SmartpayPaymentProvider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
@@ -6,7 +6,10 @@ import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation.Builder;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
+
+import static java.util.Optional.empty;
 
 public class GatewayClientFactory {
 
@@ -17,12 +20,22 @@ public class GatewayClientFactory {
         this.clientFactory = clientFactory;
     }
 
-    public GatewayClient createGatewayClient(PaymentGatewayName gateway, GatewayOperation operation,
-                                             Map<String, String> gatewayUrlMap, BiFunction<GatewayOrder, Builder, Builder> sessionIdentier,
+    public GatewayClient createGatewayClient(PaymentGatewayName gateway, 
+                                             GatewayOperation operation,
+                                             Map<String, String> gatewayUrlMap, 
+                                             BiFunction<GatewayOrder, Builder, Builder> sessionIdentier,
                                              MetricRegistry metricRegistry)
     {
         Client client = clientFactory.createWithDropwizardClient(gateway, operation, metricRegistry);
         return new GatewayClient(client, gatewayUrlMap, sessionIdentier, metricRegistry);
     }
 
+    public GatewayClient createGatewayClient(PaymentGatewayName gateway,
+                                             Map<String, String> gatewayUrlMap, 
+                                             BiFunction<GatewayOrder, Builder, Builder> sessionIdentier,
+                                             MetricRegistry metricRegistry)
+    {
+        Client client = clientFactory.createWithDropwizardClient(gateway, metricRegistry);
+        return new GatewayClient(client, gatewayUrlMap, sessionIdentier, metricRegistry);
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -158,7 +158,7 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
 
     @Override
     public GatewayResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_QUERY_ORDER, request.getGatewayAccount(), buildQueryOrderRequestFor().apply(request));
+        Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_QUERY_ORDER, request.getGatewayAccount(), buildQueryOrderRequestFor(request));
         GatewayResponse<BaseResponse> gatewayResponse = getGatewayResponse(response, EpdqAuthorisationResponse.class);
 
         BaseAuthoriseResponse.AuthoriseStatus authoriseStatus = gatewayResponse.getBaseResponse().map(epdqStatus -> ((EpdqAuthorisationResponse) epdqStatus).authoriseStatus()).orElse(BaseAuthoriseResponse.AuthoriseStatus.ERROR);
@@ -261,8 +261,8 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
         return !respondMatches;
     }
 
-    private Function<Auth3dsResponseGatewayRequest, GatewayOrder> buildQueryOrderRequestFor() {
-        return request -> anEpdqQueryOrderRequestBuilder()
+    private GatewayOrder buildQueryOrderRequestFor(Auth3dsResponseGatewayRequest request) {
+        return anEpdqQueryOrderRequestBuilder()
                 .withOrderId(request.getChargeExternalId())
                 .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
                 .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -2,15 +2,18 @@ package uk.gov.pay.connector.gateway.smartpay;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fj.data.Either;
+import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.BasePaymentProvider;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
+import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -19,35 +22,42 @@ import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 import uk.gov.pay.connector.usernotification.model.Notifications.Builder;
 
+import javax.inject.Inject;
 import javax.ws.rs.client.Invocation;
-import java.util.EnumMap;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static fj.data.Either.left;
 import static fj.data.Either.right;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
-public class SmartpayPaymentProvider extends BasePaymentProvider<BaseResponse, Pair<String, Boolean>> {
+public class SmartpayPaymentProvider implements PaymentProvider<BaseResponse, Pair<String, Boolean>> {
 
     private final ObjectMapper objectMapper;
+    private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
+    private final GatewayClient client;
 
-    public SmartpayPaymentProvider(EnumMap<GatewayOperation, GatewayClient> clients, ObjectMapper objectMapper,
-                                   ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator) {
-        super(clients, externalRefundAvailabilityCalculator);
+    @Inject
+    public SmartpayPaymentProvider(ConnectorConfiguration configuration,
+                                   GatewayClientFactory gatewayClientFactory,
+                                   Environment environment,
+                                   ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
+        this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
+        client = gatewayClientFactory.createGatewayClient(SMARTPAY, configuration.getGatewayConfigFor(SMARTPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
     }
 
     @Override
     public PaymentGatewayName getPaymentGatewayName() {
-        return PaymentGatewayName.SMARTPAY;
+        return SMARTPAY;
     }
 
     @Override
@@ -57,27 +67,46 @@ public class SmartpayPaymentProvider extends BasePaymentProvider<BaseResponse, P
 
     @Override
     public GatewayResponse authorise(AuthorisationGatewayRequest request) {
-        return sendReceive(request, buildAuthoriseOrderFor(), SmartpayAuthorisationResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildAuthoriseOrderFor(request));
+        return getGatewayResponse(response, SmartpayAuthorisationResponse.class);
+    }
+
+    private GatewayResponse<BaseResponse> getGatewayResponse(Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
+        if (response.isLeft()) {
+            return GatewayResponse.with(response.left().value());
+        } else {
+            GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+            client.unmarshallResponse(response.right().value(), responseClass)
+                    .bimap(
+                            responseBuilder::withGatewayError,
+                            responseBuilder::withResponse
+                    );
+            return responseBuilder.build();
+        }
     }
 
     @Override
     public GatewayResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        return sendReceive(request, build3dsResponseAuthOrderFor(), SmartpayAuthorisationResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), build3dsResponseAuthOrderFor(request));
+        return getGatewayResponse(response, SmartpayAuthorisationResponse.class);
     }
 
     @Override
     public GatewayResponse capture(CaptureGatewayRequest request) {
-        return sendReceive(request, buildCaptureOrderFor(), SmartpayCaptureResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrderFor(request));
+        return getGatewayResponse(response, SmartpayCaptureResponse.class);
     }
 
     @Override
     public GatewayResponse refund(RefundGatewayRequest request) {
-        return sendReceive(request, buildRefundOrderFor(), SmartpayRefundResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildRefundOrderFor(request));
+        return getGatewayResponse(response, SmartpayRefundResponse.class);
     }
 
     @Override
     public GatewayResponse cancel(CancelGatewayRequest request) {
-        return sendReceive(request, buildCancelOrderFor(), SmartpayCancelResponse.class, extractResponseIdentifier());
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCancelOrderFor(request));
+        return getGatewayResponse(response, SmartpayCancelResponse.class);
 
     }
 
@@ -136,46 +165,44 @@ public class SmartpayPaymentProvider extends BasePaymentProvider<BaseResponse, P
         return (order, builder) -> builder;
     }
 
-    private Function<AuthorisationGatewayRequest, GatewayOrder> buildAuthoriseOrderFor() {
-        return request -> {
-            SmartpayOrderRequestBuilder smartpayOrderRequestBuilder = request.getGatewayAccount().isRequires3ds() ?
-                    SmartpayOrderRequestBuilder.aSmartpay3dsRequiredOrderRequestBuilder() : SmartpayOrderRequestBuilder.aSmartpayAuthoriseOrderRequestBuilder();
+    private GatewayOrder buildAuthoriseOrderFor(AuthorisationGatewayRequest request) {
+        SmartpayOrderRequestBuilder smartpayOrderRequestBuilder = request.getGatewayAccount().isRequires3ds() ?
+                SmartpayOrderRequestBuilder.aSmartpay3dsRequiredOrderRequestBuilder() : SmartpayOrderRequestBuilder.aSmartpayAuthoriseOrderRequestBuilder();
 
-            return smartpayOrderRequestBuilder
-                    .withMerchantCode(getMerchantCode(request))
-                    .withPaymentPlatformReference(request.getChargeExternalId())
-                    .withDescription(request.getDescription())
-                    .withAmount(request.getAmount())
-                    .withAuthorisationDetails(request.getAuthCardDetails())
-                    .build();
-        };
+        return smartpayOrderRequestBuilder
+                .withMerchantCode(getMerchantCode(request))
+                .withPaymentPlatformReference(request.getChargeExternalId())
+                .withDescription(request.getDescription())
+                .withAmount(request.getAmount())
+                .withAuthorisationDetails(request.getAuthCardDetails())
+                .build();
     }
 
-    private Function<Auth3dsResponseGatewayRequest, GatewayOrder> build3dsResponseAuthOrderFor() {
-        return request -> SmartpayOrderRequestBuilder.aSmartpayAuthorise3dsOrderRequestBuilder()
+    private GatewayOrder build3dsResponseAuthOrderFor(Auth3dsResponseGatewayRequest request) {
+        return SmartpayOrderRequestBuilder.aSmartpayAuthorise3dsOrderRequestBuilder()
                 .withPaResponse(request.getAuth3DsDetails().getPaResponse())
                 .withMd(request.getAuth3DsDetails().getMd())
                 .withMerchantCode(getMerchantCode(request))
                 .build();
     }
 
-    private Function<CaptureGatewayRequest, GatewayOrder> buildCaptureOrderFor() {
-        return request -> SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder()
+    private GatewayOrder buildCaptureOrderFor(CaptureGatewayRequest request) {
+        return SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(getMerchantCode(request))
                 .withAmount(request.getAmount())
                 .build();
     }
 
-    private Function<CancelGatewayRequest, GatewayOrder> buildCancelOrderFor() {
-        return request -> SmartpayOrderRequestBuilder.aSmartpayCancelOrderRequestBuilder()
+    private GatewayOrder buildCancelOrderFor(CancelGatewayRequest request) {
+        return SmartpayOrderRequestBuilder.aSmartpayCancelOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(getMerchantCode(request))
                 .build();
     }
 
-    private Function<RefundGatewayRequest, GatewayOrder> buildRefundOrderFor() {
-        return request -> SmartpayOrderRequestBuilder.aSmartpayRefundOrderRequestBuilder()
+    private GatewayOrder buildRefundOrderFor(RefundGatewayRequest request) {
+        return SmartpayOrderRequestBuilder.aSmartpayRefundOrderRequestBuilder()
                 .withReference(request.getReference())
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(getMerchantCode(request))
@@ -185,12 +212,5 @@ public class SmartpayPaymentProvider extends BasePaymentProvider<BaseResponse, P
 
     private String getMerchantCode(GatewayRequest request) {
         return request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID);
-    }
-
-    private Function<GatewayClient.Response, Optional<String>> extractResponseIdentifier() {
-        return response -> {
-            Optional<String> emptyResponseIdentifierForSmartpay = Optional.empty();
-            return emptyResponseIdentifierForSmartpay;
-        };
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -7,23 +7,21 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import fj.data.Either;
+import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.GatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.ClientFactory;
-import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.GatewayOperation;
-import uk.gov.pay.connector.gateway.GatewayOperationClientBuilder;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -31,7 +29,6 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
@@ -47,9 +44,6 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.function.BiFunction;
 
 import static com.google.common.io.Resources.getResource;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -64,7 +58,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
@@ -78,51 +71,36 @@ public class SmartpayPaymentProviderTest {
 
     private SmartpayPaymentProvider provider;
     private GatewayClientFactory gatewayClientFactory;
-    private Map<String, String> urlMap = ImmutableMap.of(TEST.toString(), "http://smartpay.url");
 
     @Mock
     private Client mockClient;
-    @Mock
-    private MetricRegistry mockMetricRegistry;
-    @Mock
-    private Histogram mockHistogram;
-    @Mock
-    private BiFunction<GatewayOrder, Builder, Builder> mockSessionIdentifier;
     @Mock
     private ClientFactory mockClientFactory;
     @Mock
     private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock
-    private ExternalRefundAvailabilityCalculator mockExternalRefundAvailabilityCalculator;
+    private ConnectorConfiguration configuration;
+    @Mock
+    private GatewayConfig gatewayConfig;
+    @Mock
+    private Environment environment;
+    @Mock
+    private MetricRegistry metricRegistry;
 
     @Before
     public void setup() {
         gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
 
-        when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockClientFactory.createWithDropwizardClient(eq(PaymentGatewayName.SMARTPAY), any(GatewayOperation.class), any(MetricRegistry.class)))
+        when(mockClientFactory.createWithDropwizardClient(eq(PaymentGatewayName.SMARTPAY), any(MetricRegistry.class)))
                 .thenReturn(mockClient);
+        when(configuration.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(gatewayConfig);
+        when(gatewayConfig.getUrls()).thenReturn(ImmutableMap.of(TEST.toString(), "http://smartpay.url"));
+        when(environment.metrics()).thenReturn(metricRegistry);
+        when(metricRegistry.histogram(anyString())).thenReturn(mock(Histogram.class));
 
         mockSmartpaySuccessfulOrderSubmitResponse();
 
-        GatewayClient authClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.AUTHORISE,
-                urlMap, mockSessionIdentifier, mockMetricRegistry);
-        GatewayClient cancelClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.CANCEL,
-                urlMap, mockSessionIdentifier, mockMetricRegistry);
-        GatewayClient refundClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.REFUND,
-                urlMap, mockSessionIdentifier, mockMetricRegistry);
-        GatewayClient captureClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.SMARTPAY, GatewayOperation.CAPTURE,
-                urlMap, mockSessionIdentifier, mockMetricRegistry);
-
-
-        EnumMap<GatewayOperation, GatewayClient> gatewayClients = GatewayOperationClientBuilder.builder()
-                .authClient(authClient)
-                .captureClient(captureClient)
-                .cancelClient(cancelClient)
-                .refundClient(refundClient)
-                .build();
-
-        provider = new SmartpayPaymentProvider(gatewayClients, new ObjectMapper(), mockExternalRefundAvailabilityCalculator);
+        provider = new SmartpayPaymentProvider(configuration, gatewayClientFactory, environment, new ObjectMapper());
     }
 
     @Test
@@ -252,13 +230,6 @@ public class SmartpayPaymentProviderTest {
         assertThat(provider.verifyNotification(mock(Notification.class), mockGatewayAccountEntity), is(true));
     }
 
-    @Test
-    public void shouldReturnExternalRefundAvailability() {
-        ChargeEntity mockChargeEntity = mock(ChargeEntity.class);
-        when(mockExternalRefundAvailabilityCalculator.calculate(mockChargeEntity)).thenReturn(EXTERNAL_AVAILABLE);
-        MatcherAssert.assertThat(provider.getExternalChargeRefundAvailability(mockChargeEntity), is(EXTERNAL_AVAILABLE));
-    }
-
     private GatewayAccountEntity aServiceAccount() {
         GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
         gatewayAccount.setId(1L);
@@ -295,7 +266,6 @@ public class SmartpayPaymentProviderTest {
         Builder mockBuilder = mock(Builder.class);
         when(mockTarget.request()).thenReturn(mockBuilder);
         when(mockBuilder.header(anyString(), any(Object.class))).thenReturn(mockBuilder);
-        when(mockSessionIdentifier.apply(any(GatewayOrder.class), eq(mockBuilder))).thenReturn(mockBuilder);
 
         Response response = mock(Response.class);
         when(response.readEntity(String.class)).thenReturn(responsePayload);

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryTest.java
@@ -16,7 +16,6 @@ import org.mockserver.integration.ClientAndServer;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.gateway.ClientFactory;
-import uk.gov.pay.connector.gateway.GatewayOperation;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
@@ -29,13 +28,15 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.socket.PortFactory.findFreePort;
 import static org.mockserver.verify.VerificationTimes.exactly;
 import static org.mockserver.verify.VerificationTimes.once;
+import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 
@@ -73,7 +74,7 @@ public class ClientFactoryTest {
 
         when(mockMetricRegistry.register(any(), any())).thenReturn(null);
         Client client = new ClientFactory(app.getEnvironment(), app.getConfiguration())
-                .createWithDropwizardClient(WORLDPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);
+                .createWithDropwizardClient(WORLDPAY, AUTHORISE, mockMetricRegistry);
 
         client.target(serverUrl).path("hello").request().get();
 
@@ -93,7 +94,7 @@ public class ClientFactoryTest {
         when(mockMetricRegistry.register(any(), any())).thenReturn(null);
 
         Client client = new ClientFactory(app.getEnvironment(), app.getConfiguration())
-                .createWithDropwizardClient(WORLDPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);
+                .createWithDropwizardClient(WORLDPAY, AUTHORISE, mockMetricRegistry);
 
         client.target(serverUrl).path("hello").request().get();
 
@@ -116,7 +117,7 @@ public class ClientFactoryTest {
                 .respond(response("world").withStatusCode(200).withDelay(TimeUnit.MILLISECONDS, 2000));
 
         Client client = new ClientFactory(app.getEnvironment(), app.getConfiguration())
-                .createWithDropwizardClient(WORLDPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);
+                .createWithDropwizardClient(WORLDPAY, AUTHORISE, mockMetricRegistry);
 
         Invocation.Builder request = client.target(serverUrl).path(path).request();
         long startTime = System.currentTimeMillis();
@@ -188,7 +189,7 @@ public class ClientFactoryTest {
                 .respond(response("world").withStatusCode(200).withDelay(TimeUnit.MILLISECONDS, 2000));
 
         Client client = new ClientFactory(app.getEnvironment(), app.getConfiguration())
-                .createWithDropwizardClient(WORLDPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);
+                .createWithDropwizardClient(WORLDPAY, AUTHORISE, mockMetricRegistry);
 
         Invocation.Builder request = client.target(serverUrl).path(path).request();
 
@@ -211,7 +212,7 @@ public class ClientFactoryTest {
                 .respond(response("world").withStatusCode(200).withDelay(TimeUnit.MILLISECONDS, 2000));
 
         Client client = new ClientFactory(app.getEnvironment(), app.getConfiguration())
-                .createWithDropwizardClient(SMARTPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);
+                .createWithDropwizardClient(SMARTPAY, AUTHORISE, mockMetricRegistry);
 
         Invocation.Builder request = client.target(serverUrl).path(path).request();
         Long authOverriddenTimeout = app.getConfiguration().getSmartpayConfig().getJerseyClientOverrides()

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.ClientFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
@@ -20,6 +19,7 @@ import java.util.function.BiFunction;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GatewayClientFactoryTest {
@@ -37,10 +37,10 @@ public class GatewayClientFactoryTest {
         Builder mockBuilder = mock(Builder.class);
         BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier = (GatewayOrder o, Builder b) -> mockBuilder;
 
-        GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE,
+        GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, AUTHORISE,
                 gatewayUrlMap, sessionIdentifier, mockMetricRegistry);
 
         assertNotNull(gatewayClient);
-        verify(mockClientFactory).createWithDropwizardClient(PaymentGatewayName.WORLDPAY, GatewayOperation.AUTHORISE, mockMetricRegistry);
+        verify(mockClientFactory).createWithDropwizardClient(PaymentGatewayName.WORLDPAY, AUTHORISE, mockMetricRegistry);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
@@ -1,18 +1,11 @@
 package uk.gov.pay.connector.service;
 
-import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.dropwizard.setup.Environment;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.GatewayConfig;
-import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -21,20 +14,11 @@ import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 
-import java.util.Map;
-
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
-import static uk.gov.pay.connector.gateway.GatewayOperation.CANCEL;
-import static uk.gov.pay.connector.gateway.GatewayOperation.CAPTURE;
-import static uk.gov.pay.connector.gateway.GatewayOperation.REFUND;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentProvidersTest {
@@ -44,29 +28,9 @@ public class PaymentProvidersTest {
 
     private PaymentProviders providers;
 
-    @Mock
-    GatewayClientFactory gatewayClientFactory;
-
-    @Mock
-    ConnectorConfiguration config;
-
-    @Mock
-    GatewayConfig smartpayConfig;
-
-    @Mock
-    Map<String, String> smartpayUrlMap;
-    
-    @Mock
-    MetricRegistry metricRegistry;
-
     @Before
     public void setup() {
-        Environment environment = mock(Environment.class);
-        when(config.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(smartpayConfig);
-        when(smartpayConfig.getUrls()).thenReturn(smartpayUrlMap);
-        when(environment.metrics()).thenReturn(metricRegistry);
-
-        providers = new PaymentProviders(config, gatewayClientFactory, new ObjectMapper(), environment, mock(WorldpayPaymentProvider.class), mock(EpdqPaymentProvider.class));
+        providers = new PaymentProviders(mock(WorldpayPaymentProvider.class), mock(EpdqPaymentProvider.class), mock(SmartpayPaymentProvider.class));
     }
 
     @Test
@@ -91,18 +55,5 @@ public class PaymentProvidersTest {
     public void shouldResolveEpdqPaymentProvider() {
         PaymentProvider epdq = providers.byName(EPDQ);
         assertThat(epdq, is(instanceOf(EpdqPaymentProvider.class)));
-    }
-
-    @Test
-    public void shouldSetupGatewayClientForGatewayOperations() {
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, AUTHORISE, smartpayUrlMap,
-            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, CANCEL, smartpayUrlMap,
-            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, CAPTURE, smartpayUrlMap,
-            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-        verify(gatewayClientFactory).createGatewayClient(SMARTPAY, REFUND, smartpayUrlMap,
-            SmartpayPaymentProvider.includeSessionIdentifier(), metricRegistry);
-
     }
 }


### PR DESCRIPTION
## WHAT

Makes SmartpayPaymentProvider nicer:
- It can be created by Guice via the @Inject, which means
- It can be directly injected into PaymentProviders
- It is responsible for creating its own clients, of which there is only ONE,
  unlike Worldpay and Epdq providers, which have FOUR -> simplicity!
- It implements PaymentProviders directly. In doing so,
- It doesn't extend BasePaymentProvider anymore, which means
- We can start getting rid of those sendReceive method in there

This commit reduces the number of GatewayClients from 4 previously to 1, as it
makes no sense to have 4 GatewayClients. Worldpay/Epdq payment providers have
4 because as shown in
https://github.com/alphagov/pay-connector/blob/master/src/main/resources/config/config.yaml#L29
they have different configured read timeouts which require a different client
for each operation (authorise, cancel, refund, capture). Smartpay doesn't have
these read timeouts so it makes sense to just use one GatewayClient. A side
effect of this is that GatewayClientFactory needs to be able to create a
GatewayClient without an operation parameter. This means the metric registry
names
(https://github.com/alphagov/pay-connector/blob/cde8bb205be1e3e33d8059055e994f5c290b4b2f/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java#L102)
for Smartpay are no longer "smartpay.authorise", "smartpay.cancel", etc but
simply "smartpay.all".

@oswaldquek

