### PR TITLE
PP-4340 Refactor CardAuthoriseService and Charge locking

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -75,6 +75,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_ABORTED, "");
         graph.putEdgeValue(ENTERING_CARD_DETAILS, USER_CANCELLED, "user clicked cancel");
         graph.putEdgeValue(ENTERING_CARD_DETAILS, SYSTEM_CANCELLED, "");
+        graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_ABORTED, "");
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_SUCCESS, "Gateway response: AUTHORISED");
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_REJECTED, "Gateway response: REJECTED");
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_ERROR, "Gateway error");

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/model/OperationType.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/model/OperationType.java
@@ -1,18 +1,32 @@
 package uk.gov.pay.connector.paymentprocessor.model;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READY;
+
 public enum OperationType {
-    CAPTURE("Capture"),
-    AUTHORISATION("Authorisation"),
-    AUTHORISATION_3DS("3D Secure Response Authorisation"),
-    CANCELLATION("Cancellation");
+    
+    CAPTURE("Capture", CAPTURE_READY),
+    AUTHORISATION("Authorisation", AUTHORISATION_READY),
+    AUTHORISATION_3DS("3D Secure Response Authorisation", AUTHORISATION_3DS_READY),
+    CANCELLATION("Cancellation", null);
 
     private String value;
+    private ChargeStatus lockingStatus;
 
-    OperationType(String value) {
+    OperationType(String value, ChargeStatus lockingStatus) {
         this.value = value;
+        this.lockingStatus = lockingStatus;
     }
 
     public String getValue() {
         return value;
     }
+
+    public ChargeStatus getLockingStatus() {
+        return lockingStatus;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
@@ -17,11 +16,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
-import java.util.List;
 import java.util.Optional;
-
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 
 public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3dsDetails> {
 
@@ -42,9 +37,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
 
     @Transactional
     public ChargeEntity preOperation(String chargeId, Auth3dsDetails auth3DsDetails) {
-        return chargeDao.findByExternalId(chargeId)
-                .map(chargeEntity -> chargeService.lockChargeForProcessing(chargeEntity, OperationType.AUTHORISATION_3DS, getLegalStates(), AUTHORISATION_3DS_READY))
-                .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
+        return chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION_3DS);
     }
 
     @Transactional
@@ -73,10 +66,4 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
 
-    @Override
-    protected List<ChargeStatus> getLegalStates() {
-        return ImmutableList.of(
-                AUTHORISATION_3DS_REQUIRED
-        );
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -94,9 +94,7 @@ public class CardCaptureService implements TransactionalGatewayOperation<BaseCap
     @Transactional
     @Override
     public ChargeEntity preOperation(String chargeId) {
-        return chargeDao.findByExternalId(chargeId)
-                .map(chargeEntity -> chargeService.lockChargeForProcessing(chargeEntity, OperationType.CAPTURE, LEGAL_STATUSES, CAPTURE_READY))
-                .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
+        return chargeService.lockChargeForProcessing(chargeId, OperationType.CAPTURE);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthoriseResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthoriseResourceITest.java
@@ -236,7 +236,7 @@ public class CardAuthoriseResourceITest extends ChargingITestBase {
     @Test
     public void shouldReturnAuthError_IfChargeExpired() {
         String chargeId = createNewChargeWithNoTransactionId(EXPIRED);
-        authoriseAndVerifyFor(chargeId, validCardDetails, format("Authorisation for charge failed as already expired, %s", chargeId), 400);
+        authoriseAndVerifyFor(chargeId, validCardDetails, format("Charge not in correct state to be processed, %s", chargeId), 400);
         assertFrontendChargeStatusIs(chargeId, EXPIRED.getValue());
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -249,27 +249,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
-
-    @Test(expected = ConflictRuntimeException.class)
-    public void shouldThrowAConflictRuntimeExceptionWhenOptimisticExceptionThrownAtChargeReload() throws Exception {
-
-        /**
-         * FIXME (PP-2626)
-         * This is not going to be thrown from this method, but just to test preOp throwing
-         * OptimisticLockException when commit the transaction. We won't do merge in pre-op
-         * The related code won't be removed until we know is not an issue doing it so, logging
-         * will be in place since there are not evidence (through any test or current logging)
-         * that is in reality a subject of a real scenario.
-         */
-
-        doThrow(OptimisticLockException.class).when(mockedChargeDao).findByExternalId(charge.getExternalId());
-        setupMockExecutorServiceMock();
-
-        card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
-        verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
-    }
-
-    @Test(expected = ChargeExpiredRuntimeException.class)
+    
+    @Test(expected = IllegalStateRuntimeException.class)
     public void shouldThrowChargeExpiredRuntimeExceptionWhenChargeExpired() {
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.EXPIRED);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -336,7 +336,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         try {
             cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
             fail("Expected test to fail with ConflictRuntimeException due to configuration conflicting in 3ds requirements");
-        } catch (ConflictRuntimeException e) {
+        } catch (IllegalStateRuntimeException e) {
             assertThat(charge.getStatus(), is(AUTHORISATION_ABORTED.toString()));
             verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
         }
@@ -530,28 +530,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         assertThat(response.isFailed(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
-    }
-
-    @Test(expected = ConflictRuntimeException.class)
-    public void doAuthorise_shouldThrowAConflictRuntimeException_whenOptimisticLockExceptionIsThrownInPreAuthorise() {
-
-        providerWillAuthorise();
-
-        /**
-         * FIXME (PP-2626)
-         * This is not going to be thrown from this method, but just to test preOp throwing
-         * OptimisticLockException when commit the transaction. We won't do merge in pre-op
-         * The related code won't be removed until we know is not an issue doing it so, logging
-         * will be in place since there are not evidence (through any test or current logging)
-         * that is in reality a subject of a real scenario.
-         */
-
-        doThrow(new OptimisticLockException())
-                .when(mockedChargeDao).findByExternalId(charge.getExternalId());
-
-        cardAuthorisationService.doAuthorise(charge.getExternalId(), AuthUtils.aValidAuthorisationDetails());
-
-        verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
     private void providerWillRespondToAuthoriseWith(GatewayResponse value) {


### PR DESCRIPTION
# WHAT
PP-4340 Refactor Authorise - PreOperation & Locking
Further refactoring for CardAuthoriseService and related methods. Changes include :

**ChargeService.lockChargeForProcessing**
- Removed method params - `lockingStatus,legalStatuses` as not required to be passed by payment processing functions
- Enhanced OperationType enum to derive lockingStatus based on operation
- Work around exceptions - Retained only the exceptions required and updated/removed relevant tests

**CardAuthService.preOperation**
- Moved Dao operation to ChargeService
- Breakdown into multiple methods

 @mrlumbu @IreneLau-GDS @kbottla 