### PR TITLE
BAU - Silence hyper verbose card process logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcess.java
@@ -93,8 +93,10 @@ public class CardCaptureProcess {
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram("gateway-operations.capture-process.running_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
-            logger.info("Capture complete [captured={}] [skipped={}] [capture_error={}] [failed_capture={}] [total={}]",
-                    captured, skipped, error, failedCapture, readyCaptureQueueSize);
+            if (readyCaptureQueueSize > 0) {
+                logger.info("Capture complete [captured={}] [skipped={}] [capture_error={}] [failed_capture={}] [total={}]",
+                        captured, skipped, error, failedCapture, readyCaptureQueueSize);
+            }
         }
         MDC.remove(HEADER_REQUEST_ID);
     }


### PR DESCRIPTION
## WHAT
We are running the process multiple time per minute and we generate a log line each time, which pollutes the logs and makes everything really hard to follow.
This PR makes it so that we generate the logs only when the capture size is not 0.

