### PR TITLE
PP-4352 - Remove generics from PaymentProvider interface

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureHandler.java
@@ -4,8 +4,8 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
-public interface CaptureHandler<T extends BaseCaptureResponse> {
+public interface CaptureHandler {
 
-    GatewayResponse<T> capture(CaptureGatewayRequest request);
+    GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request);
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -4,10 +4,13 @@ import fj.data.Either;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
@@ -15,7 +18,7 @@ import uk.gov.pay.connector.usernotification.model.Notifications;
 
 import java.util.Optional;
 
-public interface PaymentProvider<T extends BaseResponse, R> {
+public interface PaymentProvider<R> {
 
     PaymentGatewayName getPaymentGatewayName();
 
@@ -23,15 +26,15 @@ public interface PaymentProvider<T extends BaseResponse, R> {
 
     Optional<String> generateTransactionId();
 
-    GatewayResponse<T> authorise(CardAuthorisationGatewayRequest request);
+    GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request);
 
-    GatewayResponse<T> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
-    
+    GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
+
     CaptureHandler getCaptureHandler();
 
-    GatewayResponse<T> refund(RefundGatewayRequest request);
+    GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request);
 
-    GatewayResponse<T> cancel(CancelGatewayRequest request);
+    GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request);
 
     Either<String, Notifications<R>> parseNotification(String payload);
 
@@ -43,3 +46,4 @@ public interface PaymentProvider<T extends BaseResponse, R> {
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity);
 }
+

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 
@@ -26,7 +27,7 @@ public class EpdqCaptureHandler implements CaptureHandler {
     }
 
     @Override
-    public GatewayResponse<EpdqCaptureResponse> capture(CaptureGatewayRequest request) {
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCaptureOrder(request));
         return GatewayResponseGenerator.getEpdqGatewayResponse(client, response, EpdqCaptureResponse.class);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -56,9 +56,9 @@ public class GatewayResponse<T extends BaseResponse> {
         }
     }
 
