### PR TITLE
PP-4352: Refactor out Capture logic ready for Stripe Integration

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.gateway;
 
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
-public interface CaptureHandler {
+public interface CaptureHandler<T extends BaseCaptureResponse> {
 
-    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request);
+    public GatewayResponse<T> capture(CaptureGatewayRequest request);
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.gateway;
+
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+public interface CaptureHandler {
+
+    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request);
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
@@ -6,6 +6,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 public interface CaptureHandler<T extends BaseCaptureResponse> {
 
-    public GatewayResponse<T> capture(CaptureGatewayRequest request);
+    GatewayResponse<T> capture(CaptureGatewayRequest request);
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
@@ -6,10 +6,7 @@ import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation.Builder;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiFunction;
-
-import static java.util.Optional.empty;
 
 public class GatewayClientFactory {
 
@@ -32,10 +29,10 @@ public class GatewayClientFactory {
 
     public GatewayClient createGatewayClient(PaymentGatewayName gateway,
                                              Map<String, String> gatewayUrlMap, 
-                                             BiFunction<GatewayOrder, Builder, Builder> sessionIdentier,
+                                             BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier,
                                              MetricRegistry metricRegistry)
     {
         Client client = clientFactory.createWithDropwizardClient(gateway, metricRegistry);
-        return new GatewayClient(client, gatewayUrlMap, sessionIdentier, metricRegistry);
+        return new GatewayClient(client, gatewayUrlMap, sessionIdentifier, metricRegistry);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -6,7 +6,6 @@ import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -29,8 +28,6 @@ public interface PaymentProvider<T extends BaseResponse, R> {
     GatewayResponse<T> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
     
     CaptureHandler getCaptureHandler();
-
-    GatewayResponse<T> capture(CaptureGatewayRequest request);
 
     GatewayResponse<T> refund(RefundGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -27,6 +27,8 @@ public interface PaymentProvider<T extends BaseResponse, R> {
     GatewayResponse<T> authorise(AuthorisationGatewayRequest request);
 
     GatewayResponse<T> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
+    
+    CaptureHandler getCaptureHandler();
 
     GatewayResponse<T> capture(CaptureGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -7,7 +7,6 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 
@@ -27,7 +26,7 @@ public class EpdqCaptureHandler implements CaptureHandler {
     }
 
     @Override
-    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
+    public GatewayResponse<EpdqCaptureResponse> capture(CaptureGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCaptureOrder(request));
         return GatewayResponseGenerator.getEpdqGatewayResponse(client, response, EpdqCaptureResponse.class);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import fj.data.Either;
+import uk.gov.pay.connector.gateway.CaptureHandler;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
+
+import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqCaptureOrderRequestBuilder;
+import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_MAINTENANCE_ORDER;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+
+public class EpdqCaptureHandler implements CaptureHandler {
+
+    private final GatewayClient client;
+
+    public EpdqCaptureHandler(GatewayClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCaptureOrder(request));
+        return GatewayResponseGenerator.getEpdqGatewayResponse(client, response, EpdqCaptureResponse.class);
+    }
+
+    private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
+        return anEpdqCaptureOrderRequestBuilder()
+                .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
+                .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
+                .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
+                        CREDENTIALS_SHA_IN_PASSPHRASE))
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withTransactionId(request.getTransactionId())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -17,7 +18,6 @@ import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCancelResponse;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
@@ -41,10 +42,8 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static fj.data.Either.left;
-import static fj.data.Either.reduce;
 import static fj.data.Either.right;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
@@ -57,7 +56,6 @@ import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.SHASIGN_KEY;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdq3DsAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqCancelOrderRequestBuilder;
-import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqCaptureOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqQueryOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqRefundOrderRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -93,6 +91,8 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
     private final GatewayClient refundClient;
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 
+    private final EpdqCaptureHandler epdqCaptureHandler;
+
     @Inject
     public EpdqPaymentProvider(ConnectorConfiguration configuration,
                                GatewayClientFactory gatewayClientFactory,
@@ -106,6 +106,8 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
         this.frontendUrl = configuration.getLinks().getFrontendUrl();
         this.metricRegistry = environment.metrics();
         this.externalRefundAvailabilityCalculator = new EpdqExternalRefundAvailabilityCalculator();
+
+        epdqCaptureHandler = new EpdqCaptureHandler(captureClient);
     }
 
     @Override
@@ -121,45 +123,30 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
     @Override
     public GatewayResponse authorise(AuthorisationGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_NEW_ORDER, request.getGatewayAccount(), buildAuthoriseOrder(request, frontendUrl));
-        return getGatewayResponse(response, EpdqAuthorisationResponse.class);
-    }
-
-    private GatewayResponse<BaseResponse> getGatewayResponse(Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
-        if (response.isLeft()) {
-            return GatewayResponse.with(response.left().value());
-        } else {
-            GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
-            authoriseClient.unmarshallResponse(response.right().value(), responseClass)
-                    .bimap(
-                            responseBuilder::withGatewayError,
-                            responseBuilder::withResponse
-                    );
-            return responseBuilder.build();
-        }
+        return GatewayResponseGenerator.getEpdqGatewayResponse(authoriseClient, response, EpdqAuthorisationResponse.class);
     }
 
     @Override
     public GatewayResponse capture(CaptureGatewayRequest request) {
-        Either<GatewayError, GatewayClient.Response> response = captureClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCaptureOrder(request));
-        return getGatewayResponse(response, EpdqCaptureResponse.class);
+        return getCaptureHandler().capture(request);
     }
 
     @Override
     public GatewayResponse refund(RefundGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = refundClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildRefundOrder(request));
-        return getGatewayResponse(response, EpdqRefundResponse.class);
+        return GatewayResponseGenerator.getEpdqGatewayResponse(refundClient, response, EpdqRefundResponse.class);
     }
 
     @Override
     public GatewayResponse cancel(CancelGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = cancelClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCancelOrder(request));
-        return getGatewayResponse(response, EpdqCancelResponse.class);
+        return GatewayResponseGenerator.getEpdqGatewayResponse(cancelClient, response, EpdqCancelResponse.class);
     }
 
     @Override
     public GatewayResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_QUERY_ORDER, request.getGatewayAccount(), buildQueryOrderRequestFor(request));
-        GatewayResponse<BaseResponse> gatewayResponse = getGatewayResponse(response, EpdqAuthorisationResponse.class);
+        GatewayResponse<BaseResponse> gatewayResponse = GatewayResponseGenerator.getEpdqGatewayResponse(authoriseClient, response, EpdqAuthorisationResponse.class);
 
         BaseAuthoriseResponse.AuthoriseStatus authoriseStatus = gatewayResponse.getBaseResponse().map(epdqStatus -> ((EpdqAuthorisationResponse) epdqStatus).authoriseStatus()).orElse(BaseAuthoriseResponse.AuthoriseStatus.ERROR);
         final Auth3dsDetails.Auth3dsResult auth3DResult = request.getAuth3DsDetails().getAuth3DsResult() == null ?
@@ -178,6 +165,11 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
 
         }
         return gatewayResponse;
+    }
+
+    @Override
+    public CaptureHandler getCaptureHandler() {
+        return epdqCaptureHandler;
     }
 
     @Override
