### PR TITLE
[WIP] PP-4341 Separate authorise interface

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -10,9 +10,12 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
 import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
 import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
 import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
+import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
@@ -38,9 +41,11 @@ public class ConnectorModule extends AbstractModule {
         bind(Environment.class).toInstance(environment);
         bind(CardExecutorService.class).in(Singleton.class);
         bind(PaymentProviders.class).in(Singleton.class);
-        bind(EntityBuilder.class);
-        bind(HashUtil.class);
-        bind(RequestValidator.class);
+        bind(EpdqPaymentProvider.class).in(Singleton.class);
+        bind(SmartpayPaymentProvider.class).in(Singleton.class);
+        bind(WorldpayPaymentProvider.class).in(Singleton.class);
+        bind(SandboxPaymentProvider.class).in(Singleton.class);
+        
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
 
         install(jpaModule(configuration));
@@ -90,10 +95,5 @@ public class ConnectorModule extends AbstractModule {
     @Provides
     public SignatureGenerator signatureGenerator() {
         return new EpdqSha512SignatureGenerator();
-    }
-    
-    @Provides
-    public SandboxPaymentProvider sandboxPaymentProvider() {
-        return new SandboxPaymentProvider();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/AuthorisationProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/AuthorisationProvider.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.connector.gateway;
+
+import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import java.util.Optional;
+
+public interface AuthorisationProvider<T extends BaseAuthoriseResponse> {
+    PaymentGatewayName getPaymentGatewayName();
+    
+    Optional<String> generateTransactionId();
+
+    GatewayResponse<T> authorise(AuthorisationGatewayRequest request);
+
+    GatewayResponse<T> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/AuthorisationProviders.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/AuthorisationProviders.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.gateway;
+
+import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
+import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
+
+import javax.inject.Inject;
+import java.util.Map;
+
+import static jersey.repackaged.com.google.common.collect.Maps.newHashMap;
+
+public class AuthorisationProviders {
+    private final Map<PaymentGatewayName, AuthorisationProvider> authorisationProviders = newHashMap();
+
+    @Inject
+    public AuthorisationProviders(WorldpayPaymentProvider worldpayPaymentProvider,
+                            EpdqPaymentProvider epdqPaymentProvider,
+                            SmartpayPaymentProvider smartpayPaymentProvider,
+                            SandboxPaymentProvider sandboxPaymentProvider) {
+        this.authorisationProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
+        this.authorisationProviders.put(PaymentGatewayName.SMARTPAY, smartpayPaymentProvider);
+        this.authorisationProviders.put(PaymentGatewayName.SANDBOX, sandboxPaymentProvider);
+        this.authorisationProviders.put(PaymentGatewayName.EPDQ, epdqPaymentProvider);
+    }
+
+    public AuthorisationProvider<BaseAuthoriseResponse> byName(PaymentGatewayName gateway) {
+        return authorisationProviders.get(gateway);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -3,8 +3,6 @@ package uk.gov.pay.connector.gateway;
 import fj.data.Either;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
@@ -14,20 +12,12 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 
-import java.util.Optional;
-
 public interface PaymentProvider<T extends BaseResponse, R> {
 
     PaymentGatewayName getPaymentGatewayName();
 
     StatusMapper getStatusMapper();
-
-    Optional<String> generateTransactionId();
-
-    GatewayResponse<T> authorise(AuthorisationGatewayRequest request);
-
-    GatewayResponse<T> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
-
+    
     GatewayResponse<T> capture(CaptureGatewayRequest request);
 
     GatewayResponse<T> refund(RefundGatewayRequest request);

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.AuthorisationProvider;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -41,10 +42,8 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static fj.data.Either.left;
-import static fj.data.Either.reduce;
 import static fj.data.Either.right;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
@@ -66,7 +65,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 
-public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String> {
+public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String>, AuthorisationProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EpdqPaymentProvider.class);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.sandbox;
 import fj.data.Either;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.AuthorisationProvider;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
@@ -32,7 +33,7 @@ import static java.util.UUID.randomUUID;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
-public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, String> {
+public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, String>, AuthorisationProvider {
 
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.AuthorisationProvider;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -39,7 +40,7 @@ import static fj.data.Either.right;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
-public class SmartpayPaymentProvider implements PaymentProvider<BaseResponse, Pair<String, Boolean>> {
+public class SmartpayPaymentProvider implements PaymentProvider<BaseResponse, Pair<String, Boolean>>, AuthorisationProvider {
 
     private final ObjectMapper objectMapper;
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -7,6 +7,7 @@ import org.joda.time.DateTimeZone;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.AuthorisationProvider;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -49,7 +50,7 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
-public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, String> {
+public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, String>, AuthorisationProvider {
 
     public static final String WORLDPAY_MACHINE_COOKIE_NAME = "machine";
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -8,7 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
-import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.AuthorisationProviders;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -23,7 +23,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
     @Inject
     public Card3dsResponseAuthService(ChargeDao chargeDao,
                                       ChargeEventDao chargeEventDao,
-                                      PaymentProviders providers,
+                                      AuthorisationProviders providers,
                                       CardExecutorService cardExecutorService,
                                       ChargeService chargeService,
                                       Environment environment) {
@@ -32,7 +32,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity chargeEntity, Auth3dsDetails auth3DsDetails) {
-        return getPaymentProviderFor(chargeEntity)
+        return getAuthorisationProviderFor(chargeEntity)
                 .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(chargeEntity, auth3DsDetails));
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -11,8 +11,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.gateway.PaymentProvider;
-import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.AuthorisationProvider;
+import uk.gov.pay.connector.gateway.AuthorisationProviders;
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.gateway.model.AuthorisationDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
@@ -31,19 +31,17 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 
 public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CardAuthoriseBaseService.class);
-
     private final CardExecutorService cardExecutorService;
 
     protected final ChargeService chargeService;
     protected final ChargeDao chargeDao;
     protected final ChargeEventDao chargeEventDao;
-    private final PaymentProviders providers;
+    private final AuthorisationProviders providers;
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected MetricRegistry metricRegistry;
 
-    public CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao,
-                                    PaymentProviders providers,
+    CardAuthoriseBaseService(ChargeDao chargeDao, ChargeEventDao chargeEventDao,
+                                    AuthorisationProviders providers,
                                     CardExecutorService cardExecutorService,
                                     ChargeService chargeService,
                                     Environment environment) {
@@ -81,7 +79,7 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
 
     protected abstract GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, T gatewayAuthRequest);
 
-    protected ChargeStatus determineChargeStatus(Optional<BaseAuthoriseResponse> baseResponse,
+    ChargeStatus determineChargeStatus(Optional<BaseAuthoriseResponse> baseResponse,
                                                  Optional<GatewayError> gatewayError) {
 
         return baseResponse
@@ -92,7 +90,7 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
                         .orElse(ChargeStatus.AUTHORISATION_ERROR));
     }
 
-    protected PaymentProvider<BaseAuthoriseResponse, ?> getPaymentProviderFor(ChargeEntity chargeEntity) {
+    AuthorisationProvider<BaseAuthoriseResponse> getAuthorisationProviderFor(ChargeEntity chargeEntity) {
         return providers.byName(chargeEntity.getPaymentGatewayName());
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -13,7 +13,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
-import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.AuthorisationProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -36,7 +36,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
     public CardAuthoriseService(ChargeDao chargeDao,
                                 ChargeEventDao chargeEventDao,
                                 CardTypeDao cardTypeDao,
-                                PaymentProviders providers,
+                                AuthorisationProviders providers,
                                 CardExecutorService cardExecutorService,
                                 ChargeService chargeService,
                                 Environment environment) {
@@ -60,7 +60,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
         ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
         ensureCardBrandGateway3DSCompatibility(charge, authCardDetails.getCardBrand());
         getCorporateCardSurchargeFor(authCardDetails, charge).ifPresent(charge::setCorporateSurcharge);
-        getPaymentProviderFor(charge).generateTransactionId().ifPresent(charge::setGatewayTransactionId);
+        getAuthorisationProviderFor(charge).generateTransactionId().ifPresent(charge::setGatewayTransactionId);
         return charge;
     }
 
@@ -77,7 +77,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
-        return getPaymentProviderFor(chargeEntity)
+        return getAuthorisationProviderFor(chargeEntity)
                 .authorise(AuthorisationGatewayRequest.valueOf(chargeEntity, authCardDetails));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -19,9 +19,7 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
-import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
 import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
@@ -80,7 +78,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldAuthoriseSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        EpdqPaymentProvider paymentProvider = getEpdqPaymentProvider();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -89,7 +87,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldAuthoriseWith3dsOnSuccessfully() {
         setUpFor3dsAndCheckThatEpdqIsUp();
-        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        EpdqPaymentProvider paymentProvider = getEpdqPaymentProvider();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -99,7 +97,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldCheckAuthorisationStatusSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        EpdqPaymentProvider paymentProvider = getEpdqPaymentProvider();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -113,7 +111,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldAuthoriseSuccessfullyWhenCardholderNameContainsRightSingleQuotationMark() {
         setUpAndCheckThatEpdqIsUp();
-        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        EpdqPaymentProvider paymentProvider = getEpdqPaymentProvider();
         String cardholderName = "John O’Connor"; // That’s a U+2019 RIGHT SINGLE QUOTATION MARK, not a U+0027 APOSTROPHE
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity, cardholderName);
         GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
@@ -123,7 +121,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldCaptureSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        EpdqPaymentProvider paymentProvider = getEpdqPaymentProvider();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -140,7 +138,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldCancelSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        EpdqPaymentProvider paymentProvider = getEpdqPaymentProvider();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -157,7 +155,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldRefundSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        PaymentProvider paymentProvider = getEpdqPaymentProvider();
+        EpdqPaymentProvider paymentProvider = getEpdqPaymentProvider();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -175,7 +173,7 @@ public class EpdqPaymentProviderTest {
         assertThat(refundResponse.isSuccessful(), is(true));
     }
 
-    private PaymentProvider getEpdqPaymentProvider() {
+    private EpdqPaymentProvider getEpdqPaymentProvider() {
         Client client = TestClientFactory.createJerseyClient();
         GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
                 EpdqPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
@@ -191,7 +189,7 @@ public class EpdqPaymentProviderTest {
         
         return new EpdqPaymentProvider(configuration, gatewayClientFactory, environment, mock(SignatureGenerator.class));
     }
-
+    
     private static AuthorisationGatewayRequest buildAuthorisationRequest(ChargeEntity chargeEntity) {
         return buildAuthorisationRequest(chargeEntity, "Mr. Payment");
     }


### PR DESCRIPTION
In order to make payment providers more flexible, this
commit extracts an `AuthorisationProvider` interface from
the rather sprawling `PaymentProvider` interface. This allows
easier evolution of the authorisation path independently of
other paths.