-    public static <T extends BaseResponse> GatewayResponse<T> with(GatewayError gatewayError) {
+    public static GatewayResponse with(GatewayError gatewayError) {
         logger.error("Error received from gateway: {}", gatewayError);
-        return new GatewayResponse<>(gatewayError);
+        return new GatewayResponse(gatewayError);
     }
 
     public static class GatewayResponseBuilder<T extends BaseResponse> {
@@ -69,34 +69,34 @@ public class GatewayResponse<T extends BaseResponse> {
         private GatewayResponseBuilder() {
         }
 
-        public static <T extends BaseResponse> GatewayResponseBuilder<T> responseBuilder() {
-            return new GatewayResponseBuilder<>();
+        public static GatewayResponseBuilder responseBuilder() {
+            return new GatewayResponseBuilder();
         }
 
-        public GatewayResponseBuilder<T> withResponse(T response) {
+        public GatewayResponseBuilder withResponse(T response) {
             this.response = response;
             return this;
         }
 
-        public GatewayResponseBuilder<T> withSessionIdentifier(String responseIdentifier) {
+        public GatewayResponseBuilder withSessionIdentifier(String responseIdentifier) {
             this.sessionIdentifier = responseIdentifier;
             return this;
         }
 
-        public GatewayResponseBuilder<T> withGatewayError(GatewayError gatewayError) {
+        public GatewayResponseBuilder withGatewayError(GatewayError gatewayError) {
             this.gatewayError = gatewayError;
             return this;
         }
 
-        public GatewayResponse<T> build() {
+        public GatewayResponse build() {
             if (gatewayError != null) {
-                return new GatewayResponse<>(gatewayError);
+                return new GatewayResponse(gatewayError);
             }
             if (StringUtils.isNotBlank(response.getErrorCode()) ||
                     StringUtils.isNotBlank(response.getErrorMessage())) {
                 return new GatewayResponse<>(genericGatewayError(response.toString()));
             }
-            return new GatewayResponse<>(response, sessionIdentifier);
+            return new GatewayResponse(response, sessionIdentifier);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -31,7 +31,7 @@ import static java.util.UUID.randomUUID;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
-public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, String> {
+public class SandboxPaymentProvider implements PaymentProvider<String> {
 
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 
@@ -43,7 +43,7 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
     }
 
     @Override
-    public GatewayResponse authorise(CardAuthorisationGatewayRequest request) {
+    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) {
         String cardNumber = request.getAuthCardDetails().getCardNo();
         GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
 
@@ -64,7 +64,7 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
     }
 
     @Override
-    public GatewayResponse<BaseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+    public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
         return gatewayResponseBuilder
                 .withGatewayError(new GatewayError("3D Secure not implemented for Sandbox", GENERIC_GATEWAY_ERROR))
@@ -87,7 +87,7 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
     }
 
     @Override
-    public GatewayResponse cancel(CancelGatewayRequest request) {
+    public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) {
         return createGatewayBaseCancelResponse();
     }
 
@@ -107,7 +107,7 @@ public class SandboxPaymentProvider implements PaymentProvider<BaseResponse, Str
     }
 
     @Override
-    public GatewayResponse refund(RefundGatewayRequest request) {
+    public GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request) {
         return createGatewayBaseRefundResponse(request);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 
@@ -23,7 +24,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
     }
 
     @Override
-    public GatewayResponse<SmartpayCaptureResponse> capture(CaptureGatewayRequest request) {
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrderFor(request));
         return GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayCaptureResponse.class);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -19,6 +19,9 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
@@ -54,9 +57,8 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
 import static uk.gov.pay.connector.gateway.model.GatewayError.unexpectedStatusCodeFromGateway;
 
-
 @Singleton
-public class StripePaymentProvider implements PaymentProvider<BaseResponse, String> {
+public class StripePaymentProvider implements PaymentProvider<String> {
 
     private static final Logger logger = LoggerFactory.getLogger(StripePaymentProvider.class);
 
@@ -209,7 +211,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
     }
 
     @Override
-    public GatewayResponse<BaseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+    public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         return null;
     }
 
@@ -219,12 +221,12 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
     }
 
     @Override
-    public GatewayResponse<BaseResponse> refund(RefundGatewayRequest request) {
+    public GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request) {
         return null;
     }
 
     @Override
-    public GatewayResponse<BaseResponse> cancel(CancelGatewayRequest request) {
+    public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) {
         return null;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.DownstreamException;
@@ -43,7 +44,7 @@ public class StripeCaptureHandler implements CaptureHandler {
     }
 
     @Override
-    public GatewayResponse capture(CaptureGatewayRequest request) {
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
 
         String url = stripeGatewayConfig.getUrl() + "/v1/charges/" + request.getTransactionId() + "/capture";
         GatewayAccountEntity gatewayAccount = request.getGatewayAccount();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 
@@ -23,7 +24,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
     }
 
     @Override
-    public GatewayResponse<WorldpayCaptureResponse> capture(CaptureGatewayRequest request) {
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrder(request));
         return GatewayResponseGenerator.getWorldpayGatewayResponse(client, response, WorldpayCaptureResponse.class);
      }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -14,10 +14,12 @@ import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
@@ -47,7 +49,7 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
-public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, String> {
+public class WorldpayPaymentProvider implements PaymentProvider<String> {
 
     public static final String WORLDPAY_MACHINE_COOKIE_NAME = "machine";
 
@@ -87,13 +89,13 @@ public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, St
     }
 
     @Override
-    public GatewayResponse authorise(CardAuthorisationGatewayRequest request) {
+    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), buildAuthoriseOrder(request));
         return GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
     }
 
     @Override
-    public GatewayResponse<BaseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+    public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), build3dsResponseAuthOrder(request));
         return GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
     }
@@ -104,13 +106,13 @@ public class WorldpayPaymentProvider implements PaymentProvider<BaseResponse, St
     }
 
     @Override
-    public GatewayResponse refund(RefundGatewayRequest request) {
+    public GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = refundClient.postRequestFor(null, request.getGatewayAccount(), buildRefundOrder(request));
         return GatewayResponseGenerator.getWorldpayGatewayResponse(refundClient, response, WorldpayRefundResponse.class);
     }
 
     @Override
-    public GatewayResponse cancel(CancelGatewayRequest request) {
+    public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = cancelClient.postRequestFor(null, request.getGatewayAccount(), buildCancelOrder(request));
         return GatewayResponseGenerator.getWorldpayGatewayResponse(cancelClient, response, WorldpayCancelResponse.class);
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -87,7 +87,7 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
                         .orElse(ChargeStatus.AUTHORISATION_ERROR));
     }
 
