### PR TITLE
PP-4312 Add endpoint for authorising e-wallet payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -8,6 +8,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.persist.jpa.JpaPersistModule;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
+import uk.gov.pay.connector.applepay.ApplePayDecrypter;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -40,6 +41,7 @@ public class ConnectorModule extends AbstractModule {
         bind(ConnectorConfiguration.class).toInstance(configuration);
         bind(Environment.class).toInstance(environment);
         bind(CardExecutorService.class).in(Singleton.class);
+        bind(ApplePayDecrypter.class).in(Singleton.class);
         bind(PaymentProviders.class).in(Singleton.class);
         bind(EntityBuilder.class);
         bind(HashUtil.class);

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePayService.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePayService.java
@@ -36,11 +36,15 @@ public class ApplePayService {
 
         LOGGER.info("Authorising apple pay charge with id {} ", chargeId);
         GatewayResponse<BaseAuthoriseResponse> response = authoriseService.doAuthorise(chargeId, data);
-        return handleGatewayAuthoriseResponse(response);
+        if (isAuthorisationSubmitted(response)) {
+            return badRequestResponse("This transaction was deferred.");
+        }
+
+        return isAuthorisationDeclined(response) ? badRequestResponse("This transaction was declined.") : handleGatewayAuthoriseResponse(response);
     }
 
 
-    //PP-4314 This is duplicated from the CardResource. This kind of handling shouldn't be there in the first place, so will refactor to be embedded in services rather than at resource level
+    //PP-4314 These methods duplicated from the CardResource. This kind of handling shouldn't be there in the first place, so will refactor to be embedded in services rather than at resource level
     private Response handleGatewayAuthoriseResponse(GatewayResponse<? extends BaseAuthoriseResponse> response) {
         return response.getGatewayError()
                 .map(this::handleError)
@@ -48,6 +52,7 @@ public class ApplePayService {
                         .map(r -> ResponseUtil.successResponseWithEntity(ImmutableMap.of("status", r.authoriseStatus().getMappedChargeStatus().toString())))
                         .orElseGet(() -> ResponseUtil.serviceErrorResponse("InterpretedStatus not found for Gateway response")));
     }
+    
     private Response handleError(GatewayError error) {
         switch (error.getErrorType()) {
             case UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY:
@@ -59,5 +64,18 @@ public class ApplePayService {
             default:
                 return badRequestResponse(error.getMessage());
         }
+    }
+    
+    private static boolean isAuthorisationSubmitted(GatewayResponse<BaseAuthoriseResponse> response) {
+        return response.getBaseResponse()
+                .filter(baseResponse -> baseResponse.authoriseStatus() == BaseAuthoriseResponse.AuthoriseStatus.SUBMITTED)
+                .isPresent();
+    }
+
+    private static boolean isAuthorisationDeclined(GatewayResponse<BaseAuthoriseResponse> response) {
+        return response.getBaseResponse()
+                .filter(baseResponse -> baseResponse.authoriseStatus() == BaseAuthoriseResponse.AuthoriseStatus.REJECTED ||
+                        baseResponse.authoriseStatus() == BaseAuthoriseResponse.AuthoriseStatus.ERROR)
+                .isPresent();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/applepay/api/ApplePayToken.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/api/ApplePayToken.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.applepay.api;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -8,6 +9,7 @@ public class ApplePayToken  {
     private ApplePaymentInfo applePaymentInfo;
     private EncryptedPaymentData encryptedPaymentData;
 
+    @JsonProperty("payment_info")
     public ApplePaymentInfo getApplePaymentInfo() {
         return applePaymentInfo;
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardExecutorService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardExecutorService.java
@@ -112,6 +112,8 @@ public class CardExecutorService<T> {
         } catch (ExecutionException | InterruptedException exception) {
             if (exception.getCause() instanceof WebApplicationException) {
                 throw (WebApplicationException) exception.getCause();
+            } else if (exception.getCause() instanceof UnsupportedOperationException) { //ooof
+                throw (UnsupportedOperationException) exception.getCause();
             }
             return Pair.of(FAILED, null);
         } catch (TimeoutException timeoutException) {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -27,8 +27,8 @@ worldpay:
   notificationDomain: ${SECURE_WORLDPAY_NOTIFICATION_DOMAIN:-worldpay.com}
   credentials: ['username','password','merchant_id']
   applePay:
-    privateKey: ${WORLDPAY_APPLE_PAY_PRIVATE_KEY:-}
-    publicCertificate: ${WORLDPAY_APPLE_PAY_PUBLIC_CERTIFICATE:-}
+    privateKey: ${WORLDPAY_APPLE_PAY_PRIVATE_KEY:-privateKeyWhichShouldBeBase64Encoded}
+    publicCertificate: ${WORLDPAY_APPLE_PAY_PUBLIC_CERTIFICATE:-publicCertificateWhichShouldBeBase64Encoded}
   jerseyClientOverrides:
     auth:
       # Auth is run in a background thread which will release the HTTP request from frontend after 1 second

--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -136,7 +136,33 @@ public class JsonRequestHelper {
 
         return toJson(authorisationDetails);
     }
+    
+    public static String buildJsonApplePayAuthorisationDetails(String cardHolderName, String email) {
+        JsonObject header = new JsonObject();
+        header.addProperty("public_key_hash", "LbsUwAT6w1JV9tFXocU813TCHks+LSuFF0R/eBkrWnQ=");
+        header.addProperty("ephemeral_public_key", "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMwliotf2ICjiMwREdqyHSilqZzuV2fZey86nBIDlTY8sNMJv9CPpL5/DKg4bIEMe6qaj67mz4LWdr7Er0Ld5qA==");
+        header.addProperty("transaction_id", "2686f5297f123ec7fd9d31074d43d201953ca75f098890375f13aed2737d92f2");
+        header.addProperty("application_data", "some");
+        header.addProperty("wrapped_key", "some");
 
+        JsonObject encryptedPaymentData = new JsonObject();
+        encryptedPaymentData.addProperty("version", "EC_v1");
+        encryptedPaymentData.addProperty("signature", "MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0BBwEAAKCAMIID4jCCA4igAwIBAgIIJEPyqAad9XcwCgYIKoZIzj0EAwIwejEuMCwGA1UEAwwlQXBwbGUgQXBwbGljYXRpb24gSW50ZWdyYXRpb24gQ0EgLSBHMzEmMCQGA1UECwwdQXBwbGUgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkxEzARBgNVBAoMCkFwcGxlIEluYy4xCzAJBgNVBAYTAlVTMB4XDTE0MDkyNTIyMDYxMVoXDTE5MDkyNDIyMDYxMVowXzElMCMGA1UEAwwcZWNjLXNtcC1icm9rZXItc2lnbl9VQzQtUFJPRDEUMBIGA1UECwwLaU9TIFN5c3RlbXMxEzARBgNVBAoMCkFwcGxlIEluYy4xCzAJBgNVBAYTAlVTMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwhV37evWx7Ihj2jdcJChIY3HsL1vLCg9hGCV2Ur0pUEbg0IO2BHzQH6DMx8cVMP36zIg1rrV1O/0komJPnwPE6OCAhEwggINMEUGCCsGAQUFBwEBBDkwNzA1BggrBgEFBQcwAYYpaHR0cDovL29jc3AuYXBwbGUuY29tL29jc3AwNC1hcHBsZWFpY2EzMDEwHQYDVR0OBBYEFJRX22/VdIGGiYl2L35XhQfnm1gkMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUI/JJxE+T5O8n5sT2KGw/orv9LkswggEdBgNVHSAEggEUMIIBEDCCAQwGCSqGSIb3Y2QFATCB/jCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA2BggrBgEFBQcCARYqaHR0cDovL3d3dy5hcHBsZS5jb20vY2VydGlmaWNhdGVhdXRob3JpdHkvMDQGA1UdHwQtMCswKaAnoCWGI2h0dHA6Ly9jcmwuYXBwbGUuY29tL2FwcGxlYWljYTMuY3JsMA4GA1UdDwEB/wQEAwIHgDAPBgkqhkiG92NkBh0EAgUAMAoGCCqGSM49BAMCA0gAMEUCIHKKnw+Soyq5mXQr1V62c0BXKpaHodYu9TWXEPUWPpbpAiEAkTecfW6+W5l0r0ADfzTCPq2YtbS39w01XIayqBNy8bEwggLuMIICdaADAgECAghJbS+/OpjalzAKBggqhkjOPQQDAjBnMRswGQYDVQQDDBJBcHBsZSBSb290IENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzAeFw0xNDA1MDYyMzQ2MzBaFw0yOTA1MDYyMzQ2MzBaMHoxLjAsBgNVBAMMJUFwcGxlIEFwcGxpY2F0aW9uIEludGVncmF0aW9uIENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPAXEYQZ12SF1RpeJYEHduiAou/ee65N4I38S5PhM1bVZls1riLQl3YNIk57ugj9dhfOiMt2u2ZwvsjoKYT/VEWjgfcwgfQwRgYIKwYBBQUHAQEEOjA4MDYGCCsGAQUFBzABhipodHRwOi8vb2NzcC5hcHBsZS5jb20vb2NzcDA0LWFwcGxlcm9vdGNhZzMwHQYDVR0OBBYEFCPyScRPk+TvJ+bE9ihsP6K7/S5LMA8GA1UdEwEB/wQFMAMBAf8wHwYDVR0jBBgwFoAUu7DeoVgziJqkipnevr3rr9rLJKswNwYDVR0fBDAwLjAsoCqgKIYmaHR0cDovL2NybC5hcHBsZS5jb20vYXBwbGVyb290Y2FnMy5jcmwwDgYDVR0PAQH/BAQDAgEGMBAGCiqGSIb3Y2QGAg4EAgUAMAoGCCqGSM49BAMCA2cAMGQCMDrPcoNRFpmxhvs1w1bKYr/0F+3ZD3VNoo6+8ZyBXkK3ifiY95tZn5jVQQ2PnenC/gIwMi3VRCGwowV3bF3zODuQZ/0XfCwhbZZPxnJpghJvVPh6fRuZy5sJiSFhBpkPCZIdAAAxggFfMIIBWwIBATCBhjB6MS4wLAYDVQQDDCVBcHBsZSBBcHBsaWNhdGlvbiBJbnRlZ3JhdGlvbiBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMCCCRD8qgGnfV3MA0GCWCGSAFlAwQCAQUAoGkwGAYJKoZIhvcNAQkDMQsGCSqGSIb3DQEHATAcBgkqhkiG9w0BCQUxDxcNMTQxMDI3MTk1MTQzWjAvBgkqhkiG9w0BCQQxIgQge01fe4e1+woRnaV3o8bZL7vmTLEDsnZfTQq+D7GYjnIwCgYIKoZIzj0EAwIERzBFAiEA5090eyrUE7pjWb8MqUeDp/vEY98vtrT0Uvre/66ccqQCICYe6cen516x/xsfi/tJr3SbTdxO25ZdN1bPH0Jiqgw7AAAAAAAA");
+        encryptedPaymentData.add("header", header);
+        encryptedPaymentData.addProperty("data", "4OZho15e9Yp5K0EtKergKzeRpPAjnKHwmSNnagxhjwhKQ5d29sfTXjdbh1CtTJ4DYjsD6kfulNUnYmBTsruphBz7RRVI1WI8P0LrmfTnImjcq1mi+BRN7EtR2y6MkDmAr78anff91hlc+x8eWD/NpO/oZ1ey5qV5RBy/Jp5zh6ndVUVq8MHHhvQv4pLy5Tfi57Yo4RUhAsyXyTh4x/p1360BZmoWomK15NcJfUmoUCuwEYoi7xUkRwNr1z4MKnzMfneSRpUgdc0wADMeB6u1jcuwqQnnh2cusiagOTCfD6jO6tmouvu6KO54uU7bAbKz6cocIOEAOc6keyFXG5dfw8i3hJg6G2vIefHCwcKu1zFCHr4P7jLnYFDEhvxLm1KskDcuZeQHAkBMmLRSgj9NIcpBa94VN/JTga8W75IWAA==");
+
+        JsonObject paymentInfo = new JsonObject();
+        paymentInfo.addProperty("last_digits_card_number", "4242");
+        paymentInfo.addProperty("brand", "visa");
+        paymentInfo.addProperty("card_type", "DEBIT");
+        paymentInfo.addProperty("cardholder_name", cardHolderName);
+        paymentInfo.addProperty("email", email);
+
+        JsonObject payload = new JsonObject();
+        payload.add("payment_info", paymentInfo);
+        payload.add("encrypted_payment_data", encryptedPaymentData);
+        return toJson(payload);
+    }
     private static JsonObject buildJsonAuthorisationDetailsWithoutAddress(String cardHolderName,
                                                                           String cardNumber,
                                                                           String cvc,

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -224,7 +224,7 @@ public class ChargingITestBase {
                 .contentType(JSON);
     }
 
-    protected void shouldReturnErrorForAuthorisationDetailsWithMessage(String authorisationDetails, String errorMessage, String status) throws Exception {
+    protected void shouldReturnErrorForAuthorisationDetailsWithMessage(String authorisationDetails, String errorMessage, String status) {
 
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
 
@@ -239,7 +239,11 @@ public class ChargingITestBase {
         assertFrontendChargeStatusIs(chargeId, status);
     }
 
-    protected static String authoriseChargeUrlFor(String chargeId) {
+    public static String authoriseChargeUrlForWallet(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets".replace("{chargeId}", chargeId);
+    }
+    
+    public static String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
@@ -35,6 +35,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CAR
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildCorporateJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildDetailedJsonAuthorisationDetailsFor;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithFullAddress;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
@@ -68,6 +69,16 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
         }
     }
 
+    @Test
+    public void shouldAuthoriseCharge_ForApplePay() {
+        shouldAuthoriseChargeForApplePay(buildJsonApplePayAuthorisationDetails("mr payment", "mr@payment.test"));
+    }
+
+    @Test
+    public void shouldAuthoriseCharge_ForApplePay_withMinData() {
+        shouldAuthoriseChargeForApplePay(buildJsonApplePayAuthorisationDetails(null, null));
+    }
+    
     @Test
     public void shouldAuthoriseCharge_ForAValidAmericanExpress() {
         shouldAuthoriseChargeFor(buildJsonAuthorisationDetailsFor("371449635398431", "1234", "11/99", "american-express"));
@@ -239,7 +250,18 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
         return chargeId;
     }
+    private String shouldAuthoriseChargeForApplePay(String cardDetails) {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
 
+        givenSetup()
+                .body(cardDetails)
+                .post(authoriseChargeUrlForWallet(chargeId))
+                .then()
+                .statusCode(200);
+
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
+        return chargeId;
+    }
     @Test
     public void shouldPersistCorporateSurcharge() {
         String accountId = String.valueOf(RandomUtils.nextInt());


### PR DESCRIPTION
## WHAT
- Adding a new endpoint in the card resource to receive e-wallets (apple pay, for now) payment data from frontend
- Using Dropwizard's built it jersey support do deserialise the payload sent by frontend containing both payment info data and encrypted data coming from the e-wallet payment provider itself
- Cardholder name and email seem to be optional coming from apple pay, so either or both of them might be null. This is ok as both are nullable in connector's db
- We are currently duplicating a bit of code to move the handling of the auth response out from the resource - this will be refactored to be in a better shape

with @cobainc0 