### PR TITLE
PP-4164 Use AuthCardDetailsFixture instead of AuthUtils in tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -25,9 +25,9 @@ import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
-import uk.gov.pay.connector.util.AuthUtils;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import javax.ws.rs.client.Client;
@@ -317,7 +317,14 @@ public abstract class BaseEpdqPaymentProviderTest {
 
     private AuthCardDetails buildTestAuthCardDetails() {
         Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", null, "GB");
-        return AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
+        return AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Mr. Payment")
+                .withCardNo("5555444433331111")
+                .withCvc("737")
+                .withEndDate("08/18")
+                .withCardBrand("visa")
+                .withAddress(address)
+                .build();
     }
 
     void assertEquals(GatewayError actual, GatewayError expected) {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqOrderRequestBuilderTest.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
-import uk.gov.pay.connector.util.AuthUtils;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static org.junit.Assert.assertEquals;
@@ -24,8 +24,7 @@ public class EpdqOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidAuthoriseOrderRequestForAddressWithAllFields() {
-        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", "London", "GB");
-        AuthCardDetails authCardDetails = AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
+        AuthCardDetails authCardDetails = aValidEpdqAuthCardDetails();
 
         GatewayOrder actualRequest = anEpdqAuthoriseOrderRequestBuilder()
                 .withOrderId("mq4ht90j2oir6am585afk58kml")
@@ -45,8 +44,7 @@ public class EpdqOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidAuthorise3dsOrderRequestForAddressWithAllFields() {
-        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", "London", "GB");
-        AuthCardDetails authCardDetails = AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
+        AuthCardDetails authCardDetails = aValidEpdqAuthCardDetails();
 
         GatewayOrder actualRequest = anEpdq3DsAuthoriseOrderRequestBuilder("http://www.frontend.example.com")
                 .withOrderId("mq4ht90j2oir6am585afk58kml")
@@ -106,5 +104,18 @@ public class EpdqOrderRequestBuilderTest {
 
         assertEquals(TestTemplateResourceLoader.load(EPDQ_REFUND_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.REFUND, gatewayOrder.getOrderRequestType());
+    }
+
+    private AuthCardDetails aValidEpdqAuthCardDetails() {
+        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", "London", "GB");
+
+        return AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Mr. Payment")
+                .withCardNo("5555444433331111")
+                .withCvc("737")
+                .withEndDate("08/18")
+                .withCardBrand("visa")
+                .withAddress(address)
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
@@ -8,7 +8,7 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
-import uk.gov.pay.connector.util.AuthUtils;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
@@ -237,6 +237,13 @@ public class SmartpayOrderRequestBuilderTest {
     }
 
     private AuthCardDetails getValidTestCard(Address address) {
-        return AuthUtils.buildAuthCardDetails("Mr. Payment", "5555444433331111", "737", "08/18", "visa", address);
+        return AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Mr. Payment")
+                .withCardNo("5555444433331111")
+                .withCvc("737")
+                .withEndDate("08/18")
+                .withCardBrand("visa")
+                .withAddress(address)
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -18,6 +18,7 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 import uk.gov.pay.connector.util.AuthUtils;
@@ -194,7 +195,14 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
     private AuthCardDetails getValidTestCard() {
         Address address = new Address("123 My Street", "This road", "SW8URR", "London", "London state", "GB");
 
-        return AuthUtils.buildAuthCardDetails("Mr. Payment", "4111111111111111", "123", "12/15", "visa", address);
+        return AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Mr. Payment")
+                .withCardNo("4111111111111111")
+                .withCvc("123")
+                .withEndDate("12/15")
+                .withCardBrand("visa")
+                .withAddress(address)
+                .build();
     }
 
     private String notificationPayloadForTransaction(String originalReference, String pspReference, String merchantReference, String fileName) throws IOException {

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -11,7 +11,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -77,7 +76,7 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
     @Test
     public void shouldSendSuccessfullyAOrderForMerchant() throws Exception {
 
-        AuthCardDetails authCardDetails = getValidTestCard();
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(aServiceAccount())
@@ -93,7 +92,7 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
 
     @Test
     public void shouldRequire3dsFor3dsRequiredMerchant() throws Exception {
-        AuthCardDetails authCardDetails = getValidTestCard();
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         GatewayAccountEntity gatewayAccountEntity = aServiceAccount();
         gatewayAccountEntity.setRequires3ds(true);
         ChargeEntity chargeEntity = aValidChargeEntity()
@@ -190,19 +189,6 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
 
     private String successCaptureResponse() {
         return TestTemplateResourceLoader.load(SMARTPAY_CAPTURE_SUCCESS_RESPONSE).replace("{{pspReference}}", "8614440510830227");
-    }
-
-    private AuthCardDetails getValidTestCard() {
-        Address address = new Address("123 My Street", "This road", "SW8URR", "London", "London state", "GB");
-
-        return AuthCardDetailsFixture.anAuthCardDetails()
-                .withCardHolder("Mr. Payment")
-                .withCardNo("4111111111111111")
-                .withCvc("123")
-                .withEndDate("12/15")
-                .withCardBrand("visa")
-                .withAddress(address)
-                .build();
     }
 
     private String notificationPayloadForTransaction(String originalReference, String pspReference, String merchantReference, String fileName) throws IOException {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -6,7 +6,7 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
-import uk.gov.pay.connector.util.AuthUtils;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
@@ -215,6 +215,13 @@ public class WorldpayOrderRequestBuilderTest {
     }
 
     private AuthCardDetails getValidTestCard(Address address) {
-        return AuthUtils.buildAuthCardDetails("Mr. Payment", "4111111111111111", "123", "12/15", "visa", address);
+        return AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Mr. Payment")
+                .withCardNo("4111111111111111")
+                .withCvc("123")
+                .withEndDate("12/15")
+                .withCardBrand("visa")
+                .withAddress(address)
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -26,12 +26,12 @@ import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
-import uk.gov.pay.connector.util.AuthUtils;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.io.IOException;
@@ -391,6 +391,13 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
     private AuthCardDetails getValidTestCard() {
         Address address = new Address("123 My Street", "This road", "SW8URR", "London", "London state", "GB");
 
-        return AuthUtils.buildAuthCardDetails("Mr. Payment", "4111111111111111", "123", "12/15", "visa", address);
+        return AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Mr. Payment")
+                .withCardNo("4111111111111111")
+                .withCvc("123")
+                .withEndDate("12/15")
+                .withCardBrand("visa")
+                .withAddress(address)
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
@@ -20,11 +20,13 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import java.util.List;
@@ -40,7 +42,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.junit.DropwizardJUnitRunner.WIREMOCK_PORT;
-import static uk.gov.pay.connector.util.AuthUtils.aValidAuthorisationDetails;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -67,7 +68,7 @@ public class GatewayAuthFailuresITest {
         gatewayStub = new GatewayStub(TRANSACTION_ID);
 
         databaseTestHelper = testContext.getDatabaseTestHelper();
-        
+
         DatabaseFixtures.TestAccount testAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
@@ -100,12 +101,13 @@ public class GatewayAuthFailuresITest {
 
         String errorMessage = "Unexpected HTTP status code 999 from gateway";
         String cardAuthUrl = "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeTestRecord.getExternalChargeId());
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
         given().config(RestAssured.config().connectionConfig(connectionConfig().closeIdleConnectionsAfterEachResponse()))
                 .port(testContext.getPort())
                 .contentType(JSON)
                 .when()
-                .body(aValidAuthorisationDetails())
+                .body(authCardDetails)
                 .post(cardAuthUrl)
                 .then()
                 .statusCode(500)

--- a/src/test/java/uk/gov/pay/connector/model/domain/AddressFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AddressFixture.java
@@ -8,7 +8,7 @@ public class AddressFixture {
     private String postcode = "WC2B 6NH";
     private String city = "London";
     private String county = "London";
-    private String country = "United Kingdom";
+    private String country = "GB";
 
     public static AddressFixture anAddress() {
         return new AddressFixture();

--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -4,348 +4,520 @@ import org.junit.Test;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.common.validator.AuthCardDetailsValidator;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.model.domain.AddressFixture;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static uk.gov.pay.connector.util.AuthUtils.aValidAuthorisationDetails;
-import static uk.gov.pay.connector.util.AuthUtils.addressFor;
-import static uk.gov.pay.connector.util.AuthUtils.buildAuthCardDetails;
-import static uk.gov.pay.connector.util.AuthUtils.goodAddress;
 
 public class AuthCardDetailsValidatorTest {
-
-    private String validCVC = "999";
-    private String validCardNumber = "4242424242424242";
-    private String validExpiryDate = "12/99";
-    private String cardBrand = "card-brand";
 
     private String sneakyCardNumber = "this12card3number4is5hidden6;7 89-0(1+2.";
 
     @Test
     public void validationSucceedForCorrectAuthorisationCardDetails() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand);
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
+
+        assertThat(AuthCardDetailsValidator.isWellFormatted(authCardDetails), is(true));
     }
 
     @Test
     public void validationSucceedForCVCwith4Digits() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor("12345678901234", "1234", validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCvc("1234")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
-    public void validationSucceedFor4digitsCardNumber() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor("12345678901234", validCVC, validExpiryDate, cardBrand);
+    public void validationSucceedFor14digitsCardNumber() {
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo("12345678901234")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingCVC() {
-        AuthCardDetails wrongauthorisationDetails = buildAuthCardDetailsFor(validCardNumber, null, validExpiryDate, cardBrand);
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(wrongauthorisationDetails));
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCvc(null)
+                .build();
+
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingCardNumber() {
-        AuthCardDetails wrongauthorisationDetails = buildAuthCardDetailsFor(null, validCVC, validExpiryDate, cardBrand);
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(wrongauthorisationDetails));
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo(null)
+                .build();
+
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingExpiryDate() {
-        AuthCardDetails wrongauthorisationDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, null, cardBrand);
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(wrongauthorisationDetails));
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withEndDate(null)
+                .build();
+
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
-    public void validationFailsForMissingCardTypeId() {
-        AuthCardDetails wrongauthorisationDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, null);
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(wrongauthorisationDetails));
+    public void validationFailsForMissingCardBrand() {
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardBrand(null)
+                .build();
+
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForEmptyFields() {
-        AuthCardDetails wrongauthorisationDetails = buildAuthCardDetailsFor("", "", "", "");
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(wrongauthorisationDetails));
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo("")
+                .withCvc("")
+                .withEndDate("")
+                .withCardBrand("")
+                .build();
+
+        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsFor11digitsCardNumber() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor("12345678901", validCVC, validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo("12345678901")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsFor12digitsCardNumber() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor("123456789012", validCVC, validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo("123456789012")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsFor19digitsCardNumber() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor("1234567890123456789", validCVC, validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo("1234567890123456789")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsFor20digitsCardNumber() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor("12345678901234567890", validCVC, validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo("12345678901234567890")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForCardNumberWithNonDigits() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor("123456789012345A", validCVC, validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo("123456789012345A")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForCVCwithNonDigits() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, "45A", validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCvc("45A")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForCVCwithMoreThan4Digits() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, "12345", validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCvc("12345")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForCVCwithLessThan3Digits() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, "12", validExpiryDate, cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCvc("12")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForExpiryDateWithWrongFormat() {
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, "1290", cardBrand);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withEndDate("1290")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
-    
+
     @Test
     public void validationFailsForMissingCityAddress() {
-        Address address = addressFor("L1", null, "WJWHE", "GB");
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
+        Address address = AddressFixture.anAddress()
+                .withCity(null)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingLine1Address() {
-        Address address = addressFor(null, "London", "WJWHE", "GB");
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
+        Address address = AddressFixture.anAddress()
+                .withLine1(null)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingCountryAddress() {
-        Address address = addressFor("L1", "London", "WJWHE", null);
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
+        Address address = AddressFixture.anAddress()
+                .withCountry(null)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsForMissingPostcodeAddress() {
-        Address address = addressFor("L1", "London", null, "GB");
-        cardBrand = "card-brand";
-        AuthCardDetails authCardDetails = buildAuthCardDetailsFor(validCardNumber, validCVC, validExpiryDate, cardBrand, address);
+        Address address = AddressFixture.anAddress()
+                .withPostcode(null)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCardHolderContainsMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder(sneakyCardNumber);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder(sneakyCardNumber)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCardHolderContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("1 Mr John 123456789 Smith 0");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("1 Mr John 123456789 Smith 0")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCardBrandContainsMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardBrand(sneakyCardNumber);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardBrand(sneakyCardNumber)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCardBrandContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardBrand("12345678901");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardBrand("12345678901")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfAddressLine1ContainsMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setLine1(sneakyCardNumber);
+        Address address = AddressFixture.anAddress()
+                .withLine1(sneakyCardNumber)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedIfAddressLine1ContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setLine2("01234/5678 90th Street");
+        Address address = AddressFixture.anAddress()
+                .withLine1("01234/5678 90th Street")
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfAddressLine2ContainsMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setLine2(sneakyCardNumber);
+        Address address = AddressFixture.anAddress()
+                .withLine2(sneakyCardNumber)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedIfAddressLine2ContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setLine2("01234/5678 90th Street");
+        Address address = AddressFixture.anAddress()
+                .withLine2("01234/5678 90th Street")
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedIfAddressLine2IsNull() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setLine2(null);
+        Address address = AddressFixture.anAddress()
+                .withLine2(null)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedIfAddressIsNull() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setAddress(null);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(null)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfPostCodeContainsMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setPostcode(sneakyCardNumber);
+        Address address = AddressFixture.anAddress()
+                .withPostcode(sneakyCardNumber)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfPostCodeContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setPostcode("12N3446789M01");
+        Address address = AddressFixture.anAddress()
+                .withPostcode("12N3446789M01")
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCityContainsMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setCity(sneakyCardNumber);
+        Address address = AddressFixture.anAddress()
+                .withCity(sneakyCardNumber)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCityContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setCity("12N3446789M01");
+        Address address = AddressFixture.anAddress()
+                .withCity("12N3446789M01")
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCountyMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setCounty(sneakyCardNumber);
+        Address address = AddressFixture.anAddress()
+                .withCounty(sneakyCardNumber)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCountyContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setCounty("12N3446789M01");
+        Address address = AddressFixture.anAddress()
+                .withCounty("12N3446789M01")
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCountyIsNull() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setCounty(null);
+        Address address = AddressFixture.anAddress()
+                .withCounty(null)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCountryMoreThanElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setCountry(sneakyCardNumber);
+        Address address = AddressFixture.anAddress()
+                .withCountry(sneakyCardNumber)
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCountryContainsExactlyElevenDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.getAddress().setCountry("12N3446789M01");
+        Address address = AddressFixture.anAddress()
+                .withCountry("12N3446789M01")
+                .build();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(address)
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCardHolderIsThreeDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("555");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("555")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCardHolderIsFourDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("5678");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("5678")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCardHolderIsThreeDigitsSurroundedByWhitespace() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder(" \t 321 ");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder(" \t 321 ")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationFailsIfCardHolderIsFourDigitsSurroundedByWhitespace() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder(" 1234 \t");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder(" 1234 \t")
+                .build();
+
         assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCardHolderContainsThreeDigitsSurroundedByNonWhitespace() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("Ms 333");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("Ms 333")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCardHolderContainsFourDigitsSurroundedByNonWhitespace() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("1234 Jr.");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("1234 Jr.")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCardHolderContainsTwoDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("22");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("22")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
     }
 
     @Test
     public void validationSucceedsIfCardHolderContainsFiveDigits() {
-        AuthCardDetails authCardDetails = aValidAuthorisationDetails();
-        authCardDetails.setCardHolder("12345");
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardHolder("12345")
+                .build();
+
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
-    }
-
-    private AuthCardDetails buildAuthCardDetailsFor(String cardNo, String cvc, String expiry, String cardBrand) {
-        return buildAuthCardDetailsFor(cardNo, cvc, expiry, cardBrand, goodAddress());
-    }
-
-    private AuthCardDetails buildAuthCardDetailsFor(String cardNo, String cvc, String expiry, String cardBrand, Address address) {
-        return buildAuthCardDetails("Mr. Payment", cardNo, cvc, expiry, cardBrand, address);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
+++ b/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
@@ -1,58 +1,9 @@
 package uk.gov.pay.connector.util;
 
-import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
-import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
-import static uk.gov.pay.connector.gateway.model.AuthCardDetails.anAuthCardDetails;
 
 public class AuthUtils {
-
-    private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM/yy");
-    private static String expiryDate = ZonedDateTime.now().plusYears(1).format(formatter);
-
-    public static AuthCardDetails aValidAuthorisationDetails() {
-        String validSandboxCard = "4242424242424242";
-        return buildAuthCardDetails(validSandboxCard, "123", expiryDate, "card-brand");
-    }
-
-    public static AuthCardDetails buildAuthCardDetails(String cardHolderName) {
-        String validSandboxCard = "4242424242424242";
-        return buildAuthCardDetails(cardHolderName, validSandboxCard, "123", expiryDate, "card-brand", goodAddress());
-    }
-
-    public static AuthCardDetails buildAuthCardDetails(String cardNumber, String cvc, String expiryDate, String cardBrand) {
-        return buildAuthCardDetails("Mr. Payment", cardNumber, cvc, expiryDate, cardBrand, goodAddress());
-    }
-
-    public static AuthCardDetails buildAuthCardDetails(String cardholderName, String cardNumber, String cvc, String expiryDate, String cardBrand, Address address) {
-        AuthCardDetails authCardDetails = anAuthCardDetails();
-        authCardDetails.setCvc(cvc);
-        authCardDetails.setCardHolder(cardholderName);
-        authCardDetails.setEndDate(expiryDate);
-        authCardDetails.setCardNo(cardNumber);
-        authCardDetails.setCardBrand(cardBrand);
-        authCardDetails.setAddress(address);
-        authCardDetails.setAcceptHeader("text/html");
-        authCardDetails.setUserAgentHeader("Mozilla/5.0");
-        return authCardDetails;
-    }
-
-    public static Address goodAddress() {
-        return addressFor("The Money Pool", "London", "DO11 4RS", "GB");
-    }
-
-    public static Address addressFor(String line1, String city, String postcode, String country) {
-        return addressFor(line1, line1, city, postcode, null, country);
-    }
-
-    public static Address addressFor(String line1, String line2, String city, String postcode, String county, String country) {
-        return new Address(line1, line2, postcode, city, county, country);
-    }
-
+    
     public static Auth3dsDetails buildAuth3dsDetails() {
         Auth3dsDetails auth3dsDetails = new Auth3dsDetails();
         auth3dsDetails.setPaResponse("sample-pa-response");


### PR DESCRIPTION
## WHAT
- Replace all usages of methods in AuthUtils to create AuthCardDetails with use of AuthCardDetailsFixture
- Remove now unused methods in AuthUtils


