### PR TITLE
PP-4341: Use Sources to charge a card

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
@@ -9,7 +9,7 @@ public enum OrderRequestType {
 
     private final String name;
 
-    private OrderRequestType(String s) {
+    OrderRequestType(String s) {
         name = s;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeSourcesResponse {
+
+    @JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeTokenResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeTokenResponse.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeTokenResponse {
+
+    @JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -15,11 +15,12 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_SUCCESS_RESPONSE;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
 
 public class StripeMockClient {
     public void mockCreateToken() {
-        String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCE_SUCCESS_RESPONSE);
+        String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/tokens", 200);
     }
 
@@ -38,5 +39,10 @@ public class StripeMockClient {
                 "message", "Invalid API Key provided: sk_test_****", 
                 "type", "invalid_request_error"));
         setupResponse(new JSONObject(unauthorizedResponse).toString(), "/v1/tokens", 401);
+    }
+
+    public void mockCreateSource() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE);
+        setupResponse(payload, "/v1/sources", 200);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -111,7 +111,8 @@ public class TestTemplateResourceLoader {
     public static final String EPDQ_NOTIFICATION_TEMPLATE = EPDQ_BASE_NAME + "/notification-template.txt";
 
     public static final String STRIPE_AUTHORISATION_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/authorisation_success_response.json";
-    public static final String STRIPE_CREATE_SOURCE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_source_response.json";
+    public static final String STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_token_response.json";
+    public static final String STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_response.json";
 
     public static String load(String location) {
         return fixture(location);

--- a/src/test/resources/templates/stripe/create_sources_response.json
+++ b/src/test/resources/templates/stripe/create_sources_response.json
@@ -9,9 +9,9 @@
     "swift_code": "TSTEZ122"
   },
   "amount": null,
-  "client_secret": "src_client_secret_DuzaXmh4NTvdIMUbTNEBPARx",
-  "created": 1541430199,
-  "currency": "usd",
+  "client_secret": "src_client_secret_DxuWZClP9tqqDxbKSYNAs2FW",
+  "created": 1542103251,
+  "currency": "gbp",
   "flow": "receiver",
   "livemode": false,
   "metadata": {

--- a/src/test/resources/templates/stripe/create_token_response.json
+++ b/src/test/resources/templates/stripe/create_token_response.json
@@ -1,0 +1,34 @@
+{
+  "id": "tok_1DJfnpHj08j2jFuBPMcHN1F8",
+  "object": "token",
+  "card": {
+    "id": "card_1DJfnpHj08j2jFuBgoQQQWWD",
+    "object": "card",
+    "address_city": null,
+    "address_country": null,
+    "address_line1": null,
+    "address_line1_check": null,
+    "address_line2": null,
+    "address_state": null,
+    "address_zip": null,
+    "address_zip_check": null,
+    "brand": "Visa",
+    "country": "US",
+    "cvc_check": null,
+    "dynamic_last4": null,
+    "exp_month": 8,
+    "exp_year": 2019,
+    "fingerprint": "ZheQLfso3KIOOPXq",
+    "funding": "credit",
+    "last4": "4242",
+    "metadata": {
+    },
+    "name": "Jenny Rosen",
+    "tokenization_method": null
+  },
+  "client_ip": null,
+  "created": 1539170673,
+  "livemode": false,
+  "type": "card",
+  "used": false
+}


### PR DESCRIPTION
In anticipation of the fact that 3D Secure payments will require the use of
Sources, it seemed appropriate to make direct charges the "right" way, which is
also to use Sources.

This PR doesn't deal with errors from api calls to Stripe. Those are  "api_connection_error",              "api_error",  "authentication_error",  "card_error",  "idempotency_error", "invalid_request_error" and                  "rate_limit_error" which will be dealt with in another PR.

@oswaldquek
