### PR TITLE
PP-4164 Make billing address Optional in CardDetailsEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -9,6 +9,7 @@ import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
+import java.util.Optional;
 
 @Embeddable
 public class CardDetailsEntity {
@@ -18,7 +19,7 @@ public class CardDetailsEntity {
     @Convert(converter = FirstDigitsCardNumberConverter.class)
     @JsonSerialize(using = ToStringSerializer.class)
     private FirstDigitsCardNumber firstDigitsCardNumber;
-    
+
     @Column(name = "last_digits_card_number")
     @JsonProperty("last_digits_card_number")
     @Convert(converter = LastDigitsCardNumberConverter.class)
@@ -66,7 +67,7 @@ public class CardDetailsEntity {
     public LastDigitsCardNumber getLastDigitsCardNumber() {
         return lastDigitsCardNumber;
     }
-    
+
     public FirstDigitsCardNumber getFirstDigitsCardNumber() {
         return firstDigitsCardNumber;
     }
@@ -95,8 +96,8 @@ public class CardDetailsEntity {
         this.expiryDate = expiryDate;
     }
 
-    public AddressEntity getBillingAddress() {
-        return billingAddress;
+    public Optional<AddressEntity> getBillingAddress() {
+        return Optional.ofNullable(billingAddress);
     }
 
     public void setBillingAddress(AddressEntity billingAddress) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsITest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNotNull;
 
 
 public class ChargeDaoCardDetailsITest extends DaoITestBase {
@@ -77,13 +76,13 @@ public class ChargeDaoCardDetailsITest extends DaoITestBase {
         assertThat(cardDetailsEntity.getLastDigitsCardNumber(), is(testCardDetails.getLastDigitsCardNumber()));
         assertThat(cardDetailsEntity.getFirstDigitsCardNumber(), is(testCardDetails.getFirstDigitsCardNumber()));
         assertThat(cardDetailsEntity.getExpiryDate(), is(testCardDetails.getExpiryDate()));
-        assertNotNull(cardDetailsEntity.getBillingAddress());
-        assertThat(cardDetailsEntity.getBillingAddress().getLine1(), is(testCardDetails.getBillingAddress().getLine1()));
-        assertThat(cardDetailsEntity.getBillingAddress().getLine2(), is(testCardDetails.getBillingAddress().getLine2()));
-        assertThat(cardDetailsEntity.getBillingAddress().getPostcode(), is(testCardDetails.getBillingAddress().getPostcode()));
-        assertThat(cardDetailsEntity.getBillingAddress().getCity(), is(testCardDetails.getBillingAddress().getCity()));
-        assertThat(cardDetailsEntity.getBillingAddress().getCounty(), is(testCardDetails.getBillingAddress().getCounty()));
-        assertThat(cardDetailsEntity.getBillingAddress().getCountry(), is(testCardDetails.getBillingAddress().getCountry()));
+        assertThat(cardDetailsEntity.getBillingAddress().isPresent(), is(true));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getLine1(), is(testCardDetails.getBillingAddress().getLine1()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getLine2(), is(testCardDetails.getBillingAddress().getLine2()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getPostcode(), is(testCardDetails.getBillingAddress().getPostcode()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getCity(), is(testCardDetails.getBillingAddress().getCity()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getCounty(), is(testCardDetails.getBillingAddress().getCounty()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getCountry(), is(testCardDetails.getBillingAddress().getCountry()));
     }
 
     @Test
@@ -105,13 +104,13 @@ public class ChargeDaoCardDetailsITest extends DaoITestBase {
         assertThat(cardDetailsEntity.getLastDigitsCardNumber(), is(nullValue()));
         assertThat(cardDetailsEntity.getFirstDigitsCardNumber(), is(nullValue()));
         assertThat(cardDetailsEntity.getExpiryDate(), is(testCardDetails.getExpiryDate()));
-        assertNotNull(cardDetailsEntity.getBillingAddress());
-        assertThat(cardDetailsEntity.getBillingAddress().getLine1(), is(testCardDetails.getBillingAddress().getLine1()));
-        assertThat(cardDetailsEntity.getBillingAddress().getLine2(), is(testCardDetails.getBillingAddress().getLine2()));
-        assertThat(cardDetailsEntity.getBillingAddress().getPostcode(), is(testCardDetails.getBillingAddress().getPostcode()));
-        assertThat(cardDetailsEntity.getBillingAddress().getCity(), is(testCardDetails.getBillingAddress().getCity()));
-        assertThat(cardDetailsEntity.getBillingAddress().getCounty(), is(testCardDetails.getBillingAddress().getCounty()));
-        assertThat(cardDetailsEntity.getBillingAddress().getCountry(), is(testCardDetails.getBillingAddress().getCountry()));
+        assertThat(cardDetailsEntity.getBillingAddress().isPresent(), is(true));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getLine1(), is(testCardDetails.getBillingAddress().getLine1()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getLine2(), is(testCardDetails.getBillingAddress().getLine2()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getPostcode(), is(testCardDetails.getBillingAddress().getPostcode()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getCity(), is(testCardDetails.getBillingAddress().getCity()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getCounty(), is(testCardDetails.getBillingAddress().getCounty()));
+        assertThat(cardDetailsEntity.getBillingAddress().get().getCountry(), is(testCardDetails.getBillingAddress().getCountry()));
     }
 
     @Test
@@ -130,11 +129,11 @@ public class ChargeDaoCardDetailsITest extends DaoITestBase {
         assertThat(cardDetailsSaved, hasEntry("first_digits_card_number", "123456"));
         assertThat(cardDetailsSaved, hasEntry("cardholder_name", cardDetailsEntity.getCardHolderName()));
         assertThat(cardDetailsSaved, hasEntry("expiry_date", cardDetailsEntity.getExpiryDate()));
-        assertThat(cardDetailsSaved, hasEntry("address_line1", cardDetailsEntity.getBillingAddress().getLine1()));
-        assertThat(cardDetailsSaved, hasEntry("address_line2", cardDetailsEntity.getBillingAddress().getLine2()));
-        assertThat(cardDetailsSaved, hasEntry("address_postcode", cardDetailsEntity.getBillingAddress().getPostcode()));
-        assertThat(cardDetailsSaved, hasEntry("address_city", cardDetailsEntity.getBillingAddress().getCity()));
-        assertThat(cardDetailsSaved, hasEntry("address_county", cardDetailsEntity.getBillingAddress().getCounty()));
-        assertThat(cardDetailsSaved, hasEntry("address_country", cardDetailsEntity.getBillingAddress().getCountry()));
+        assertThat(cardDetailsSaved, hasEntry("address_line1", cardDetailsEntity.getBillingAddress().get().getLine1()));
+        assertThat(cardDetailsSaved, hasEntry("address_line2", cardDetailsEntity.getBillingAddress().get().getLine2()));
+        assertThat(cardDetailsSaved, hasEntry("address_postcode", cardDetailsEntity.getBillingAddress().get().getPostcode()));
+        assertThat(cardDetailsSaved, hasEntry("address_city", cardDetailsEntity.getBillingAddress().get().getCity()));
+        assertThat(cardDetailsSaved, hasEntry("address_county", cardDetailsEntity.getBillingAddress().get().getCounty()));
+        assertThat(cardDetailsSaved, hasEntry("address_country", cardDetailsEntity.getBillingAddress().get().getCountry()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -173,7 +173,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
-        assertThat(charge.getCardDetails().getBillingAddress(), is(nullValue()));
+        assertThat(charge.getCardDetails().getBillingAddress().isPresent(), is(false));
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
     }
 
@@ -458,12 +458,13 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(cardDetails.getExpiryDate(), is(expiryDate));
         assertThat(cardDetails.getLastDigitsCardNumber().toString(), is("4242"));
         assertThat(cardDetails.getFirstDigitsCardNumber().toString(), is("424242"));
-        assertThat(cardDetails.getBillingAddress().getLine1(), is(addressLine1));
-        assertThat(cardDetails.getBillingAddress().getLine2(), is(addressLine2));
-        assertThat(cardDetails.getBillingAddress().getPostcode(), is(postcode));
-        assertThat(cardDetails.getBillingAddress().getCity(), is(city));
-        assertThat(cardDetails.getBillingAddress().getCountry(), is(country));
-        assertThat(cardDetails.getBillingAddress().getCounty(), is(county));
+        assertThat(cardDetails.getBillingAddress().isPresent(), is(true));
+        assertThat(cardDetails.getBillingAddress().get().getLine1(), is(addressLine1));
+        assertThat(cardDetails.getBillingAddress().get().getLine2(), is(addressLine2));
+        assertThat(cardDetails.getBillingAddress().get().getPostcode(), is(postcode));
+        assertThat(cardDetails.getBillingAddress().get().getCity(), is(city));
+        assertThat(cardDetails.getBillingAddress().get().getCountry(), is(country));
+        assertThat(cardDetails.getBillingAddress().get().getCounty(), is(county));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
Make the billing address in CardDetailsEntity Optional to reflect its new-found optionality.


