### PR TITLE
PP_4352 ChargeEntity.setStatus - reinstate delimiters in logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -217,7 +217,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void setStatus(ChargeStatus targetStatus)  {
         if (isValidTransition(fromString(this.status), targetStatus)) {
-            logger.info("Changing charge status for externalId {} {}->{}",
+            logger.info("Changing charge status for externalId [{}] [{}]->[{}]",
                     externalId, this.status, targetStatus.getValue());
             
             this.status = targetStatus.getValue();


### PR DESCRIPTION
## WHAT
- Added delimiters deleted during CardCaptureService refactoring PR #815
