### PR TITLE
PP-4162 - Allow no billing address in frontend card authorisation request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -361,11 +361,14 @@ public class ChargeService {
     private CardDetailsEntity buildCardDetailsEntity(AuthCardDetails authCardDetails) {
         CardDetailsEntity detailsEntity = new CardDetailsEntity();
         detailsEntity.setCardBrand(sanitize(authCardDetails.getCardBrand()));
-        detailsEntity.setBillingAddress(new AddressEntity(authCardDetails.getAddress()));
         detailsEntity.setCardHolderName(sanitize(authCardDetails.getCardHolder()));
         detailsEntity.setExpiryDate(authCardDetails.getEndDate());
         detailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of(StringUtils.left(authCardDetails.getCardNo(), 6)));
         detailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of(StringUtils.right(authCardDetails.getCardNo(), 4)));
+
+        if (authCardDetails.getAddress() != null)
+            detailsEntity.setBillingAddress(new AddressEntity(authCardDetails.getAddress()));
+
         return detailsEntity;
     }
 

--- a/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
@@ -21,22 +21,20 @@ public class AuthCardDetailsValidator {
         return isValidCardNumberLength(authCardDetails.getCardNo()) &&
                 isBetween3To4Digits(authCardDetails.getCvc()) &&
                 hasExpiryDateFormat(authCardDetails.getEndDate()) &&
-                hasAddress(authCardDetails.getAddress()) &&
+                isValidAddress(authCardDetails.getAddress()) &&
                 hasCardBrand(authCardDetails.getCardBrand()) &&
                 unlikelyToBeCvc(authCardDetails.getCardHolder()) &&
                 unlikelyToContainACardNumber(authCardDetails.getCardHolder()) &&
                 unlikelyToContainACardNumber(authCardDetails.getCardBrand()) &&
-                unlikelyToContainACardNumber(authCardDetails.getAddress().getLine1()) &&
-                unlikelyToContainACardNumber(authCardDetails.getAddress().getLine2()) &&
-                unlikelyToContainACardNumber(authCardDetails.getAddress().getCity()) &&
-                unlikelyToContainACardNumber(authCardDetails.getAddress().getCounty()) &&
-                unlikelyToContainACardNumber(authCardDetails.getAddress().getPostcode()) &&
-                unlikelyToContainACardNumber(authCardDetails.getAddress().getCountry());
+                addressUnlikelyToContainACardNumber(authCardDetails.getAddress());
     }
 
