### PR TITLE
PP-4352 Stripe Capture

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
@@ -59,7 +59,6 @@ public class StripeGatewayClient {
                 incrementFailureCounter(metricRegistry, metricsPrefix);
                 throw new WebApplicationException("Unexpected HTTP status code " + response.getStatus() + " from gateway");
             }
-
             return response;
         } catch (ProcessingException pe) {
             incrementFailureCounter(metricRegistry, metricsPrefix);
@@ -79,6 +78,10 @@ public class StripeGatewayClient {
             }
             logger.error(format("Exception for gateway url=%s", url.toString()), pe);
             throw new WebApplicationException(pe.getMessage());
+        } catch (Exception e) {
+            incrementFailureCounter(metricRegistry, metricsPrefix);
+            logger.error(format("Exception for gateway url=%s", url.toString()), e);
+            throw new WebApplicationException(e.getMessage());
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram(metricsPrefix + ".response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -19,9 +19,9 @@ import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
-import uk.gov.pay.connector.gateway.stripe.json.StripeError;
 import uk.gov.pay.connector.gateway.stripe.json.StripeSourcesResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeTokenResponse;
+import uk.gov.pay.connector.gateway.stripe.response.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.util.StripeAuthUtil;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
@@ -95,7 +95,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
                 APPLICATION_FORM_URLENCODED_TYPE);
 
         if (tokenResponse.getStatusInfo().getFamily() == Response.Status.Family.CLIENT_ERROR) {
-            String reason = tokenResponse.readEntity(StripeError.class).getError().getMessage();
+            String reason = tokenResponse.readEntity(StripeErrorResponse.class).getError().getMessage();
             String errorId = UUID.randomUUID().toString();
             logger.error("There was error calling /v1/tokens. Reason: {}, ErrorId: {}", reason, errorId);
             throw new WebApplicationException("There was an internal server error. ErrorId: " + errorId);

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -18,9 +18,11 @@ import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
 import uk.gov.pay.connector.gateway.stripe.json.StripeError;
 import uk.gov.pay.connector.gateway.stripe.json.StripeSourcesResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeTokenResponse;
+import uk.gov.pay.connector.gateway.stripe.util.StripeAuthUtil;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -54,6 +56,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
     private final StripeGatewayClient client;
     private final StripeGatewayConfig stripeGatewayConfig;
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
+    private final StripeCaptureHandler stripeCaptureHandler;
 
     @Inject
     public StripePaymentProvider(StripeGatewayClient stripeGatewayClient,
@@ -61,6 +64,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
         this.stripeGatewayConfig = configuration.getStripeConfig();
         this.client = stripeGatewayClient;
         this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
+        stripeCaptureHandler = new StripeCaptureHandler(client, stripeGatewayConfig);
     }
 
     @Override
@@ -87,7 +91,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
                 AUTHORISE,
                 URI.create(stripeGatewayConfig.getUrl() + "/v1/tokens"),
                 tokenPayload(request),
-                getAuthHeaderValue(),
+                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
                 APPLICATION_FORM_URLENCODED_TYPE);
 
         if (tokenResponse.getStatusInfo().getFamily() == Response.Status.Family.CLIENT_ERROR) {
@@ -104,7 +108,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
                 AUTHORISE,
                 URI.create(stripeGatewayConfig.getUrl() + "/v1/sources"),
                 sourcesPayload(token),
-                getAuthHeaderValue(),
+                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
                 APPLICATION_FORM_URLENCODED_TYPE);
         
         String sourceId = sourcesResponse.readEntity(StripeSourcesResponse.class).getId();
@@ -114,15 +118,11 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
                 AUTHORISE,
                 URI.create(stripeGatewayConfig.getUrl() + "/v1/charges"),
                 authorisePayload(request, sourceId),
-                getAuthHeaderValue(),
+                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
                 APPLICATION_FORM_URLENCODED_TYPE);
 
         GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         return responseBuilder.withResponse(StripeAuthorisationResponse.of(authorisationResponse)).build();
-    }
-
-    private String getAuthHeaderValue() {
-        return "Bearer " + stripeGatewayConfig.getAuthToken();
     }
 
     @Override
