### PR TITLE
PP-4397 Pull encrypted secrets from S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM govukpay/openjdk:alpine-3.8.1-jre-base-8.181.13
 
 RUN apk --no-cache upgrade
 
-RUN apk --no-cache add bash
+RUN apk --no-cache add bash gnupg openssl curl
 
 ENV PORT 8080
 ENV ADMIN_PORT 8081
@@ -16,5 +16,7 @@ ADD target/*.yaml .
 ADD target/pay-*-allinone.jar .
 ADD docker-startup.sh .
 ADD run-with-chamber.sh .
-
+ADD get_bucket_contents.sh . 
+ADD fetch-from-pay-secrets.sh . 
+ADD run-with-aws-credentials.sh .
 CMD bash ./docker-startup.sh

--- a/fetch-from-pay-secrets.sh
+++ b/fetch-from-pay-secrets.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eu
+
+PREFIX=PAY_SECRETS_DECRYPT__
+
+for i in $(env | grep "^${PREFIX}")
+do
+    key=${i%=*}
+    target_key=${key/$PREFIX/}
+
+    secret=$(
+        BUCKET="${PAY_SECRETS_BUCKET}" \
+        OBJECT="${ECS_SERVICE}"/"${target_key}" \
+        ./get_bucket_contents.sh | gpg --quiet -d --batch --yes --passphrase "${!key}")
+
+    unset key
+    export ${target_key}="${secret}"
+done
+
+if [[ $# -eq 0 ]]
+then
+    exec ./docker-startup.sh
+else
+    exec "$@"
+fi

--- a/get_bucket_contents.sh
+++ b/get_bucket_contents.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -eu
+
+function hmac_sha256 () {
+  key="$1"
+  data="$2"
+  printf '%b' "$data" | openssl dgst -sha256 -mac HMAC -macopt "$key" | sed 's/^.* //'
+}
+
+service=s3
+region=eu-west-1
+
+http_method=GET
+canonical_url="/${OBJECT}"
+canonical_query_string=''
+hashed_payload=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+timestamp=$(date -u +"%Y%m%dT%H%M00Z")
+date=$(date -u +"%Y%m%d")
+
+host="${BUCKET}.s3.${region}.amazonaws.com"
+
+date_key=$(hmac_sha256 "key:AWS4${AWS_SECRET_ACCESS_KEY}" "${date}")
+date_region_key=$(hmac_sha256 "hexkey:${date_key}" "${region}")
+date_region_service_key=$(hmac_sha256 "hexkey:${date_region_key}" "${service}")
+signing_key=$(hmac_sha256 "hexkey:${date_region_service_key}" "aws4_request")
+
+canonical_headers="host:$host\nx-amz-content-sha256:$hashed_payload\nx-amz-date:$timestamp\nx-amz-security-token:$AWS_SESSION_TOKEN\n"
+
+signed_headers='host;x-amz-content-sha256;x-amz-date;x-amz-security-token'
+
+canonical_request="${http_method}\n${canonical_url}\n${canonical_query_string}\n${canonical_headers}\n${signed_headers}\n${hashed_payload}"
+
+canonical_request_hash=$(printf '%b' "${canonical_request}" | openssl sha256 | sed 's/^.* //')
+
+scope=${date}/${region}/${service}/aws4_request
+
+message="AWS4-HMAC-SHA256\n${timestamp}\n${scope}\n${canonical_request_hash}"
+
+signature=$(hmac_sha256 "hexkey:${signing_key}" "${message}")
+
+curl -S --proxy '' https://"${host}"/${OBJECT} \
+    -H "Authorization: AWS4-HMAC-SHA256 \
+        Credential=${AWS_ACCESS_KEY_ID}/${scope}, \
+        SignedHeaders=${signed_headers}, \
+        Signature=${signature}" \
+    -H "x-amz-content-sha256: $hashed_payload" \
+    -H "x-amz-date: $timestamp" \
+    -H "x-amz-security-token: $AWS_SESSION_TOKEN"

--- a/run-with-aws-credentials.sh
+++ b/run-with-aws-credentials.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eu
+
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN
+
+function get_value_for_key {
+    key="$1"
+    json="$2"
+
+    regex='"'"${key}"'"\s*:\s*"([^"]*)'
+
+    if [[ ${json} =~ ${regex} ]]
+    then
+	echo ${BASH_REMATCH[1]}
+    fi
+}
+
+response=$(curl 169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI)
+
+export AWS_ACCESS_KEY_ID=$(get_value_for_key 'AccessKeyId' $response)
+export AWS_SECRET_ACCESS_KEY=$(get_value_for_key 'SecretAccessKey' $response)
+export AWS_SESSION_TOKEN=$(get_value_for_key 'Token' $response)
+
+exec "$@"

--- a/run-with-chamber.sh
+++ b/run-with-chamber.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 
-AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- ./docker-startup.sh
+if [[ $# -eq 0 ]]
+then 
+    AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" -- ./docker-startup.sh
+else
+    AWS_REGION="${ECS_AWS_REGION}" chamber exec "${ECS_SERVICE}" --  "$@"
+fi


### PR DESCRIPTION
## WHAT
The secrets are encrypted in S3 with a symmetric key, the access to the
S3 is restricted but it is not considered the control point for access
to the secret.

The control point for access of the secret is access to the decryption
key.

The decryption key is stored in parameter store. So the secret has the
same control point as existing secrets stored in parameter store.

## HOW
Currently this will not change how the container is ran, the entry point is still run-with-chamber.sh

run-with-chamber.sh will by default run docker-startup.sh this bypasses the S3 workflow.

to test this code the entrypoint needs to be changed to `run-with-chamber.sh run-with-aws-credentials.sh fetch-from-pay-secrets.sh`