### PR TITLE
PP-4341 Make StripeGatewayClient more generic

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayClientException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayClientException.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import javax.ws.rs.core.Response;
+
+public class GatewayClientException extends Exception{
+    private final transient Response response;
+    
+    GatewayClientException(String message, Response response) {
+        super(message);
+        this.response = response;
+    }
+
+    public Response getResponse() {
+        return response;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
@@ -73,7 +73,7 @@ public class StripeGatewayClient {
             }
             logger.error(format("Exception for gateway url=%s", url.toString()), pe);
             throw new WebApplicationException(pe.getMessage());
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             metricRegistry.counter(metricsPrefix + ".failures").inc();
             logger.error(format("Exception for gateway url=%s", url.toString()), e);
             throw new WebApplicationException(e.getMessage());

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
@@ -9,6 +9,7 @@ import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
@@ -47,9 +48,12 @@ public class StripeGatewayClient {
                                 String metricsPrefix) throws GatewayClientException {
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
         try {
-            Response response = client.target(url.toString())
-                    .request()
-                    .headers(new MultivaluedHashMap<>(headers))
+
+            Invocation.Builder clientBuilder = client.target(url.toString())
+                    .request();
+            headers.keySet().forEach(headerKey -> clientBuilder.header(headerKey, headers.get(headerKey)));
+            
+            Response response = clientBuilder
                     .post(Entity.entity(payload, mediaType));
             
             throwIfErrorResponse(response, metricsPrefix);

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -60,6 +61,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
     private final StripeCaptureHandler stripeCaptureHandler;
 
+    @Inject
     public StripePaymentProvider(StripeGatewayClient stripeGatewayClient,
                                  ConnectorConfiguration configuration) {
         this.stripeGatewayConfig = configuration.getStripeConfig();

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe;
 
+import com.google.common.collect.ImmutableMap;
 import fj.data.Either;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -12,6 +13,8 @@ import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
+import uk.gov.pay.connector.gateway.model.ErrorType;
+import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -29,7 +32,6 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.usernotification.model.Notification;
 import uk.gov.pay.connector.usernotification.model.Notifications;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -40,13 +42,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
-import static uk.gov.pay.connector.gateway.model.OrderRequestType.AUTHORISE;
+
 
 @Singleton
 public class StripePaymentProvider implements PaymentProvider<BaseResponse, String> {
@@ -58,7 +60,6 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
     private final StripeCaptureHandler stripeCaptureHandler;
 
-    @Inject
     public StripePaymentProvider(StripeGatewayClient stripeGatewayClient,
                                  ConnectorConfiguration configuration) {
         this.stripeGatewayConfig = configuration.getStripeConfig();
@@ -86,43 +87,77 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
     public GatewayResponse authorise(AuthorisationGatewayRequest request) {
         logger.info("Calling Stripe for authorisation of charge [{}]", request.getChargeExternalId());
 
-        Response tokenResponse = client.postRequest(
-                request.getGatewayAccount(),
-                AUTHORISE,
-                URI.create(stripeGatewayConfig.getUrl() + "/v1/tokens"),
-                tokenPayload(request),
-                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
-                APPLICATION_FORM_URLENCODED_TYPE);
-
-        if (tokenResponse.getStatusInfo().getFamily() == Response.Status.Family.CLIENT_ERROR) {
-            String reason = tokenResponse.readEntity(StripeErrorResponse.class).getError().getMessage();
-            String errorId = UUID.randomUUID().toString();
-            logger.error("There was error calling /v1/tokens. Reason: {}, ErrorId: {}", reason, errorId);
-            throw new WebApplicationException("There was an internal server error. ErrorId: " + errorId);
+        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse
+                .GatewayResponseBuilder
+                .responseBuilder();
+        
+        try {
+            Response tokenResponse = createToken(request);
+            Response sourceResponse = createSource(
+                    request,
+                    tokenResponse.readEntity(StripeTokenResponse.class).getId()
+            );
+            Response authorisationResponse = createCharge(
+                    request,
+                    sourceResponse.readEntity(StripeSourcesResponse.class).getId()
+            );
+            
+            return responseBuilder.withResponse(StripeAuthorisationResponse.of(authorisationResponse)).build();
+        } catch(GatewayClientException e) {
+            logger.error(
+                    "There was error calling Stripe. Reason: {}",
+                    e.getResponse().readEntity(StripeErrorResponse.class).getError().getMessage()
+            );
+            
+            return responseBuilder.withGatewayError(
+                    new GatewayError(
+                            "Stripe returned unexpected response",
+                            ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY)
+            ).build();
         }
+    }
 
-        String token = tokenResponse.readEntity(StripeTokenResponse.class).getId();
-        
-        Response sourcesResponse = client.postRequest(
-                request.getGatewayAccount(),
-                AUTHORISE,
-                URI.create(stripeGatewayConfig.getUrl() + "/v1/sources"),
-                sourcesPayload(token),
-                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
-                APPLICATION_FORM_URLENCODED_TYPE);
-        
-        String sourceId = sourcesResponse.readEntity(StripeSourcesResponse.class).getId();
-
-        Response authorisationResponse = client.postRequest(
-                request.getGatewayAccount(),
-                AUTHORISE,
-                URI.create(stripeGatewayConfig.getUrl() + "/v1/charges"),
+    private Response createCharge(AuthorisationGatewayRequest request, String sourceId) throws GatewayClientException{
+        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
+        return postToStripe(
+                "/v1/charges",
                 authorisePayload(request, sourceId),
-                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
-                APPLICATION_FORM_URLENCODED_TYPE);
+                format("gateway-operations.%s.%s.authorise.create_source",
+                        gatewayAccount.getGatewayName(),
+                        gatewayAccount.getType())
+        );
+    }
 
-        GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
-        return responseBuilder.withResponse(StripeAuthorisationResponse.of(authorisationResponse)).build();
+    private Response createSource(AuthorisationGatewayRequest request, String tokenId) throws GatewayClientException{
+        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
+        return postToStripe(
+                "/v1/sources",
+                sourcesPayload(tokenId),
+                format("gateway-operations.%s.%s.authorise.create_source",
+                        gatewayAccount.getGatewayName(),
+                        gatewayAccount.getType())
+        );
+    }
+    
+    private Response createToken(AuthorisationGatewayRequest request) throws GatewayClientException{
+        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
+        return postToStripe(
+                "/v1/tokens", 
+                tokenPayload(request), 
+                format("gateway-operations.%s.%s.authorise.create_token",
+                gatewayAccount.getGatewayName(),
+                gatewayAccount.getType())
+        );
+    }
+
+    private Response postToStripe(String path, String payload, String metricsPrefix) throws GatewayClientException {
+        return client.postRequest(
+                URI.create(stripeGatewayConfig.getUrl() + path),
+                payload,
+                ImmutableMap.of(AUTHORIZATION, StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig)),
+                APPLICATION_FORM_URLENCODED_TYPE,
+                metricsPrefix
+        );
     }
 
     @Override
@@ -177,7 +212,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
         params.put("usage", "single_use");
         return encode(params);
     }
-    
+
     private String authorisePayload(AuthorisationGatewayRequest request, String sourceId) {
         Map<String, String> params = new HashMap<>();
         params.put("amount", request.getAmount());

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -113,7 +114,7 @@ public class StripePaymentProvider implements PaymentProvider<BaseResponse, Stri
             
             return responseBuilder.withGatewayError(
                     new GatewayError(
-                            "Stripe returned unexpected response",
+                            "There was an internal server error. ErrorId:" + UUID.randomUUID(),
                             ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY)
             ).build();
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -46,7 +46,7 @@ public class StripeCaptureHandler implements CaptureHandler {
                     StringUtils.EMPTY,
                     ImmutableMap.of(AUTHORIZATION, StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig)),
                     APPLICATION_FORM_URLENCODED_TYPE,
-                    format("gateway-operations.%s.%s.authorise.create_source",
+                    format("gateway-operations.%s.%s.capture",
                             gatewayAccount.getGatewayName(),
                             gatewayAccount.getType()));
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe.handler;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.CaptureHandler;
@@ -7,16 +8,19 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.GatewayClientException;
 import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
 import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
 import uk.gov.pay.connector.gateway.stripe.response.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.util.StripeAuthUtil;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.ws.rs.core.Response;
 import java.net.URI;
 
+import static java.lang.String.format;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
-import static uk.gov.pay.connector.gateway.model.OrderRequestType.CAPTURE;
 
 public class StripeCaptureHandler implements CaptureHandler {
 
@@ -33,23 +37,29 @@ public class StripeCaptureHandler implements CaptureHandler {
     public GatewayResponse capture(CaptureGatewayRequest request) {
 
         String url = stripeGatewayConfig.getUrl() + "/v1/charges/" + request.getTransactionId() + "/capture";
-
-        Response captureResponse = client.postRequest(
-                request.getGatewayAccount(),
-                CAPTURE,
-                URI.create(url),
-                StringUtils.EMPTY,
-                StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig),
-                APPLICATION_FORM_URLENCODED_TYPE);
-
+        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
         GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
 
-        if (StripeErrorHandler.hasClientError(captureResponse)) {
-            StripeErrorResponse stripeErrorResponse = StripeErrorHandler.toErrorResponse(captureResponse);
-            GatewayError gatewayError = GatewayError.unexpectedStatusCodeFromGateway(stripeErrorResponse.getError().getMessage());
+        try {
+            Response captureResponse = client.postRequest(
+                    URI.create(url),
+                    StringUtils.EMPTY,
+                    ImmutableMap.of(AUTHORIZATION, StripeAuthUtil.getAuthHeaderValue(stripeGatewayConfig)),
+                    APPLICATION_FORM_URLENCODED_TYPE,
+                    format("gateway-operations.%s.%s.authorise.create_source",
+                            gatewayAccount.getGatewayName(),
+                            gatewayAccount.getType()));
+
+            return responseBuilder.withResponse(StripeCaptureResponse.of(captureResponse)).build();
+
+        } catch (GatewayClientException e) {
+            GatewayError gatewayError = GatewayError.unexpectedStatusCodeFromGateway(e
+                    .getResponse()
+                    .readEntity(StripeErrorResponse.class)
+                    .getError()
+                    .getMessage());
+            
             return responseBuilder.withGatewayError(gatewayError).build();
         }
-
-        return responseBuilder.withResponse(StripeCaptureResponse.of(captureResponse)).build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -47,10 +47,14 @@ public class StripeCaptureHandlerTest extends BaseStripePaymentProviderTest {
                 UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
-    @Test(expected = WebApplicationException.class)
-    public void shouldThrowException_whenPaymentProviderReturns5xxHttpStatusCode() throws IOException {
+    @Test
+    public void shouldNotCaptureIfPaymentProviderReturns5xxHttpStatusCode() throws IOException {
         mockPaymentProviderErrorResponse(500, errorCaptureResponse());
         GatewayResponse<StripeCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+        assertThat(response.isFailed(), is(true));
+        assertThat(response.getGatewayError().isPresent(), is(true));
+        assertEquals(response.getGatewayError().get(), new GatewayError("No such charge: ch_123456 or something similar",
+                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
 }


### PR DESCRIPTION
The StripeGatewayClient is intended to eventually become the GatewayClient
for all gateways. For this to work, it needs to only now about 'clienty' things: urls, payloads, headers... So this commit refactors the StripeGatewayClient
so that it only takes as arguments things that make sense for a generic client
to know about. The only mildly controversial one is the metrics prefix, which
we use within the client to emit correctly namespaced metrics. I think this is
fine.

This change in the client has prompted a small refactoring of StripePaymentProvider; it now catches a checked exception from the client before deserialising
StripeErrorResponse - I think this is the right place for this to happen.

I have also taken the opportunity to extract out smaller methods to make the main
authorise method easier to read.