### PR TITLE
PP-4313 Add decrypter for apple pay payloads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,11 @@
             <version>1.1.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.60</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/uk/gov/pay/connector/app/ApplePayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/ApplePayConfig.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.app;
+
+
+public class ApplePayConfig extends GatewayConfig {
+    private String publicCertificate;
+    private String privateKey;
+
+    public byte[] getPublicCertificate() {
+        return publicCertificate.getBytes();
+    }
+
+    public byte[] getPrivateKey() {
+        return privateKey.getBytes();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/app/ApplePayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/ApplePayConfig.java
@@ -1,15 +1,17 @@
 package uk.gov.pay.connector.app;
 
 
-public class ApplePayConfig extends GatewayConfig {
+import java.nio.charset.StandardCharsets;
+
+public class ApplePayConfig {
     private String publicCertificate;
     private String privateKey;
 
     public byte[] getPublicCertificate() {
-        return publicCertificate.getBytes();
+        return publicCertificate.getBytes(StandardCharsets.UTF_8);
     }
 
     public byte[] getPrivateKey() {
-        return privateKey.getBytes();
+        return privateKey.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/WorldpayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/WorldpayConfig.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.connector.app;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class WorldpayConfig extends GatewayConfig {
     private boolean secureNotificationEnabled;
     private String notificationDomain;
-    private ApplePayConfig applePay;
+    private ApplePayConfig applePayConfig;
 
     public String getNotificationDomain() {
         return notificationDomain;
@@ -14,7 +16,8 @@ public class WorldpayConfig extends GatewayConfig {
         return secureNotificationEnabled;
     }
 
+    @JsonProperty("applePay")
     public ApplePayConfig getApplePayConfig() {
-        return applePay;
+        return applePayConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/WorldpayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/WorldpayConfig.java
@@ -14,7 +14,7 @@ public class WorldpayConfig extends GatewayConfig {
         return secureNotificationEnabled;
     }
 
-    public ApplePayConfig getApplePay() {
+    public ApplePayConfig getApplePayConfig() {
         return applePay;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/WorldpayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/WorldpayConfig.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.connector.app;
 
+
 public class WorldpayConfig extends GatewayConfig {
     private boolean secureNotificationEnabled;
     private String notificationDomain;
+    private ApplePayConfig applePay;
 
     public String getNotificationDomain() {
         return notificationDomain;
@@ -10,5 +12,9 @@ public class WorldpayConfig extends GatewayConfig {
 
     public boolean isSecureNotificationEnabled() {
         return secureNotificationEnabled;
+    }
+
+    public ApplePayConfig getApplePay() {
+        return applePay;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePayDecrypter.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePayDecrypter.java
@@ -15,15 +15,19 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyFactory;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
+import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 
@@ -107,15 +111,14 @@ public class ApplePayDecrypter {
                 .digest(byteArrayOutputStream.toByteArray());
     }
 
-    private Certificate generateCertificate() throws Exception {
-        InputStream stream = new ByteArrayInputStream(publicCertificate);
-        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-        Certificate certificate = certificateFactory.generateCertificate(stream);
-        stream.close();
-        return certificate;
+    private Certificate generateCertificate() throws IOException, CertificateException {
+        try (InputStream stream = new ByteArrayInputStream(publicCertificate)) {
+            CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+            return certificateFactory.generateCertificate(stream);
+        }
     }
 
-    private PrivateKey generatePrivateKey() throws Exception {
+    private PrivateKey generatePrivateKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
         return KeyFactory.getInstance("EC")
                 .generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
     }

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePayDecrypter.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePayDecrypter.java
@@ -35,15 +35,15 @@ public class ApplePayDecrypter {
     private static final byte[] COUNTER = {0x00, 0x00, 0x00, 0x01};
     private static final byte[] APPLE_OEM = "Apple".getBytes(UTF_8);
     private static final byte[] ALG_IDENTIFIER_BYTES = "id-aes256-GCM".getBytes(UTF_8);
-
+    private static final String MERCHANT_ID_CERTIFICATE_OID = "1.2.840.113635.100.6.32";
     static {
         Security.addProvider(new BouncyCastleProvider());
     }
 
-    private byte[] privateKeyBytes;
-    private byte[] publicCertificate;
+    private final byte[] privateKeyBytes;
+    private final byte[] publicCertificate;
 
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     @Inject
     public ApplePayDecrypter(ConnectorConfiguration configuration, ObjectMapper objectMapper) {
@@ -66,8 +66,8 @@ public class ApplePayDecrypter {
             byte[] rawData = decrypt(certificate, privateKey, ephemeralKey, data);
             return objectMapper.readValue(new String(rawData, UTF_8), ApplePaymentData.class);
         } catch (Exception e) {
-            LOGGER.error("Error while trying to decrypt apple payload");
-            throw new InvalidKeyException("Error while trying to decrypt apple payload");
+            LOGGER.error("Error while trying to decrypt apple pay payload");
+            throw new InvalidKeyException("Error while trying to decrypt apple pay payload");
         }
     }
 
@@ -102,7 +102,7 @@ public class ApplePayDecrypter {
         byteArrayOutputStream.write(ALG_IDENTIFIER_BYTES);
         byteArrayOutputStream.write(APPLE_OEM);
         // Add Merchant Id
-        byteArrayOutputStream.write(Hex.decode(new String((certificate.getExtensionValue("1.2.840.113635.100.6.32")), UTF_8).substring(4)));
+        byteArrayOutputStream.write(Hex.decode(new String((certificate.getExtensionValue(MERCHANT_ID_CERTIFICATE_OID)), UTF_8).substring(4)));
         return MessageDigest.getInstance("SHA256", "BC")
                 .digest(byteArrayOutputStream.toByteArray());
     }

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePayDecrypter.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePayDecrypter.java
@@ -1,0 +1,124 @@
+package uk.gov.pay.connector.applepay;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import com.sun.org.apache.xerces.internal.impl.dv.util.HexBin;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ApplePayConfig;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.util.ResponseUtil;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyAgreement;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+
+public class ApplePayDecrypter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplePayDecrypter.class);
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+    private static final byte[] COUNTER = {0x00, 0x00, 0x00, 0x01};
+    private static final byte[] APPLE_OEM = "Apple".getBytes(UTF_8);
+    private static final byte[] ALG_IDENTIFIER_BYTES = "id-aes256-GCM".getBytes(UTF_8);
+
+    static {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
+    private byte[] privateKeyBytes;
+    private byte[] publicCertificate;
+
+    private ObjectMapper objectMapper;
+
+    @Inject
+    public ApplePayDecrypter(ConnectorConfiguration configuration, ObjectMapper objectMapper) {
+        ApplePayConfig applePayConfig = configuration.getWorldpayConfig().getApplePay();
+        this.privateKeyBytes = applePayConfig.getPrivateKey();
+        this.publicCertificate = applePayConfig.getPublicCertificate();
+        this.objectMapper = objectMapper;
+    }
+
+    public ApplePaymentData performDecryptOperation(byte[] data, byte[] ephemeralKey)  {
+        try {
+
+            PrivateKey privateKey = generatePrivateKey();
+            Certificate certificate = generateCertificate();
+
+            AsymmetricKeyVerifier verifier = new AsymmetricKeyVerifier(privateKey, certificate.getPublicKey());
+            if (!verifier.verify()) {
+                throw new InvalidKeyException("Asymmetric keys do not match!");
+            }
+            byte[] rawData = decrypt(certificate, privateKey, ephemeralKey, data);
+            return objectMapper.readValue(new String(rawData, UTF_8), ApplePaymentData.class);
+        } catch (Exception e) {
+            LOGGER.error("Error while trying to decrypt apple payload");
+            throw new InvalidKeyException("Error while trying to decrypt apple payload");
+        }
+    }
+
+    private byte[] decrypt(Certificate certificate, PrivateKey merchantPrivateKey, byte[] ephemeralPublicKeyBytes, byte[] data) throws Exception {
+        // Reconstitute Ephemeral Public Key
+        KeyFactory keyFactory = KeyFactory.getInstance("ECDH", "BC");
+        X509EncodedKeySpec encodedKeySpec = new X509EncodedKeySpec(ephemeralPublicKeyBytes);
+        ECPublicKey ephemeralPublicKey = (ECPublicKey) keyFactory.generatePublic(encodedKeySpec);
+        // Perform KeyAgreement
+        KeyAgreement agreement = KeyAgreement.getInstance("ECDH", "BC");
+        agreement.init(merchantPrivateKey);
+        agreement.doPhase(ephemeralPublicKey, true);
+        byte[] sharedSecret = agreement.generateSecret();
+
+        // Perform KDF
+        byte[] derivedSecret = performKeyDerivationFunction(((X509Certificate) certificate), sharedSecret);
+
+        // Use the derived secret to decrypt the data
+        SecretKeySpec key = new SecretKeySpec(derivedSecret, "AES");
+        byte[] ivBytes = new byte[16];
+        IvParameterSpec ivSpec = new IvParameterSpec(ivBytes);
+        Cipher aesCipher = Cipher.getInstance("AES/GCM/NoPadding", "BC");
+        aesCipher.init(Cipher.DECRYPT_MODE, key, ivSpec);
+        return aesCipher.doFinal(data);
+    }
+
+    private byte[] performKeyDerivationFunction(X509Certificate certificate, byte[] sharedSecret) throws Exception {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        byteArrayOutputStream.write(COUNTER);
+        byteArrayOutputStream.write(sharedSecret);
+        byteArrayOutputStream.write(ALG_IDENTIFIER_BYTES.length);
+        byteArrayOutputStream.write(ALG_IDENTIFIER_BYTES);
+        byteArrayOutputStream.write(APPLE_OEM);
+        // Add Merchant Id
+        byteArrayOutputStream.write(HexBin.decode(new String((certificate.getExtensionValue("1.2.840.113635.100.6.32")), UTF_8).substring(4)));
+        return MessageDigest.getInstance("SHA256", "BC")
+                .digest(byteArrayOutputStream.toByteArray());
+    }
+
+    private Certificate generateCertificate() throws Exception {
+        InputStream stream = new ByteArrayInputStream(publicCertificate);
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        Certificate certificate = certificateFactory.generateCertificate(stream);
+        stream.close();
+        return certificate;
+    }
+
+    private PrivateKey generatePrivateKey() throws Exception {
+        return KeyFactory.getInstance("EC")
+                .generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePaymentData.java
@@ -1,10 +1,11 @@
 package uk.gov.pay.connector.applepay;
 
-import uk.gov.pay.connector.gateway.model.AuthorisationDetails;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Map;
 
-public class ApplePaymentData implements AuthorisationDetails {
+public class ApplePaymentData {
     private String applicationPrimaryAccountNumber;
     private String applicationExpirationDate;
     private String currencyCode;

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePaymentData.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.applepay;
+
+import uk.gov.pay.connector.gateway.model.AuthorisationDetails;
+
+import java.util.Map;
+
+public class ApplePaymentData implements AuthorisationDetails {
+    private String applicationPrimaryAccountNumber;
+    private String applicationExpirationDate;
+    private String currencyCode;
+    private String transactionAmount;
+    private String deviceManufacturerIdentifier;
+    private String paymentDataType;
+    private Map<String, String> paymentData;
+
+
+    public String getApplicationPrimaryAccountNumber() {
+        return applicationPrimaryAccountNumber;
+    }
+
+    public String getApplicationExpirationDate() {
+        return applicationExpirationDate;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public String getTransactionAmount() {
+        return transactionAmount;
+    }
+
+    public String getDeviceManufacturerIdentifier() {
+        return deviceManufacturerIdentifier;
+    }
+
+    public String getPaymentDataType() {
+        return paymentDataType;
+    }
+
+    public Map<String, String> getPaymentData() {
+        return paymentData;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
@@ -6,6 +6,7 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.SecureRandom;
 import java.security.Signature;
 import java.security.SignatureException;
 
@@ -21,7 +22,8 @@ public class AsymmetricKeyVerifier {
     }
 
     boolean verify() throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        byte[] data = RandomUtils.nextBytes(16);
+        byte[] data = new byte[16];
+        SecureRandom.getInstanceStrong().nextBytes(data);
         byte[] digitalSignature = signData(data);
         Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM_NAME);
         signer.initVerify(publicKey);

--- a/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.applepay;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.util.UUID;
+
+public class AsymmetricKeyVerifier {
+    private static final String SIGNATURE_ALGORITHM_NAME = "SHA256withECDSA";
+
+    private final PrivateKey privateKey;
+    private final PublicKey publicKey;
+
+    AsymmetricKeyVerifier(PrivateKey privateKey, PublicKey publicKey) {
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
+    }
+
+    boolean verify() throws Exception {
+        byte[] data = UUID.randomUUID().toString().getBytes();
+        byte[] digitalSignature = signData(data);
+        return verifySig(data, digitalSignature);
+    }
+
+    private byte[] signData(byte[] data) throws Exception {
+        Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM_NAME);
+        signer.initSign(privateKey);
+        signer.update(data);
+        return signer.sign();
+    }
+
+    private boolean verifySig(byte[] data, byte[] sig) throws Exception {
+        Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM_NAME);
+        signer.initVerify(publicKey);
+        signer.update(data);
+        return signer.verify(sig);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
@@ -1,9 +1,14 @@
 package uk.gov.pay.connector.applepay;
 
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
+import java.security.SignatureException;
 import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class AsymmetricKeyVerifier {
     private static final String SIGNATURE_ALGORITHM_NAME = "SHA256withECDSA";
@@ -16,23 +21,19 @@ public class AsymmetricKeyVerifier {
         this.publicKey = publicKey;
     }
 
-    boolean verify() throws Exception {
-        byte[] data = UUID.randomUUID().toString().getBytes();
+    boolean verify() throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
+        byte[] data = UUID.randomUUID().toString().getBytes(UTF_8);
         byte[] digitalSignature = signData(data);
-        return verifySig(data, digitalSignature);
+        Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM_NAME);
+        signer.initVerify(publicKey);
+        signer.update(data);
+        return signer.verify(digitalSignature);
     }
 
-    private byte[] signData(byte[] data) throws Exception {
+    private byte[] signData(byte[] data) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
         Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM_NAME);
         signer.initSign(privateKey);
         signer.update(data);
         return signer.sign();
-    }
-
-    private boolean verifySig(byte[] data, byte[] sig) throws Exception {
-        Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM_NAME);
-        signer.initVerify(publicKey);
-        signer.update(data);
-        return signer.verify(sig);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
@@ -1,14 +1,13 @@
 package uk.gov.pay.connector.applepay;
 
+import org.apache.commons.lang3.RandomUtils;
+
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.Signature;
 import java.security.SignatureException;
-import java.util.UUID;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class AsymmetricKeyVerifier {
     private static final String SIGNATURE_ALGORITHM_NAME = "SHA256withECDSA";
@@ -22,7 +21,7 @@ public class AsymmetricKeyVerifier {
     }
 
     boolean verify() throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
-        byte[] data = UUID.randomUUID().toString().getBytes(UTF_8);
+        byte[] data = RandomUtils.nextBytes(16);
         byte[] digitalSignature = signData(data);
         Signature signer = Signature.getInstance(SIGNATURE_ALGORITHM_NAME);
         signer.initVerify(publicKey);

--- a/src/main/java/uk/gov/pay/connector/applepay/InvalidKeyException.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/InvalidKeyException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.applepay;
+
+import javax.ws.rs.BadRequestException;
+
+public class InvalidKeyException extends BadRequestException {
+    public InvalidKeyException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/util/XMLUnmarshaller.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/XMLUnmarshaller.java
@@ -15,6 +15,7 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.sax.SAXSource;
 import java.io.ByteArrayInputStream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING;
 
 public class XMLUnmarshaller {
@@ -43,7 +44,7 @@ public class XMLUnmarshaller {
     }
 
     private static <T> T unmarshall(String payload, Class<T> clazz, XMLReader xmlReader) throws JAXBException {
-        InputSource inputSource = new InputSource(new ByteArrayInputStream(payload.getBytes()));
+        InputSource inputSource = new InputSource(new ByteArrayInputStream(payload.getBytes(UTF_8)));
         JAXBContext jaxbContext = JAXBContext.newInstance(clazz);
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         return unmarshaller.unmarshal(new SAXSource(xmlReader, inputSource), clazz).getValue();

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -26,6 +26,9 @@ worldpay:
   secureNotificationEnabled: ${SECURE_WORLDPAY_NOTIFICATION_ENABLED:-false}
   notificationDomain: ${SECURE_WORLDPAY_NOTIFICATION_DOMAIN:-worldpay.com}
   credentials: ['username','password','merchant_id']
+  applePay:
+   privateKey: ${WORLDPAY_APPLE_PAY_PRIVATE_KEY:-}
+   publicCertificate: ${WORLDPAY_APPLE_PAY_PUBLIC_CERTIFICATE:-}
   jerseyClientOverrides:
     auth:
       # Auth is run in a background thread which will release the HTTP request from frontend after 1 second

--- a/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.app.ApplePayConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.WorldpayConfig;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
@@ -26,20 +27,27 @@ public class ApplePayDecrypterTest {
     private ApplePayConfig mockApplePayConfig;
     private ObjectMapper objectMapper = new ObjectMapper();
     
+    
+    private final String encodedData = "0cWHZj3Py20Nxh8VrANfcXSFFaaNCJM9HpCPiUhb63GWi7+Aya0BmsKfELoK/Pp+1hvmJzO0DtkdYrtLQRnKRKUMX+KfEsQO3eKLEOaRm12qf1jgXG7HUE1r+BlrK9BC24QzyZkqYVbdTSbE8CTmDuiDSVjQi0fBwxo+MdjsWg+ap6RDlmSXVKXuGS1to5Ae/VDnwBBMuDNYJiJYSR9LWU7eO6HL6ke6+xjXcRhfxexeZ1y9XToTcDrC0M7xM3kAHkTyDV30m63MKdb7cpSV/7DVgj99AX9XrLlVJndAnBLI7jMsOFCTho86U0fJJ40XDklR8X5x43NKL+c2SimUNBMZkiZLygQSUrFD41cKb/7UIyB9c7Sk9UJmTM24FOeVt/RH2cIX+okRB6UzewVGZEFvV/PWbJqaOCWxISMjJc8HAkWa0Q1ARVKTzCS6ZgsPFZcao0Z3/j46kCxN/RYeYG7hfgrtaH8hqnvicac3khhFAU9RbjMZCmGdVzyuaxz/4SKGtDgN22y8sPsiWORi6NM+1As5nHWMgP7dO2ouI3wcuaxHADHfGm5aNQ==";
+    
+    private final String encodedEphemeralKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl/XAbOgrSCupps/QbIxJ3u4QZ1PlbO5uGDD1zj/JGMoephYSEgw+63gHQHekx3T8duXN3CoYafUpuQlwOeK6/w==";
+    
+    private final String encodedPrivateKey = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy";
+    
+    private final String encodedPublicCertificate = "MIIEeTCCBCCgAwIBAgIIUkIKsiYxaKowCgYIKoZIzj0EAwIwgYExOzA5BgNVBAMMMlRlc3QgQXBwbGUgV29ybGR3aWRlIERldmVsb3BlcnMgUmVsYXRpb25zIENBIC0gRUNDMSAwHgYDVQQLDBdDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTYwNzI1MTUyMDM4WhcNMTgwODI0MTUyMDM4WjCBlzErMCkGCgmSJomT8ixkAQEMG21lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzExMC8GA1UEAwwoTWVyY2hhbnQgSUQ6IG1lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzETMBEGA1UECwwKTVlUVThZNURRTTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvyo4ICaDCCAmQwTwYIKwYBBQUHAQEEQzBBMD8GCCsGAQUFBzABhjNodHRwOi8vb2NzcC11YXQuY29ycC5hcHBsZS5jb20vb2NzcDA0LXRlc3R3d2RyY2FlY2MwHQYDVR0OBBYEFAV7nS4mNDLy1gxvOAcCS1hOgY4lMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU1tbVWuX//cJ8NMND3r1odlw2qb4wggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwtdWF0LmNvcnAuYXBwbGUuY29tL2FwcGxld3dkcmNhZWNjLmNybDAOBgNVHQ8BAf8EBAMCAygwTwYJKoZIhvdjZAYgBEIMQDU4MDJEMUM3NzRGMDk2MkY4MTEyNDhFNTM4REUzQkVGNjgwQzc5ODZCQjVCNERDRTBCNTYyNDlGMzdDQkI5NDMwCgYIKoZIzj0EAwIDRwAwRAIgTjtiYjk/BKp3V8Dg6mIlcm5FCOF06zub7Jsr6wCsvKACIH8U114DI5HnmfcNvwM4RXFDPToop4+jjMAPvidipKkg";
+    
     private ApplePayDecrypter applePayDecrypter;
     
-    private final byte[] data = Base64.decode( "0cWHZj3Py20Nxh8VrANfcXSFFaaNCJM9HpCPiUhb63GWi7+Aya0BmsKfELoK/Pp+1hvmJzO0DtkdYrtLQRnKRKUMX+KfEsQO3eKLEOaRm12qf1jgXG7HUE1r+BlrK9BC24QzyZkqYVbdTSbE8CTmDuiDSVjQi0fBwxo+MdjsWg+ap6RDlmSXVKXuGS1to5Ae/VDnwBBMuDNYJiJYSR9LWU7eO6HL6ke6+xjXcRhfxexeZ1y9XToTcDrC0M7xM3kAHkTyDV30m63MKdb7cpSV/7DVgj99AX9XrLlVJndAnBLI7jMsOFCTho86U0fJJ40XDklR8X5x43NKL+c2SimUNBMZkiZLygQSUrFD41cKb/7UIyB9c7Sk9UJmTM24FOeVt/RH2cIX+okRB6UzewVGZEFvV/PWbJqaOCWxISMjJc8HAkWa0Q1ARVKTzCS6ZgsPFZcao0Z3/j46kCxN/RYeYG7hfgrtaH8hqnvicac3khhFAU9RbjMZCmGdVzyuaxz/4SKGtDgN22y8sPsiWORi6NM+1As5nHWMgP7dO2ouI3wcuaxHADHfGm5aNQ==" );
+    private final byte[] data = Base64.decode(encodedData);
 
-    private final byte[] ephemeralKey = Base64.decode( "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl/XAbOgrSCupps/QbIxJ3u4QZ1PlbO5uGDD1zj/JGMoephYSEgw+63gHQHekx3T8duXN3CoYafUpuQlwOeK6/w==");
+    private final byte[] ephemeralKey = Base64.decode(encodedEphemeralKey);
 
     @Before
     public void setUp() {
         when(mockConfig.getWorldpayConfig()).thenReturn(mockWorldpayConfig);
-        when(mockWorldpayConfig.getApplePay()).thenReturn(mockApplePayConfig);
-        byte[] privateKey = Base64.decode("MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy");
-        when(mockApplePayConfig.getPrivateKey()).thenReturn(privateKey);
-        byte[] publicCertificate = Base64.decode("MIIEeTCCBCCgAwIBAgIIUkIKsiYxaKowCgYIKoZIzj0EAwIwgYExOzA5BgNVBAMMMlRlc3QgQXBwbGUgV29ybGR3aWRlIERldmVsb3BlcnMgUmVsYXRpb25zIENBIC0gRUNDMSAwHgYDVQQLDBdDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTYwNzI1MTUyMDM4WhcNMTgwODI0MTUyMDM4WjCBlzErMCkGCgmSJomT8ixkAQEMG21lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzExMC8GA1UEAwwoTWVyY2hhbnQgSUQ6IG1lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzETMBEGA1UECwwKTVlUVThZNURRTTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvyo4ICaDCCAmQwTwYIKwYBBQUHAQEEQzBBMD8GCCsGAQUFBzABhjNodHRwOi8vb2NzcC11YXQuY29ycC5hcHBsZS5jb20vb2NzcDA0LXRlc3R3d2RyY2FlY2MwHQYDVR0OBBYEFAV7nS4mNDLy1gxvOAcCS1hOgY4lMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU1tbVWuX//cJ8NMND3r1odlw2qb4wggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwtdWF0LmNvcnAuYXBwbGUuY29tL2FwcGxld3dkcmNhZWNjLmNybDAOBgNVHQ8BAf8EBAMCAygwTwYJKoZIhvdjZAYgBEIMQDU4MDJEMUM3NzRGMDk2MkY4MTEyNDhFNTM4REUzQkVGNjgwQzc5ODZCQjVCNERDRTBCNTYyNDlGMzdDQkI5NDMwCgYIKoZIzj0EAwIDRwAwRAIgTjtiYjk/BKp3V8Dg6mIlcm5FCOF06zub7Jsr6wCsvKACIH8U114DI5HnmfcNvwM4RXFDPToop4+jjMAPvidipKkg");
-        when(mockApplePayConfig.getPublicCertificate()).thenReturn(publicCertificate);
+        when(mockWorldpayConfig.getApplePayConfig()).thenReturn(mockApplePayConfig);
+        when(mockApplePayConfig.getPrivateKey()).thenReturn(Base64.decode(encodedPrivateKey));
+        when(mockApplePayConfig.getPublicCertificate()).thenReturn(Base64.decode(encodedPublicCertificate));
         applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
     }
 
@@ -82,14 +90,14 @@ public class ApplePayDecrypterTest {
     public void shouldThrowException_whenEphemeralKeyIsInvalid() {
         applePayDecrypter.performDecryptOperation(
                 data,
-                "nope".getBytes()
+                "nope".getBytes(UTF_8)
         );
     }
     
     @Test(expected = InvalidKeyException.class)
     public void shouldThrowException_whenDataIsInvalid() {
         applePayDecrypter.performDecryptOperation(
-                "nope".getBytes(),
+                "nope".getBytes(UTF_8),
                 ephemeralKey
         );
     }

--- a/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
@@ -27,13 +27,13 @@ public class ApplePayDecrypterTest {
     private ApplePayConfig mockApplePayConfig;
     private ObjectMapper objectMapper = new ObjectMapper();
     
-    private final static String ENCODED_PRIVATE_KEY = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy";
+    private static final String ENCODED_PRIVATE_KEY = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy";
     
-    private final static String ENCODED_PUBLIC_CERTIFICATE = "MIIEeTCCBCCgAwIBAgIIUkIKsiYxaKowCgYIKoZIzj0EAwIwgYExOzA5BgNVBAMMMlRlc3QgQXBwbGUgV29ybGR3aWRlIERldmVsb3BlcnMgUmVsYXRpb25zIENBIC0gRUNDMSAwHgYDVQQLDBdDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTYwNzI1MTUyMDM4WhcNMTgwODI0MTUyMDM4WjCBlzErMCkGCgmSJomT8ixkAQEMG21lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzExMC8GA1UEAwwoTWVyY2hhbnQgSUQ6IG1lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzETMBEGA1UECwwKTVlUVThZNURRTTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvyo4ICaDCCAmQwTwYIKwYBBQUHAQEEQzBBMD8GCCsGAQUFBzABhjNodHRwOi8vb2NzcC11YXQuY29ycC5hcHBsZS5jb20vb2NzcDA0LXRlc3R3d2RyY2FlY2MwHQYDVR0OBBYEFAV7nS4mNDLy1gxvOAcCS1hOgY4lMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU1tbVWuX//cJ8NMND3r1odlw2qb4wggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwtdWF0LmNvcnAuYXBwbGUuY29tL2FwcGxld3dkcmNhZWNjLmNybDAOBgNVHQ8BAf8EBAMCAygwTwYJKoZIhvdjZAYgBEIMQDU4MDJEMUM3NzRGMDk2MkY4MTEyNDhFNTM4REUzQkVGNjgwQzc5ODZCQjVCNERDRTBCNTYyNDlGMzdDQkI5NDMwCgYIKoZIzj0EAwIDRwAwRAIgTjtiYjk/BKp3V8Dg6mIlcm5FCOF06zub7Jsr6wCsvKACIH8U114DI5HnmfcNvwM4RXFDPToop4+jjMAPvidipKkg";
+    private static final String ENCODED_PUBLIC_CERTIFICATE = "MIIEeTCCBCCgAwIBAgIIUkIKsiYxaKowCgYIKoZIzj0EAwIwgYExOzA5BgNVBAMMMlRlc3QgQXBwbGUgV29ybGR3aWRlIERldmVsb3BlcnMgUmVsYXRpb25zIENBIC0gRUNDMSAwHgYDVQQLDBdDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTYwNzI1MTUyMDM4WhcNMTgwODI0MTUyMDM4WjCBlzErMCkGCgmSJomT8ixkAQEMG21lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzExMC8GA1UEAwwoTWVyY2hhbnQgSUQ6IG1lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzETMBEGA1UECwwKTVlUVThZNURRTTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvyo4ICaDCCAmQwTwYIKwYBBQUHAQEEQzBBMD8GCCsGAQUFBzABhjNodHRwOi8vb2NzcC11YXQuY29ycC5hcHBsZS5jb20vb2NzcDA0LXRlc3R3d2RyY2FlY2MwHQYDVR0OBBYEFAV7nS4mNDLy1gxvOAcCS1hOgY4lMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU1tbVWuX//cJ8NMND3r1odlw2qb4wggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwtdWF0LmNvcnAuYXBwbGUuY29tL2FwcGxld3dkcmNhZWNjLmNybDAOBgNVHQ8BAf8EBAMCAygwTwYJKoZIhvdjZAYgBEIMQDU4MDJEMUM3NzRGMDk2MkY4MTEyNDhFNTM4REUzQkVGNjgwQzc5ODZCQjVCNERDRTBCNTYyNDlGMzdDQkI5NDMwCgYIKoZIzj0EAwIDRwAwRAIgTjtiYjk/BKp3V8Dg6mIlcm5FCOF06zub7Jsr6wCsvKACIH8U114DI5HnmfcNvwM4RXFDPToop4+jjMAPvidipKkg";
 
-    private final static byte[] DATA = Base64.decode("0cWHZj3Py20Nxh8VrANfcXSFFaaNCJM9HpCPiUhb63GWi7+Aya0BmsKfELoK/Pp+1hvmJzO0DtkdYrtLQRnKRKUMX+KfEsQO3eKLEOaRm12qf1jgXG7HUE1r+BlrK9BC24QzyZkqYVbdTSbE8CTmDuiDSVjQi0fBwxo+MdjsWg+ap6RDlmSXVKXuGS1to5Ae/VDnwBBMuDNYJiJYSR9LWU7eO6HL6ke6+xjXcRhfxexeZ1y9XToTcDrC0M7xM3kAHkTyDV30m63MKdb7cpSV/7DVgj99AX9XrLlVJndAnBLI7jMsOFCTho86U0fJJ40XDklR8X5x43NKL+c2SimUNBMZkiZLygQSUrFD41cKb/7UIyB9c7Sk9UJmTM24FOeVt/RH2cIX+okRB6UzewVGZEFvV/PWbJqaOCWxISMjJc8HAkWa0Q1ARVKTzCS6ZgsPFZcao0Z3/j46kCxN/RYeYG7hfgrtaH8hqnvicac3khhFAU9RbjMZCmGdVzyuaxz/4SKGtDgN22y8sPsiWORi6NM+1As5nHWMgP7dO2ouI3wcuaxHADHfGm5aNQ==");
+    private static final byte[] DATA = Base64.decode("0cWHZj3Py20Nxh8VrANfcXSFFaaNCJM9HpCPiUhb63GWi7+Aya0BmsKfELoK/Pp+1hvmJzO0DtkdYrtLQRnKRKUMX+KfEsQO3eKLEOaRm12qf1jgXG7HUE1r+BlrK9BC24QzyZkqYVbdTSbE8CTmDuiDSVjQi0fBwxo+MdjsWg+ap6RDlmSXVKXuGS1to5Ae/VDnwBBMuDNYJiJYSR9LWU7eO6HL6ke6+xjXcRhfxexeZ1y9XToTcDrC0M7xM3kAHkTyDV30m63MKdb7cpSV/7DVgj99AX9XrLlVJndAnBLI7jMsOFCTho86U0fJJ40XDklR8X5x43NKL+c2SimUNBMZkiZLygQSUrFD41cKb/7UIyB9c7Sk9UJmTM24FOeVt/RH2cIX+okRB6UzewVGZEFvV/PWbJqaOCWxISMjJc8HAkWa0Q1ARVKTzCS6ZgsPFZcao0Z3/j46kCxN/RYeYG7hfgrtaH8hqnvicac3khhFAU9RbjMZCmGdVzyuaxz/4SKGtDgN22y8sPsiWORi6NM+1As5nHWMgP7dO2ouI3wcuaxHADHfGm5aNQ==");
     
-    private final byte[] ephemeralKey = Base64.decode("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl/XAbOgrSCupps/QbIxJ3u4QZ1PlbO5uGDD1zj/JGMoephYSEgw+63gHQHekx3T8duXN3CoYafUpuQlwOeK6/w==");
+    private static final byte[] EPHEMERAL_KEY = Base64.decode("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl/XAbOgrSCupps/QbIxJ3u4QZ1PlbO5uGDD1zj/JGMoephYSEgw+63gHQHekx3T8duXN3CoYafUpuQlwOeK6/w==");
     
     private ApplePayDecrypter applePayDecrypter;
     
@@ -50,7 +50,7 @@ public class ApplePayDecrypterTest {
     public void shouldDecryptData_whenPrivateKeyAndPublicCertificateAreValid() {
         ApplePaymentData applePaymentData = applePayDecrypter.performDecryptOperation(
                 DATA,
-                ephemeralKey
+                EPHEMERAL_KEY
         );
         assertThat(applePaymentData.getApplicationExpirationDate(), is("191031"));
         assertThat(applePaymentData.getApplicationPrimaryAccountNumber(), is("5186009300800808"));
@@ -67,7 +67,7 @@ public class ApplePayDecrypterTest {
         applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
         applePayDecrypter.performDecryptOperation(
                 DATA,
-                ephemeralKey
+                EPHEMERAL_KEY
         );
     }
     
@@ -77,7 +77,7 @@ public class ApplePayDecrypterTest {
         applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
         applePayDecrypter.performDecryptOperation(
                 DATA,
-                ephemeralKey
+                EPHEMERAL_KEY
         );
     }
     
@@ -93,7 +93,7 @@ public class ApplePayDecrypterTest {
     public void shouldThrowException_whenDataIsInvalid() {
         applePayDecrypter.performDecryptOperation(
                 "nope".getBytes(UTF_8),
-                ephemeralKey
+                EPHEMERAL_KEY
         );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
@@ -1,0 +1,96 @@
+package uk.gov.pay.connector.applepay;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ApplePayConfig;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.WorldpayConfig;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplePayDecrypterTest {
+    
+    @Mock
+    private ConnectorConfiguration mockConfig;
+    @Mock
+    private WorldpayConfig mockWorldpayConfig;
+    @Mock
+    private ApplePayConfig mockApplePayConfig;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    
+    private ApplePayDecrypter applePayDecrypter;
+    
+    private final byte[] data = Base64.decode( "0cWHZj3Py20Nxh8VrANfcXSFFaaNCJM9HpCPiUhb63GWi7+Aya0BmsKfELoK/Pp+1hvmJzO0DtkdYrtLQRnKRKUMX+KfEsQO3eKLEOaRm12qf1jgXG7HUE1r+BlrK9BC24QzyZkqYVbdTSbE8CTmDuiDSVjQi0fBwxo+MdjsWg+ap6RDlmSXVKXuGS1to5Ae/VDnwBBMuDNYJiJYSR9LWU7eO6HL6ke6+xjXcRhfxexeZ1y9XToTcDrC0M7xM3kAHkTyDV30m63MKdb7cpSV/7DVgj99AX9XrLlVJndAnBLI7jMsOFCTho86U0fJJ40XDklR8X5x43NKL+c2SimUNBMZkiZLygQSUrFD41cKb/7UIyB9c7Sk9UJmTM24FOeVt/RH2cIX+okRB6UzewVGZEFvV/PWbJqaOCWxISMjJc8HAkWa0Q1ARVKTzCS6ZgsPFZcao0Z3/j46kCxN/RYeYG7hfgrtaH8hqnvicac3khhFAU9RbjMZCmGdVzyuaxz/4SKGtDgN22y8sPsiWORi6NM+1As5nHWMgP7dO2ouI3wcuaxHADHfGm5aNQ==" );
+
+    private final byte[] ephemeralKey = Base64.decode( "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl/XAbOgrSCupps/QbIxJ3u4QZ1PlbO5uGDD1zj/JGMoephYSEgw+63gHQHekx3T8duXN3CoYafUpuQlwOeK6/w==");
+
+    @Before
+    public void setUp() {
+        when(mockConfig.getWorldpayConfig()).thenReturn(mockWorldpayConfig);
+        when(mockWorldpayConfig.getApplePay()).thenReturn(mockApplePayConfig);
+        byte[] privateKey = Base64.decode("MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy");
+        when(mockApplePayConfig.getPrivateKey()).thenReturn(privateKey);
+        byte[] publicCertificate = Base64.decode("MIIEeTCCBCCgAwIBAgIIUkIKsiYxaKowCgYIKoZIzj0EAwIwgYExOzA5BgNVBAMMMlRlc3QgQXBwbGUgV29ybGR3aWRlIERldmVsb3BlcnMgUmVsYXRpb25zIENBIC0gRUNDMSAwHgYDVQQLDBdDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTYwNzI1MTUyMDM4WhcNMTgwODI0MTUyMDM4WjCBlzErMCkGCgmSJomT8ixkAQEMG21lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzExMC8GA1UEAwwoTWVyY2hhbnQgSUQ6IG1lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzETMBEGA1UECwwKTVlUVThZNURRTTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvyo4ICaDCCAmQwTwYIKwYBBQUHAQEEQzBBMD8GCCsGAQUFBzABhjNodHRwOi8vb2NzcC11YXQuY29ycC5hcHBsZS5jb20vb2NzcDA0LXRlc3R3d2RyY2FlY2MwHQYDVR0OBBYEFAV7nS4mNDLy1gxvOAcCS1hOgY4lMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU1tbVWuX//cJ8NMND3r1odlw2qb4wggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwtdWF0LmNvcnAuYXBwbGUuY29tL2FwcGxld3dkcmNhZWNjLmNybDAOBgNVHQ8BAf8EBAMCAygwTwYJKoZIhvdjZAYgBEIMQDU4MDJEMUM3NzRGMDk2MkY4MTEyNDhFNTM4REUzQkVGNjgwQzc5ODZCQjVCNERDRTBCNTYyNDlGMzdDQkI5NDMwCgYIKoZIzj0EAwIDRwAwRAIgTjtiYjk/BKp3V8Dg6mIlcm5FCOF06zub7Jsr6wCsvKACIH8U114DI5HnmfcNvwM4RXFDPToop4+jjMAPvidipKkg");
+        when(mockApplePayConfig.getPublicCertificate()).thenReturn(publicCertificate);
+        applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
+    }
+
+    @Test
+    public void shouldDecryptData_whenPrivateKeyAndPublicCertificateAreValid() {
+        ApplePaymentData applePaymentData = applePayDecrypter.performDecryptOperation(
+                data,
+                ephemeralKey
+        );
+        assertThat(applePaymentData.getApplicationExpirationDate(), is("191031"));
+        assertThat(applePaymentData.getApplicationPrimaryAccountNumber(), is("5186009300800808"));
+        assertThat(applePaymentData.getCurrencyCode(), is("840"));
+        assertThat(applePaymentData.getDeviceManufacturerIdentifier(), is("050110030273"));
+        assertThat(applePaymentData.getPaymentDataType(), is("EMV"));
+        assertThat(applePaymentData.getTransactionAmount(), is("500"));
+        assertThat(applePaymentData.getPaymentData().get("emvData"), is("nyYIM2LtbOmXgn2fEBIBFKUAAAAAAAAAAAAAAAAAAACfNgIAA5UFAAAAAACfJwGAnzQDAQACnzcE0qE2H58CBgAAAAAFAJ8DBgAAAAAAAF8qAghAmgMWCAicAQCEB6AAAAAEEBBaCFGGAJMAgAgIXzQBAF8kAxkQMZ8aAghAggICgA=="));
+    }
+
+    @Test(expected = InvalidKeyException.class)
+    public void shouldThrowException_whenPublicCertificateIsInvalid() {
+        when(mockApplePayConfig.getPublicCertificate()).thenReturn("nope".getBytes());
+        applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
+        applePayDecrypter.performDecryptOperation(
+                data,
+                ephemeralKey
+        );
+    }
+    
+    @Test(expected = InvalidKeyException.class)
+    public void shouldThrowException_whenPrivateKeyIsInvalid() {
+        when(mockApplePayConfig.getPrivateKey()).thenReturn("nope".getBytes());
+        applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
+        applePayDecrypter.performDecryptOperation(
+                data,
+                ephemeralKey
+        );
+    }
+    
+    @Test(expected = InvalidKeyException.class)
+    public void shouldThrowException_whenEphemeralKeyIsInvalid() {
+        applePayDecrypter.performDecryptOperation(
+                data,
+                "nope".getBytes()
+        );
+    }
+    
+    @Test(expected = InvalidKeyException.class)
+    public void shouldThrowException_whenDataIsInvalid() {
+        applePayDecrypter.performDecryptOperation(
+                "nope".getBytes(),
+                ephemeralKey
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
@@ -27,34 +27,29 @@ public class ApplePayDecrypterTest {
     private ApplePayConfig mockApplePayConfig;
     private ObjectMapper objectMapper = new ObjectMapper();
     
+    private final static String ENCODED_PRIVATE_KEY = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy";
     
-    private final String encodedData = "0cWHZj3Py20Nxh8VrANfcXSFFaaNCJM9HpCPiUhb63GWi7+Aya0BmsKfELoK/Pp+1hvmJzO0DtkdYrtLQRnKRKUMX+KfEsQO3eKLEOaRm12qf1jgXG7HUE1r+BlrK9BC24QzyZkqYVbdTSbE8CTmDuiDSVjQi0fBwxo+MdjsWg+ap6RDlmSXVKXuGS1to5Ae/VDnwBBMuDNYJiJYSR9LWU7eO6HL6ke6+xjXcRhfxexeZ1y9XToTcDrC0M7xM3kAHkTyDV30m63MKdb7cpSV/7DVgj99AX9XrLlVJndAnBLI7jMsOFCTho86U0fJJ40XDklR8X5x43NKL+c2SimUNBMZkiZLygQSUrFD41cKb/7UIyB9c7Sk9UJmTM24FOeVt/RH2cIX+okRB6UzewVGZEFvV/PWbJqaOCWxISMjJc8HAkWa0Q1ARVKTzCS6ZgsPFZcao0Z3/j46kCxN/RYeYG7hfgrtaH8hqnvicac3khhFAU9RbjMZCmGdVzyuaxz/4SKGtDgN22y8sPsiWORi6NM+1As5nHWMgP7dO2ouI3wcuaxHADHfGm5aNQ==";
+    private final static String ENCODED_PUBLIC_CERTIFICATE = "MIIEeTCCBCCgAwIBAgIIUkIKsiYxaKowCgYIKoZIzj0EAwIwgYExOzA5BgNVBAMMMlRlc3QgQXBwbGUgV29ybGR3aWRlIERldmVsb3BlcnMgUmVsYXRpb25zIENBIC0gRUNDMSAwHgYDVQQLDBdDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTYwNzI1MTUyMDM4WhcNMTgwODI0MTUyMDM4WjCBlzErMCkGCgmSJomT8ixkAQEMG21lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzExMC8GA1UEAwwoTWVyY2hhbnQgSUQ6IG1lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzETMBEGA1UECwwKTVlUVThZNURRTTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvyo4ICaDCCAmQwTwYIKwYBBQUHAQEEQzBBMD8GCCsGAQUFBzABhjNodHRwOi8vb2NzcC11YXQuY29ycC5hcHBsZS5jb20vb2NzcDA0LXRlc3R3d2RyY2FlY2MwHQYDVR0OBBYEFAV7nS4mNDLy1gxvOAcCS1hOgY4lMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU1tbVWuX//cJ8NMND3r1odlw2qb4wggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwtdWF0LmNvcnAuYXBwbGUuY29tL2FwcGxld3dkcmNhZWNjLmNybDAOBgNVHQ8BAf8EBAMCAygwTwYJKoZIhvdjZAYgBEIMQDU4MDJEMUM3NzRGMDk2MkY4MTEyNDhFNTM4REUzQkVGNjgwQzc5ODZCQjVCNERDRTBCNTYyNDlGMzdDQkI5NDMwCgYIKoZIzj0EAwIDRwAwRAIgTjtiYjk/BKp3V8Dg6mIlcm5FCOF06zub7Jsr6wCsvKACIH8U114DI5HnmfcNvwM4RXFDPToop4+jjMAPvidipKkg";
+
+    private final static byte[] DATA = Base64.decode("0cWHZj3Py20Nxh8VrANfcXSFFaaNCJM9HpCPiUhb63GWi7+Aya0BmsKfELoK/Pp+1hvmJzO0DtkdYrtLQRnKRKUMX+KfEsQO3eKLEOaRm12qf1jgXG7HUE1r+BlrK9BC24QzyZkqYVbdTSbE8CTmDuiDSVjQi0fBwxo+MdjsWg+ap6RDlmSXVKXuGS1to5Ae/VDnwBBMuDNYJiJYSR9LWU7eO6HL6ke6+xjXcRhfxexeZ1y9XToTcDrC0M7xM3kAHkTyDV30m63MKdb7cpSV/7DVgj99AX9XrLlVJndAnBLI7jMsOFCTho86U0fJJ40XDklR8X5x43NKL+c2SimUNBMZkiZLygQSUrFD41cKb/7UIyB9c7Sk9UJmTM24FOeVt/RH2cIX+okRB6UzewVGZEFvV/PWbJqaOCWxISMjJc8HAkWa0Q1ARVKTzCS6ZgsPFZcao0Z3/j46kCxN/RYeYG7hfgrtaH8hqnvicac3khhFAU9RbjMZCmGdVzyuaxz/4SKGtDgN22y8sPsiWORi6NM+1As5nHWMgP7dO2ouI3wcuaxHADHfGm5aNQ==");
     
-    private final String encodedEphemeralKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl/XAbOgrSCupps/QbIxJ3u4QZ1PlbO5uGDD1zj/JGMoephYSEgw+63gHQHekx3T8duXN3CoYafUpuQlwOeK6/w==";
-    
-    private final String encodedPrivateKey = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgjyo3fzxT7j+CFxC7I4B5iVee2FUyn2vfOSjcgp2/g6qhRANCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvy";
-    
-    private final String encodedPublicCertificate = "MIIEeTCCBCCgAwIBAgIIUkIKsiYxaKowCgYIKoZIzj0EAwIwgYExOzA5BgNVBAMMMlRlc3QgQXBwbGUgV29ybGR3aWRlIERldmVsb3BlcnMgUmVsYXRpb25zIENBIC0gRUNDMSAwHgYDVQQLDBdDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTYwNzI1MTUyMDM4WhcNMTgwODI0MTUyMDM4WjCBlzErMCkGCgmSJomT8ixkAQEMG21lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzExMC8GA1UEAwwoTWVyY2hhbnQgSUQ6IG1lcmNoYW50LnJlZHRlYW0ud2Fyc2F3LmxibzETMBEGA1UECwwKTVlUVThZNURRTTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAARdoBFEtnuapXFKw4DYWsW0yV4bavpdWKszkefi19AhlIRE3WSNWSn25W5tZNFjMWtLISBmqANyufx2xP19oRvyo4ICaDCCAmQwTwYIKwYBBQUHAQEEQzBBMD8GCCsGAQUFBzABhjNodHRwOi8vb2NzcC11YXQuY29ycC5hcHBsZS5jb20vb2NzcDA0LXRlc3R3d2RyY2FlY2MwHQYDVR0OBBYEFAV7nS4mNDLy1gxvOAcCS1hOgY4lMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU1tbVWuX//cJ8NMND3r1odlw2qb4wggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMEEGA1UdHwQ6MDgwNqA0oDKGMGh0dHA6Ly9jcmwtdWF0LmNvcnAuYXBwbGUuY29tL2FwcGxld3dkcmNhZWNjLmNybDAOBgNVHQ8BAf8EBAMCAygwTwYJKoZIhvdjZAYgBEIMQDU4MDJEMUM3NzRGMDk2MkY4MTEyNDhFNTM4REUzQkVGNjgwQzc5ODZCQjVCNERDRTBCNTYyNDlGMzdDQkI5NDMwCgYIKoZIzj0EAwIDRwAwRAIgTjtiYjk/BKp3V8Dg6mIlcm5FCOF06zub7Jsr6wCsvKACIH8U114DI5HnmfcNvwM4RXFDPToop4+jjMAPvidipKkg";
+    private final byte[] ephemeralKey = Base64.decode("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEl/XAbOgrSCupps/QbIxJ3u4QZ1PlbO5uGDD1zj/JGMoephYSEgw+63gHQHekx3T8duXN3CoYafUpuQlwOeK6/w==");
     
     private ApplePayDecrypter applePayDecrypter;
     
-    private final byte[] data = Base64.decode(encodedData);
-
-    private final byte[] ephemeralKey = Base64.decode(encodedEphemeralKey);
-
     @Before
     public void setUp() {
         when(mockConfig.getWorldpayConfig()).thenReturn(mockWorldpayConfig);
         when(mockWorldpayConfig.getApplePayConfig()).thenReturn(mockApplePayConfig);
-        when(mockApplePayConfig.getPrivateKey()).thenReturn(Base64.decode(encodedPrivateKey));
-        when(mockApplePayConfig.getPublicCertificate()).thenReturn(Base64.decode(encodedPublicCertificate));
+        when(mockApplePayConfig.getPrivateKey()).thenReturn(Base64.decode(ENCODED_PRIVATE_KEY));
+        when(mockApplePayConfig.getPublicCertificate()).thenReturn(Base64.decode(ENCODED_PUBLIC_CERTIFICATE));
         applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
     }
 
     @Test
     public void shouldDecryptData_whenPrivateKeyAndPublicCertificateAreValid() {
         ApplePaymentData applePaymentData = applePayDecrypter.performDecryptOperation(
-                data,
+                DATA,
                 ephemeralKey
         );
         assertThat(applePaymentData.getApplicationExpirationDate(), is("191031"));
@@ -68,20 +63,20 @@ public class ApplePayDecrypterTest {
 
     @Test(expected = InvalidKeyException.class)
     public void shouldThrowException_whenPublicCertificateIsInvalid() {
-        when(mockApplePayConfig.getPublicCertificate()).thenReturn("nope".getBytes());
+        when(mockApplePayConfig.getPublicCertificate()).thenReturn("nope".getBytes(UTF_8));
         applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
         applePayDecrypter.performDecryptOperation(
-                data,
+                DATA,
                 ephemeralKey
         );
     }
     
     @Test(expected = InvalidKeyException.class)
     public void shouldThrowException_whenPrivateKeyIsInvalid() {
-        when(mockApplePayConfig.getPrivateKey()).thenReturn("nope".getBytes());
+        when(mockApplePayConfig.getPrivateKey()).thenReturn("nope".getBytes(UTF_8));
         applePayDecrypter = new ApplePayDecrypter(mockConfig, objectMapper);
         applePayDecrypter.performDecryptOperation(
-                data,
+                DATA,
                 ephemeralKey
         );
     }
@@ -89,7 +84,7 @@ public class ApplePayDecrypterTest {
     @Test(expected = InvalidKeyException.class)
     public void shouldThrowException_whenEphemeralKeyIsInvalid() {
         applePayDecrypter.performDecryptOperation(
-                data,
+                DATA,
                 "nope".getBytes(UTF_8)
         );
     }

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -26,6 +26,9 @@ worldpay:
   secureNotificationEnabled: true
   notificationDomain: "amazonaws.com"
   credentials: ['username','password','merchant_id']
+  applePay:
+    privateKey: some-private-key
+    publicCertificate: some-public-certificate
 
 smartpay:
   urls:


### PR DESCRIPTION
## WHAT
A first stab at integrating Apple's suggested implementation of a decrypter. There are a few things which will be improved, like `private Map<String, String> paymentData;` (still unsure as to what values contained in the map we are actually going to use, so will be more strongly typed as other stories progress), and exception throwing/handling.

