### PR TITLE
PP-4341: Handle a card authorisation failure

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -32,7 +32,7 @@ import static uk.gov.pay.connector.charge.service.CancelServiceFunctions.doGatew
 import static uk.gov.pay.connector.charge.service.CancelServiceFunctions.prepareForTerminate;
 import static uk.gov.pay.connector.charge.service.StatusFlow.SYSTEM_CANCELLATION_FLOW;
 import static uk.gov.pay.connector.charge.service.StatusFlow.USER_CANCELLATION_FLOW;
-import static uk.gov.pay.connector.gateway.model.GatewayError.baseError;
+import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
 public class ChargeCancelService {
@@ -139,7 +139,7 @@ public class ChargeCancelService {
             logger.error("Could not update charge - charge_external-id={}, status={}, to_status={}",
                     processedCharge.getExternalId(), processedCharge.getStatus(), completeStatus);
             return gatewayResponseBuilder
-                    .withGatewayError(baseError(errorMsg))
+                    .withGatewayError(genericGatewayError(errorMsg))
                     .build();
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -27,7 +27,7 @@ import static fj.data.Either.right;
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.Response.Status.OK;
-import static uk.gov.pay.connector.gateway.model.GatewayError.baseError;
+import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionSocketException;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionTimeoutException;
 import static uk.gov.pay.connector.gateway.model.GatewayError.malformedResponseReceivedFromGateway;
@@ -102,11 +102,11 @@ public class GatewayClient {
                 }
             }
             logger.error(format("Exception for gateway url=%s", gatewayUrl), pe);
-            return left(baseError(pe.getMessage()));
+            return left(genericGatewayError(pe.getMessage()));
         } catch (Exception e) {
             incrementFailureCounter(metricRegistry, metricsPrefix);
             logger.error(format("Exception for gateway url=%s", gatewayUrl), e);
-            return left(baseError(e.getMessage()));
+            return left(genericGatewayError(e.getMessage()));
         } finally {
             responseTimeStopwatch.stop();
             metricRegistry.histogram(metricsPrefix + ".response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -227,7 +227,7 @@ public class EpdqPaymentProvider implements PaymentProvider<BaseResponse, String
     private GatewayResponse reconstructErrorBiasedGatewayResponse(GatewayResponse<BaseResponse> gatewayResponse, BaseAuthoriseResponse.AuthoriseStatus authoriseStatus, Auth3dsDetails.Auth3dsResult auth3DResult) {
         GatewayResponse.GatewayResponseBuilder<EpdqAuthorisationResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         if (auth3DResult.equals(Auth3dsDetails.Auth3dsResult.ERROR)) {
-            return responseBuilder.withGatewayError(GatewayError.baseError(format("epdq.authorise-3ds.result.mismatch expected=%s, actual=%s", Auth3dsDetails.Auth3dsResult.ERROR, authoriseStatus.name())))
+            return responseBuilder.withGatewayError(GatewayError.genericGatewayError(format("epdq.authorise-3ds.result.mismatch expected=%s, actual=%s", Auth3dsDetails.Auth3dsResult.ERROR, authoriseStatus.name())))
                     .build();
         } else if (auth3DResult.equals(Auth3dsDetails.Auth3dsResult.DECLINED)) {
             EpdqAuthorisationResponse epdqAuthorisationResponse = new EpdqAuthorisationResponse();

--- a/src/main/java/uk/gov/pay/connector/gateway/model/GatewayError.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/GatewayError.java
@@ -27,7 +27,7 @@ public class GatewayError {
         this.errorType = errorType;
     }
 
-    public static GatewayError baseError(String msg) {
+    public static GatewayError genericGatewayError(String msg) {
         return new GatewayError(msg, GENERIC_GATEWAY_ERROR);
     }
 
@@ -66,10 +66,10 @@ public class GatewayError {
                 logger.error(format("Socket Exception for gateway url=%s", e.getUrl()), e);
                 gatewayError = GatewayError.gatewayConnectionSocketException("Gateway connection socket error");
             } else {
-                gatewayError = GatewayError.baseError(e.getMessage());
+                gatewayError = GatewayError.genericGatewayError(e.getMessage());
             }
         } else {
-            gatewayError = GatewayError.baseError(e.getMessage());
+            gatewayError = GatewayError.genericGatewayError(e.getMessage());
         }
 
         return gatewayError;

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -7,7 +7,7 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 
 import java.util.Optional;
 
-import static uk.gov.pay.connector.gateway.model.GatewayError.baseError;
+import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
 
 public class GatewayResponse<T extends BaseResponse> {
 
@@ -94,7 +94,7 @@ public class GatewayResponse<T extends BaseResponse> {
             }
             if (StringUtils.isNotBlank(response.getErrorCode()) ||
                     StringUtils.isNotBlank(response.getErrorMessage())) {
-                return new GatewayResponse<>(baseError(response.toString()));
+                return new GatewayResponse<>(genericGatewayError(response.toString()));
             }
             return new GatewayResponse<>(response, sessionIdentifier);
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/DownstreamException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/DownstreamException.java
@@ -1,4 +1,23 @@
 package uk.gov.pay.connector.gateway.stripe;
 
-public class DownstreamException {
+/**
+ * This class represents 5xx exceptions
+ */
+public class DownstreamException extends Exception {
+    private final int statusCode;
+    private final String jsonErrorEntity;
+
+    public DownstreamException(int statusCode, String jsonErrorEntity) {
+        this.statusCode = statusCode;
+        this.jsonErrorEntity = jsonErrorEntity;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    @Override
+    public String getMessage() {
+        return jsonErrorEntity;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/DownstreamException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/DownstreamException.java
@@ -1,0 +1,4 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+public class DownstreamException {
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayClientException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayClientException.java
@@ -2,6 +2,9 @@ package uk.gov.pay.connector.gateway.stripe;
 
 import javax.ws.rs.core.Response;
 
+/**
+ * This class represents 4xx exceptions
+ */
 public class GatewayClientException extends Exception{
     private final transient Response response;
     

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayException.java
@@ -1,5 +1,9 @@
 package uk.gov.pay.connector.gateway.stripe;
 
+/**
+ * This class represents any other exception (non 4xx or 5xx) that occurred while making a request to the external 
+ * payment provider
+ */
 public class GatewayException extends Exception {
     private final transient String url;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -1,20 +1,18 @@
 package uk.gov.pay.connector.gateway.stripe;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeCreateChargeResponse;
 
-import javax.ws.rs.core.Response;
 import java.util.Optional;
 
 import static java.lang.String.format;
 
 public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
 
-    private StripeJsonResponse jsonResponse;
+    private StripeCreateChargeResponse jsonResponse;
 
-    private StripeAuthorisationResponse(StripeJsonResponse jsonResponse) {
+    public StripeAuthorisationResponse(StripeCreateChargeResponse jsonResponse) {
         this.jsonResponse = jsonResponse;
     }
 
@@ -27,7 +25,8 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
     public AuthoriseStatus authoriseStatus() {
         String stripeStatus = jsonResponse.getStatus();
         switch (stripeStatus) {
-            case "succeeded": return AuthoriseStatus.AUTHORISED;
+            case "succeeded": 
+                return AuthoriseStatus.AUTHORISED;
             default: throw new IllegalArgumentException(format("Cannot map stripe status of %s to an %s", stripeStatus, AuthoriseStatus.class.getName()));
         }
     }
@@ -45,25 +44,5 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
     @Override
     public String getErrorMessage() {
         return null;
-    }
-
-    public static StripeAuthorisationResponse of(Response response) {
-        return new StripeAuthorisationResponse(response.readEntity(StripeJsonResponse.class));
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class StripeJsonResponse {
-        @JsonProperty("id")
-        private String id;
-        @JsonProperty("status")
-        private String status;
-
-        public String getTransactionId() {
-            return id;
-        }
-
-        public String getStatus() {
-            return status;
-        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
@@ -45,8 +45,7 @@ public class StripeGatewayClient {
         Response response;
         try {
 
-            Invocation.Builder clientBuilder = client.target(url.toString())
-                    .request();
+            Invocation.Builder clientBuilder = client.target(url.toString()).request();
             headers.keySet().forEach(headerKey -> clientBuilder.header(headerKey, headers.get(headerKey)));
 
             response = clientBuilder

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -2,29 +2,37 @@ package uk.gov.pay.connector.gateway.stripe.handler;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.DownstreamException;
 import uk.gov.pay.connector.gateway.stripe.GatewayClientException;
 import uk.gov.pay.connector.gateway.stripe.GatewayException;
 import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
-import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
 import uk.gov.pay.connector.gateway.stripe.util.StripeAuthUtil;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.util.UUID;
 
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
+import static uk.gov.pay.connector.gateway.model.GatewayError.unexpectedStatusCodeFromGateway;
 
 public class StripeCaptureHandler implements CaptureHandler {
 
+    private static final Logger logger = LoggerFactory.getLogger(StripeCaptureHandler.class);
+    
     private final StripeGatewayClient client;
     private final StripeGatewayConfig stripeGatewayConfig;
 
@@ -54,15 +62,25 @@ public class StripeCaptureHandler implements CaptureHandler {
             return responseBuilder.withResponse(StripeCaptureResponse.of(captureResponse)).build();
 
         } catch (GatewayClientException e) {
-            GatewayError gatewayError = GatewayError.unexpectedStatusCodeFromGateway(e
-                    .getResponse()
-                    .readEntity(StripeErrorResponse.class)
-                    .getError()
-                    .getMessage());
-
+            
+            Response response = e.getResponse();
+            StripeErrorResponse stripeErrorResponse = response.readEntity(StripeErrorResponse.class);
+            String errorId = UUID.randomUUID().toString();
+            logger.error("Capture failed for transaction id {}. Failure code from Stripe: {}, failure message from Stripe: {}. ErrorId: {}. Response code from Stripe: {}",
+                    request.getTransactionId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), errorId, response.getStatus());
+            GatewayError gatewayError = genericGatewayError(stripeErrorResponse.getError().getMessage());
             return responseBuilder.withGatewayError(gatewayError).build();
+        
         } catch (GatewayException e) {
+        
             return responseBuilder.withGatewayError(GatewayError.of(e)).build();
+        
+        } catch (DownstreamException e) {
+            String errorId = UUID.randomUUID().toString();
+            logger.error("Capture failed for transaction id {}. Reason: {}. Status code from Stripe: {}. ErrorId: {}",
+                    request.getTransactionId(), e.getMessage(), e.getStatusCode(), errorId);
+            GatewayError gatewayError = unexpectedStatusCodeFromGateway("An internal server error occurred. ErrorId: " + errorId);
+            return responseBuilder.withGatewayError(gatewayError).build();
         }
 
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.gateway.stripe.GatewayClientException;
 import uk.gov.pay.connector.gateway.stripe.GatewayException;
 import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
 import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
-import uk.gov.pay.connector.gateway.stripe.response.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.util.StripeAuthUtil;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCreateChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCreateChargeResponse.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeCreateChargeResponse {
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("failure_code")
+    private String failureCode;
+    @JsonProperty("failure_message")
+    private String failureMessage;
+
+    public String getTransactionId() {
+        return id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getFailureCode() {
+        return failureCode;
+    }
+
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCreateChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCreateChargeResponse.java
@@ -9,10 +9,6 @@ public class StripeCreateChargeResponse {
     private String id;
     @JsonProperty("status")
     private String status;
-    @JsonProperty("failure_code")
-    private String failureCode;
-    @JsonProperty("failure_message")
-    private String failureMessage;
 
     public String getTransactionId() {
         return id;
@@ -22,11 +18,4 @@ public class StripeCreateChargeResponse {
         return status;
     }
 
-    public String getFailureCode() {
-        return failureCode;
-    }
-
-    public String getFailureMessage() {
-        return failureMessage;
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.gateway.stripe.response;
+package uk.gov.pay.connector.gateway.stripe.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
@@ -46,6 +46,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE_GENERAL;
 
 public abstract class BaseStripePaymentProviderTest {
 
@@ -107,6 +108,10 @@ public abstract class BaseStripePaymentProviderTest {
 
     String errorCaptureResponse() {
         return TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
+    }
+
+    String stripeInternalServerError() {
+        return TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE_GENERAL);
     }
 
     CaptureGatewayRequest buildTestCaptureRequest() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
@@ -19,7 +19,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.stripe.response.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -71,8 +71,8 @@ public class StripePaymentProviderTest extends BaseStripePaymentProviderTest {
     }
 
     @Test
-    public void shouldNotAuthorise_whenPaymentProviderReturnsUnexpectedStatusCode() throws IOException {
-        mockPaymentProviderErrorResponse(500, generalErrorResponse());
+    public void shouldNotAuthorise_whenPaymentProviderReturnsUnexpectedStatusCode() {
+        mockResponseWithPayload(500);
 
         GatewayResponse<BaseAuthoriseResponse> authoriseResponse = provider.authorise(buildTestAuthorisationRequest());
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -25,7 +25,6 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE_GENERAL;

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceITest.java
@@ -90,6 +90,23 @@ public class StripeResourceITest {
     }
 
     @Test
+    public void cardAuthorisationFailureShouldReturnBadRequest() {
+        stripeMockClient.mockAuthorisationFailed();
+        
+        addGatewayAccount(ImmutableMap.of("stripe_account_id", stripeAccountId));
+
+        String externalChargeId = addCharge();
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .body(validAuthorisationDetails)
+                .post(authoriseChargeUrlFor(externalChargeId))
+                .then()
+                .statusCode(400)
+                .body("message", is("Your card has expired."));
+    }
+    
+    @Test
     public void authoriseCharge() {
         addGatewayAccount(ImmutableMap.of("stripe_account_id", stripeAccountId));
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -128,7 +128,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private void worldpayWillRespondWithError() {
         GatewayResponseBuilder<WorldpayCaptureResponse> gatewayResponseBuilder = responseBuilder();
         GatewayResponse captureResponse = gatewayResponseBuilder
-                .withGatewayError(GatewayError.baseError("something went wrong")).build();
+                .withGatewayError(GatewayError.genericGatewayError("something went wrong")).build();
         when(mockCaptureHandler.capture(any())).thenReturn(captureResponse);
     }
 

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -14,6 +14,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_FAILED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_3DS_SOURCES_RESPONSE;
@@ -65,6 +66,11 @@ public class StripeMockClient {
     public void mockCreateSource() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/sources", 200);
+    }
+
+    public void mockAuthorisationFailed() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE);
+        setupResponse(payload, "/v1/charges", 400);
     }
 
     public void mockCreateSourceWithThreeDSecureRequired() {

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -113,6 +113,7 @@ public class TestTemplateResourceLoader {
     public static final String EPDQ_NOTIFICATION_TEMPLATE = EPDQ_BASE_NAME + "/notification-template.txt";
 
     public static final String STRIPE_AUTHORISATION_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/authorisation_success_response.json";
+    public static final String STRIPE_AUTHORISATION_FAILED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/authorisation_failed_response.json";
     public static final String STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_token_response.json";
     public static final String STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_response.json";
     public static final String STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_3ds_required_response.json";

--- a/src/test/resources/templates/stripe/authorisation_failed_response.json
+++ b/src/test/resources/templates/stripe/authorisation_failed_response.json
@@ -1,0 +1,10 @@
+{
+  "error": {
+    "charge": "ch_1DYXEIHj08j2jFuBsOaFNQ7W",
+    "code": "expired_card",
+    "doc_url": "https://stripe.com/docs/error-codes/expired-card",
+    "message": "Your card has expired.",
+    "param": "exp_month",
+    "type": "card_error"
+  }
+}


### PR DESCRIPTION
Technically a 400 is a response to a malformed syntax but for consistentcy with
    the current code in CardResource.authoriseCharge:

```
return isAuthorisationDeclined(response) ? badRequestResponse("This transaction was declined.")
```

a relevant test
    (StripeResourceITest.cardAuthorisationFailureShouldReturnBadRequest) has been
    added to handle a card auth failure (this covers the scenarios in
    https://stripe.com/docs/testing#cards-responses).

From manual testing, auth failure responses from Stripe have a 402 status code and a json body that
looks like
```
    {
      "error": {
        "charge": "ch_1DYXEIHj08j2jFuBsOaFNQ7W",
        "code": "expired_card",
        "doc_url": "https://stripe.com/docs/error-codes/expired-card",
        "message": "Your card has expired.",
        "param": "exp_month",
        "type": "card_error"
      }
    }
```

I've also taken the opportunity to improve the logging by logging the relevant external charge id as well.

@oswaldquek

