### PR TITLE
PP-4164 Add gateway tests for 3DS authorisation with no billing address

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -151,6 +151,21 @@ public class EpdqPaymentProviderTest {
     }
 
     @Test
+    public void shouldAuthoriseWith3dsOnAndNoAddressInRequestSuccessfully() {
+        setUpFor3dsAndCheckThatEpdqIsUp();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withAddress(null)
+                .build();
+
+        AuthorisationGatewayRequest request = new AuthorisationGatewayRequest(chargeEntity, authCardDetails);
+
+        GatewayResponse<EpdqAuthorisationResponse> response = paymentProvider.authorise(request);
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
+    }
+
+    @Test
     public void shouldCheckAuthorisationStatusSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
         AuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -139,6 +139,24 @@ public class SmartpayPaymentProviderTest {
     }
 
     @Test
+    public void shouldSendA3dsOrderForMerchantWithNoBillingAddressSuccessfully() throws Exception {
+        gatewayAccountEntity.setRequires3ds(true);
+        PaymentProvider paymentProvider = getSmartpayPaymentProvider();
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo(VALID_SMARTPAY_3DS_CARD_NUMBER)
+                .withAddress(null)
+                .build();
+
+        AuthorisationGatewayRequest request = new AuthorisationGatewayRequest(chargeEntity, authCardDetails);
+        GatewayResponse<SmartpayAuthorisationResponse> response = paymentProvider.authorise(request);
+        assertTrue(response.isSuccessful());
+        assertThat(response.getBaseResponse().get().getIssuerUrl(), is(notNullValue()));
+        assertThat(response.getBaseResponse().get().getMd(), is(notNullValue()));
+        assertThat(response.getBaseResponse().get().getPaRequest(), is(notNullValue()));
+    }
+
+    @Test
     public void shouldFailRequestAuthorisationIfCredentialsAreNotCorrect() throws Exception {
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
         GatewayAccountEntity accountWithInvalidCredentials = new GatewayAccountEntity();
@@ -246,8 +264,6 @@ public class SmartpayPaymentProviderTest {
     public static AuthorisationGatewayRequest getCard3dsAuthorisationRequest(ChargeEntity chargeEntity) {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCardNo(VALID_SMARTPAY_3DS_CARD_NUMBER)
-                .withAcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
-                .withUserAgentHeader("Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9) Gecko/2008052912 Firefox/3.0")
                 .build();
 
         return new AuthorisationGatewayRequest(chargeEntity, authCardDetails);


### PR DESCRIPTION
## WHAT
- Added SmartPay and ePDQ gateway tests for 3DS turned on and no billing
  address in request. Such a test already exists for WorldPay