@@ -132,7 +132,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
 
     @Override
     public CaptureHandler getCaptureHandler() {
-        throw new UnsupportedOperationException();
+        return stripeCaptureHandler;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.gateway.stripe.handler;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.CaptureHandler;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
+import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
+import uk.gov.pay.connector.gateway.stripe.util.StripeAuthUtil;
+
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+import static uk.gov.pay.connector.gateway.model.OrderRequestType.CAPTURE;
+
+public class StripeCaptureHandler implements CaptureHandler {
+
+    private final StripeGatewayClient client;
+    private final StripeGatewayConfig stripeGatewayConfig;
+
+    public StripeCaptureHandler(StripeGatewayClient client,
+                                StripeGatewayConfig stripeGatewayConfig) {
+        this.client = client;
+        this.stripeGatewayConfig = stripeGatewayConfig;
+    }
+
+    @Override
+    public GatewayResponse capture(CaptureGatewayRequest request) {
+
+        String url = stripeGatewayConfig.getUrl() + "/v1/charges/" + request.getTransactionId() + "/capture";
+
+        Response captureResponse = client.postRequest(
+                request.getGatewayAccount(),
+                CAPTURE,
+                URI.create(url),
+                StringUtils.EMPTY,
+                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
+                APPLICATION_FORM_URLENCODED_TYPE);
+        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+        return responseBuilder.withResponse(StripeCaptureResponse.of(captureResponse)).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeErrorHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeErrorHandler.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.gateway.stripe.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.stripe.response.StripeErrorResponse;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import java.util.UUID;
+
+public class StripeErrorHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(StripeErrorHandler.class);
+
+    private StripeErrorHandler() {
+    }
+
+    public static void checkResponseForClientError(String url, Response response) {
+        if (hasClientError(response)) {
+
+            StripeErrorResponse stripeErrorResponse = toErrorResponse(response);
+            String errorId = UUID.randomUUID().toString();
+
+            logger.error("Gateway returned unexpected status code: {}, for gateway url={} with error [code={},message={}. ErrorId : {}]",
+                    response.getStatus(), url,
+                    stripeErrorResponse.getError().getCode(),
+                    stripeErrorResponse.getError().getMessage(),
+                    errorId);
+
+            throw new WebApplicationException(String.format("Unexpected HTTP status code %s from gateway. ErrorId : %s", response.getStatus(), errorId));
+        }
+    }
+
+    public static StripeErrorResponse toErrorResponse(Response response) {
+        return response.readEntity(StripeErrorResponse.class);
+    }
+
+    public static boolean hasClientError(Response response) {
+        return response.getStatusInfo().getFamily() == Response.Status.Family.CLIENT_ERROR;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeCaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeCaptureResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+public class StripeCaptureResponse implements BaseCaptureResponse {
+
+    private String transactionId;
+
+    private StripeCaptureResponse(String id) {
+        this.transactionId = id;
+    }
+
+    @Override
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return null;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return null;
+    }
+
+    public static StripeCaptureResponse of(Response response) {
+        return new StripeCaptureResponse((String) response.readEntity(Map.class).get("id"));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeErrorResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.gateway.stripe.json;
+package uk.gov.pay.connector.gateway.stripe.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 }
  **/
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class StripeError {
+public class StripeErrorResponse {
 
     @JsonProperty("error")
     private Error error;
@@ -24,8 +24,14 @@ public class StripeError {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public class Error {
 
+        @JsonProperty("code")
+        private String code;
         @JsonProperty("message")
         private String message;
+
+        public String getCode() {
+            return code;
+        }
 
         public String getMessage() {
             return message;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/util/StripeAuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/util/StripeAuthUtil.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.stripe.util;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+
+public class StripeAuthUtil {
+
+    private StripeAuthUtil() {
+    }
+
+    public static String getAuthHeaderValue(StripeGatewayConfig stripeGatewayConfig) {
+        return "Bearer " + stripeGatewayConfig.getAuthToken();
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
@@ -1,0 +1,155 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.mockito.Mock;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.ClientFactory;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.stripe.response.StripeErrorResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
+
+public abstract class BaseStripePaymentProviderTest {
+
+    protected GatewayClientFactory gatewayClientFactory;
+    protected StripePaymentProvider provider;
+
+    @Mock
+    private Client mockClient;
+    @Mock
+    MetricRegistry mockMetricRegistry;
+    @Mock
+    Histogram mockHistogram;
+    @Mock
+    Counter mockCounter;
+    @Mock
+    ClientFactory mockClientFactory;
+    @Mock
+    ConnectorConfiguration configuration;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+
+    @Mock
+    Invocation.Builder mockClientInvocationBuilder;
+
+    @Before
+    public void setup() {
+        gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
+
+        when(mockMetricRegistry.histogram(anyString())).thenReturn(mockHistogram);
+        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
+
+        when(stripeGatewayConfig.getUrl()).thenReturn("http://stripe.url");
+        when(configuration.getStripeConfig()).thenReturn(stripeGatewayConfig);
+
+        StripeGatewayClient stripeGatewayClient = new StripeGatewayClient(mockClient, mockMetricRegistry);
+        provider = new StripePaymentProvider(stripeGatewayClient, configuration);
+    }
+
+    String successCaptureResponse() {
+        return TestTemplateResourceLoader.load(STRIPE_CAPTURE_SUCCESS_RESPONSE);
+    }
+
+    String errorCaptureResponse() {
+        return TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
+    }
+
+    CaptureGatewayRequest buildTestCaptureRequest() {
+        return buildTestCaptureRequest(buildTestGatewayAccountEntity());
+    }
+
+    void assertEquals(GatewayError actual, GatewayError expected) {
+        assertNotNull(actual);
+        assertThat(actual.getMessage(), is(expected.getMessage()));
+        assertThat(actual.getErrorType(), is(expected.getErrorType()));
+    }
+
+    void mockPaymentProviderCaptureResponse(int responseHttpStatus, String responsePayload) throws IOException {
+        Response response = mockResponseWithPayload(responseHttpStatus);
+        Map<String, Object> responsePayloadMap = new ObjectMapper().readValue(responsePayload, HashMap.class);
+        when(response.readEntity(Map.class)).thenReturn(responsePayloadMap);
+    }
+
+    @NotNull
+    private Response mockResponseWithPayload(int responseHttpStatus) {
+        Response response = mockInvocationBuilder();
+
+        Response.StatusType statusType = mock(Response.StatusType.class);
+        when(response.getStatusInfo()).thenReturn(statusType);
+
+        when(response.getStatus()).thenReturn(responseHttpStatus);
+        when(statusType.getFamily()).thenReturn(Response.Status.Family.familyOf(responseHttpStatus));
+        return response;
+    }
+
+    private Response mockInvocationBuilder() {
+        when(mockClientInvocationBuilder.header(anyString(), any(Object.class))).thenReturn(mockClientInvocationBuilder);
+
+        WebTarget mockTarget = mock(WebTarget.class);
+        when(mockTarget.request()).thenReturn(mockClientInvocationBuilder);
+        when(mockClient.target(anyString())).thenReturn(mockTarget);
+
+        Response response = mock(Response.class);
+        when(mockClientInvocationBuilder.post(any())).thenReturn(response);
+        return response;
+    }
+
+    void mockPaymentProviderErrorResponse(int responseHttpStatus, String responsePayload) throws IOException {
+        Response response = mockResponseWithPayload(responseHttpStatus);
+        StripeErrorResponse stripeErrorResponse = new ObjectMapper().readValue(responsePayload, StripeErrorResponse.class);
+        when(response.readEntity(StripeErrorResponse.class)).thenReturn(stripeErrorResponse);
+    }
+
+    private CaptureGatewayRequest buildTestCaptureRequest(GatewayAccountEntity accountEntity) {
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(accountEntity)
+                .withTransactionId("ch_1231231123123")
+                .build();
+        return buildTestCaptureRequest(chargeEntity);
+    }
+
+    private GatewayAccountEntity buildTestGatewayAccountEntity() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("stripe");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
+    }
+
+    private CaptureGatewayRequest buildTestCaptureRequest(ChargeEntity chargeEntity) {
+        return CaptureGatewayRequest.valueOf(chargeEntity);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
+import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
+
+import javax.ws.rs.WebApplicationException;
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeCaptureHandlerTest extends BaseStripePaymentProviderTest {
+
+    protected StripeCaptureHandler stripeCaptureHandler;
+
+    @Before
+    public void setup() {
+        super.setup();
+        stripeCaptureHandler = (StripeCaptureHandler) provider.getCaptureHandler();
+    }
+
+    @Test
+    public void shouldCapture() throws IOException {
+        mockPaymentProviderCaptureResponse(200, successCaptureResponse());
+
+        GatewayResponse<StripeCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+        assertTrue(response.isSuccessful());
+        assertThat(response.getBaseResponse().get().getTransactionId(), is("ch_123456"));
+    }
+
+    @Test
+    public void shouldNotCaptureIfPaymentProviderReturns4xxHttpStatusCode() throws IOException {
+        mockPaymentProviderErrorResponse(400, errorCaptureResponse());
+        GatewayResponse<StripeCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
+        assertEquals(response.getGatewayError().get(), new GatewayError("No such charge: ch_123456 or something similar",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void shouldThrowException_whenPaymentProviderReturns5xxHttpStatusCode() throws IOException {
+        mockPaymentProviderErrorResponse(500, errorCaptureResponse());
+        GatewayResponse<StripeCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
@@ -3,8 +3,8 @@ package uk.gov.pay.connector.it.service;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
-import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 import uk.gov.pay.connector.util.PortFactory;
 
@@ -37,6 +37,7 @@ abstract public class CardCaptureProcessBaseITest {
     public GuiceAppWithPostgresRule app = new GuiceAppWithPostgresRule(
             config("worldpay.urls.test", "http://localhost:" + port + "/jsp/merchant/xml/paymentService.jsp"),
             config("smartpay.urls.test", "http://localhost:" + port + "/pal/servlet/soap/Payment"),
+            config("stripe.url", "http://localhost:" + port ),
             config("epdq.urls.test", "http://localhost:" + port + "/epdq"),
             config("captureProcessConfig.maximumRetries", Integer.toString(CAPTURE_MAX_RETRIES)),
             config("captureProcessConfig.retryFailuresEvery", "0 minutes"));

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.connector.it.service.stripe;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.service.CardCaptureProcessBaseITest;
+import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
+import uk.gov.pay.connector.rules.StripeMockClient;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
+
+    private static final String PAYMENT_PROVIDER = "stripe";
+
+    @Test
+    public void shouldCapture() {
+        DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
+
+        new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+    }
+
+    @Test
+    public void shouldNotCaptureWhenChargeIsNotInCorrectState() {
+        DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
+
+        new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
+    }
+
+    @Test
+    public void shouldNotCaptureWhenGatewayRepondsWithAnError() {
+        DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
+
+        new StripeMockClient().mockCaptureError(testCharge.getTransactionId());
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+    }
+
+    @Test
+    public void shouldNotCaptureWhenGatewayRepondsWithAnErrorAndAttemptsExceeded() {
+        DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
+
+        new StripeMockClient().mockCaptureError(testCharge.getTransactionId());
+        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        }
+
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -15,8 +15,10 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 
 public class StripeMockClient {
     public void mockCreateToken() {
@@ -34,9 +36,19 @@ public class StripeMockClient {
         setupResponse(payload, "/v1/charges", 200);
     }
 
+    public void mockCaptureSuccess(String gatewayTransactionId) {
+        String payload = TestTemplateResourceLoader.load(STRIPE_CAPTURE_SUCCESS_RESPONSE);
+        setupResponse(payload, "/v1/charges/" + gatewayTransactionId + "/capture", 200);
+    }
+
+    public void mockCaptureError(String gatewayTransactionId) {
+        String payload = TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
+        setupResponse(payload, "/v1/charges/" + gatewayTransactionId + "/capture", 401);
+    }
+
     public void mockUnauthorizedResponse() {
         Map<String, Object> unauthorizedResponse = ImmutableMap.of("error", ImmutableMap.of(
-                "message", "Invalid API Key provided: sk_test_****", 
+                "message", "Invalid API Key provided: sk_test_****",
                 "type", "invalid_request_error"));
         setupResponse(new JSONObject(unauthorizedResponse).toString(), "/v1/tokens", 401);
     }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -113,6 +113,8 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_AUTHORISATION_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/authorisation_success_response.json";
     public static final String STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_token_response.json";
     public static final String STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_response.json";
+    public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response.json";
+    public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
 
     public static String load(String location) {
         return fixture(location);

--- a/src/test/resources/templates/stripe/capture_success_response.json
+++ b/src/test/resources/templates/stripe/capture_success_response.json
@@ -1,0 +1,6 @@
+{
+  "id": "ch_123456",
+  "object": "charge",
+  "balance_transaction": "txn_1DUA6xHj08j2jFuBh4p9vEXz",
+  "captured": true
+}

--- a/src/test/resources/templates/stripe/error_response.json
+++ b/src/test/resources/templates/stripe/error_response.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "resource_missing",
+    "message": "No such charge: ch_123456 or something similar",
+    "type": "invalid_request_error"
+  }
+}


### PR DESCRIPTION
## WHAT

Functionality to capture charges from Stripe

- Added capture functionality for Stripe gateway charges
- Added `StripeAuthUtil` from common Stripe auth functions
- Includes tests

## HOW 
- set environment variable GDS_CONNECTOR_STRIPE_AUTH_TOKEN with valid stripe API key
- set `stripeAccountId` (uk.gov.pay.connector.it.contract.StripePaymentProviderTest) field to valid destination account id
- Remove @Ignore annotation on StripePaymentProviderTest
- Run `uk.gov.pay.connector.it.contract.StripePaymentProviderTest.captureStripeCharge`


