### PR TITLE
PP-4341: Integration test for creating a charge with Stripe

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
@@ -6,7 +6,6 @@ public enum GatewayOperation {
     REFUND("refund"),
     CANCEL("cancel");
 
-
     private final String description;
 
     GatewayOperation(String auth) {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -3,6 +3,9 @@ package uk.gov.pay.connector.gateway.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.connector.common.model.domain.Address;
 
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
 import static uk.gov.pay.connector.gateway.model.PayersCardType.CREDIT_OR_DEBIT;
 
 public class AuthCardDetails implements AuthorisationDetails {
@@ -86,6 +89,16 @@ public class AuthCardDetails implements AuthorisationDetails {
 
     public String getEndDate() {
         return endDate;
+    }
+    
+    public String expiryMonth() {
+        YearMonth yearMonth = YearMonth.parse(endDate, DateTimeFormatter.ofPattern("MM/yy"));
+        return String.valueOf(yearMonth.getMonthValue());
+    }
+    
+    public String expiryYear() {
+        YearMonth yearMonth = YearMonth.parse(endDate, DateTimeFormatter.ofPattern("MM/yy"));
+        return String.valueOf(yearMonth.getYear());
     }
 
     public Address getAddress() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
@@ -11,6 +11,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
@@ -20,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 public class StripeGatewayClient {
 
@@ -34,11 +34,12 @@ public class StripeGatewayClient {
         this.metricRegistry = metricRegistry;
     }
 
-    public Response postRequest(GatewayAccountEntity account, 
-                                OrderRequestType requestType, 
-                                URI url, 
-                                String jsonPayload, 
-                                String authHeaderValue) {
+    public Response postRequest(GatewayAccountEntity account,
+                                OrderRequestType requestType,
+                                URI url,
+                                String payload,
+                                String authHeaderValue,
+                                MediaType mediaType) {
         String metricsPrefix = format("gateway-operations.%s.%s.%s", account.getGatewayName(), account.getType(), requestType);
 
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
@@ -47,7 +48,7 @@ public class StripeGatewayClient {
             Response response = client.target(url.toString())
                     .request()
                     .header(AUTHORIZATION, authHeaderValue)
-                    .post(Entity.entity(jsonPayload, APPLICATION_JSON_TYPE));
+                    .post(Entity.entity(payload, mediaType));
 
             if (response.getStatusInfo().getFamily() == Response.Status.Family.SERVER_ERROR) {
                 logger.error("Stripe gateway returned server error: {}, for gateway url={} with type {}", response.getStatus(), url.toString(), account.getType());

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -92,12 +92,12 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
                 stripeUrlEncodedSourcePayload(request),
                 getAuthHeaderValue(),
                 APPLICATION_FORM_URLENCODED_TYPE);
-        String sourceId = sourceResponse.readEntity(Map.class).get("id").toString();
+        String token = sourceResponse.readEntity(Map.class).get("id").toString();
         Response authorisationResponse = client.postRequest(
                 request.getGatewayAccount(),
                 AUTHORISE,
                 URI.create(stripeGatewayConfig.getUrl() + "/v1/charges"),
-                stripeAuthoriseJsonPayload(request, sourceId),
+                stripeAuthoriseJsonPayload(request, token),
                 getAuthHeaderValue(),
                 APPLICATION_JSON_TYPE);
 
@@ -154,12 +154,12 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
         throw new UnsupportedOperationException();
     }
 
-    private String stripeAuthoriseJsonPayload(AuthorisationGatewayRequest request, String sourceId) {
+    private String stripeAuthoriseJsonPayload(AuthorisationGatewayRequest request, String token) {
         Map<String, Object> params = new HashMap<>();
         params.put("amount", request.getAmount());
         params.put("currency", "GBP");
         params.put("description", request.getDescription());
-        params.put("source", sourceId);
+        params.put("source", token);
         params.put("capture", false);
         Map<String, Object> destinationParams = new HashMap<>();
         String stripeAccountId = request.getGatewayAccount().getCredentials().get("stripe_account_id");

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.connector.it.contract;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.ClientFactory;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
+import uk.gov.pay.connector.util.TestClientFactory;
+
+import static java.util.UUID.randomUUID;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsBuilder.anAuthCardDetails;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+/**
+ * This is an integration test with Stripe that should be run manually. In order to make it work you need to set
+ * a valid stripe.authToken in the test-it-config.yaml and a valid stripeAccountId (a field in the test).
+ * This test will hit the external https://api.stripe.com which is set in in stripe.url in the test-it-config.yaml.
+ */
+@Ignore
+@RunWith(MockitoJUnitRunner.class)
+public class StripePaymentProviderTest {
+
+    @Rule
+    public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
+    
+    @Mock
+    private ClientFactory clientFactory;
+    
+    private StripePaymentProvider stripePaymentProvider;
+    
+    private String stripeAccountId = "<replace me>";
+
+    @Before
+    public void setup() {
+        GatewayClientFactory gatewayClientFactory = new GatewayClientFactory(clientFactory);
+        when(clientFactory.createWithDropwizardClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(MetricRegistry.class)))
+                .thenReturn(TestClientFactory.createJerseyClient());
+        Environment environment = app.getInstanceFromGuiceContainer(Environment.class);
+        ConnectorConfiguration connectorConfig = app.getInstanceFromGuiceContainer(ConnectorConfiguration.class);
+        stripePaymentProvider = new StripePaymentProvider(gatewayClientFactory, environment, connectorConfig);
+    }
+    
+    @Test
+    public void createChargeInStripe() {
+        AuthorisationGatewayRequest request = AuthorisationGatewayRequest.valueOf(getCharge(), anAuthCardDetails().withEndDate("01/21").build());
+        GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request);
+        assertThat(gatewayResponse.isSuccessful()).isTrue();
+    }
+
+    private ChargeEntity getCharge() {
+        GatewayAccountEntity validGatewayAccount = new GatewayAccountEntity();
+        validGatewayAccount.setId(123L);
+        validGatewayAccount.setGatewayName(PaymentGatewayName.STRIPE.getName());
+        validGatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", stripeAccountId));
+        validGatewayAccount.setType(TEST);
+        return aValidChargeEntity()
+                .withGatewayAccountEntity(validGatewayAccount)
+                .withTransactionId(randomUUID().toString())
+                .withDescription("stripe payment provider test charge")
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceITest.java
@@ -1,9 +1,11 @@
 package uk.gov.pay.connector.it.resources.stripe;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.math.RandomUtils;
 import org.hamcrest.Matchers;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,11 +19,24 @@ import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.rules.StripeMockClient;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -32,34 +47,38 @@ import static uk.gov.pay.connector.junit.DropwizardJUnitRunner.WIREMOCK_PORT;
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class StripeResourceITest {
 
-    private String validAuthorisationDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "visa");
-    
+    private static final String CVC = "123";
+    private static final String EXP_MONTH = "11";
+    private static final String EXP_YEAR = "99";
+    private static final String CARD_NUMBER = "4444333322221111";
+    private static final String AMOUNT = "6234";
+    private static final String DESCRIPTION = "Test description";
+    private static final String STRIPE_ACCOUNT_ID = "123";
+
+    private String validAuthorisationDetails = buildJsonAuthorisationDetailsFor("4444333322221111", CVC, EXP_MONTH + "/" + EXP_YEAR, "visa");
     private String paymentProvider = PaymentGatewayName.STRIPE.getName();
-    
     private String accountId;
-    
     private StripeMockClient stripeMockClient = new StripeMockClient();
+    private DatabaseTestHelper databaseTestHelper;
 
     @DropwizardTestContext
     private TestContext testContext;
     
-    private DatabaseTestHelper databaseTestHelper;
-
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);
-    
+
     @Before
     public void setup() {
         databaseTestHelper = testContext.getDatabaseTestHelper();
         accountId = String.valueOf(RandomUtils.nextInt());
-        
+
         stripeMockClient.mockCreateToken();
         stripeMockClient.mockCreateCharge();
     }
-    
+
     @Test
     public void authoriseCharge() {
-        addGatewayAccount(ImmutableMap.of("stripe_account_id", "123"));
+        addGatewayAccount(ImmutableMap.of("stripe_account_id", STRIPE_ACCOUNT_ID));
 
         String externalChargeId = addCharge();
 
@@ -70,8 +89,26 @@ public class StripeResourceITest {
                 .then()
                 .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))
                 .statusCode(200);
+
+        verify(postRequestedFor(urlEqualTo("/v1/tokens"))
+                .withHeader("Content-Type", equalTo(APPLICATION_FORM_URLENCODED))
+                .withRequestBody(matching(constructExpectedRequestBody())));
+
+        verify(postRequestedFor(urlEqualTo("/v1/charges"))
+                .withHeader("Content-Type", equalTo(APPLICATION_JSON)));
+
+        List<LoggedRequest> requests = findAll(postRequestedFor(urlMatching("/v1/charges")));
+        assertThat(requests).hasSize(1);
+        assertThat(requests.get(0).getBodyAsString()).isEqualTo(stripeAuthoriseJsonPayload());
     }
-    
+
+    private String constructExpectedRequestBody() {
+        return format("card[cvc]=123&card[exp_month]=11&card[exp_year]=2099&card[number]=4444333322221111",
+                CVC, EXP_MONTH, EXP_YEAR, CARD_NUMBER)
+                .replace("[", "%5B")
+                .replace("]", "%5D");
+    }
+
     @Test
     public void shouldReturnInternalServerResponseWhenGatewayAccountHasNoStripeAccountId() {
         addGatewayAccount(emptyMap());
@@ -86,19 +123,31 @@ public class StripeResourceITest {
                 .statusCode(500)
                 .body("message", containsString("There is no stripe_account_id for gateway account with id"));
     }
-    
+
     private String addCharge() {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge-" + chargeId;
-        databaseTestHelper.addCharge(chargeId, externalChargeId, accountId, 6234L, ENTERING_CARD_DETAILS, "RETURN_URL", null);
+        databaseTestHelper.addCharge(chargeId, externalChargeId, accountId, Long.valueOf(AMOUNT), ENTERING_CARD_DETAILS, "RETURN_URL", null, DESCRIPTION);
         return externalChargeId;
     }
 
     private void addGatewayAccount(Map credentials) {
         databaseTestHelper.addGatewayAccount(accountId, paymentProvider, credentials);
     }
-    
+
     private String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
+    }
+    private String stripeAuthoriseJsonPayload() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("amount", AMOUNT);
+        params.put("currency", "GBP");
+        params.put("description", DESCRIPTION);
+        params.put("source", "src_1DT9bn2eZvKYlo2Cg5okt8WC");
+        params.put("capture", false);
+        Map<String, Object> destinationParams = new HashMap<>();
+        destinationParams.put("account", STRIPE_ACCOUNT_ID);
+        params.put("destination", destinationParams);
+        return new JSONObject(params).toString();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceITest.java
@@ -53,7 +53,7 @@ public class StripeResourceITest {
         databaseTestHelper = testContext.getDatabaseTestHelper();
         accountId = String.valueOf(RandomUtils.nextInt());
         
-        stripeMockClient.mockCreateSource();
+        stripeMockClient.mockCreateToken();
         stripeMockClient.mockCreateCharge();
     }
     

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -12,9 +12,9 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHOR
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCE_SUCCESS_RESPONSE;
 
 public class StripeMockClient {
-    public void mockCreateSource() {
+    public void mockCreateToken() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCE_SUCCESS_RESPONSE);
-        paymentServiceResponse(payload, "/v1/sources");
+        paymentServiceResponse(payload, "/v1/tokens");
     }
 
     private void paymentServiceResponse(String responseBody, String path) {

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -3,10 +3,12 @@ package uk.gov.pay.connector.rules;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCE_SUCCESS_RESPONSE;
@@ -14,23 +16,16 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE
 public class StripeMockClient {
     public void mockCreateToken() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCE_SUCCESS_RESPONSE);
-        paymentServiceResponse(payload, "/v1/tokens");
+        paymentServiceResponse(payload, "/v1/tokens", APPLICATION_FORM_URLENCODED);
     }
 
-    private void paymentServiceResponse(String responseBody, String path) {
-        stubFor(
-                post(urlPathEqualTo(path))
-                        .willReturn(
-                                aResponse()
-                                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
-                                        .withStatus(200)
-                                        .withBody(responseBody)
-                        )
-        );
+    private void paymentServiceResponse(String responseBody, String path, String mediaType) {
+        stubFor(post(urlPathEqualTo(path)).withHeader(CONTENT_TYPE, matching(mediaType))
+                .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON).withStatus(200).withBody(responseBody)));
     }
 
     public void mockCreateCharge() {
         String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_SUCCESS_RESPONSE);
-        paymentServiceResponse(payload, "/v1/charges");
+        paymentServiceResponse(payload, "/v1/charges", APPLICATION_JSON);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -26,6 +26,6 @@ public class StripeMockClient {
 
     public void mockCreateCharge() {
         String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_SUCCESS_RESPONSE);
-        paymentServiceResponse(payload, "/v1/charges", APPLICATION_JSON);
+        paymentServiceResponse(payload, "/v1/charges", APPLICATION_FORM_URLENCODED);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -111,6 +111,12 @@ public class DatabaseTestHelper {
                 ServicePaymentReference.of("Test reference"), now(), 1, "email@fake.test", SupportedLanguage.ENGLISH, false);
     }
 
+    public void addCharge(Long chargeId, String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl,
+                          String transactionId, String description) {
+        addCharge(chargeId, externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId, description,
+                ServicePaymentReference.of("Test reference"), now(), 1, "email@fake.test", SupportedLanguage.ENGLISH, false);
+    }
+
     public void addCharge(String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl, String transactionId) {
         addCharge((long) RandomUtils.nextInt(1, 9999999), externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId,
                 "Test description", ServicePaymentReference.of("Test reference"), now(), 1, null, SupportedLanguage.ENGLISH, false);


### PR DESCRIPTION
This PR creates a StripePaymentProviderTest with the intention of it being run manually, similar to other tests in the `uk.gov.pay.connector.it.contract` package.
This commit doesn't include configuring timeouts when connecting to api.stripe.com. That will be in another commit.

@oswaldquek 