### PR TITLE
 PP-4164 Handle missing address when creating Smartpay authorise payload

### DIFF
--- a/src/main/resources/templates/smartpay/Smartpay3dsRequiredOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/Smartpay3dsRequiredOrderTemplate.xml
@@ -27,24 +27,21 @@
                     <ns1:expiryYear>20${authCardDetails.endDate?split('/')?last}</ns1:expiryYear>
                     <ns1:holderName>${authCardDetails.cardHolder?xml}</ns1:holderName>
                     <ns1:number>${authCardDetails.cardNo}</ns1:number>
+                    <#if authCardDetails.address??>
                     <ns1:billingAddress>
                         <ns2:houseNumberOrName>${authCardDetails.address.line1?xml}</ns2:houseNumberOrName>
-                        <ns2:street><#if authCardDetails.address.line2?has_content>${authCardDetails.address.line2?xml}<
-                            #else>N/A
-                        </#if>
-                    </ns2:street>
-                    <ns2:postalCode>${authCardDetails.address.postcode?xml}</ns2:postalCode>
-                    <ns2:stateOrProvince><#if authCardDetails.address.county??>${authCardDetails.address.county?xml}
+                        <ns2:street><#if authCardDetails.address.line2?has_content>${authCardDetails.address.line2?xml}<#else>N/A</#if></ns2:street>
+                        <ns2:postalCode>${authCardDetails.address.postcode?xml}</ns2:postalCode>
+                        <ns2:stateOrProvince><#if authCardDetails.address.county??>${authCardDetails.address.county?xml}</#if></ns2:stateOrProvince>
+                        <ns2:city>${authCardDetails.address.city?xml}</ns2:city>
+                        <ns2:country>${authCardDetails.address.country?xml}</ns2:country>
+                    </ns1:billingAddress>
                     </#if>
-                </ns2:stateOrProvince>
-                <ns2:city>${authCardDetails.address.city?xml}</ns2:city>
-                <ns2:country>${authCardDetails.address.country?xml}</ns2:country>
-            </ns1:billingAddress>
-        </ns1:card>
-        <ns1:merchantAccount>${merchantCode}</ns1:merchantAccount>
-        <ns1:reference>${paymentPlatformReference?xml}</ns1:reference>
-        <ns1:shopperReference>${description?xml}</ns1:shopperReference>
-    </ns1:paymentRequest>
-</ns1:authorise>
-        </soap:Body>
-        </soap:Envelope>
+                </ns1:card>
+                <ns1:merchantAccount>${merchantCode}</ns1:merchantAccount>
+                <ns1:reference>${paymentPlatformReference?xml}</ns1:reference>
+                <ns1:shopperReference>${description?xml}</ns1:shopperReference>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>

--- a/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
@@ -16,6 +16,7 @@
                     <ns1:expiryYear>20${authCardDetails.endDate?split('/')?last}</ns1:expiryYear>
                     <ns1:holderName>${authCardDetails.cardHolder?xml}</ns1:holderName>
                     <ns1:number>${authCardDetails.cardNo}</ns1:number>
+                    <#if authCardDetails.address??>
                     <ns1:billingAddress>
                         <ns2:houseNumberOrName>${authCardDetails.address.line1?xml}</ns2:houseNumberOrName>
                         <ns2:street><#if authCardDetails.address.line2?has_content>${authCardDetails.address.line2?xml}<#else>N/A</#if></ns2:street>
@@ -24,6 +25,7 @@
                         <ns2:city>${authCardDetails.address.city?xml}</ns2:city>
                         <ns2:country>${authCardDetails.address.country?xml}</ns2:country>
                     </ns1:billingAddress>
