### PR TITLE
PP-4340 Make timeout test faster

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
@@ -19,7 +19,8 @@ public class GatewaySocketReadTimeoutITest extends BaseGatewayITest {
 
     @Rule
     public GuiceAppWithPostgresRule app = new GuiceAppWithPostgresRule(
-            config("smartpay.urls.test", "http://localhost:" + port + "/pal/servlet/soap/Payment"));
+            config("smartpay.urls.test", "http://localhost:" + port + "/pal/servlet/soap/Payment"),
+            config("customJerseyClient.readTimeout", "5ms"));
 
     @Before
     public void setUp() {

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayStub.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayStub.java
@@ -98,6 +98,6 @@ public class GatewayStub {
     }
 
     public void respondWithTimeoutWhenCapture() {
-        respondWithStatusCodeAndPayloadWhenCapture(OK_200, CAPTURE_SUCCESS_PAYLOAD, 100000);
+        respondWithStatusCodeAndPayloadWhenCapture(OK_200, CAPTURE_SUCCESS_PAYLOAD, 10);
     }
 }


### PR DESCRIPTION
Previously we checked the capture timeout behaviour using
the jersey client configured to timeout after 90000ms, then
configured the stub to timeout after 100000ms.
This commit overrides the timeout to be 5ms, and the stub
timeout to be 10ms, saving us 99990ms \o/