-    PaymentProvider<BaseAuthoriseResponse, ?> getPaymentProviderFor(ChargeEntity chargeEntity) {
+    PaymentProvider<?> getPaymentProviderFor(ChargeEntity chargeEntity) {
         return providers.byName(chargeEntity.getPaymentGatewayName());
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -1,16 +1,13 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -22,15 +19,11 @@ import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import javax.inject.Inject;
 import javax.persistence.OptimisticLockException;
-import java.util.List;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 
 public class CardCaptureService {
@@ -44,7 +37,7 @@ public class CardCaptureService {
     protected MetricRegistry metricRegistry;
 
     @Inject
-    public CardCaptureService(ChargeService chargeService, PaymentProviders providers, 
+    public CardCaptureService(ChargeService chargeService, PaymentProviders providers,
                               UserNotificationService userNotificationService,
                               Environment environment) {
         this.chargeService = chargeService;
@@ -135,7 +128,7 @@ public class CardCaptureService {
         }
     }
 
-    PaymentProvider<BaseCaptureResponse, ?> getPaymentProviderFor(ChargeEntity chargeEntity) {
+    PaymentProvider<?> getPaymentProviderFor(ChargeEntity chargeEntity) {
         return providers.byName(chargeEntity.getPaymentGatewayName());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -233,8 +233,8 @@ public class ChargeRefundService {
         return "";
     }
 
-    public PaymentProvider<BaseRefundResponse, ?> getPaymentProviderFor(PaymentProviders providers, ChargeEntity chargeEntity) {
-        PaymentProvider<BaseRefundResponse, ?> paymentProvider = providers.byName(chargeEntity.getPaymentGatewayName());
+    public PaymentProvider<?> getPaymentProviderFor(PaymentProviders providers, ChargeEntity chargeEntity) {
+        PaymentProvider<?> paymentProvider = providers.byName(chargeEntity.getPaymentGatewayName());
         return paymentProvider;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -4,8 +4,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,7 +27,7 @@ public class EpdqCaptureHandlerTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldCapture() {
         mockPaymentProviderResponse(200, successCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
         verifyPaymentProviderRequest(successCaptureRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
@@ -36,7 +36,7 @@ public class EpdqCaptureHandlerTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsUnexpectedStatusCode() {
         mockPaymentProviderResponse(200, errorCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
     }
@@ -44,7 +44,7 @@ public class EpdqCaptureHandlerTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorCaptureResponse());
-        GatewayResponse<EpdqCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
@@ -3,8 +3,8 @@ package uk.gov.pay.connector.gateway.epdq;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import static java.lang.String.format;
@@ -25,7 +25,7 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldRequire3dsAuthoriseRequest() {
         mockPaymentProviderResponse(200, successAuth3dResponse());
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise(buildTestAuthorisationRequest());
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
         verifyPaymentProviderRequest(successAuthRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
@@ -34,7 +34,7 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldAuthorise3dsResponseIfMatchesWithEpdqStatus() {
         mockPaymentProviderResponse(200, successAuthorisedQueryResponse());
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise3dsResponse(buildTestAuthorisation3dsVerifyRequest("AUTHORISED"));
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(buildTestAuthorisation3dsVerifyRequest("AUTHORISED"));
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(AUTHORISED));
@@ -44,7 +44,7 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldRejectOnRejectedEpdqStatusResponse_evenIfFrontendStatusIsSuccess() {
         mockPaymentProviderResponse(200, declinedAuthorisedQueryResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("AUTHORISED");
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise3dsResponse(request);
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REJECTED));
@@ -56,7 +56,7 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldErrorOnErrorEpdqStatusResponse_evenIfFrontendStatusIsSuccess() {
         mockPaymentProviderResponse(200, errorAuthorisedQueryResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("AUTHORISED");
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise3dsResponse(request);
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isFailed());
         assertThat(response.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
@@ -68,7 +68,7 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldErrorAuthorisationWhenFrontendStatusIsError_evenIfEpdqStatusIsSuccess() {
         mockPaymentProviderResponse(200, successAuthResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("ERROR");
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise3dsResponse(request);
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isFailed());
         assertThat(response.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
@@ -80,7 +80,7 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldRejectAuthorisationWhenFrontendStatusIsDeclined_evenIfEpdqStatusIsSuccess() {
         mockPaymentProviderResponse(200, successAuthResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("DECLINED");
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise3dsResponse(request);
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REJECTED));
@@ -92,7 +92,7 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldRejectAuthorisationWhenFrontendStatusIsDeclined_evenIfEpdqStatusIsError() {
         mockPaymentProviderResponse(200, errorAuthResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("DECLINED");
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise3dsResponse(request);
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(REJECTED));

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -8,11 +8,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCancelResponse;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
@@ -45,7 +44,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldAuthorise() {
         mockPaymentProviderResponse(200, successAuthResponse());
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise(buildTestAuthorisationRequest());
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
         verifyPaymentProviderRequest(successAuthRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
@@ -54,7 +53,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotAuthoriseIfPaymentProviderReturnsUnexpectedStatusCode() {
         mockPaymentProviderResponse(200, errorAuthResponse());
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise(buildTestAuthorisationRequest());
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
     }
@@ -62,7 +61,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotAuthoriseIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorAuthResponse());
-        GatewayResponse<EpdqAuthorisationResponse> response = provider.authorise(buildTestAuthorisationRequest());
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
@@ -72,7 +71,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldCancel() {
         mockPaymentProviderResponse(200, successCancelResponse());
-        GatewayResponse<EpdqCancelResponse> response = provider.cancel(buildTestCancelRequest());
+        GatewayResponse<BaseCancelResponse> response = provider.cancel(buildTestCancelRequest());
         verifyPaymentProviderRequest(successCancelRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
@@ -81,7 +80,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotCancelIfPaymentProviderReturnsUnexpectedStatusCode() {
         mockPaymentProviderResponse(200, errorCancelResponse());
-        GatewayResponse<EpdqCaptureResponse> response = provider.cancel(buildTestCancelRequest());
+        GatewayResponse<BaseCancelResponse> response = provider.cancel(buildTestCancelRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
     }
@@ -89,7 +88,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotCancelIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorCancelResponse());
-        GatewayResponse<EpdqCaptureResponse> response = provider.cancel(buildTestCancelRequest());
+        GatewayResponse<BaseCancelResponse> response = provider.cancel(buildTestCancelRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
@@ -99,7 +98,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldRefund() {
         mockPaymentProviderResponse(200, successRefundResponse());
-        GatewayResponse<EpdqRefundResponse> response = provider.refund(buildTestRefundRequest());
+        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
         verifyPaymentProviderRequest(successRefundRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getReference(), is(Optional.of("3014644340/1")));
@@ -108,7 +107,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldRefundWithPaymentDeletion() {
         mockPaymentProviderResponse(200, successDeletionResponse());
-        GatewayResponse<EpdqRefundResponse> response = provider.refund(buildTestRefundRequest());
+        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
         verifyPaymentProviderRequest(successRefundRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getReference(), is(Optional.of("3014644340/1")));
@@ -117,7 +116,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotRefundIfPaymentProviderReturnsErrorStatusCode() {
         mockPaymentProviderResponse(200, errorRefundResponse());
-        GatewayResponse<EpdqRefundResponse> response = provider.refund(buildTestRefundRequest());
+        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
     }
@@ -125,7 +124,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotRefundIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorRefundResponse());
-        GatewayResponse<EpdqRefundResponse> response = provider.refund(buildTestRefundRequest());
+        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
@@ -33,7 +34,7 @@ public class SmartpayCaptureHandlerTest extends BaseSmartpayPaymentProviderTest 
                 .withGatewayAccountEntity(aServiceAccount())
                 .build();
 
-        GatewayResponse<SmartpayCaptureResponse> response = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse<BaseCaptureResponse> response = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(response.isSuccessful());
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -14,7 +14,9 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -82,11 +84,11 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
                 .withGatewayAccountEntity(aServiceAccount())
                 .build();
 
-        GatewayResponse<SmartpayAuthorisationResponse> response = provider.authorise(new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails));
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails));
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), CoreMatchers.is(true));
-        String transactionId = response.getBaseResponse().get().getPspReference();
+        String transactionId = response.getBaseResponse().get().getTransactionId();
         assertThat(transactionId, is(not(nullValue())));
     }
 
@@ -100,11 +102,11 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
                 .build();
         mockSmartpay3dsRequiredOrderSubmitResponse();
 
-        GatewayResponse<SmartpayAuthorisationResponse> response = provider.authorise(new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails));
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails));
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), is(true));
-        SmartpayAuthorisationResponse smartpayAuthorisationResponse = response.getBaseResponse().get();
+        SmartpayAuthorisationResponse smartpayAuthorisationResponse = (SmartpayAuthorisationResponse) response.getBaseResponse().get();
         assertThat(smartpayAuthorisationResponse.authoriseStatus(), is(REQUIRES_3DS));
         assertThat(smartpayAuthorisationResponse.getMd(), is(not(nullValue())));
         assertThat(smartpayAuthorisationResponse.getIssuerUrl(), is(not(nullValue())));
@@ -122,11 +124,11 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
         Auth3dsDetails auth3dsDetails = AuthUtils.buildAuth3dsDetails();
         auth3dsDetails.setMd("Some smart text here");
 
-        GatewayResponse<SmartpayAuthorisationResponse> response = provider.authorise3dsResponse(new Auth3dsResponseGatewayRequest(chargeEntity, auth3dsDetails));
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(new Auth3dsResponseGatewayRequest(chargeEntity, auth3dsDetails));
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), is(true));
-        SmartpayAuthorisationResponse smartpayAuthorisationResponse = response.getBaseResponse().get();
+        SmartpayAuthorisationResponse smartpayAuthorisationResponse = (SmartpayAuthorisationResponse) response.getBaseResponse().get();
         assertThat(smartpayAuthorisationResponse.authoriseStatus(), is(AUTHORISED));
         assertThat(smartpayAuthorisationResponse.getPspReference(), is(not(nullValue())));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -5,11 +5,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
-import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
 
-import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -34,7 +33,7 @@ public class StripeCaptureHandlerTest extends BaseStripePaymentProviderTest {
     public void shouldCapture() throws IOException {
         mockPaymentProviderCaptureResponse(200, successCaptureResponse());
 
-        GatewayResponse<StripeCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("ch_123456"));
     }
@@ -42,7 +41,7 @@ public class StripeCaptureHandlerTest extends BaseStripePaymentProviderTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturns4xxHttpStatusCode() throws IOException {
         mockPaymentProviderErrorResponse(400, errorCaptureResponse());
-        GatewayResponse<StripeCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("No such charge: ch_123456 or something similar",
@@ -52,7 +51,7 @@ public class StripeCaptureHandlerTest extends BaseStripePaymentProviderTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturns5xxHttpStatusCode() throws IOException {
         mockPaymentProviderErrorResponse(500, stripeInternalServerError());
-        GatewayResponse<StripeCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(response.getGatewayError().get().getMessage(), containsString("An internal server error occurred. ErrorId:"));

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,16 +7,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -42,7 +39,7 @@ public class WorldpayCaptureHandlerTest extends WorldpayBasePaymentProviderTest 
     @Test
     public void shouldErrorIfOrderReferenceNotKnownInCapture() {
         mockWorldpayErrorResponse(200);
-        GatewayResponse<WorldpayCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
 
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
@@ -52,7 +49,7 @@ public class WorldpayCaptureHandlerTest extends WorldpayBasePaymentProviderTest 
     @Test
     public void shouldErrorIfWorldpayResponseIsNot200() {
         mockWorldpayErrorResponse(400);
-        GatewayResponse<WorldpayCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
+        GatewayResponse<BaseCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -259,7 +260,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
 
     @Test
     public void shouldSendSuccessfullyAnOrderForMerchant() throws Exception {
-        GatewayResponse<WorldpayOrderStatusResponse> response = provider.authorise(getCardAuthorisationRequest());
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(getCardAuthorisationRequest());
         assertTrue(response.isSuccessful());
         assertTrue(response.getSessionIdentifier().isPresent());
     }
@@ -267,7 +268,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
     @Test
     public void shouldErrorIfAuthorisationIsUnsuccessful() {
         mockWorldpayErrorResponse(401);
-        GatewayResponse<WorldpayOrderStatusResponse> response = provider.authorise(getCardAuthorisationRequest());
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(getCardAuthorisationRequest());
 
         assertThat(response.isFailed(), is(true));
         assertFalse(response.getSessionIdentifier().isPresent());

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -24,10 +24,10 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayAuthorisationResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayCaptureHandler;
-import uk.gov.pay.connector.gateway.smartpay.SmartpayCaptureResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -192,7 +192,7 @@ public class SmartpayPaymentProviderTest {
 
         chargeEntity.setGatewayTransactionId(transactionId);
 
-        GatewayResponse<SmartpayCaptureResponse> captureGatewayResponse = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse<BaseCaptureResponse> captureGatewayResponse = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(captureGatewayResponse.isSuccessful());
     }
 
@@ -224,7 +224,7 @@ public class SmartpayPaymentProviderTest {
 
         chargeEntity.setGatewayTransactionId(authoriseResponse.getBaseResponse().get().getPspReference());
 
-        GatewayResponse<SmartpayCaptureResponse> captureGatewayResponse = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse<BaseCaptureResponse> captureGatewayResponse = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(captureGatewayResponse.isSuccessful());
 
         RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -17,15 +17,17 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureHandler;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -120,8 +122,7 @@ public class WorldpayPaymentProviderTest {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
-
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertTrue(response.isSuccessful());
     }
 
@@ -134,7 +135,7 @@ public class WorldpayPaymentProviderTest {
                 .build();
 
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
 
         assertTrue(response.isSuccessful());
     }
@@ -147,7 +148,7 @@ public class WorldpayPaymentProviderTest {
                 .build();
 
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequestWithRequired3ds(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
 
         assertTrue(response.isSuccessful());
         assertTrue(response.getBaseResponse().isPresent());
@@ -169,7 +170,7 @@ public class WorldpayPaymentProviderTest {
 
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequestWithRequired3ds(authCardDetails);
 
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertTrue(response.isSuccessful());
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getSessionIdentifier().isPresent());
@@ -200,7 +201,7 @@ public class WorldpayPaymentProviderTest {
         WorldpayCaptureHandler worldpayCaptureHandler = (WorldpayCaptureHandler) paymentProvider.getCaptureHandler();
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         String transactionId = response.getBaseResponse().get().getTransactionId();
 
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -209,7 +210,7 @@ public class WorldpayPaymentProviderTest {
         assertThat(transactionId, is(not(nullValue())));
 
         chargeEntity.setGatewayTransactionId(transactionId);
-        GatewayResponse<WorldpayCaptureResponse> captureResponse = worldpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse<BaseCaptureResponse> captureResponse = worldpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
 
         assertThat(captureResponse.isSuccessful(), is(true));
 
@@ -225,7 +226,7 @@ public class WorldpayPaymentProviderTest {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
 
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().isPresent(), is(true));
@@ -263,7 +264,7 @@ public class WorldpayPaymentProviderTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(charge, authCardDetails);
-        GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
 
         assertFalse(response.isSuccessful());
     }


### PR DESCRIPTION
## WHAT
Removed generic type from PaymentProvider gateway operation signatures and replaced with relevant BaseXxx classes for the operation (authorise, capture, cancel, refund)