+                    </#if>
                   </ns1:card>
                 <ns1:merchantAccount>${merchantCode}</ns1:merchantAccount>
                 <ns1:reference>${paymentPlatformReference?xml}</ns1:reference>

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
@@ -4,23 +4,29 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.util.AuthUtils;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.assertEquals;
+import static uk.gov.pay.connector.gateway.smartpay.SmartpayOrderRequestBuilder.aSmartpay3dsRequiredOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.smartpay.SmartpayOrderRequestBuilder.aSmartpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.smartpay.SmartpayOrderRequestBuilder.aSmartpayCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.smartpay.SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.smartpay.SmartpayOrderRequestBuilder.aSmartpayRefundOrderRequestBuilder;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_SPECIAL_CHAR_VALID_CAPTURE_SMARTPAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_MINIMAL;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_CANCEL_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_CAPTURE_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_REFUND_SMARTPAY_REQUEST;
@@ -44,7 +50,7 @@ public class SmartpayOrderRequestBuilderTest {
     public void shouldGenerateValidAuthoriseOrderRequestForAddressWithAllFields() throws Exception {
         Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", "London", "GB");
 
-        AuthCardDetails authCardDetails = AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
+        AuthCardDetails authCardDetails = getValidTestCard(address);
 
         GatewayOrder actualRequest = aSmartpayAuthoriseOrderRequestBuilder()
                 .withMerchantCode("MerchantAccount")
@@ -58,12 +64,27 @@ public class SmartpayOrderRequestBuilderTest {
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 
+    @Test
+    public void shouldGenerateValidAuthoriseOrderRequestWhenAddressIsMissing() throws Exception {
+        AuthCardDetails authCardDetails = getValidTestCard(null);
+
+        GatewayOrder actualRequest = aSmartpayAuthoriseOrderRequestBuilder()
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription")
+                .withPaymentPlatformReference("MyPlatformReference")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITHOUT_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
 
     @Test
     public void shouldGenerateValidAuthoriseOrderRequestWithSpecialCharactersInUserInput() throws Exception {
-        Address address = new Address("41", "Scala & Haskell Rocks", "EC2A 1AE", "London <!-- ","London -->", "GB");
+        Address address = new Address("41", "Scala & Haskell Rocks", "EC2A 1AE", "London <!-- ", "London -->", "GB");
 
-        AuthCardDetails authCardDetails = AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
+        AuthCardDetails authCardDetails = getValidTestCard(address);
 
         GatewayOrder actualRequest = aSmartpayAuthoriseOrderRequestBuilder()
                 .withMerchantCode("MerchantAccount")
@@ -82,7 +103,7 @@ public class SmartpayOrderRequestBuilderTest {
 
         Address address = new Address("41 Acacia Avenue", null, "EC2A 1AE", "London", null, "GB");
 
-        AuthCardDetails authCardDetails = AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
+        AuthCardDetails authCardDetails = getValidTestCard(address);
 
         GatewayOrder actualRequest = aSmartpayAuthoriseOrderRequestBuilder()
                 .withMerchantCode("MerchantAccount")
@@ -94,6 +115,77 @@ public class SmartpayOrderRequestBuilderTest {
 
         assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthorise3dsRequiredOrderRequestForAddressWithAllFields() throws Exception {
+        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", "London", "GB");
+
+        AuthCardDetails authCardDetails = getValidTestCard(address);
+
+        GatewayOrder actualRequest = aSmartpay3dsRequiredOrderRequestBuilder()
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription")
+                .withPaymentPlatformReference("MyPlatformReference")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthorise3dsRequiredOrderRequestWhenAddressIsMissing() throws Exception {
+        AuthCardDetails authCardDetails = getValidTestCard(null);
+
+        GatewayOrder actualRequest = aSmartpay3dsRequiredOrderRequestBuilder()
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription")
+                .withPaymentPlatformReference("MyPlatformReference")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_WITHOUT_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthorise3dsRequiredOrderRequestWithSpecialCharactersInUserInput() throws Exception {
+        Address address = new Address("41", "Scala & Haskell Rocks", "EC2A 1AE", "London <!-- ", "London -->", "GB");
+
+        AuthCardDetails authCardDetails = getValidTestCard(address);
+
+        GatewayOrder actualRequest = aSmartpay3dsRequiredOrderRequestBuilder()
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription <? ")
+                .withPaymentPlatformReference("MyPlatformReference &>? <")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthorise3dsRequiredOrderRequestForAddressWithOptionalFieldsMissing() throws Exception {
+
+        Address address = new Address("41 Acacia Avenue", null, "EC2A 1AE", "London", null, "GB");
+
+        AuthCardDetails authCardDetails = getValidTestCard(address);
+
+        GatewayOrder actualRequest = aSmartpay3dsRequiredOrderRequestBuilder()
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription")
+                .withPaymentPlatformReference("MyPlatformReference")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_MINIMAL), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
     }
 
     @Test
@@ -142,5 +234,9 @@ public class SmartpayOrderRequestBuilderTest {
 
         assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_REFUND_SMARTPAY_REQUEST), actualRequest.getPayload());
         assertEquals(OrderRequestType.REFUND, actualRequest.getOrderRequestType());
+    }
+
+    private AuthCardDetails getValidTestCard(Address address) {
+        return AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -51,6 +51,11 @@ public class TestTemplateResourceLoader {
     public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-minimal.xml";
+    public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITHOUT_ADDRESS = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-without-address.xml";
+    public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-3ds-request.xml";
+    public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request.xml";
+    public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_MINIMAL = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request-minimal.xml";
+    public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_WITHOUT_ADDRESS = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request-without-address.xml";
 
     static final String SMARTPAY_CANCEL_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/cancel-error-response.xml";
     public static final String SMARTPAY_CANCEL_SUCCESS_RESPONSE = SMARTPAY_BASE_NAME + "/cancel-success-response.xml";

--- a/src/test/resources/templates/smartpay/special-char-valid-authorise-smartpay-3ds-request.xml
+++ b/src/test/resources/templates/smartpay/special-char-valid-authorise-smartpay-3ds-request.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://payment.services.adyen.com"
+        xmlns:ns2="http://common.services.adyen.com"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soap:Body>
+        <ns1:authorise>
+            <ns1:paymentRequest>
+                <ns1:additionalData>
+                    <ns2:entry>
+                        <ns2:key xsi:type="xsd:string">executeThreeD</ns2:key>
+                        <ns2:value xsi:type="xsd:string">true</ns2:value>
+                    </ns2:entry>
+                </ns1:additionalData>
+                <ns1:browserInfo>
+                    <ns2:acceptHeader>text/html</ns2:acceptHeader>
+                    <ns2:userAgent>Mozilla/5.0</ns2:userAgent>
+                </ns1:browserInfo>
+                <ns1:amount>
+                    <ns2:currency>GBP</ns2:currency>
+                    <ns2:value>2000</ns2:value>
+                </ns1:amount>
+                <ns1:card>
+                    <ns1:cvc>737</ns1:cvc>
+                    <ns1:expiryMonth>08</ns1:expiryMonth>
+                    <ns1:expiryYear>2018</ns1:expiryYear>
+                    <ns1:holderName>Mr. Payment</ns1:holderName>
+                    <ns1:number>5555444433331111</ns1:number>
+                    <ns1:billingAddress>
+                        <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
+                        <ns2:street>Scala &amp; Haskell Rocks</ns2:street>
+                        <ns2:postalCode>EC2A 1AE</ns2:postalCode>
+                        <ns2:stateOrProvince>London --&gt;</ns2:stateOrProvince>
+                        <ns2:city>London &lt;!-- </ns2:city>
+                        <ns2:country>GB</ns2:country>
+                    </ns1:billingAddress>
+                </ns1:card>
+                <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>
+                <ns1:reference>MyPlatformReference &amp;&gt;? &lt;</ns1:reference>
+                <ns1:shopperReference>MyDescription &lt;? </ns1:shopperReference>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request-minimal.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request-minimal.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://payment.services.adyen.com"
+        xmlns:ns2="http://common.services.adyen.com"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soap:Body>
+        <ns1:authorise>
+            <ns1:paymentRequest>
+                <ns1:additionalData>
+                    <ns2:entry>
+                        <ns2:key xsi:type="xsd:string">executeThreeD</ns2:key>
+                        <ns2:value xsi:type="xsd:string">true</ns2:value>
+                    </ns2:entry>
+                </ns1:additionalData>
+                <ns1:browserInfo>
+                    <ns2:acceptHeader>text/html</ns2:acceptHeader>
+                    <ns2:userAgent>Mozilla/5.0</ns2:userAgent>
+                </ns1:browserInfo>
+                <ns1:amount>
+                    <ns2:currency>GBP</ns2:currency>
+                    <ns2:value>2000</ns2:value>
+                </ns1:amount>
+                <ns1:card>
+                    <ns1:cvc>737</ns1:cvc>
+                    <ns1:expiryMonth>08</ns1:expiryMonth>
+                    <ns1:expiryYear>2018</ns1:expiryYear>
+                    <ns1:holderName>Mr. Payment</ns1:holderName>
+                    <ns1:number>5555444433331111</ns1:number>
+                    <ns1:billingAddress>
+                        <ns2:houseNumberOrName>41 Acacia Avenue</ns2:houseNumberOrName>
+                        <ns2:street>N/A</ns2:street>
+                        <ns2:postalCode>EC2A 1AE</ns2:postalCode>
+                        <ns2:stateOrProvince></ns2:stateOrProvince>
+                        <ns2:city>London</ns2:city>
+                        <ns2:country>GB</ns2:country>
+                    </ns1:billingAddress>
+                </ns1:card>
+                <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>
+                <ns1:reference>MyPlatformReference</ns1:reference>
+                <ns1:shopperReference>MyDescription</ns1:shopperReference>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request-without-address.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request-without-address.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://payment.services.adyen.com"
+        xmlns:ns2="http://common.services.adyen.com"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soap:Body>
+        <ns1:authorise>
+            <ns1:paymentRequest>
+                <ns1:additionalData>
+                    <ns2:entry>
+                        <ns2:key xsi:type="xsd:string">executeThreeD</ns2:key>
+                        <ns2:value xsi:type="xsd:string">true</ns2:value>
+                    </ns2:entry>
+                </ns1:additionalData>
+                <ns1:browserInfo>
+                    <ns2:acceptHeader>text/html</ns2:acceptHeader>
+                    <ns2:userAgent>Mozilla/5.0</ns2:userAgent>
+                </ns1:browserInfo>
+                <ns1:amount>
+                    <ns2:currency>GBP</ns2:currency>
+                    <ns2:value>2000</ns2:value>
+                </ns1:amount>
+                <ns1:card>
+                    <ns1:cvc>737</ns1:cvc>
+                    <ns1:expiryMonth>08</ns1:expiryMonth>
+                    <ns1:expiryYear>2018</ns1:expiryYear>
+                    <ns1:holderName>Mr. Payment</ns1:holderName>
+                    <ns1:number>5555444433331111</ns1:number>
+                </ns1:card>
+                <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>
+                <ns1:reference>MyPlatformReference</ns1:reference>
+                <ns1:shopperReference>MyDescription</ns1:shopperReference>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://payment.services.adyen.com"
+        xmlns:ns2="http://common.services.adyen.com"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soap:Body>
+        <ns1:authorise>
+            <ns1:paymentRequest>
+                <ns1:additionalData>
+                    <ns2:entry>
+                        <ns2:key xsi:type="xsd:string">executeThreeD</ns2:key>
+                        <ns2:value xsi:type="xsd:string">true</ns2:value>
+                    </ns2:entry>
+                </ns1:additionalData>
+                <ns1:browserInfo>
+                    <ns2:acceptHeader>text/html</ns2:acceptHeader>
+                    <ns2:userAgent>Mozilla/5.0</ns2:userAgent>
+                </ns1:browserInfo>
+                <ns1:amount>
+                    <ns2:currency>GBP</ns2:currency>
+                    <ns2:value>2000</ns2:value>
+                </ns1:amount>
+                <ns1:card>
+                    <ns1:cvc>737</ns1:cvc>
+                    <ns1:expiryMonth>08</ns1:expiryMonth>
+                    <ns1:expiryYear>2018</ns1:expiryYear>
+                    <ns1:holderName>Mr. Payment</ns1:holderName>
+                    <ns1:number>5555444433331111</ns1:number>
+                    <ns1:billingAddress>
+                        <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
+                        <ns2:street>Scala Street</ns2:street>
+                        <ns2:postalCode>EC2A 1AE</ns2:postalCode>
+                        <ns2:stateOrProvince>London</ns2:stateOrProvince>
+                        <ns2:city>London</ns2:city>
+                        <ns2:country>GB</ns2:country>
+                    </ns1:billingAddress>
+                </ns1:card>
+                <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>
+                <ns1:reference>MyPlatformReference</ns1:reference>
+                <ns1:shopperReference>MyDescription</ns1:shopperReference>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-without-address.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-without-address.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://payment.services.adyen.com"
+        xmlns:ns2="http://common.services.adyen.com">
+    <soap:Body>
+        <ns1:authorise>
+            <ns1:paymentRequest>
+                <ns1:amount>
+                    <ns2:currency>GBP</ns2:currency>
+                    <ns2:value>2000</ns2:value>
+                </ns1:amount>
+                <ns1:card>
+                    <ns1:cvc>737</ns1:cvc>
+                    <ns1:expiryMonth>08</ns1:expiryMonth>
+                    <ns1:expiryYear>2018</ns1:expiryYear>
+                    <ns1:holderName>Mr. Payment</ns1:holderName>
+                    <ns1:number>5555444433331111</ns1:number>
+                </ns1:card>
+                <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>
+                <ns1:reference>MyPlatformReference</ns1:reference>
+                <ns1:shopperReference>MyDescription</ns1:shopperReference>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
## WHAT
Modify creation of the payload XML for a Smartpay authorisation order request to omit the address element when the address for the charge is empty in the database.

## HOW 
- Modify payload xml template to skip adding 'billingAddress' element when address in CardEntity is null
- Add test for building payload when input address is null
- Add no address scenario to the integration tests

with @danworth