-    private static boolean hasAddress(Address address) {
-        return address != null &&
-                isNotBlank(address.getCity()) &&
+    private static boolean isValidAddress(Address address) {
+        return address == null || isAddressComplete(address);
+    }
+
+    private static boolean isAddressComplete(Address address) {
+        return isNotBlank(address.getCity()) &&
                 isNotBlank(address.getLine1()) &&
                 isNotBlank(address.getPostcode()) &&
                 isNotBlank(address.getCountry());
@@ -57,7 +55,17 @@ public class AuthCardDetailsValidator {
     private static boolean hasExpiryDateFormat(String date) {
         return notNullAndMatches(EXPIRY_DATE, date);
     }
-
+    
+    private static boolean addressUnlikelyToContainACardNumber(Address address) {
+        return address == null ||
+                (unlikelyToContainACardNumber(address.getLine1()) &&
+                        unlikelyToContainACardNumber(address.getLine2()) &&
+                        unlikelyToContainACardNumber(address.getCity()) &&
+                        unlikelyToContainACardNumber(address.getCounty()) &&
+                        unlikelyToContainACardNumber(address.getPostcode()) &&
+                        unlikelyToContainACardNumber(address.getCountry()));
+    }
+    
     private static boolean unlikelyToContainACardNumber(String field) {
         return nullOrDoesNotMatch(CONTAINS_MORE_THAN_11_NOT_NECESSARILY_CONTIGUOUS_DIGITS, field);
     }

--- a/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
@@ -30,14 +30,11 @@ public class AuthCardDetailsValidator {
     }
 
     private static boolean isValidAddress(Address address) {
-        return address == null || isAddressComplete(address);
-    }
-
-    private static boolean isAddressComplete(Address address) {
-        return isNotBlank(address.getCity()) &&
-                isNotBlank(address.getLine1()) &&
-                isNotBlank(address.getPostcode()) &&
-                isNotBlank(address.getCountry());
+        return address == null ||
+                (isNotBlank(address.getCity()) &&
+                        isNotBlank(address.getLine1()) &&
+                        isNotBlank(address.getPostcode()) &&
+                        isNotBlank(address.getCountry()));
     }
 
     private static boolean hasCardBrand(String cardBrand) {
@@ -55,7 +52,7 @@ public class AuthCardDetailsValidator {
     private static boolean hasExpiryDateFormat(String date) {
         return notNullAndMatches(EXPIRY_DATE, date);
     }
-    
+
     private static boolean addressUnlikelyToContainACardNumber(Address address) {
         return address == null ||
                 (unlikelyToContainACardNumber(address.getLine1()) &&
@@ -65,7 +62,7 @@ public class AuthCardDetailsValidator {
                         unlikelyToContainACardNumber(address.getPostcode()) &&
                         unlikelyToContainACardNumber(address.getCountry()));
     }
-    
+
     private static boolean unlikelyToContainACardNumber(String field) {
         return nullOrDoesNotMatch(CONTAINS_MORE_THAN_11_NOT_NECESSARILY_CONTIGUOUS_DIGITS, field);
     }

--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -18,48 +18,48 @@ public class JsonRequestHelper {
     private static final String CARD_BRAND = "cardBrand";
     private static final String ADDRESS_LINE_2 = "Moneybags Avenue";
     private static final String ADDRESS_COUNTY = "Greater London";
-    
+
     public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cardBrand) {
         return buildJsonAuthorisationDetailsFor(cardNumber, CVC, EXPIRY_DATE, cardBrand);
     }
 
     public static String buildJsonAuthorisationDetailsFor(String cardHolderName, String cardNumber, String cardBrand) {
-        return buildJsonAuthorisationDetailsFor(cardHolderName, cardNumber, CVC, EXPIRY_DATE, cardBrand, ADDRESS_LINE_1, 
+        return buildJsonAuthorisationDetailsFor(cardHolderName, cardNumber, CVC, EXPIRY_DATE, cardBrand, ADDRESS_LINE_1,
                 null, ADDRESS_CITY, null, ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     }
 
     public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cvc, String expiryDate, String cardBrand) {
-        return buildJsonAuthorisationDetailsFor(CARD_HOLDER_NAME, cardNumber, cvc, expiryDate, cardBrand, ADDRESS_LINE_1, 
+        return buildJsonAuthorisationDetailsFor(CARD_HOLDER_NAME, cardNumber, cvc, expiryDate, cardBrand, ADDRESS_LINE_1,
                 null, ADDRESS_CITY, null, ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     }
 
-    public static String buildDetailedJsonAuthorisationDetailsFor(String cardNumber, 
-                                                                  String cvc, 
-                                                                  String expiryDate, 
-                                                                  String cardBrand, 
-                                                                  String cardHolderName, 
-                                                                  String addressLine1, 
-                                                                  String addressLine2, 
-                                                                  String city, 
-                                                                  String county, 
-                                                                  String postcode, 
+    public static String buildDetailedJsonAuthorisationDetailsFor(String cardNumber,
+                                                                  String cvc,
+                                                                  String expiryDate,
+                                                                  String cardBrand,
+                                                                  String cardHolderName,
+                                                                  String addressLine1,
+                                                                  String addressLine2,
+                                                                  String city,
+                                                                  String county,
+                                                                  String postcode,
                                                                   String country) {
         return buildJsonAuthorisationDetailsFor(cardHolderName, cardNumber, cvc, expiryDate, cardBrand, addressLine1, addressLine2, city, county, postcode, country);
     }
 
-    public static String buildJsonAuthorisationDetailsFor(String cardHolderName, 
-                                                          String cardNumber, 
-                                                          String cvc, 
-                                                          String expiryDate, 
+    public static String buildJsonAuthorisationDetailsFor(String cardHolderName,
+                                                          String cardNumber,
+                                                          String cvc,
+                                                          String expiryDate,
                                                           String cardBrand,
-                                                          String line1, 
-                                                          String line2, 
-                                                          String city, 
-                                                          String county, 
-                                                          String postCode, 
+                                                          String line1,
+                                                          String line2,
+                                                          String city,
+                                                          String county,
+                                                          String postCode,
                                                           String countryCode) {
-        return buildCorporateJsonAuthorisationDetailsFor(cardHolderName, cardNumber, cvc, expiryDate, cardBrand, line1, 
-                line2, city, county, postCode, countryCode,null, null);
+        return buildCorporateJsonAuthorisationDetailsFor(cardHolderName, cardNumber, cvc, expiryDate, cardBrand, line1,
+                line2, city, county, postCode, countryCode, null, null);
     }
 
     public static String buildCorporateJsonAuthorisationDetailsFor(PayersCardType payersCardType) {
@@ -67,7 +67,7 @@ public class JsonRequestHelper {
                 CARD_HOLDER_NAME,
                 CARD_NUMBER,
                 CVC,
-                EXPIRY_DATE, 
+                EXPIRY_DATE,
                 CARD_BRAND,
                 ADDRESS_LINE_1,
                 null,
@@ -95,27 +95,50 @@ public class JsonRequestHelper {
         );
     }
 
-    private static String buildCorporateJsonAuthorisationDetailsFor(String cardHolderName, 
-                                                                    String cardNumber, 
-                                                                    String cvc, 
-                                                                    String expiryDate, 
-                                                                    String cardBrand,
-                                                                    String line1, 
-                                                                    String line2, 
-                                                                    String city, 
-                                                                    String county, 
-                                                                    String postCode, 
-                                                                    String countryCode,
-                                                                    Boolean isCorporateCard, 
-                                                                    PayersCardType payersCardType) {
-        JsonObject addressObject = new JsonObject();
+    public static String buildJsonAuthorisationDetailsWithoutAddress() {
+        JsonObject authorisationDetails = buildJsonAuthorisationDetailsWithoutAddress(
+                CARD_HOLDER_NAME,
+                CARD_NUMBER,
+                CVC,
+                EXPIRY_DATE,
+                CARD_BRAND,
+                Boolean.TRUE,
+                null);
 
-        addressObject.addProperty("line1", line1);
-        addressObject.addProperty("line2", line2);
-        addressObject.addProperty("city", city);
-        addressObject.addProperty("county", county);
-        addressObject.addProperty("postcode", postCode);
-        addressObject.addProperty("country", countryCode);
+        return toJson(authorisationDetails);
+    }
+
+    private static String buildCorporateJsonAuthorisationDetailsFor(String cardHolderName,
+                                                                    String cardNumber,
+                                                                    String cvc,
+                                                                    String expiryDate,
+                                                                    String cardBrand,
+                                                                    String line1,
+                                                                    String line2,
+                                                                    String city,
+                                                                    String county,
+                                                                    String postCode,
+                                                                    String countryCode,
+                                                                    Boolean isCorporateCard,
+                                                                    PayersCardType payersCardType) {
+
+        JsonObject addressObject = buildAddressObject(line1, line2, city, county, postCode, countryCode);
+
+        JsonObject authorisationDetails = buildJsonAuthorisationDetailsWithoutAddress(cardHolderName,
+                cardNumber, cvc, expiryDate, cardBrand, isCorporateCard, payersCardType);
+
+        authorisationDetails.add("address", addressObject);
+
+        return toJson(authorisationDetails);
+    }
+
+    private static JsonObject buildJsonAuthorisationDetailsWithoutAddress(String cardHolderName,
+                                                                          String cardNumber,
+                                                                          String cvc,
+                                                                          String expiryDate,
+                                                                          String cardBrand,
+                                                                          Boolean isCorporateCard,
+                                                                          PayersCardType payersCardType) {
 
         JsonObject authorisationDetails = new JsonObject();
         authorisationDetails.addProperty("card_number", cardNumber);
@@ -123,7 +146,6 @@ public class JsonRequestHelper {
         authorisationDetails.addProperty("expiry_date", expiryDate);
         authorisationDetails.addProperty("card_brand", cardBrand);
         authorisationDetails.addProperty("cardholder_name", cardHolderName);
-        authorisationDetails.add("address", addressObject);
         authorisationDetails.addProperty("accept_header", "text/html");
         authorisationDetails.addProperty("user_agent_header", "Mozilla/5.0");
 
@@ -133,7 +155,19 @@ public class JsonRequestHelper {
         if (payersCardType != null) {
             authorisationDetails.addProperty("card_type", payersCardType.toString());
         }
+        return authorisationDetails;
+    }
 
-        return toJson(authorisationDetails);
+    private static JsonObject buildAddressObject(String line1, String line2, String city, String county, String postCode, String countryCode) {
+
+        JsonObject addressObject = new JsonObject();
+
+        addressObject.addProperty("line1", line1);
+        addressObject.addProperty("line2", line2);
+        addressObject.addProperty("city", city);
+        addressObject.addProperty("county", county);
+        addressObject.addProperty("postcode", postCode);
+        addressObject.addProperty("country", countryCode);
+        return addressObject;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -103,7 +103,7 @@ public class JsonRequestHelper {
                 EXPIRY_DATE,
                 CARD_BRAND,
                 Boolean.TRUE,
-                null);
+                PayersCardType.CREDIT);
 
         return toJson(authorisationDetails);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.it.resources.worldpay;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +28,6 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 public class WorldpayCardResourceITest extends ChargingITestBase {
 
     private String validAuthorisationDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "visa");
-    private ObjectMapper objectMapper = new ObjectMapper();
 
     public WorldpayCardResourceITest() {
         super("worldpay");

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -6,12 +6,10 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.model.domain.AuthCardDetailsBuilder;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -24,6 +22,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CAR
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildCorporateJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -76,12 +75,10 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         worldpayMockClient.mockAuthorisationSuccess();
 
-        AuthCardDetails authCardDetails = AuthCardDetailsBuilder.anAuthCardDetails()
-                .withAddress(null)
-                .build();
+        String authDetails = buildJsonAuthorisationDetailsWithoutAddress();
 
         givenSetup()
-                .body(objectMapper.writeValueAsString(authCardDetails))
+                .body(authDetails)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
                 .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -28,7 +28,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.model.domain.AuthCardDetailsBuilder;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 
 import java.util.Map;
@@ -157,7 +157,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     public void doAuthoriseWithoutBillingAddress_shouldRespondAuthorisationSuccess() {
 
         providerWillAuthorise();
-        AuthCardDetails authCardDetails = AuthCardDetailsBuilder.anAuthCardDetails()
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withAddress(null)
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -28,6 +28,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsBuilder;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 
 import java.util.Map;
@@ -149,6 +150,30 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
+        assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
+    }
+
+    @Test
+    public void doAuthoriseWithoutBillingAddress_shouldRespondAuthorisationSuccess() {
+
+        providerWillAuthorise();
+        AuthCardDetails authCardDetails = AuthCardDetailsBuilder.anAuthCardDetails()
+                .withAddress(null)
+                .build();
+
+        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getSessionIdentifier().isPresent(), is(true));
+        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        assertThat(charge.get3dsDetails(), is(nullValue()));
+        assertThat(charge.getCardDetails(), is(notNullValue()));
+        assertThat(charge.getCardDetails().getBillingAddress(), is(nullValue()));
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
     }
 

--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -224,6 +224,13 @@ public class AuthCardDetailsValidatorTest {
     }
 
     @Test
+    public void validationSucceedIfAddressIsNull() {
+        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
+        authCardDetails.setAddress(null);
+        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
     public void validationFailsIfPostCodeContainsMoreThanElevenDigits() {
         AuthCardDetails authCardDetails = aValidAuthorisationDetails();
         authCardDetails.getAddress().setPostcode(sneakyCardNumber);

--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -74,19 +74,19 @@ public class AuthCardDetailsValidatorTest {
         AuthCardDetails authCardDetails = buildAuthCardDetailsFor("12345678901", validCVC, validExpiryDate, cardBrand);
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
-	
+
     @Test
     public void validationSucceedsFor12digitsCardNumber() {
         AuthCardDetails authCardDetails = buildAuthCardDetailsFor("123456789012", validCVC, validExpiryDate, cardBrand);
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
-	
+
     @Test
     public void validationSucceedsFor19digitsCardNumber() {
         AuthCardDetails authCardDetails = buildAuthCardDetailsFor("1234567890123456789", validCVC, validExpiryDate, cardBrand);
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
-	
+
     @Test
     public void validationFailsFor20digitsCardNumber() {
         AuthCardDetails authCardDetails = buildAuthCardDetailsFor("12345678901234567890", validCVC, validExpiryDate, cardBrand);
@@ -122,33 +122,25 @@ public class AuthCardDetailsValidatorTest {
         AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, "1290", cardBrand);
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
-
-
-    @Test
-    public void validationFailsForMissingAddress() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, "1290", cardBrand, null);
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
-    }
-
-
+    
     @Test
     public void validationFailsForMissingCityAddress() {
         Address address = addressFor("L1", null, "WJWHE", "GB");
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, "1290", cardBrand, address);
+        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingLine1Address() {
         Address address = addressFor(null, "London", "WJWHE", "GB");
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, "1290", cardBrand, address);
+        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingCountryAddress() {
         Address address = addressFor("L1", "London", "WJWHE", null);
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, "1290", cardBrand, address);
+        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
@@ -156,7 +148,7 @@ public class AuthCardDetailsValidatorTest {
     public void validationFailsForMissingPostcodeAddress() {
         Address address = addressFor("L1", "London", null, "GB");
         cardBrand = "card-brand";
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCVC, "1290", cardBrand, cardBrand, address);
+        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
@@ -187,7 +179,7 @@ public class AuthCardDetailsValidatorTest {
         authCardDetails.setCardBrand("12345678901");
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
-    
+
     @Test
     public void validationFailsIfAddressLine1ContainsMoreThanElevenDigits() {
         AuthCardDetails authCardDetails = aValidAuthorisationDetails();


### PR DESCRIPTION
## WHAT
- Modify validation of request body to pass if no billing address is provided
- Modify charge service to allow persistence of card details with no billing address

with @danworth and @SandorArpa


