### PR TITLE
PP-4164 Handle missing address when creating Worldpay authorise payload

### DIFF
--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -14,6 +14,7 @@
                     </expiryDate>
                     <cardHolderName>${authCardDetails.cardHolder?xml}</cardHolderName>
                     <cvc>${authCardDetails.cvc}</cvc>
+                    <#if authCardDetails.address??>
                     <cardAddress>
                         <address>
                             <address1>${authCardDetails.address.line1?xml}</address1>
@@ -28,6 +29,7 @@
                             <countryCode>${authCardDetails.address.country?xml}</countryCode>
                         </address>
                     </cardAddress>
+                    </#if>
                 </VISA-SSL>
                 <#if requires3ds>
                 <session id="${sessionId?xml}"/>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -2,10 +2,10 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.util.AuthUtils;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
@@ -13,7 +13,6 @@ import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.common.model.domain.Address.anAddress;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
@@ -25,6 +24,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CANCEL_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
@@ -56,7 +56,7 @@ public class WorldpayOrderRequestBuilderTest {
     @Test
     public void shouldGenerateValidAuthoriseOrderRequestForAddressWithMinimumFieldsWhen3dsEnabled() throws Exception {
 
-        Address minAddress = new Address("123 My Street", null,"SW8URR", "London", null,"GB");
+        Address minAddress = new Address("123 My Street", null, "SW8URR", "London", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(minAddress);
 
@@ -101,7 +101,7 @@ public class WorldpayOrderRequestBuilderTest {
     @Test
     public void shouldGenerateValidAuthoriseOrderRequestWhenSpecialCharactersInUserInput() throws Exception {
 
-        Address address = new Address("123 & My Street","This road -->", "SW8 > URR", "London !>", null, "GB");
+        Address address = new Address("123 & My Street", "This road -->", "SW8 > URR", "London !>", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(address);
 
@@ -117,6 +117,25 @@ public class WorldpayOrderRequestBuilderTest {
                 .build();
 
         assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthoriseOrderRequestWhenAddressIsMissing() throws Exception {
+        AuthCardDetails authCardDetails = getValidTestCard(null);
+
+        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
+                .withSessionId("uniqueSessionId")
+                .withAcceptHeader("text/html")
+                .withUserAgentHeader("Mozilla/5.0")
+                .withTransactionId("MyUniqueTransactionId!")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
+++ b/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
@@ -4,18 +4,24 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 import static uk.gov.pay.connector.gateway.model.AuthCardDetails.anAuthCardDetails;
 
 public class AuthUtils {
 
+    private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/yy");
+    private static String expiryDate = ZonedDateTime.now().plusYears(1).format(formatter);
+
     public static AuthCardDetails aValidAuthorisationDetails() {
         String validSandboxCard = "4242424242424242";
-        return buildAuthCardDetails(validSandboxCard, "123", "12/17", "card-brand");
+        return buildAuthCardDetails(validSandboxCard, "123", expiryDate, "card-brand");
     }
 
     public static AuthCardDetails buildAuthCardDetails(String cardHolderName) {
         String validSandboxCard = "4242424242424242";
-        return buildAuthCardDetails(cardHolderName, validSandboxCard, "123", "12/21", "card-brand", goodAddress());
+        return buildAuthCardDetails(cardHolderName, validSandboxCard, "123", expiryDate, "card-brand", goodAddress());
     }
 
     public static AuthCardDetails buildAuthCardDetails(String cardNumber, String cvc, String expiryDate, String cardBrand) {

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -19,6 +19,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-full-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-min-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-3ds-response-auth-worldpay-request.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-without-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-without-address.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <VISA-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                </VISA-SSL>
+            </paymentDetails>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
- Modify payload xml template to skip adding 'cardAddress' element when
  address in CardEntity is null
- Add test for building payload when address is null
- Add integration test using Worldpay test account

with @danworth @stephencdaly 
