### PR TITLE
PP 4340 Refactor cardAuthorise/3dsAuthorise Service postOperation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.charge.service;
 
 import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.commons.model.SupportedLanguage;
@@ -9,10 +10,15 @@ import uk.gov.pay.connector.app.LinksConfig;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.AddressEntity;
+import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.ChargeCreateRequest;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
+import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
@@ -24,6 +30,7 @@ import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
@@ -42,6 +49,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -187,6 +195,55 @@ public class ChargeService {
         }
 
         return builderOfResponse;
+    }
+
+    public void updateChargePostAuthorisation(ChargeStatus status,
+                                              ChargeEntity chargeEntity,
+                                              Optional<String> transactionId,
+                                              Optional<Auth3dsDetailsEntity> auth3dsDetailsEntity,
+                                              Optional<String> sessionIdentifier,
+                                              AuthCardDetails authCardDetails) {
+
+        chargeEntity.setStatus(status);
+        setTransactionId(chargeEntity, transactionId);
+        sessionIdentifier.ifPresent(chargeEntity::setProviderSessionId);
+
+        auth3dsDetailsEntity.ifPresent(chargeEntity::set3dsDetails);
+
+        CardDetailsEntity detailsEntity = buildCardDetailsEntity(authCardDetails);
+        chargeEntity.setCardDetails(detailsEntity);
+
+        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+        logger.info("Stored confirmation details for charge - charge_external_id={}",
+                chargeEntity.getExternalId());
+
+    }
+
+    public void updateChargePost3dsAuthorisation(ChargeStatus status, ChargeEntity chargeEntity,
+                                                 Optional<String> transactionId) {
+        chargeEntity.setStatus(status);
+        setTransactionId(chargeEntity, transactionId);
+
+        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+    }
+
+    private void setTransactionId(ChargeEntity chargeEntity, Optional<String> transactionId) {
+        transactionId.ifPresent(txId -> {
+            if (!isBlank(txId)) {
+                chargeEntity.setGatewayTransactionId(txId);
+            }
+        });
+    }
+
+    private CardDetailsEntity buildCardDetailsEntity(AuthCardDetails authCardDetails) {
+        CardDetailsEntity detailsEntity = new CardDetailsEntity();
+        detailsEntity.setCardBrand(sanitize(authCardDetails.getCardBrand()));
+        detailsEntity.setBillingAddress(new AddressEntity(authCardDetails.getAddress()));
+        detailsEntity.setCardHolderName(sanitize(authCardDetails.getCardHolder()));
+        detailsEntity.setExpiryDate(authCardDetails.getEndDate());
+        detailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of(StringUtils.left(authCardDetails.getCardNo(), 6)));
+        detailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of(StringUtils.right(authCardDetails.getCardNo(), 4)));
+        return detailsEntity;
     }
 
     private TokenEntity createNewChargeEntityToken(ChargeEntity chargeEntity) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -80,7 +80,7 @@ public class CardCaptureService extends CardService implements TransactionalGate
     @Override
     public ChargeEntity preOperation(String chargeId) {
         return chargeDao.findByExternalId(chargeId)
-                .map(chargeEntity -> preOperation(chargeEntity, CardService.OperationType.CAPTURE, LEGAL_STATUSES, CAPTURE_READY))
+                .map(chargeEntity -> lockChargeForProcessing(chargeEntity, CardService.OperationType.CAPTURE, LEGAL_STATUSES, CAPTURE_READY))
                 .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardService.java
@@ -52,7 +52,7 @@ public abstract class CardService<T extends BaseResponse> {
         this.metricRegistry = environment.metrics();
     }
 
-    public ChargeEntity preOperation(ChargeEntity chargeEntity, OperationType operationType, List<ChargeStatus> legalStatuses, ChargeStatus lockingStatus) {
+    public ChargeEntity lockChargeForProcessing(ChargeEntity chargeEntity, OperationType operationType, List<ChargeStatus> legalStatuses, ChargeStatus lockingStatus) {
 
         GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -13,10 +13,12 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.exception.ChargeExpiredRuntimeException;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
@@ -59,6 +61,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
+    private ChargeService chargeService;
     private Card3dsResponseAuthService card3dsResponseAuthService;
     private CardExecutorService mockExecutorService = mock(CardExecutorService.class);
 
@@ -70,7 +73,11 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedChargeDao, mockedChargeEventDao, mockedProviders, mockExecutorService, mockEnvironment);
+        ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
+        chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
+                null, mockConfiguration, null);
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedChargeDao, mockedChargeEventDao,
+                mockedProviders, mockExecutorService, chargeService, mockEnvironment);
     }
 
     public void setupMockExecutorServiceMock() {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -10,11 +10,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
@@ -89,13 +91,19 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     private CardAuthoriseService cardAuthorisationService;
 
+    private ChargeService chargeService;
+
     @Before
     public void setUpCardAuthorisationService() {
         mockMetricRegistry = mock(MetricRegistry.class);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+
+        ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
+        chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
+                null, null, mockConfiguration, null);
         cardAuthorisationService = new CardAuthoriseService(mockedChargeDao, mockedChargeEventDao,
-                mockedCardTypeDao, mockedProviders, mockExecutorService,
+                mockedCardTypeDao, mockedProviders, mockExecutorService, chargeService,
                 mockEnvironment);
     }
 


### PR DESCRIPTION
## WHAT
* The base class's doAuthorise method essentially just composes a block of code in a lambda that gets executed later.
* There are duplicate code in the subclasses which we can tidy up and reuse. Our speculation is - the existence of the dupe code is to ensure transactional integrity is maintained within the `preOperation`, `operation` and `postOperation` calls.
* If we are to break things out into reusable smaller methods then there will be risk that someone someday might call those individual methods outside of a transaction boundary resulting in half persisted data.

## HOW 
This PR contains the changes for the first set of changes to make reviewing the changes less painful. Changes are as follows: 

    - Renamed `postOperation` to `processGatewayAuthorisationResponse`
    - Refactored method - Extracted blocks of code to individual methods
    - Extracted changeEntity update block to ChargeService
    - Renamed CardService.preOperation to `lockChargeForProcessing`

with @kbottla 