### PR TITLE
PP-4314 Add template loader for apple pay payload to worldpay

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.connector.gateway;
 
 
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.templates.PayloadBuilder;
+import uk.gov.pay.connector.gateway.worldpay.applepay.ApplePayTemplateData;
 
 import javax.ws.rs.core.MediaType;
 
@@ -15,6 +16,7 @@ public abstract class OrderRequestBuilder {
         private String merchantCode;
         private String description;
         private AuthCardDetails authCardDetails;
+        private ApplePayTemplateData applePayTemplateData;
         private String amount;
         private String paymentPlatformReference;
 
@@ -64,6 +66,14 @@ public abstract class OrderRequestBuilder {
 
         public void setPaymentPlatformReference(String paymentPlatformReference) {
             this.paymentPlatformReference = paymentPlatformReference;
+        }
+
+        public ApplePayTemplateData getApplePayTemplateData() {
+            return applePayTemplateData;
+        }
+
+        public void setApplePayTemplateData(ApplePayTemplateData applePayTemplateData) {
+            this.applePayTemplateData = applePayTemplateData;
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.model;
 public enum OrderRequestType {
     AUTHORISE("authorise"),
     AUTHORISE_3DS("authorise3DS"),
+    AUTHORISE_APPLE_PAY("authoriseApplePay"),
     CAPTURE("capture"),
     CANCEL("cancel"),
     REFUND("refund");

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -2,10 +2,11 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
+import uk.gov.pay.connector.gateway.OrderRequestBuilder;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.templates.PayloadBuilder;
 import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
-import uk.gov.pay.connector.gateway.OrderRequestBuilder;
+import uk.gov.pay.connector.gateway.worldpay.applepay.ApplePayTemplateData;
 
 import javax.ws.rs.core.MediaType;
 
@@ -90,6 +91,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     }
 
     public static final TemplateBuilder AUTHORISE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseOrderTemplate.xml");
+    public static final TemplateBuilder AUTHORISE_APPLE_PAY_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayAuthoriseApplePayOrderTemplate.xml");
     public static final TemplateBuilder AUTH_3DS_RESPONSE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/Worldpay3dsResponseAuthOrderTemplate.xml");
     public static final TemplateBuilder CAPTURE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayCaptureOrderTemplate.xml");
     public static final TemplateBuilder CANCEL_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayCancelOrderTemplate.xml");
@@ -99,6 +101,10 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public static WorldpayOrderRequestBuilder aWorldpayAuthoriseOrderRequestBuilder() {
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
+    }
+    
+    public static WorldpayOrderRequestBuilder aWorldpayAuthoriseApplePayOrderRequestBuilder() {
+        return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_APPLE_PAY_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE_APPLE_PAY);
     }
 
     public static WorldpayOrderRequestBuilder aWorldpay3dsResponseAuthOrderRequestBuilder() {
@@ -142,6 +148,11 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         return this;
     }
 
+    public WorldpayOrderRequestBuilder withApplePayTemplateData(ApplePayTemplateData applePayTemplateData) {
+        worldpayTemplateData.setApplePayTemplateData(applePayTemplateData);
+        return this;
+    }
+    
     public WorldpayOrderRequestBuilder withAcceptHeader(String acceptHeader) {
         worldpayTemplateData.setAcceptHeader(acceptHeader);
         return this;

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/ApplePayTemplateData.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/ApplePayTemplateData.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.connector.gateway.worldpay.applepay;
+
+import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
+
+import java.time.format.DateTimeFormatter;
+
+public class ApplePayTemplateData {
+    private String applicationPrimaryAccountNumber;
+    private String expiryDateMonth;
+    private String expiryDateYear;
+    private String cardholderName;
+    private String onlinePaymentCryptogram;
+    private String eciIndicator;
+
+    private ApplePayTemplateData(String applicationPrimaryAccountNumber, String expiryDateMonth, String expiryDateYear, String cardholderName, String onlinePaymentCryptogram, String eciIndicator) {
+        this.applicationPrimaryAccountNumber = applicationPrimaryAccountNumber;
+        this.expiryDateMonth = expiryDateMonth;
+        this.expiryDateYear = expiryDateYear;
+        this.cardholderName = cardholderName;
+        this.onlinePaymentCryptogram = onlinePaymentCryptogram;
+        this.eciIndicator = eciIndicator;
+    }
+
+    public static ApplePayTemplateData from(AppleDecryptedPaymentData appleDecryptedPaymentData) {
+        return new ApplePayTemplateData(
+                appleDecryptedPaymentData.getApplicationPrimaryAccountNumber(), 
+                appleDecryptedPaymentData.getApplicationExpirationDate().format(DateTimeFormatter.ofPattern("MM")),
+                appleDecryptedPaymentData.getApplicationExpirationDate().format(DateTimeFormatter.ofPattern("yyyy")),
+                appleDecryptedPaymentData.getPaymentInfo().getCardholderName(),
+                appleDecryptedPaymentData.getPaymentData().getOnlinePaymentCryptogram(),
+                appleDecryptedPaymentData.getPaymentData().getEciIndicator()
+        );
+    }
+
+    public String getApplicationPrimaryAccountNumber() {
+        return applicationPrimaryAccountNumber;
+    }
+
+    public String getExpiryDateMonth() {
+        return expiryDateMonth;
+    }
+
+    public String getExpiryDateYear() {
+        return expiryDateYear;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getOnlinePaymentCryptogram() {
+        return onlinePaymentCryptogram;
+    }
+
+    public String getEciIndicator() {
+        return eciIndicator;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -2,11 +2,14 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import org.joda.time.DateTime;
 import org.junit.Test;
+import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.worldpay.applepay.ApplePayTemplateData;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+import uk.gov.pay.connector.util.AuthUtils;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
@@ -14,6 +17,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseApplePayOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCaptureOrderRequestBuilder;
@@ -22,6 +26,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPEC
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS;
@@ -156,6 +162,44 @@ public class WorldpayOrderRequestBuilderTest {
         assertThat(actualRequest.getProviderSessionId().get(), is(providerSessionId));
     }
 
+    @Test
+    public void shouldGenerateValidAuthoriseApplePayOrderRequest() throws Exception {
+        AppleDecryptedPaymentData data = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", "4818528840010767");
+        
+        GatewayOrder actualRequest = aWorldpayAuthoriseApplePayOrderRequestBuilder()
+                .withApplePayTemplateData(ApplePayTemplateData.from(data))
+                .withSessionId("uniqueSessionId")
+                .withAcceptHeader("text/html")
+                .withUserAgentHeader("Mozilla/5.0")
+                .withTransactionId("MyUniqueTransactionId!")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.getOrderRequestType());
+    }
+    
+    @Test
+    public void shouldGenerateValidAuthoriseApplePayOrderRequest_withMinData() throws Exception {
+        AppleDecryptedPaymentData data = AuthUtils.ApplePay.buildDecryptedMinimalPaymentData("4242424242424242");
+
+        GatewayOrder actualRequest = aWorldpayAuthoriseApplePayOrderRequestBuilder()
+                .withApplePayTemplateData(ApplePayTemplateData.from(data))
+                .withSessionId("uniqueSessionId")
+                .withAcceptHeader("text/html")
+                .withUserAgentHeader("Mozilla/5.0")
+                .withTransactionId("MyUniqueTransactionId!")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_APPLE_PAY, actualRequest.getOrderRequestType());
+    }
+    
     @Test
     public void shouldGenerateValidCaptureOrderRequest() throws Exception {
 

--- a/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
+++ b/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
@@ -1,13 +1,52 @@
 package uk.gov.pay.connector.util;
 
+import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
+import uk.gov.pay.connector.applepay.api.ApplePaymentInfo;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+
+import java.time.LocalDate;
 
 public class AuthUtils {
-    
     public static Auth3dsDetails buildAuth3dsDetails() {
         Auth3dsDetails auth3dsDetails = new Auth3dsDetails();
         auth3dsDetails.setPaResponse("sample-pa-response");
         return auth3dsDetails;
+    }
+
+
+    public static class ApplePay {
+        private static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String tokenNumber, AppleDecryptedPaymentData.PaymentData paymentData) {
+            return new AppleDecryptedPaymentData(
+                    new ApplePaymentInfo(
+                            "4242",
+                            "visa",
+                            PayersCardType.DEBIT,
+                            cardHolderName,
+                            email
+                    ),
+                    tokenNumber,
+                    LocalDate.of(2023, 12, 31),
+                    "643",
+                    10L,
+                    "040010030273",
+                    "3DSecure",
+                    paymentData
+            );
+        }
+
+        public static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String tokenNumber) {
+            return buildDecryptedPaymentData(cardHolderName, email, tokenNumber, new AppleDecryptedPaymentData.PaymentData(
+                    "Ao/fzpIAFvp1eB9y8WVDMAACAAA=",
+                    "7"
+            ));
+        }
+        public static AppleDecryptedPaymentData buildDecryptedMinimalPaymentData(String tokenNumber) {
+            return buildDecryptedPaymentData(null, null, tokenNumber, new AppleDecryptedPaymentData.PaymentData(
+                    "Ao/fzpIAFvp1eB9y8WVDMAACAAA=",
+                    null
+            ));
+        }
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -20,6 +20,8 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-min-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-min-data.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-3ds-response-auth-worldpay-request.xml";


### PR DESCRIPTION
## WHAT
Adding the template loader which will populate the xml we send to worldpay with apple pay data. Instead of having logic directly in the template (using freemarker, like we do for card stuff), I am introducing a "template data" class which shapes the information as we need it in the template.

