### PR TITLE
PP-4376 Tidy up creating a new charge with no corporate surcharge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -129,14 +129,14 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public ChargeEntity(Long amount, String returnUrl, String description, ServicePaymentReference reference,
                         GatewayAccountEntity gatewayAccount, String email, SupportedLanguage language,
-                        boolean delayedCapture, Long corporateSurcharge) {
-        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture, corporateSurcharge);
+                        boolean delayedCapture) {
+        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture);
     }
 
-    //for fixture
+    // Only the ChargeEntityFixture should directly call this constructor
     public ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, ServicePaymentReference reference,
                         GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate, SupportedLanguage language,
-                        boolean delayedCapture, Long corporateSurcharge) {
+                        boolean delayedCapture) {
         this.amount = amount;
         this.status = status.getValue();
         this.returnUrl = returnUrl;
@@ -148,7 +148,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.email = email;
         this.language = language;
         this.delayedCapture = delayedCapture;
-        this.corporateSurcharge = corporateSurcharge;
     }
 
     public Long getId() {

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -127,8 +127,7 @@ public class ChargeService {
                     gatewayAccount,
                     chargeRequest.getEmail(),
                     language,
-                    chargeRequest.isDelayedCapture(),
-                    null); //TODO add logic
+                    chargeRequest.isDelayedCapture());
             chargeDao.persist(chargeEntity);
 
             chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -50,10 +50,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntity build() {
         ChargeEntity chargeEntity = new ChargeEntity(amount, status, returnUrl, description, reference,
-                gatewayAccountEntity, email, createdDate, language, delayedCapture, corporateSurcharge);
+                gatewayAccountEntity, email, createdDate, language, delayedCapture);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setGatewayTransactionId(transactionId);
+        chargeEntity.setCorporateSurcharge(corporateSurcharge);
         chargeEntity.getEvents().addAll(events);
         chargeEntity.getRefunds().addAll(refunds);
         chargeEntity.setProviderSessionId(providerSessionId);


### PR DESCRIPTION
- Change the `ChargeEntity` constructor called by `ChargeService` for creating a completely new charge (i.e. from a new charge creation request) so that it does not have a corporate card surcharge parameter because this will always be null for a completely new charge

- Also remove the corporate card surcharge parameter from the other `ChargeEntity` constructor (called by the first constructor and also directly by `ChargeEntityFixture`) and have `ChargeEntityFixture` set the corporate card surcharge after it has created the `ChargeEntity`

- Remove the `//TODO add logic` comment from `ChargeService` because there is not logic to add: as discussed above, completely new charges never have corporate card surcharges set