### PR TITLE
PP-4371 Create Stripe 3DS source

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/Stripe3dsSourceAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/Stripe3dsSourceAuthorisationResponse.java
@@ -1,0 +1,51 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsSourceResponse;
+import uk.gov.pay.connector.gateway.stripe.response.StripeParamsFor3ds;
+
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+
+public class Stripe3dsSourceAuthorisationResponse implements BaseAuthoriseResponse {
+
+    private Stripe3dsSourceResponse jsonResponse;
+
+    private Stripe3dsSourceAuthorisationResponse(Stripe3dsSourceResponse jsonResponse) {
+        this.jsonResponse = jsonResponse;
+    }
+
+    @Override
+    public String getTransactionId() {
+        return jsonResponse.getId();
+    }
+
+    @Override
+    public AuthoriseStatus authoriseStatus() {
+        if ("pending".equals(jsonResponse.getStatus())) {
+            return AuthoriseStatus.REQUIRES_3DS;
+        }
+        return AuthoriseStatus.ERROR;
+    }
+
+    @Override
+    public Optional<? extends GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+        return Optional.of(new StripeParamsFor3ds(jsonResponse.getRedirectUrl()));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return null;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return null;
+    }
+
+    public static Stripe3dsSourceAuthorisationResponse of(Response response) {
+        return new Stripe3dsSourceAuthorisationResponse(response.readEntity(Stripe3dsSourceResponse.class));
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
@@ -9,7 +9,24 @@ public class StripeSourcesResponse {
     @JsonProperty("id")
     private String id;
 
+    @JsonProperty("card")
+    private Card card;
+
     public String getId() {
         return id;
+    }
+
+    public boolean require3ds() {
+        return card != null && "required".equals(card.getThreeDSecure());
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class Card {
+        @JsonProperty("three_d_secure")
+        private String threeDSecure;
+
+        public String getThreeDSecure() {
+            return threeDSecure;
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/Stripe3dsSourceResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/Stripe3dsSourceResponse.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Stripe3dsSourceResponse {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("status")
+    private String status;
+    @JsonProperty("redirect")
+    private Redirect redirect;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getRedirectUrl() {
+        return redirect.getUrl();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class Redirect {
+        @JsonProperty("url")
+        private String url;
+
+        public String getUrl() {
+            return url;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeParamsFor3ds.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeParamsFor3ds.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
+import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+
+public class StripeParamsFor3ds implements GatewayParamsFor3ds {
+
+    private final String issuerUrl;
+
+    public StripeParamsFor3ds(String issuerUrl) {
+        this.issuerUrl = issuerUrl;
+    }
+
+    @Override
+    public Auth3dsDetailsEntity toAuth3dsDetailsEntity() {
+        Auth3dsDetailsEntity auth3dsDetailsEntity = new Auth3dsDetailsEntity();
+        auth3dsDetailsEntity.setIssuerUrl(issuerUrl);
+        return auth3dsDetailsEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -1,0 +1,110 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeSourcesResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeTokenResponse;
+import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsSourceResponse;
+import uk.gov.pay.connector.gateway.stripe.response.StripeParamsFor3ds;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE_GENERAL;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripePaymentProviderTest extends BaseStripePaymentProviderTest {
+
+    @Test
+    public void shouldGetPaymentProviderName() {
+        assertThat(provider.getPaymentGatewayName().getName(), is("stripe"));
+    }
+
+    @Test
+    public void shouldGenerateNoTransactionId() {
+        Assert.assertThat(provider.generateTransactionId().isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldAuthoriseAs3dsRequired_whenChargeRequired3ds() throws IOException {
+        mockPaymentProvider3dsRequiredResponse();
+
+        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
+
+        assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
+        assertTrue(response.isSuccessful());
+        assertThat(response.getBaseResponse().get().getTransactionId(), is("src_1DXAxYC6H5MjhE5Y4jZVJwNV")); // id from templates/stripe/create_3ds_sources_response.json
+        
+        Optional<StripeParamsFor3ds> stripeParamsFor3ds = (Optional<StripeParamsFor3ds>) response.getBaseResponse().get().getGatewayParamsFor3ds();
+        assertThat(stripeParamsFor3ds.isPresent(), is(true));
+        assertThat(stripeParamsFor3ds.get().toAuth3dsDetailsEntity().getIssuerUrl(), containsString("https://hooks.stripe.com")); //from templates/stripe/create_3ds_sources_response.json
+
+    }
+
+    @Test
+    public void shouldNotAuthorise_whenProcessingExceptionIsThrown() {
+        mockProcessingException();
+
+        GatewayResponse<BaseAuthoriseResponse> authoriseResponse = provider.authorise(buildTestAuthorisationRequest());
+
+        assertThat(authoriseResponse.isFailed(), is(true));
+        assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
+        assertEquals(authoriseResponse.getGatewayError().get(), new GatewayError("javax.ws.rs.ProcessingException",
+                GENERIC_GATEWAY_ERROR));
+    }
+
+    @Test
+    public void shouldNotAuthorise_whenPaymentProviderReturnsUnexpectedStatusCode() throws IOException {
+        mockPaymentProviderErrorResponse(500, generalErrorResponse());
+
+        GatewayResponse<BaseAuthoriseResponse> authoriseResponse = provider.authorise(buildTestAuthorisationRequest());
+
+        assertThat(authoriseResponse.isFailed(), is(true));
+        assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
+        assertThat(authoriseResponse.getGatewayError().get().getMessage(),
+                containsString("There was an internal server error"));
+        assertThat(authoriseResponse.getGatewayError().get().getErrorType(), is(UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+
+    }
+
+    String generalErrorResponse() {
+        return TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE_GENERAL);
+    }
+
+    private void mockProcessingException() {
+        mockInvocationBuilder();
+        when(mockClientInvocationBuilder.post(any())).thenThrow(ProcessingException.class);
+    }
+
+    private void mockPaymentProvider3dsRequiredResponse() throws IOException {
+        Response response = mockResponseWithPayload(200);
+
+        StripeTokenResponse stripeTokenResponse = new ObjectMapper().readValue(successTokenResponse(), StripeTokenResponse.class);
+        when(response.readEntity(StripeTokenResponse.class)).thenReturn(stripeTokenResponse);
+
+        StripeSourcesResponse stripeSourcesResponse = new ObjectMapper().readValue(successSourceResponseWith3dsRequired(), StripeSourcesResponse.class);
+        when(response.readEntity(StripeSourcesResponse.class)).thenReturn(stripeSourcesResponse);
+
+        Stripe3dsSourceResponse stripe3dsSourceResponse = new ObjectMapper().readValue(success3dsSourceResponse(), Stripe3dsSourceResponse.class);
+        when(response.readEntity(Stripe3dsSourceResponse.class)).thenReturn(stripe3dsSourceResponse);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -16,6 +16,8 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_3DS_SOURCES_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
@@ -28,6 +30,13 @@ public class StripeMockClient {
 
     private void setupResponse(String responseBody, String path, int status) {
         stubFor(post(urlPathEqualTo(path)).withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
+                .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON).withStatus(status).withBody(responseBody)));
+    }
+
+    private void setupResponse(String requestBodyPattern, String responseBody, String path, int status) {
+        stubFor(post(urlPathEqualTo(path))
+                .withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
+                .withRequestBody(matching(".*" + requestBodyPattern + ".*"))
                 .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON).withStatus(status).withBody(responseBody)));
     }
 
@@ -56,5 +65,15 @@ public class StripeMockClient {
     public void mockCreateSource() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/sources", 200);
+    }
+
+    public void mockCreateSourceWithThreeDSecureRequired() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE);
+        setupResponse(payload, "/v1/sources", 200);
+    }
+
+    public void mockCreate3dsSource() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_3DS_SOURCES_RESPONSE);
+        setupResponse("three_d_secure", payload, "/v1/sources", 200);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -115,8 +115,11 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_AUTHORISATION_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/authorisation_success_response.json";
     public static final String STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_token_response.json";
     public static final String STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_response.json";
+    public static final String STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_3ds_required_response.json";
+    public static final String STRIPE_CREATE_3DS_SOURCES_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_3ds_sources_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response.json";
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
+    public static final String STRIPE_ERROR_RESPONSE_GENERAL = TEMPLATE_BASE_NAME + "/stripe/error_response_general.json";
 
     public static String load(String location) {
         return fixture(location);

--- a/src/test/resources/templates/stripe/create_3ds_sources_response.json
+++ b/src/test/resources/templates/stripe/create_3ds_sources_response.json
@@ -1,0 +1,22 @@
+{
+  "id": "src_1DXAxYC6H5MjhE5Y4jZVJwNV",
+  "object": "source",
+  "amount": 1099,
+  "client_secret": "src_client_secret_Dz9Gdfev1r48Lq5Ayox6qOD6",
+  "currency": "gbp",
+  "flow": "redirect",
+  "livemode": false,
+  "redirect": {
+    "failure_reason": null,
+    "return_url": "https://example.com",
+    "status": "pending",
+    "url": "https://hooks.stripe.com/redirect/authenticate/src_1DXAxYC6H5MjhE5Y4jZVJwNV?client_secret=src_client_secret_Dz9Gdfev1r48Lq5Ayox6qOD6"
+  },
+  "status": "pending",
+  "three_d_secure": {
+    "card": "src_1DXAwDC6H5MjhE5YtbPXsoBL",
+    "three_d_secure": "required"
+  },
+  "type": "three_d_secure",
+  "usage": "single_use"
+}

--- a/src/test/resources/templates/stripe/create_sources_3ds_required_response.json
+++ b/src/test/resources/templates/stripe/create_sources_3ds_required_response.json
@@ -1,0 +1,15 @@
+{
+  "id": "src_1DXAwDC6H5MjhE5YtbPXsoBL",
+  "object": "source",
+  "amount": null,
+  "card": {
+    "three_d_secure": "required"
+  },
+  "client_secret": "src_client_secret_Dz9E1oktM2D04med4z8Il4Df",
+  "currency": null,
+  "flow": "none",
+  "livemode": false,
+  "status": "chargeable",
+  "type": "card",
+  "usage": "reusable"
+}

--- a/src/test/resources/templates/stripe/error_response_general.json
+++ b/src/test/resources/templates/stripe/error_response_general.json
@@ -1,0 +1,9 @@
+{
+  "error": {
+    "charge": "ch_1DX3j5C6H5MjhE5YhPcLhENF",
+    "code": "processing_error",
+    "doc_url": "https://stripe.com/docs/error-codes/processing-error",
+    "message": "An error occurred while processing your card. Try again in a little bit.",
+    "type": "card_error"
+  }
+}


### PR DESCRIPTION
## WHAT
Part of Stripe 3DS journey:

For a card authorisation without 3DS, sequence of steps is
`create token -> create source -> authorise a charge using source`
In case of 3DS, first steps are
`create token -> create source -> create 3DS source` -> and further to frontend for 3DS redirect

**This change includes**
- Create `Stripe 3DS source` if 3DS authentication is required for card
