### PR TITLE
PP-4304 Replace `unstable` Google class

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -5,7 +5,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Resources;
 import fj.data.Either;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
@@ -42,10 +41,8 @@ import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.Charset;
 
-import static com.google.common.io.Resources.getResource;
+import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -289,8 +286,7 @@ public class SmartpayPaymentProviderTest {
     }
 
     private String notificationPayloadForTransaction(String originalReference, String pspReference, String merchantReference, String fileName) throws IOException {
-        URL resource = getResource("templates/smartpay/" + fileName + ".json");
-        return Resources.toString(resource, Charset.defaultCharset())
+        return fixture("templates/smartpay/" + fileName + ".json")
                 .replace("{{originalReference}}", originalReference)
                 .replace("{{pspReference}}", pspReference)
                 .replace("{{merchantReference}}", merchantReference);

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthITest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.it.resources.smartpay;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Resources;
 import com.jayway.restassured.response.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
@@ -14,13 +13,11 @@ import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.common.io.Resources.getResource;
 import static com.jayway.restassured.RestAssured.given;
+import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -148,7 +145,7 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthITest extends Ch
     }
 
     @Test
-    public void shouldHandleMultipleSmartpayNotifications() throws Exception {
+    public void shouldHandleMultipleSmartpayNotifications() {
 
         String transactionId = randomId();
         String transactionId2 = randomId();
@@ -167,7 +164,7 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthITest extends Ch
     }
 
     @Test
-    public void shouldKeepLatestSmartpayStatusFromNotifications() throws Exception {
+    public void shouldKeepLatestSmartpayStatusFromNotifications() {
         String transactionId = randomId();
         String chargeId = createNewChargeWith(CAPTURE_SUBMITTED, transactionId);
 
@@ -209,7 +206,7 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthITest extends Ch
                 .statusCode(415);
     }
 
-    private Response notifyConnector(String payload) throws IOException {
+    private Response notifyConnector(String payload) {
         return given()
                 .port(testContext.getPort())
                 .auth().basic("bob", "bobsbigsecret")
@@ -218,7 +215,7 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthITest extends Ch
                 .post(NOTIFICATION_PATH);
     }
 
-    private Response notifyConnectorWithCredentials(String payload, String username, String password) throws IOException {
+    private Response notifyConnectorWithCredentials(String payload, String username, String password) {
         return given()
                 .port(testContext.getPort())
                 .auth().basic(username, password)
@@ -228,14 +225,13 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthITest extends Ch
     }
 
     private String notificationPayloadForTransaction(String merchantReference, String originalReference, String pspReference, String fileName) throws IOException {
-        URL resource = getResource("templates/smartpay/" + fileName + ".json");
-        return Resources.toString(resource, Charset.defaultCharset())
+        return fixture("templates/smartpay/" + fileName + ".json")
                 .replace("{{merchantReference}}", merchantReference)
                 .replace("{{originalReference}}", originalReference)
                 .replace("{{pspReference}}", pspReference);
     }
 
-    private String multipleNotifications(String transactionId, String transactionId2) throws IOException {
+    private String multipleNotifications(String transactionId, String transactionId2) {
         return TestTemplateResourceLoader.load(SMARTPAY_MULTIPLE_NOTIFICATIONS)
                 .replace("{{pspReference1}}", transactionId)
                 .replace("{{pspReference2}}", transactionId2);

--- a/src/test/java/uk/gov/pay/connector/it/util/XMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/XMLUnmarshallerTest.java
@@ -1,15 +1,14 @@
 package uk.gov.pay.connector.it.util;
 
-import com.google.common.io.Resources;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayCancelResponse;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
+import uk.gov.pay.connector.gateway.util.XMLUnmarshallerException;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayCancelResponse;
 
-import java.nio.charset.Charset;
-
+import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -31,9 +30,9 @@ public class XMLUnmarshallerTest {
     }
 
     @Test
-    public void shouldUnmarshallXmlIgnoringDTD() throws Exception {
+    public void shouldUnmarshallXmlIgnoringDTD() throws XMLUnmarshallerException {
 
-        String successPayload = Resources.toString(Resources.getResource("templates/it/worldpay-cancel-notfication-example-it-dtd-validation-disabled.xml"), Charset.defaultCharset())
+        String successPayload = fixture("templates/it/worldpay-cancel-notfication-example-it-dtd-validation-disabled.xml")
                 .replace("{{port}}", String.valueOf(MOCKSERVER_PORT));
 
         mockServer

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -1,9 +1,6 @@
 package uk.gov.pay.connector.util;
 
-import com.google.common.io.Resources;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
+import static io.dropwizard.testing.FixtureHelpers.fixture;
 
 public class TestTemplateResourceLoader {
     private static final String TEMPLATE_BASE_NAME = "templates";
@@ -13,9 +10,9 @@ public class TestTemplateResourceLoader {
     private static final String WORLDPAY_BASE_NAME = TEMPLATE_BASE_NAME + "/worldpay";
 
     public static final String WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-success-response.xml";
-    public static final String WORLDPAY_AUTHORISATION_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-error-response.xml";
+    static final String WORLDPAY_AUTHORISATION_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String WORLDPAY_AUTHORISATION_FAILED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-failed-response.xml";
-    public static final String WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-cancelled-response.xml";
+    static final String WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-cancelled-response.xml";
     public static final String WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS = WORLDPAY_BASE_NAME + "/special-char-valid-authorise-worldpay-request-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-min-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-excluding-3ds.xml";
@@ -49,12 +46,12 @@ public class TestTemplateResourceLoader {
     public static final String SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-success-response.xml";
     public static final String SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-3ds-required-response.xml";
     public static final String SMARTPAY_AUTHORISATION_FAILED_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-failed-response.xml";
-    public static final String SMARTPAY_AUTHORISATION_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-error-response.xml";
+    static final String SMARTPAY_AUTHORISATION_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-minimal.xml";
 
-    public static final String SMARTPAY_CANCEL_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/cancel-error-response.xml";
+    static final String SMARTPAY_CANCEL_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/cancel-error-response.xml";
     public static final String SMARTPAY_CANCEL_SUCCESS_RESPONSE = SMARTPAY_BASE_NAME + "/cancel-success-response.xml";
     public static final String SMARTPAY_VALID_CANCEL_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/valid-cancel-smartpay-request.xml";
 
@@ -75,9 +72,7 @@ public class TestTemplateResourceLoader {
     public static final String SMARTPAY_VALID_REFUND_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/valid-refund-smartpay-request.xml";
 
     // EPDQ
-
-    public static final String EPDQ_BASE_NAME = TEMPLATE_BASE_NAME + "/epdq";
-
+    private static final String EPDQ_BASE_NAME = TEMPLATE_BASE_NAME + "/epdq";
     public static final String EPDQ_AUTHORISATION_SUCCESS_RESPONSE = EPDQ_BASE_NAME + "/authorisation-success-response.xml";
     public static final String EPDQ_AUTHORISATION_SUCCESS_3D_RESPONSE = EPDQ_BASE_NAME + "/authorisation-success-3d-response.xml";
     public static final String EPDQ_AUTHORISATION_ERROR_RESPONSE = EPDQ_BASE_NAME + "/authorisation-error-response.xml";
@@ -97,7 +92,7 @@ public class TestTemplateResourceLoader {
 
     public static final String EPDQ_CANCEL_REQUEST = EPDQ_BASE_NAME + "/cancel-request.txt";
     public static final String EPDQ_CANCEL_SUCCESS_RESPONSE = EPDQ_BASE_NAME + "/cancel-success-response.xml";
-    public static final String EPDQ_CANCEL_WAITING_RESPONSE = EPDQ_BASE_NAME + "/cancel-waiting-response.xml";
+    static final String EPDQ_CANCEL_WAITING_RESPONSE = EPDQ_BASE_NAME + "/cancel-waiting-response.xml";
     public static final String EPDQ_CANCEL_ERROR_RESPONSE = EPDQ_BASE_NAME + "/cancel-error-response.xml";
 
     public static final String EPDQ_REFUND_REQUEST = EPDQ_BASE_NAME + "/refund-request.txt";
@@ -108,12 +103,8 @@ public class TestTemplateResourceLoader {
 
     public static final String EPDQ_NOTIFICATION_TEMPLATE = EPDQ_BASE_NAME + "/notification-template.txt";
 
-    static public String load(String location) {
-        try {
-            return Resources.toString(Resources.getResource(location), Charset.defaultCharset());
-        } catch (IOException e) {
-            throw new RuntimeException("Could not load template", e);
-        }
+    public static String load(String location) {
+        return fixture(location);
     }
 
 }


### PR DESCRIPTION
## WHAT
- Replaced `Resources` from Google's library that is marked as `unstable` with Dropwizard's built in `fixture`.
Under the hoods, `fixture` is implemented using `Resources`, but it makes easier to be consistent and use the
recommended way. Also we don't have to handle exceptions thrown by `Resource` every time we use it.