@@ -288,17 +280,6 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
                 .withDescription(request.getDescription())
                 .withAmount(request.getAmount())
                 .withAuthorisationDetails(request.getAuthCardDetails())
-                .build();
-    }
-
-    private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
-        return anEpdqCaptureOrderRequestBuilder()
-                .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
-                .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
-                .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
-                        CREDENTIALS_SHA_IN_PASSPHRASE))
-                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withTransactionId(request.getTransactionId())
                 .build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -127,11 +127,6 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
     }
 
     @Override
-    public GatewayResponse capture(CaptureGatewayRequest request) {
-        return getCaptureHandler().capture(request);
-    }
-
-    @Override
     public GatewayResponse refund(RefundGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = refundClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildRefundOrder(request));
         return GatewayResponseGenerator.getEpdqGatewayResponse(refundClient, response, EpdqRefundResponse.class);

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandler.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+import uk.gov.pay.connector.gateway.CaptureHandler;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import static java.util.UUID.randomUUID;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
+
+public class SandboxCaptureHandler implements CaptureHandler {
+
+    @Override
+    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
+        GatewayResponse.GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
+        return gatewayResponseBuilder.withResponse(new BaseCaptureResponse() {
+
+            private final String transactionId = randomUUID().toString();
+
+            @Override
+            public String getErrorCode() {
+                return null;
+            }
+
+            @Override
+            public String getErrorMessage() {
+                return null;
+            }
+
+            @Override
+            public String getTransactionId() {
+                return transactionId;
+            }
+
+            @Override
+            public String toString() {
+                return "Sandbox capture response (transactionId: " + getTransactionId() + ')';
+            }
+        }).build();
+
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandler.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.gateway.sandbox;
 import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import static java.util.UUID.randomUUID;
@@ -12,8 +11,8 @@ import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.Gatewa
 public class SandboxCaptureHandler implements CaptureHandler {
 
     @Override
-    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
-        GatewayResponse.GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
+        GatewayResponse.GatewayResponseBuilder<BaseCaptureResponse> gatewayResponseBuilder = responseBuilder();
         return gatewayResponseBuilder.withResponse(new BaseCaptureResponse() {
 
             private final String transactionId = randomUUID().toString();

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.sandbox;
 import fj.data.Either;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
@@ -15,7 +16,6 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -36,8 +36,11 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
 
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 
+    SandboxCaptureHandler sandboxCaptureHandler;
+
     public SandboxPaymentProvider() {
         this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
+        this.sandboxCaptureHandler = new SandboxCaptureHandler();
     }
 
     @Override
@@ -70,6 +73,11 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
     }
 
     @Override
+    public CaptureHandler getCaptureHandler() {
+        return sandboxCaptureHandler;
+    }
+
+    @Override
     public PaymentGatewayName getPaymentGatewayName() {
         return PaymentGatewayName.SANDBOX;
     }
@@ -81,7 +89,7 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
 
     @Override
     public GatewayResponse capture(CaptureGatewayRequest request) {
-        return createGatewayBaseCaptureResponse();
+        return getCaptureHandler().capture(request);
     }
 
     @Override
@@ -192,34 +200,6 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
             @Override
             public String toString() {
                 return "Sandbox cancel response (transactionId: " + getTransactionId() + ')';
-            }
-        }).build();
-    }
-
-    private GatewayResponse<BaseCaptureResponse> createGatewayBaseCaptureResponse() {
-        GatewayResponseBuilder<BaseCaptureResponse> gatewayResponseBuilder = responseBuilder();
-        return gatewayResponseBuilder.withResponse(new BaseCaptureResponse() {
-
-            private final String transactionId = randomUUID().toString();
-
-            @Override
-            public String getErrorCode() {
-                return null;
-            }
-
-            @Override
-            public String getErrorMessage() {
-                return null;
-            }
-
-            @Override
-            public String getTransactionId() {
-                return transactionId;
-            }
-
-            @Override
-            public String toString() {
-                return "Sandbox capture response (transactionId: " + getTransactionId() + ')';
             }
         }).build();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -88,11 +88,6 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
     }
 
     @Override
-    public GatewayResponse capture(CaptureGatewayRequest request) {
-        return getCaptureHandler().capture(request);
-    }
-
-    @Override
     public GatewayResponse cancel(CancelGatewayRequest request) {
         return createGatewayBaseCancelResponse();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import fj.data.Either;
+import uk.gov.pay.connector.gateway.CaptureHandler;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
+
+import javax.ws.rs.client.Invocation;
+import java.util.function.BiFunction;
+
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+
+public class SmartpayCaptureHandler implements CaptureHandler {
+
+    private final GatewayClient client;
+
+    public SmartpayCaptureHandler(GatewayClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrderFor(request));
+        return GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayCaptureResponse.class);
+    }
+
+    public static BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> includeSessionIdentifier() {
+        return (order, builder) -> builder;
+    }
+
+    private GatewayOrder buildCaptureOrderFor(CaptureGatewayRequest request) {
+        return SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder()
+                .withTransactionId(request.getTransactionId())
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withAmount(request.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -6,7 +6,6 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 
@@ -24,7 +23,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
     }
 
     @Override
-    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
+    public GatewayResponse<SmartpayCaptureResponse> capture(CaptureGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrderFor(request));
         return GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayCaptureResponse.class);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -18,7 +18,6 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
@@ -55,7 +54,7 @@ public class SmartpayPaymentProvider implements PaymentProvider<BaseResponse, Pa
                                    Environment environment,
                                    ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
+        externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
         client = gatewayClientFactory.createGatewayClient(SMARTPAY, configuration.getGatewayConfigFor(SMARTPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
         
         this.smartpayCaptureHandler = new SmartpayCaptureHandler(client);
@@ -86,11 +85,6 @@ public class SmartpayPaymentProvider implements PaymentProvider<BaseResponse, Pa
     @Override
     public CaptureHandler getCaptureHandler() {
         return smartpayCaptureHandler;
-    }
-
-    @Override
-    public GatewayResponse capture(CaptureGatewayRequest request) {
-        return getCaptureHandler().capture(request);
     }
 
     @Override
@@ -198,7 +192,6 @@ public class SmartpayPaymentProvider implements PaymentProvider<BaseResponse, Pa
         return request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID);
     }
     
-    // fixme - get rid of me later
     public static BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> includeSessionIdentifier() {
         return (order, builder) -> builder;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/GatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/GatewayResponseGenerator.java
@@ -12,7 +12,7 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORL
 
 public class GatewayResponseGenerator {
 
-    public static GatewayResponse<BaseResponse> getSmartpayGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
+    public static GatewayResponse getSmartpayGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
         if (response.isLeft()) {
             return GatewayResponse.with(response.left().value());
         } else {
@@ -26,7 +26,7 @@ public class GatewayResponseGenerator {
         }
     }
 
-    public static GatewayResponse<BaseResponse> getEpdqGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
+    public static GatewayResponse getEpdqGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
         if (response.isLeft()) {
             return GatewayResponse.with(response.left().value());
         } else {
@@ -40,7 +40,7 @@ public class GatewayResponseGenerator {
         }
     }
 
-    public static GatewayResponse<BaseResponse> getWorldpayGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass
+    public static GatewayResponse getWorldpayGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass
                                                                    ) {
         if (response.isLeft()) {
             return GatewayResponse.with(response.left().value());

--- a/src/main/java/uk/gov/pay/connector/gateway/util/GatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/GatewayResponseGenerator.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.gateway.util;
+
+import fj.data.Either;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import java.util.Optional;
+
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
+
+public class GatewayResponseGenerator {
+
+    public static GatewayResponse<BaseResponse> getSmartpayGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
+        if (response.isLeft()) {
+            return GatewayResponse.with(response.left().value());
+        } else {
+            GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+            client.unmarshallResponse(response.right().value(), responseClass)
+                    .bimap(
+                            responseBuilder::withGatewayError,
+                            responseBuilder::withResponse
+                    );
+            return responseBuilder.build();
+        }
+    }
+
+    public static GatewayResponse<BaseResponse> getEpdqGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass) {
+        if (response.isLeft()) {
+            return GatewayResponse.with(response.left().value());
+        } else {
+            GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+            client.unmarshallResponse(response.right().value(), responseClass)
+                    .bimap(
+                            responseBuilder::withGatewayError,
+                            responseBuilder::withResponse
+                    );
+            return responseBuilder.build();
+        }
+    }
+
+    public static GatewayResponse<BaseResponse> getWorldpayGatewayResponse(GatewayClient client, Either<GatewayError, GatewayClient.Response> response, Class<? extends BaseResponse> responseClass
+                                                                   ) {
+        if (response.isLeft()) {
+            return GatewayResponse.with(response.left().value());
+        } else {
+            GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+            client.unmarshallResponse(response.right().value(), responseClass)
+                    .bimap(
+                            responseBuilder::withGatewayError,
+                            responseBuilder::withResponse
+                    );
+            Optional.ofNullable(response.right().value().getResponseCookies().get(WORLDPAY_MACHINE_COOKIE_NAME))
+                    .ifPresent(responseBuilder::withSessionIdentifier);
+            return responseBuilder.build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -8,7 +8,6 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 
@@ -24,7 +23,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
     }
 
     @Override
-    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
+    public GatewayResponse<WorldpayCaptureResponse> capture(CaptureGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrder(request));
         return GatewayResponseGenerator.getWorldpayGatewayResponse(client, response, WorldpayCaptureResponse.class);
      }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import fj.data.Either;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import uk.gov.pay.connector.gateway.CaptureHandler;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
+
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCaptureOrderRequestBuilder;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+
+public class WorldpayCaptureHandler implements CaptureHandler {
+
+    private final GatewayClient client;
+
+    public WorldpayCaptureHandler(GatewayClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public GatewayResponse<BaseResponse> capture(CaptureGatewayRequest request) {
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrder(request));
+        return GatewayResponseGenerator.getWorldpayGatewayResponse(client, response, WorldpayCaptureResponse.class);
+     }
+
+    private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
+        return aWorldpayCaptureOrderRequestBuilder()
+                .withDate(DateTime.now(DateTimeZone.UTC))
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withAmount(request.getAmount())
+                .withTransactionId(request.getTransactionId())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -16,7 +16,6 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -70,12 +69,11 @@ public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, St
         cancelClient = gatewayClientFactory.createGatewayClient(WORLDPAY, CANCEL, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
         captureClient = gatewayClientFactory.createGatewayClient(WORLDPAY, CAPTURE, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
         refundClient = gatewayClientFactory.createGatewayClient(WORLDPAY, REFUND, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
-        this.isNotificationEndpointSecured = configuration.getWorldpayConfig().isSecureNotificationEnabled();
-        this.notificationDomain = configuration.getWorldpayConfig().getNotificationDomain();
-        this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
+        isNotificationEndpointSecured = configuration.getWorldpayConfig().isSecureNotificationEnabled();
+        notificationDomain = configuration.getWorldpayConfig().getNotificationDomain();
+        externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
 
         worldpayCaptureHandler = new WorldpayCaptureHandler(captureClient);
-
     }
 
     @Override
@@ -103,11 +101,6 @@ public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, St
     @Override
     public CaptureHandler getCaptureHandler() {
         return worldpayCaptureHandler;
-    }
-
-    @Override
-    public GatewayResponse capture(CaptureGatewayRequest request) {
-        return getCaptureHandler().capture(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -144,6 +144,7 @@ public class CardCaptureService implements TransactionalGatewayOperation<BaseCap
     @Override
     public GatewayResponse<BaseCaptureResponse> operation(ChargeEntity chargeEntity) {
         return getPaymentProviderFor(chargeEntity)
+                .getCaptureHandler()
                 .capture(CaptureGatewayRequest.valueOf(chargeEntity));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -78,6 +78,7 @@ public abstract class BaseEpdqPaymentProviderTest {
 
     protected GatewayClientFactory gatewayClientFactory;
     protected EpdqPaymentProvider provider;
+    protected EpdqCaptureHandler epdqCaptureHandler;
 
     @Mock
     private Client mockClient;
@@ -125,6 +126,7 @@ public abstract class BaseEpdqPaymentProviderTest {
         when(linksConfig.getFrontendUrl()).thenReturn("http://frontendUrl");
         
         provider = new EpdqPaymentProvider(configuration, gatewayClientFactory, environment, mockSignatureGenerator);
+        epdqCaptureHandler = (EpdqCaptureHandler) provider.getCaptureHandler();
     }
 
     private Invocation.Builder mockClientInvocationBuilder() {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -78,7 +78,7 @@ public abstract class BaseEpdqPaymentProviderTest {
 
     protected GatewayClientFactory gatewayClientFactory;
     protected EpdqPaymentProvider provider;
-    protected EpdqCaptureHandler epdqCaptureHandler;
+
 
     @Mock
     private Client mockClient;
@@ -110,7 +110,7 @@ public abstract class BaseEpdqPaymentProviderTest {
     @Before
     public void setup() {
         gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
-        
+
         mockClientInvocationBuilder = mockClientInvocationBuilder();
         when(environment.metrics()).thenReturn(mockMetricRegistry);
         when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
@@ -124,9 +124,8 @@ public abstract class BaseEpdqPaymentProviderTest {
 
         when(configuration.getLinks()).thenReturn(linksConfig);
         when(linksConfig.getFrontendUrl()).thenReturn("http://frontendUrl");
-        
+
         provider = new EpdqPaymentProvider(configuration, gatewayClientFactory, environment, mockSignatureGenerator);
-        epdqCaptureHandler = (EpdqCaptureHandler) provider.getCaptureHandler();
     }
 
     private Invocation.Builder mockClientInvocationBuilder() {
@@ -316,8 +315,8 @@ public abstract class BaseEpdqPaymentProviderTest {
         return buildTestRefundRequest(chargeEntity);
     }
 
-   private AuthCardDetails buildTestAuthCardDetails() {
-       Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", null, "GB");
+    private AuthCardDetails buildTestAuthCardDetails() {
+        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", null, "GB");
         return AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -1,0 +1,54 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EpdqCaptureHandlerTest extends BaseEpdqPaymentProviderTest {
+
+    protected EpdqCaptureHandler epdqCaptureHandler;
+
+    @Before
+    public void setup() {
+        super.setup();
+        epdqCaptureHandler = (EpdqCaptureHandler) provider.getCaptureHandler();
+    }
+
+    @Test
+    public void shouldCapture() {
+        mockPaymentProviderResponse(200, successCaptureResponse());
+        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        verifyPaymentProviderRequest(successCaptureRequest());
+        assertTrue(response.isSuccessful());
+        assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
+    }
+
+    @Test
+    public void shouldNotCaptureIfPaymentProviderReturnsUnexpectedStatusCode() {
+        mockPaymentProviderResponse(200, errorCaptureResponse());
+        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
+    }
+
+    @Test
+    public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() {
+        mockPaymentProviderResponse(400, errorCaptureResponse());
+        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -75,7 +75,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldCapture() {
         mockPaymentProviderResponse(200, successCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = provider.capture(buildTestCaptureRequest());
+        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
         verifyPaymentProviderRequest(successCaptureRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
@@ -84,7 +84,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsUnexpectedStatusCode() {
         mockPaymentProviderResponse(200, errorCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = provider.capture(buildTestCaptureRequest());
+        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
     }
@@ -92,7 +92,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = provider.capture(buildTestCaptureRequest());
+        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -8,7 +8,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCancelResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
@@ -26,9 +25,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 
@@ -66,33 +63,6 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     public void shouldNotAuthoriseIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorAuthResponse());
         GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise(buildTestAuthorisationRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
-                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
-    }
-
-    @Test
-    public void shouldCapture() {
-        mockPaymentProviderResponse(200, successCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
-        verifyPaymentProviderRequest(successCaptureRequest());
-        assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
-    }
-
-    @Test
-    public void shouldNotCaptureIfPaymentProviderReturnsUnexpectedStatusCode() {
-        mockPaymentProviderResponse(200, errorCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-    }
-
-    @Test
-    public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() {
-        mockPaymentProviderResponse(400, errorCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
@@ -206,7 +176,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
 
         assertThat(provider.verifyNotification(mockNotification, mockGatewayAccountEntity), is(false));
     }
-    
+
     @Test
     public void shouldNotVerifyNotificationIfEmptyPayload() {
         when(mockNotification.getPayload()).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandlerTest.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SandboxCaptureHandlerTest {
+
+    private SandboxCaptureHandler sandboxCaptureHandler;
+    private SandboxPaymentProvider sandboxPaymentProvider;
+
+    @Before
+    public void setup() {
+        SandboxPaymentProvider sandboxPaymentProvider = new SandboxPaymentProvider();
+        sandboxCaptureHandler = (SandboxCaptureHandler) sandboxPaymentProvider.getCaptureHandler();
+    }
+
+    @Test
+    public void capture_shouldSucceedWhenCapturingAnyCharge() {
+
+        GatewayResponse<BaseCaptureResponse> gatewayResponse = sandboxCaptureHandler.capture(CaptureGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
+
+        assertThat(gatewayResponse.isSuccessful(), is(true));
+        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+
+        BaseCaptureResponse captureResponse = gatewayResponse.getBaseResponse().get();
+        assertThat(captureResponse.getTransactionId(), is(notNullValue()));
+        assertThat(captureResponse.getErrorCode(), is(nullValue()));
+        assertThat(captureResponse.getErrorMessage(), is(nullValue()));
+    }
+
+  
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -8,17 +8,14 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
@@ -33,15 +30,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SandboxPaymentProviderTest {
 
     private SandboxPaymentProvider provider;
-    private SandboxCaptureHandler sandboxCaptureHandler;
 
     @Mock
     private ExternalRefundAvailabilityCalculator mockExternalRefundAvailabilityCalculator;
@@ -52,7 +46,6 @@ public class SandboxPaymentProviderTest {
     @Before
     public void setup() {
         provider = new SandboxPaymentProvider();
-        sandboxCaptureHandler = (SandboxCaptureHandler) provider.getCaptureHandler();
     }
 
     @Test
@@ -162,38 +155,6 @@ public class SandboxPaymentProviderTest {
     }
 
     @Test
-    public void capture_shouldSucceedWhenCapturingAnyCharge() {
-
-        GatewayResponse<BaseCaptureResponse> gatewayResponse = sandboxCaptureHandler.capture(CaptureGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
-
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
-
-        BaseCaptureResponse captureResponse = gatewayResponse.getBaseResponse().get();
-        assertThat(captureResponse.getTransactionId(), is(notNullValue()));
-        assertThat(captureResponse.getErrorCode(), is(nullValue()));
-        assertThat(captureResponse.getErrorMessage(), is(nullValue()));
-    }
-
-    @Test
-    public void capture_shouldSucceedWhenCancellingAnyCharge() {
-
-        GatewayResponse<BaseCancelResponse> gatewayResponse = provider.cancel(CancelGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
-
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
-
-        BaseCancelResponse cancelResponse = gatewayResponse.getBaseResponse().get();
-        assertThat(cancelResponse.getTransactionId(), is(notNullValue()));
-        assertThat(cancelResponse.getErrorCode(), is(nullValue()));
-        assertThat(cancelResponse.getErrorMessage(), is(nullValue()));
-    }
-
-    @Test
     public void refund_shouldSucceedWhenRefundingAnyCharge() {
 
         GatewayResponse<BaseRefundResponse> gatewayResponse = provider.refund(RefundGatewayRequest.valueOf(RefundEntityFixture.aValidRefundEntity().build()));
@@ -207,5 +168,21 @@ public class SandboxPaymentProviderTest {
         assertThat(refundResponse.getReference(), is(notNullValue()));
         assertThat(refundResponse.getErrorCode(), is(nullValue()));
         assertThat(refundResponse.getErrorMessage(), is(nullValue()));
+    }
+
+    @Test
+    public void cancel_shouldSucceedWhenCancellingAnyCharge() {
+
+        GatewayResponse<BaseCancelResponse> gatewayResponse = provider.cancel(CancelGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
+
+        assertThat(gatewayResponse.isSuccessful(), is(true));
+        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+
+        BaseCancelResponse cancelResponse = gatewayResponse.getBaseResponse().get();
+        assertThat(cancelResponse.getTransactionId(), is(notNullValue()));
+        assertThat(cancelResponse.getErrorCode(), is(nullValue()));
+        assertThat(cancelResponse.getErrorMessage(), is(nullValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -41,6 +41,7 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 public class SandboxPaymentProviderTest {
 
     private SandboxPaymentProvider provider;
+    private SandboxCaptureHandler sandboxCaptureHandler;
 
     @Mock
     private ExternalRefundAvailabilityCalculator mockExternalRefundAvailabilityCalculator;
@@ -51,6 +52,7 @@ public class SandboxPaymentProviderTest {
     @Before
     public void setup() {
         provider = new SandboxPaymentProvider();
+        sandboxCaptureHandler = (SandboxCaptureHandler) provider.getCaptureHandler();
     }
 
     @Test
@@ -162,7 +164,7 @@ public class SandboxPaymentProviderTest {
     @Test
     public void capture_shouldSucceedWhenCapturingAnyCharge() {
 
-        GatewayResponse<BaseCaptureResponse> gatewayResponse = provider.capture(CaptureGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
+        GatewayResponse<BaseCaptureResponse> gatewayResponse = sandboxCaptureHandler.capture(CaptureGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
         assertThat(gatewayResponse.isFailed(), is(false));

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.mockito.Mock;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.GatewayConfig;
+import uk.gov.pay.connector.gateway.ClientFactory;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+
+public abstract class BaseSmartpayPaymentProviderTest {
+
+    protected SmartpayPaymentProvider provider;
+    private GatewayClientFactory gatewayClientFactory;
+
+    @Mock
+    protected Client mockClient;
+    @Mock
+    private ClientFactory mockClientFactory;
+    @Mock
+    private ConnectorConfiguration configuration;
+    @Mock
+    private GatewayConfig gatewayConfig;
+    @Mock
+    private Environment environment;
+    @Mock
+    private MetricRegistry metricRegistry;
+
+    @Before
+    public void setup() {
+        gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
+
+        when(mockClientFactory.createWithDropwizardClient(eq(PaymentGatewayName.SMARTPAY), any(MetricRegistry.class)))
+                .thenReturn(mockClient);
+        when(configuration.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(gatewayConfig);
+        when(gatewayConfig.getUrls()).thenReturn(ImmutableMap.of(TEST.toString(), "http://smartpay.url"));
+        when(environment.metrics()).thenReturn(metricRegistry);
+        when(metricRegistry.histogram(anyString())).thenReturn(mock(Histogram.class));
+
+        provider = new SmartpayPaymentProvider(configuration, gatewayClientFactory, environment, new ObjectMapper());
+    }
+
+    protected GatewayAccountEntity aServiceAccount() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("smartpay");
+        gatewayAccount.setCredentials(ImmutableMap.of(
+                "username", "theUsername",
+                "password", "thePassword",
+                "merchant_id", "theMerchantCode"
+        ));
+        gatewayAccount.setType(TEST);
+
+        return gatewayAccount;
+    }
+
+    protected void mockSmartpayResponse(int httpStatus, String responsePayload) {
+        WebTarget mockTarget = mock(WebTarget.class);
+        when(mockClient.target(anyString())).thenReturn(mockTarget);
+        Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
+        when(mockTarget.request()).thenReturn(mockBuilder);
+        when(mockBuilder.header(anyString(), any(Object.class))).thenReturn(mockBuilder);
+
+        Response response = mock(Response.class);
+        when(response.readEntity(String.class)).thenReturn(responsePayload);
+        when(mockBuilder.post(any(Entity.class))).thenReturn(response);
+
+        when(response.getStatus()).thenReturn(httpStatus);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_SUCCESS_RESPONSE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SmartpayCaptureHandlerTest extends BaseSmartpayPaymentProviderTest {
+
+    private SmartpayCaptureHandler smartpayCaptureHandler;
+
+    @Before
+    public void setup() {
+        super.setup();
+        smartpayCaptureHandler = (SmartpayCaptureHandler) provider.getCaptureHandler();
+    }
+
+    @Test
+    public void shouldCaptureAPaymentSuccessfully() {
+
+        mockSmartpayResponse(200, successCaptureResponse());
+
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(aServiceAccount())
+                .build();
+
+        GatewayResponse<SmartpayCaptureResponse> response = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        assertTrue(response.isSuccessful());
+    }
+
+    private String successCaptureResponse() {
+        return TestTemplateResourceLoader.load(SMARTPAY_CAPTURE_SUCCESS_RESPONSE).replace("{{pspReference}}", "8614440510830227");
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -67,6 +67,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPT
 public class SmartpayPaymentProviderTest {
 
     private SmartpayPaymentProvider provider;
+    private SmartpayCaptureHandler smartpayCaptureHandler;
     private GatewayClientFactory gatewayClientFactory;
 
     @Mock
@@ -98,6 +99,7 @@ public class SmartpayPaymentProviderTest {
         mockSmartpaySuccessfulOrderSubmitResponse();
 
         provider = new SmartpayPaymentProvider(configuration, gatewayClientFactory, environment, new ObjectMapper());
+        smartpayCaptureHandler = (SmartpayCaptureHandler) provider.getCaptureHandler();
     }
 
     @Test
@@ -187,7 +189,7 @@ public class SmartpayPaymentProviderTest {
                 .withGatewayAccountEntity(aServiceAccount())
                 .build();
 
-        GatewayResponse<WorldpayCaptureResponse> response = provider.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse<SmartpayCaptureResponse> response = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(response.isSuccessful());
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -1,12 +1,7 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import fj.data.Either;
-import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -15,31 +10,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.GatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.ClientFactory;
-import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 import uk.gov.pay.connector.util.AuthUtils;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
@@ -50,56 +33,24 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_SUCCESS_RESPONSE;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SmartpayPaymentProviderTest {
+public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest {
 
-    private SmartpayPaymentProvider provider;
-    private SmartpayCaptureHandler smartpayCaptureHandler;
-    private GatewayClientFactory gatewayClientFactory;
-
-    @Mock
-    private Client mockClient;
-    @Mock
-    private ClientFactory mockClientFactory;
     @Mock
     private GatewayAccountEntity mockGatewayAccountEntity;
-    @Mock
-    private ConnectorConfiguration configuration;
-    @Mock
-    private GatewayConfig gatewayConfig;
-    @Mock
-    private Environment environment;
-    @Mock
-    private MetricRegistry metricRegistry;
 
     @Before
     public void setup() {
-        gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
-
-        when(mockClientFactory.createWithDropwizardClient(eq(PaymentGatewayName.SMARTPAY), any(MetricRegistry.class)))
-                .thenReturn(mockClient);
-        when(configuration.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(gatewayConfig);
-        when(gatewayConfig.getUrls()).thenReturn(ImmutableMap.of(TEST.toString(), "http://smartpay.url"));
-        when(environment.metrics()).thenReturn(metricRegistry);
-        when(metricRegistry.histogram(anyString())).thenReturn(mock(Histogram.class));
-
+        super.setup();
         mockSmartpaySuccessfulOrderSubmitResponse();
-
-        provider = new SmartpayPaymentProvider(configuration, gatewayClientFactory, environment, new ObjectMapper());
-        smartpayCaptureHandler = (SmartpayCaptureHandler) provider.getCaptureHandler();
     }
 
     @Test
@@ -181,19 +132,6 @@ public class SmartpayPaymentProviderTest {
     }
 
     @Test
-    public void shouldCaptureAPaymentSuccessfully() {
-
-        mockSmartpaySuccessfulCaptureResponse();
-
-        ChargeEntity chargeEntity = aValidChargeEntity()
-                .withGatewayAccountEntity(aServiceAccount())
-                .build();
-
-        GatewayResponse<SmartpayCaptureResponse> response = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
-        assertTrue(response.isSuccessful());
-    }
-
-    @Test
     public void parseNotification_shouldReturnErrorIfUnparseableSoapMessage() {
         Either<String, Notifications<Pair<String, Boolean>>> response = provider.parseNotification("not valid soap message");
         assertThat(response.isLeft(), is(true));
@@ -229,20 +167,6 @@ public class SmartpayPaymentProviderTest {
         assertThat(provider.verifyNotification(mock(Notification.class), mockGatewayAccountEntity), is(true));
     }
 
-    private GatewayAccountEntity aServiceAccount() {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
-        gatewayAccount.setId(1L);
-        gatewayAccount.setGatewayName("smartpay");
-        gatewayAccount.setCredentials(ImmutableMap.of(
-                "username", "theUsername",
-                "password", "thePassword",
-                "merchant_id", "theMerchantCode"
-        ));
-        gatewayAccount.setType(TEST);
-
-        return gatewayAccount;
-    }
-
     private void mockSmartpaySuccessfulOrderSubmitResponse() {
         mockSmartpayResponse(200, successAuthoriseResponse());
     }
@@ -257,20 +181,6 @@ public class SmartpayPaymentProviderTest {
 
     private void mockSmartpaySuccessfulCaptureResponse() {
         mockSmartpayResponse(200, successCaptureResponse());
-    }
-
-    private void mockSmartpayResponse(int httpStatus, String responsePayload) {
-        WebTarget mockTarget = mock(WebTarget.class);
-        when(mockClient.target(anyString())).thenReturn(mockTarget);
-        Builder mockBuilder = mock(Builder.class);
-        when(mockTarget.request()).thenReturn(mockBuilder);
-        when(mockBuilder.header(anyString(), any(Object.class))).thenReturn(mockBuilder);
-
-        Response response = mock(Response.class);
-        when(response.readEntity(String.class)).thenReturn(responsePayload);
-        when(mockBuilder.post(any(Entity.class))).thenReturn(response);
-
-        when(response.getStatus()).thenReturn(httpStatus);
     }
 
     private String successAuthoriseResponse() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayBasePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayBasePaymentProviderTest.java
@@ -1,0 +1,144 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.mockito.Mock;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.GatewayConfig;
+import uk.gov.pay.connector.app.WorldpayConfig;
+import uk.gov.pay.connector.gateway.ClientFactory;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+
+public abstract class WorldpayBasePaymentProviderTest {
+
+    protected WorldpayPaymentProvider provider;
+    private Map<String, String> urlMap = ImmutableMap.of(TEST.toString(), "http://worldpay.url");
+
+    @Mock
+    private Client mockClient;
+    @Mock
+    protected GatewayClient mockGatewayClient;
+    @Mock
+    protected GatewayAccountEntity mockGatewayAccountEntity;
+    @Mock
+    private MetricRegistry mockMetricRegistry;
+    @Mock
+    private Histogram mockHistogram;
+    @Mock
+    private Counter mockCounter;
+    @Mock
+    private ClientFactory mockClientFactory;
+    @Mock
+    protected ConnectorConfiguration configuration;
+    @Mock
+    private GatewayConfig gatewayConfig;
+    @Mock
+    protected Environment environment;
+
+    @Before
+    public void setup() {
+        GatewayClientFactory gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
+
+        when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
+        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
+        when(mockClientFactory.createWithDropwizardClient(
+                eq(PaymentGatewayName.WORLDPAY), any(GatewayOperation.class), any(MetricRegistry.class))
+        )
+                .thenReturn(mockClient);
+
+        when(configuration.getGatewayConfigFor(PaymentGatewayName.WORLDPAY)).thenReturn(gatewayConfig);
+        when(gatewayConfig.getUrls()).thenReturn(urlMap);
+        when(configuration.getWorldpayConfig()).thenReturn(mock(WorldpayConfig.class));
+        when(environment.metrics()).thenReturn(mockMetricRegistry);
+
+        provider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
+    }
+
+    protected GatewayAccountEntity aServiceAccount() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("worldpay");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(ImmutableMap.of(
+                CREDENTIALS_MERCHANT_ID, "worlpay-merchant",
+                CREDENTIALS_USERNAME, "worldpay-password",
+                CREDENTIALS_PASSWORD, "password"
+        ));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
+    }
+
+    protected void assertEquals(GatewayError actual, GatewayError expected) {
+        assertNotNull(actual);
+        assertThat(actual.getMessage(), is(expected.getMessage()));
+        assertThat(actual.getErrorType(), is(expected.getErrorType()));
+    }
+
+    protected void mockWorldpayErrorResponse(int httpStatus) {
+        mockWorldpayResponse(httpStatus, errorResponse());
+    }
+
+    protected void mockWorldpayResponse(int httpStatus, String responsePayload) {
+        WebTarget mockTarget = mock(WebTarget.class);
+        when(mockClient.target(anyString())).thenReturn(mockTarget);
+        Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
+        when(mockTarget.request()).thenReturn(mockBuilder);
+        when(mockBuilder.header(anyString(), any(Object.class))).thenReturn(mockBuilder);
+
+        Map<String, NewCookie> responseCookies =
+                Collections.singletonMap(WORLDPAY_MACHINE_COOKIE_NAME, NewCookie.valueOf("value-from-worldpay"));
+
+        Response response = mock(Response.class);
+        when(response.readEntity(String.class)).thenReturn(responsePayload);
+        when(mockBuilder.post(any(Entity.class))).thenReturn(response);
+        when(response.getCookies()).thenReturn(responseCookies);
+
+        when(response.getStatus()).thenReturn(httpStatus);
+    }
+
+    protected String errorResponse() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
+                "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
+                "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
+                "    <reply>\n" +
+                "        <error code=\"5\">\n" +
+                "            <![CDATA[Order has already been paid]]>\n" +
+                "        </error>\n" +
+                "    </reply>\n" +
+                "</paymentService>";
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -1,0 +1,89 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorldpayCaptureHandlerTest extends WorldpayBasePaymentProviderTest {
+
+    private WorldpayCaptureHandler worldpayCaptureHandler;
+
+    @Before
+    public void setup() {
+        super.setup();
+        worldpayCaptureHandler = (WorldpayCaptureHandler) provider.getCaptureHandler();
+    }
+
+    @Test
+    public void shouldCaptureAPaymentSuccessfully() throws Exception {
+        mockWorldpaySuccessfulCaptureResponse();
+
+        GatewayResponse response = worldpayCaptureHandler.capture(getCaptureRequest());
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    public void shouldErrorIfOrderReferenceNotKnownInCapture() {
+        mockWorldpayErrorResponse(200);
+        GatewayResponse<WorldpayCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
+
+        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Worldpay capture response (error code: 5, error: Order has already been paid)", GENERIC_GATEWAY_ERROR));
+    }
+
+    @Test
+    public void shouldErrorIfWorldpayResponseIsNot200() {
+        mockWorldpayErrorResponse(400);
+        GatewayResponse<WorldpayCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
+        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
+        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+    }
+
+    private void mockWorldpaySuccessfulCaptureResponse() {
+        mockWorldpayResponse(200, successCaptureResponse());
+    }
+
+    private CaptureGatewayRequest getCaptureRequest() {
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(aServiceAccount())
+                .build();
+        return CaptureGatewayRequest.valueOf(chargeEntity);
+    }
+
+    private String successCaptureResponse() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
+                "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
+                "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
+                "    <reply>\n" +
+                "        <ok>\n" +
+                "            <captureReceived orderCode=\"MyUniqueTransactionId!\">\n" +
+                "                <amount value=\"500\" currencyCode=\"GBP\" exponent=\"2\" debitCreditIndicator=\"credit\"/>\n" +
+                "            </captureReceived>\n" +
+                "        </ok>\n" +
+                "    </reply>\n" +
+                "</paymentService>";
+    }
+
+}
+

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -1,26 +1,16 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import fj.data.Either;
-import io.dropwizard.setup.Environment;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.GatewayConfig;
-import uk.gov.pay.connector.app.WorldpayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.CaptureHandler;
-import uk.gov.pay.connector.gateway.ClientFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
@@ -33,7 +23,6 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -45,15 +34,8 @@ import uk.gov.pay.connector.usernotification.model.Notifications;
 import uk.gov.pay.connector.util.AuthUtils;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -67,24 +49,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
 import static uk.gov.pay.connector.gateway.model.GatewayError.unexpectedStatusCodeFromGateway;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST;
@@ -92,53 +66,12 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS;
 
 @RunWith(MockitoJUnitRunner.class)
-public class WorldpayPaymentProviderTest {
-
-    private WorldpayPaymentProvider provider;
-    private WorldpayCaptureHandler worldpayCaptureHandler;
-    private Map<String, String> urlMap = ImmutableMap.of(TEST.toString(), "http://worldpay.url");
-
-    EnumMap<GatewayOperation, GatewayClient> gatewayClients;
-
-    @Mock
-    private Client mockClient;
-    @Mock
-    private GatewayClient mockGatewayClient;
-    @Mock
-    private GatewayAccountEntity mockGatewayAccountEntity;
-    @Mock
-    private MetricRegistry mockMetricRegistry;
-    @Mock
-    private Histogram mockHistogram;
-    @Mock
-    private Counter mockCounter;
-    @Mock
-    private ClientFactory mockClientFactory;
-    @Mock
-    private ConnectorConfiguration configuration;
-    @Mock
-    private GatewayConfig gatewayConfig;
-    @Mock
-    private Environment environment;
+public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest {
 
     @Before
     public void setup() {
-        GatewayClientFactory gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
+        super.setup();
         mockWorldpaySuccessfulOrderSubmitResponse();
-        when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
-        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
-        when(mockClientFactory.createWithDropwizardClient(
-                eq(PaymentGatewayName.WORLDPAY), any(GatewayOperation.class), any(MetricRegistry.class))
-        )
-                .thenReturn(mockClient);
-        
-        when(configuration.getGatewayConfigFor(PaymentGatewayName.WORLDPAY)).thenReturn(gatewayConfig);
-        when(gatewayConfig.getUrls()).thenReturn(urlMap);
-        when(configuration.getWorldpayConfig()).thenReturn(mock(WorldpayConfig.class));
-        when(environment.metrics()).thenReturn(mockMetricRegistry);
-
-        provider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
-        worldpayCaptureHandler = (WorldpayCaptureHandler) provider.getCaptureHandler();
     }
 
     @Test
@@ -176,24 +109,24 @@ public class WorldpayPaymentProviderTest {
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any(BiFunction.class), any())).thenReturn(mockGatewayClient);
-        
+
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
         worldpayPaymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity));
 
         String expectedRefundRequest =
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
-                "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
-                "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
-                "    <modify>\n" +
-                "        <orderModification orderCode=\"transaction-id\">\n" +
-                "            <refund reference=\"" +refundEntity.getExternalId()+ "\">\n" +
-                "                <amount currencyCode=\"GBP\" exponent=\"2\" value=\"500\"/>\n" +
-                "            </refund>\n" +
-                "        </orderModification>\n" +
-                "    </modify>\n" +
-                "</paymentService>\n" +
-                "";
+                        "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
+                        "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
+                        "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
+                        "    <modify>\n" +
+                        "        <orderModification orderCode=\"transaction-id\">\n" +
+                        "            <refund reference=\"" + refundEntity.getExternalId() + "\">\n" +
+                        "                <amount currencyCode=\"GBP\" exponent=\"2\" value=\"500\"/>\n" +
+                        "            </refund>\n" +
+                        "        </orderModification>\n" +
+                        "    </modify>\n" +
+                        "</paymentService>\n" +
+                        "";
 
         verify(mockGatewayClient).postRequestFor(eq(null), eq(mockGatewayAccountEntity), argThat(argument -> argument.getPayload().equals(expectedRefundRequest) && argument.getOrderRequestType().equals(OrderRequestType.REFUND)));
     }
@@ -281,7 +214,7 @@ public class WorldpayPaymentProviderTest {
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any(BiFunction.class), any())).thenReturn(mockGatewayClient);
-        
+
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
 
         worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(mockChargeEntity));
@@ -318,7 +251,7 @@ public class WorldpayPaymentProviderTest {
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any(BiFunction.class), any())).thenReturn(mockGatewayClient);
-        
+
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
 
         worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(mockChargeEntity));
@@ -339,14 +272,6 @@ public class WorldpayPaymentProviderTest {
     }
 
     @Test
-    public void shouldCaptureAPaymentSuccessfully() throws Exception {
-        mockWorldpaySuccessfulCaptureResponse();
-
-        GatewayResponse response = worldpayCaptureHandler.capture(getCaptureRequest());
-        assertTrue(response.isSuccessful());
-    }
-
-    @Test
     public void shouldErrorIfAuthorisationIsUnsuccessful() {
         mockWorldpayErrorResponse(401);
         GatewayResponse<WorldpayOrderStatusResponse> response = provider.authorise(getCardAuthorisationRequest());
@@ -355,26 +280,6 @@ public class WorldpayPaymentProviderTest {
         assertFalse(response.getSessionIdentifier().isPresent());
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 401 from gateway",
-                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
-    }
-
-    @Test
-    public void shouldErrorIfOrderReferenceNotKnownInCapture() {
-        mockWorldpayErrorResponse(200);
-        GatewayResponse<WorldpayCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
-
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Worldpay capture response (error code: 5, error: Order has already been paid)", GENERIC_GATEWAY_ERROR));
-    }
-
-    @Test
-    public void shouldErrorIfWorldpayResponseIsNot200() {
-        mockWorldpayErrorResponse(400);
-        GatewayResponse<WorldpayCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
                 UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
@@ -451,90 +356,8 @@ public class WorldpayPaymentProviderTest {
         return getCardAuthorisationRequest(chargeEntity);
     }
 
-
-    private GatewayAccountEntity aServiceAccount() {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
-        gatewayAccount.setId(1L);
-        gatewayAccount.setGatewayName("worldpay");
-        gatewayAccount.setRequires3ds(false);
-        gatewayAccount.setCredentials(ImmutableMap.of(
-                CREDENTIALS_MERCHANT_ID, "worlpay-merchant",
-                CREDENTIALS_USERNAME, "worldpay-password",
-                CREDENTIALS_PASSWORD, "password"
-        ));
-        gatewayAccount.setType(TEST);
-        return gatewayAccount;
-    }
-
-    private void assertEquals(GatewayError actual, GatewayError expected) {
-        assertNotNull(actual);
-        assertThat(actual.getMessage(), is(expected.getMessage()));
-        assertThat(actual.getErrorType(), is(expected.getErrorType()));
-    }
-
-    private CaptureGatewayRequest getCaptureRequest() {
-        ChargeEntity chargeEntity = aValidChargeEntity()
-                .withGatewayAccountEntity(aServiceAccount())
-                .build();
-        return CaptureGatewayRequest.valueOf(chargeEntity);
-    }
-
-    private void mockWorldpayErrorResponse(int httpStatus) {
-        mockWorldpayResponse(httpStatus, errorResponse());
-    }
-
-    private void mockWorldpaySuccessfulCaptureResponse() {
-        mockWorldpayResponse(200, successCaptureResponse());
-    }
-
     private void mockWorldpaySuccessfulOrderSubmitResponse() {
         mockWorldpayResponse(200, successAuthoriseResponse());
-    }
-
-    private void mockWorldpayResponse(int httpStatus, String responsePayload) {
-        WebTarget mockTarget = mock(WebTarget.class);
-        when(mockClient.target(anyString())).thenReturn(mockTarget);
-        Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
-        when(mockTarget.request()).thenReturn(mockBuilder);
-        when(mockBuilder.header(anyString(), any(Object.class))).thenReturn(mockBuilder);
-
-        Map<String, NewCookie> responseCookies =
-                Collections.singletonMap(WORLDPAY_MACHINE_COOKIE_NAME, NewCookie.valueOf("value-from-worldpay"));
-
-        Response response = mock(Response.class);
-        when(response.readEntity(String.class)).thenReturn(responsePayload);
-        when(mockBuilder.post(any(Entity.class))).thenReturn(response);
-        when(response.getCookies()).thenReturn(responseCookies);
-
-        when(response.getStatus()).thenReturn(httpStatus);
-    }
-
-    private String successCaptureResponse() {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
-                "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
-                "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
-                "    <reply>\n" +
-                "        <ok>\n" +
-                "            <captureReceived orderCode=\"MyUniqueTransactionId!\">\n" +
-                "                <amount value=\"500\" currencyCode=\"GBP\" exponent=\"2\" debitCreditIndicator=\"credit\"/>\n" +
-                "            </captureReceived>\n" +
-                "        </ok>\n" +
-                "    </reply>\n" +
-                "</paymentService>";
-    }
-
-    private String errorResponse() {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
-                "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
-                "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
-                "    <reply>\n" +
-                "        <error code=\"5\">\n" +
-                "            <![CDATA[Order has already been paid]]>\n" +
-                "        </error>\n" +
-                "    </reply>\n" +
-                "</paymentService>";
     }
 
     private String successAuthoriseResponse() {


### PR DESCRIPTION
## WHY
At present, all PaymentProvider classes implement PaymentProvider interface which constitutes signatures for multiple features (authorise, capture, refund, cancel and also some helper methods specific to feature). This is leading to `1. Fat interface 2. Multiple responsibilities for Payment Provider classes and 3. Having to work on same code base to deliver features (authorise, capture ..) in parallel`. 

As a first step, refactored `Capture` functionality

## WHAT
We introduced CaptureHandler interface and its concrete classes. As a result, we refactored all the capture logic into the relevant classes and the *PaymentProvider classes now only need to call
the capture hander to do the job.

This will help deliver functionality independently. For example, Capture feature for stripe can be implemented with new StripeCaptureHandler without need to change a lot in StripePaymentProvider

## HOW DID WE TEST THE CHANGES
Since we should not have changed any business logic because it is just pure refactoring, rerun all the exists test should be sufficient.


