### PR TITLE
PP-4314 Add ApplePayAuthorisationHandler 

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.charge.resource.ChargesFrontendResource;
 import uk.gov.pay.connector.chargeevent.resource.ChargeEventsResource;
 import uk.gov.pay.connector.command.RenderStateTransitionGraphCommand;
 import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
+import uk.gov.pay.connector.common.exception.UnsupportedOperationExceptionMapper;
 import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
 import uk.gov.pay.connector.filters.LoggingFilter;
 import uk.gov.pay.connector.filters.SchemeRewriteFilter;
@@ -97,6 +98,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         
         environment.jersey().register(new ConstraintViolationExceptionMapper());
         environment.jersey().register(new ValidationExceptionMapper());
+        environment.jersey().register(new UnsupportedOperationExceptionMapper());
         environment.jersey().register(new LoggingExceptionMapper<Throwable>() {});
         environment.jersey().register(new JsonProcessingExceptionMapper());
         environment.jersey().register(new EarlyEofExceptionMapper());

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -10,11 +10,9 @@ import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
 import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
-import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
 import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
@@ -95,11 +93,6 @@ public class ConnectorModule extends AbstractModule {
     @Provides
     public SignatureGenerator signatureGenerator() {
         return new EpdqSha512SignatureGenerator();
-    }
-    
-    @Provides
-    public SandboxPaymentProvider sandboxPaymentProvider() {
-        return new SandboxPaymentProvider();
     }
     
     @Provides

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePayAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePayAuthorisationHandler.java
@@ -3,10 +3,6 @@ package uk.gov.pay.connector.applepay;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
-import java.util.Optional;
-
-public interface ApplePayAuthoriser {
+public interface ApplePayAuthorisationHandler {
     GatewayResponse<BaseAuthoriseResponse> authorise(ApplePayAuthorisationGatewayRequest request);
-
-    Optional<String> generateTransactionId();
 }

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePayAuthoriser.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePayAuthoriser.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.applepay;
+
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import java.util.Optional;
+
+public interface ApplePayAuthoriser {
+    GatewayResponse<BaseAuthoriseResponse> authorise(ApplePayAuthorisationGatewayRequest request);
+
+    Optional<String> generateTransactionId();
+}

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -355,13 +355,12 @@ public class ChargeService {
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
     }
 
-
     private CardDetailsEntity buildCardDetailsEntity(AuthCardDetails authCardDetails) {
         CardDetailsEntity detailsEntity = new CardDetailsEntity();
         detailsEntity.setCardBrand(sanitize(authCardDetails.getCardBrand()));
         detailsEntity.setCardHolderName(sanitize(authCardDetails.getCardHolder()));
         detailsEntity.setExpiryDate(authCardDetails.getEndDate());
-        if (authCardDetails.getCardNo().length() > 6) {
+        if (hasFullCardNumber(authCardDetails)) {
             detailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of(StringUtils.left(authCardDetails.getCardNo(), 6)));
         }
         detailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of(StringUtils.right(authCardDetails.getCardNo(), 4)));
@@ -372,6 +371,10 @@ public class ChargeService {
         return detailsEntity;
     }
 
+    private boolean hasFullCardNumber(AuthCardDetails authCardDetails) {
+        return authCardDetails.getCardNo().length() > 6;
+    }
+    
     private TokenEntity createNewChargeEntityToken(ChargeEntity chargeEntity) {
         TokenEntity token = TokenEntity.generateNewTokenFor(chargeEntity);
         tokenDao.persist(token);

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -361,7 +361,9 @@ public class ChargeService {
         detailsEntity.setCardBrand(sanitize(authCardDetails.getCardBrand()));
         detailsEntity.setCardHolderName(sanitize(authCardDetails.getCardHolder()));
         detailsEntity.setExpiryDate(authCardDetails.getEndDate());
-        detailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of(StringUtils.left(authCardDetails.getCardNo(), 6)));
+        if (authCardDetails.getCardNo().length() > 6) {
+            detailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of(StringUtils.left(authCardDetails.getCardNo(), 6)));
+        }
         detailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of(StringUtils.right(authCardDetails.getCardNo(), 4)));
 
         if (authCardDetails.getAddress().isPresent())

--- a/src/main/java/uk/gov/pay/connector/common/exception/UnsupportedOperationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/UnsupportedOperationExceptionMapper.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.common.exception;
+
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+
+public class UnsupportedOperationExceptionMapper implements ExceptionMapper<UnsupportedOperationException> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnsupportedOperationExceptionMapper.class);
+
+    @Override
+    public Response toResponse(UnsupportedOperationException exception) {
+        LOGGER.error(exception.getMessage());
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity(ImmutableMap.of("message", exception.getMessage()))
+                .type(APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -1,12 +1,14 @@
 package uk.gov.pay.connector.gateway;
 
 import fj.data.Either;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationHandler;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
@@ -31,6 +33,8 @@ public interface PaymentProvider<R> {
 
     GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 
+    GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request);
+    
     GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request);
 
     GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request);
@@ -47,4 +51,3 @@ public interface PaymentProvider<R> {
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity);
 }
-

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
@@ -38,7 +38,7 @@ public class PaymentProviders {
         return cardPaymentProviders.get(gateway);
     }
     
-    public ApplePayAuthoriser getAppleAuthoriserFor(ChargeEntity chargeEntity) {
+    public ApplePayAuthoriser getApplePayAuthoriserFor(ChargeEntity chargeEntity) {
         return applePayPaymentProviders.get(chargeEntity.getPaymentGatewayName());
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
@@ -1,8 +1,7 @@
 package uk.gov.pay.connector.gateway;
 
-import uk.gov.pay.connector.applepay.ApplePayAuthoriser;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
 import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
@@ -15,8 +14,7 @@ import static jersey.repackaged.com.google.common.collect.Maps.newHashMap;
 
 public class PaymentProviders {
 
-    private final Map<PaymentGatewayName, PaymentProvider> cardPaymentProviders = newHashMap();
-    private final Map<PaymentGatewayName, ApplePayAuthoriser> applePayPaymentProviders = newHashMap();
+    private final Map<PaymentGatewayName, PaymentProvider> paymentProviders = newHashMap();
     
     @Inject
     public PaymentProviders(WorldpayPaymentProvider worldpayPaymentProvider,
@@ -24,22 +22,15 @@ public class PaymentProviders {
                             SmartpayPaymentProvider smartpayPaymentProvider,
                             SandboxPaymentProvider sandboxPaymentProvider,
                             StripePaymentProvider stripePaymentProvider) {
-        cardPaymentProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
-        cardPaymentProviders.put(PaymentGatewayName.SANDBOX, sandboxPaymentProvider);
-        cardPaymentProviders.put(PaymentGatewayName.SMARTPAY, smartpayPaymentProvider);
-        cardPaymentProviders.put(PaymentGatewayName.EPDQ, epdqPaymentProvider);
-        cardPaymentProviders.put(PaymentGatewayName.STRIPE, stripePaymentProvider);
+        paymentProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
+        paymentProviders.put(PaymentGatewayName.SANDBOX, sandboxPaymentProvider);
+        paymentProviders.put(PaymentGatewayName.SMARTPAY, smartpayPaymentProvider);
+        paymentProviders.put(PaymentGatewayName.EPDQ, epdqPaymentProvider);
+        paymentProviders.put(PaymentGatewayName.STRIPE, stripePaymentProvider);
 
-        applePayPaymentProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
-        applePayPaymentProviders.put(PaymentGatewayName.SANDBOX, sandboxPaymentProvider);
     }
 
-    public PaymentProvider byName(PaymentGatewayName gateway) {
-        return cardPaymentProviders.get(gateway);
+    public PaymentProvider<BaseResponse> byName(PaymentGatewayName gateway) {
+        return paymentProviders.get(gateway);
     }
-    
-    public ApplePayAuthoriser getApplePayAuthoriserFor(ChargeEntity chargeEntity) {
-        return applePayPaymentProviders.get(chargeEntity.getPaymentGatewayName());
-    }
-
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.gateway;
 
+import uk.gov.pay.connector.applepay.ApplePayAuthoriser;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
 import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
@@ -13,22 +15,31 @@ import static jersey.repackaged.com.google.common.collect.Maps.newHashMap;
 
 public class PaymentProviders {
 
-    private final Map<PaymentGatewayName, PaymentProvider> paymentProviders = newHashMap();
-
+    private final Map<PaymentGatewayName, PaymentProvider> cardPaymentProviders = newHashMap();
+    private final Map<PaymentGatewayName, ApplePayAuthoriser> applePayPaymentProviders = newHashMap();
+    
     @Inject
     public PaymentProviders(WorldpayPaymentProvider worldpayPaymentProvider,
                             EpdqPaymentProvider epdqPaymentProvider,
                             SmartpayPaymentProvider smartpayPaymentProvider,
                             SandboxPaymentProvider sandboxPaymentProvider,
                             StripePaymentProvider stripePaymentProvider) {
-        paymentProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
-        paymentProviders.put(PaymentGatewayName.SMARTPAY, smartpayPaymentProvider);
-        paymentProviders.put(PaymentGatewayName.SANDBOX, sandboxPaymentProvider);
-        paymentProviders.put(PaymentGatewayName.EPDQ, epdqPaymentProvider);
-        paymentProviders.put(PaymentGatewayName.STRIPE, stripePaymentProvider);
+        cardPaymentProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
+        cardPaymentProviders.put(PaymentGatewayName.SANDBOX, sandboxPaymentProvider);
+        cardPaymentProviders.put(PaymentGatewayName.SMARTPAY, smartpayPaymentProvider);
+        cardPaymentProviders.put(PaymentGatewayName.EPDQ, epdqPaymentProvider);
+        cardPaymentProviders.put(PaymentGatewayName.STRIPE, stripePaymentProvider);
+
+        applePayPaymentProviders.put(PaymentGatewayName.WORLDPAY, worldpayPaymentProvider);
+        applePayPaymentProviders.put(PaymentGatewayName.SANDBOX, sandboxPaymentProvider);
     }
 
     public PaymentProvider byName(PaymentGatewayName gateway) {
-        return paymentProviders.get(gateway);
+        return cardPaymentProviders.get(gateway);
     }
+    
+    public ApplePayAuthoriser getAppleAuthoriserFor(ChargeEntity chargeEntity) {
+        return applePayPaymentProviders.get(chargeEntity.getPaymentGatewayName());
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -7,6 +7,8 @@ import org.apache.http.NameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationHandler;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -139,6 +141,11 @@ public class EpdqPaymentProvider implements PaymentProvider<String> {
         return GatewayResponseGenerator.getEpdqGatewayResponse(cancelClient, response, EpdqCancelResponse.class);
     }
 
+    @Override
+    public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
+        throw new UnsupportedOperationException("Apple Pay is not supported for EPDQ");
+    }
+    
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_QUERY_ORDER, request.getGatewayAccount(), buildQueryOrderRequestFor(request));

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -13,35 +13,34 @@ class SandboxCardNumbers {
 
     static boolean isValidCard(String cardNumber) {
         return GOOD_CARDS.contains(cardNumber) ||
-                GOOD_CORPORATE_CARDS.contains(cardNumber);
+                GOOD_CORPORATE_CARDS.contains(cardNumber) || GOOD_APPLE_PAY_LAST_DIGITS_CARD_NUMBER.equals(cardNumber);
     }
 
     static boolean isRejectedCard(String cardNumber) {
         return REJECTED_CARDS
                 .keySet()
                 .stream()
-                .anyMatch(a -> a.contains(cardNumber));
+                .anyMatch(rejectedCards -> rejectedCards.contains(cardNumber));
     }
 
     static boolean isErrorCard(String cardNumber) {
         return ERROR_CARDS
                 .keySet()
                 .stream()
-                .anyMatch(a -> a.contains(cardNumber));
+                .anyMatch(errorCards -> errorCards.contains(cardNumber));
     }
 
     static CardError cardErrorFor(String cardNumber) {
         return ERROR_CARDS
                 .entrySet()
                 .stream()
-                .filter(a -> a.getKey().contains(cardNumber))
+                .filter(errorCards -> errorCards.getKey().contains(cardNumber))
                 .findFirst()
                 .map(Map.Entry::getValue)
                 .orElse(null);
     }
 
     private static final List<String> GOOD_CARDS = ImmutableList.of(
-            "4242",
             "4444333322221111",
             "4242424242424242",
             "4917610000000000003",
@@ -52,29 +51,28 @@ class SandboxCardNumbers {
             "3566002020360505",
             "6011000990139424",
             "36148900647913");
-
+    private static final String GOOD_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "4242";
     private static final List<String> GOOD_CORPORATE_CARDS = ImmutableList.of(
             "4000180000000002",
             "5101180000000007");
-    private static final List<String> DECLINED_CARD_NUMBERS = ImmutableList.of(
-            "4000000000000002",
-            "0002");
-    private static final List<String> CVC_ERROR_CARD_NUMBERS = ImmutableList.of(
-            "4000000000000127",
-            "0127");
-    private static final List<String> EXPIRED_CARD_NUMBERS = ImmutableList.of(
-            "4000000000000069",
-            "0069");
-    private static final List<String> PROCESSING_ERROR_CARD_NUMBERS = ImmutableList.of(
-            "4000000000000119",
-            "0119");
+    private static final String DECLINED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0002";
+    private static final String DECLINED_CARD_NUMBER = "4000000000000002";
+    private static final String CVC_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0127";
+    private static final String CVC_ERROR_CARD_NUMBER = "4000000000000127";
+    private static final String EXPIRED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0069";
+    private static final String EXPIRED_CARD_NUMBER = "4000000000000069";
+    private static final String PROCESSING_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0119";
+    private static final String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
 
     private static final Map<List<String>, CardError> ERROR_CARDS = ImmutableMap.of(
-            PROCESSING_ERROR_CARD_NUMBERS, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
+            ImmutableList.of(PROCESSING_ERROR_CARD_NUMBER,PROCESSING_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
+            new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
 
     private static final Map<List<String>, CardError> REJECTED_CARDS = ImmutableMap.of(
-            DECLINED_CARD_NUMBERS, new CardError(AUTHORISATION_REJECTED, "This transaction was declined."),
-            EXPIRED_CARD_NUMBERS, new CardError(AUTHORISATION_REJECTED, "The card is expired."),
-            CVC_ERROR_CARD_NUMBERS, new CardError(AUTHORISATION_REJECTED, "The CVC code is incorrect."));
-    
+            ImmutableList.of(DECLINED_CARD_NUMBER, DECLINED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
+            new CardError(AUTHORISATION_REJECTED, "This transaction was declined."),
+            ImmutableList.of(EXPIRED_CARD_NUMBER, EXPIRED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
+            new CardError(AUTHORISATION_REJECTED, "The card is expired."),
+            ImmutableList.of(CVC_ERROR_CARD_NUMBER, CVC_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
+            new CardError(AUTHORISATION_REJECTED, "The CVC code is incorrect."));
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -9,28 +9,28 @@ import java.util.Map;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 
-class SandboxCardNumbers {
+public class SandboxCardNumbers {
 
-    static boolean isValidCard(String cardNumber) {
+    public static boolean isValidCard(String cardNumber) {
         return GOOD_CARDS.contains(cardNumber) ||
                 GOOD_CORPORATE_CARDS.contains(cardNumber) || GOOD_APPLE_PAY_LAST_DIGITS_CARD_NUMBER.equals(cardNumber);
     }
 
-    static boolean isRejectedCard(String cardNumber) {
+    public static boolean isRejectedCard(String cardNumber) {
         return REJECTED_CARDS
                 .keySet()
                 .stream()
                 .anyMatch(rejectedCards -> rejectedCards.contains(cardNumber));
     }
 
-    static boolean isErrorCard(String cardNumber) {
+    public static boolean isErrorCard(String cardNumber) {
         return ERROR_CARDS
                 .keySet()
                 .stream()
                 .anyMatch(errorCards -> errorCards.contains(cardNumber));
     }
 
-    static CardError cardErrorFor(String cardNumber) {
+    public static CardError cardErrorFor(String cardNumber) {
         return ERROR_CARDS
                 .entrySet()
                 .stream()

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -9,26 +9,39 @@ import java.util.Map;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 
-public class SandboxCardNumbers {
+class SandboxCardNumbers {
 
-    public static boolean isValidCard(String cardNumber) {
+    static boolean isValidCard(String cardNumber) {
         return GOOD_CARDS.contains(cardNumber) ||
                 GOOD_CORPORATE_CARDS.contains(cardNumber);
     }
 
-    public static boolean isRejectedCard(String cardNumber) {
-        return REJECTED_CARDS.containsKey(cardNumber);
+    static boolean isRejectedCard(String cardNumber) {
+        return REJECTED_CARDS
+                .keySet()
+                .stream()
+                .anyMatch(a -> a.contains(cardNumber));
     }
 
-    public static boolean isErrorCard(String cardNumber) {
-        return ERROR_CARDS.containsKey(cardNumber);
+    static boolean isErrorCard(String cardNumber) {
+        return ERROR_CARDS
+                .keySet()
+                .stream()
+                .anyMatch(a -> a.contains(cardNumber));
     }
 
-    public static CardError cardErrorFor(String cardNumber) {
-        return ERROR_CARDS.get(cardNumber);
+    static CardError cardErrorFor(String cardNumber) {
+        return ERROR_CARDS
+                .entrySet()
+                .stream()
+                .filter(a -> a.getKey().contains(cardNumber))
+                .findFirst()
+                .map(Map.Entry::getValue)
+                .orElse(null);
     }
 
     private static final List<String> GOOD_CARDS = ImmutableList.of(
+            "4242",
             "4444333322221111",
             "4242424242424242",
             "4917610000000000003",
@@ -42,19 +55,26 @@ public class SandboxCardNumbers {
 
     private static final List<String> GOOD_CORPORATE_CARDS = ImmutableList.of(
             "4000180000000002",
-            "5101180000000007"
-    );
-    private static final String DECLINED_CARD_NUMBER = "4000000000000002";
-    private static final String CVC_ERROR_CARD_NUMBER = "4000000000000127";
-    private static final String EXPIRED_CARD_NUMBER = "4000000000000069";
-    private static final String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
+            "5101180000000007");
+    private static final List<String> DECLINED_CARD_NUMBERS = ImmutableList.of(
+            "4000000000000002",
+            "0002");
+    private static final List<String> CVC_ERROR_CARD_NUMBERS = ImmutableList.of(
+            "4000000000000127",
+            "0127");
+    private static final List<String> EXPIRED_CARD_NUMBERS = ImmutableList.of(
+            "4000000000000069",
+            "0069");
+    private static final List<String> PROCESSING_ERROR_CARD_NUMBERS = ImmutableList.of(
+            "4000000000000119",
+            "0119");
 
-    private static final Map<String, CardError> ERROR_CARDS = ImmutableMap.of(
-            PROCESSING_ERROR_CARD_NUMBER, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
+    private static final Map<List<String>, CardError> ERROR_CARDS = ImmutableMap.of(
+            PROCESSING_ERROR_CARD_NUMBERS, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
 
-    private static final Map<String, CardError> REJECTED_CARDS = ImmutableMap.of(
-            DECLINED_CARD_NUMBER, new CardError(AUTHORISATION_REJECTED, "This transaction was declined."),
-            EXPIRED_CARD_NUMBER, new CardError(AUTHORISATION_REJECTED, "The card is expired."),
-            CVC_ERROR_CARD_NUMBER, new CardError(AUTHORISATION_REJECTED, "The CVC code is incorrect."));
+    private static final Map<List<String>, CardError> REJECTED_CARDS = ImmutableMap.of(
+            DECLINED_CARD_NUMBERS, new CardError(AUTHORISATION_REJECTED, "This transaction was declined."),
+            EXPIRED_CARD_NUMBERS, new CardError(AUTHORISATION_REJECTED, "The card is expired."),
+            CVC_ERROR_CARD_NUMBERS, new CardError(AUTHORISATION_REJECTED, "The CVC code is incorrect."));
     
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -36,7 +36,7 @@ public class SandboxPaymentProvider implements PaymentProvider<String> {
 
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 
-    SandboxCaptureHandler sandboxCaptureHandler;
+    private SandboxCaptureHandler sandboxCaptureHandler;
 
     public SandboxPaymentProvider() {
         this.externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandler.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.gateway.sandbox.applepay;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationHandler;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.sandbox.CardError;
+import uk.gov.pay.connector.gateway.sandbox.SandboxCardNumbers;
+import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
+
+import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
+
+public class SandboxApplePayAuthorisationHandler implements ApplePayAuthorisationHandler {
+    private final static Logger LOGGER = LoggerFactory.getLogger(SandboxApplePayAuthorisationHandler.class);
+
+    @Override
+    public GatewayResponse<BaseAuthoriseResponse> authorise(ApplePayAuthorisationGatewayRequest request) {
+        LOGGER.info("sandbox apple pay auth");
+        String lastDigitsCardNumber = request.getAppleDecryptedPaymentData().getPaymentInfo().getLastDigitsCardNumber();        
+        GatewayResponse.GatewayResponseBuilder<BaseAuthoriseResponse> gatewayResponseBuilder = responseBuilder();
+
+        //PP-4314 This is duplicated from the "standard" auth in sandbox payment provider, should be extracted when we refactor further to implement the AuthorisationHandler
+        if (SandboxCardNumbers.isErrorCard(lastDigitsCardNumber)) {
+            CardError errorInfo = SandboxCardNumbers.cardErrorFor(lastDigitsCardNumber);
+            return gatewayResponseBuilder
+                    .withGatewayError(new GatewayError(errorInfo.getErrorMessage(), GENERIC_GATEWAY_ERROR))
+                    .build();
+        } else if (SandboxCardNumbers.isRejectedCard(lastDigitsCardNumber)) {
+            return GatewayResponseGenerator.getSandboxGatewayResponse(false);
+        } else if (SandboxCardNumbers.isValidCard(lastDigitsCardNumber)) {
+            return GatewayResponseGenerator.getSandboxGatewayResponse(true);
+        }
+
+        return gatewayResponseBuilder
+                .withGatewayError(new GatewayError("Unsupported card details.", GENERIC_GATEWAY_ERROR))
+                .build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -5,6 +5,8 @@ import fj.data.Either;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationHandler;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureHandler;
@@ -102,7 +104,12 @@ public class SmartpayPaymentProvider implements PaymentProvider<Pair<String, Boo
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCancelOrderFor(request));
         return GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayCancelResponse.class);
     }
-
+    
+    @Override
+    public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
+        throw new UnsupportedOperationException("Apple Pay is not supported for Smartpay");
+    }
+    
     @Override
     public Boolean isNotificationEndpointSecured() {
         return false;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
@@ -214,6 +215,11 @@ public class StripePaymentProvider implements PaymentProvider<String> {
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         return null;
+    }
+
+    @Override
+    public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
+        throw new UnsupportedOperationException("Apple Pay is not supported for Stripe");
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/util/GatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/GatewayResponseGenerator.java
@@ -3,11 +3,15 @@ package uk.gov.pay.connector.gateway.util;
 import fj.data.Either;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import java.util.Optional;
 
+import static java.util.UUID.randomUUID;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
 
 public class GatewayResponseGenerator {
@@ -55,5 +59,44 @@ public class GatewayResponseGenerator {
                     .ifPresent(responseBuilder::withSessionIdentifier);
             return responseBuilder.build();
         }
+    }
+
+    public static GatewayResponse getSandboxGatewayResponse(boolean isAuthorised) {
+        GatewayResponse.GatewayResponseBuilder<BaseAuthoriseResponse> gatewayResponseBuilder = responseBuilder();
+        return gatewayResponseBuilder.withResponse(new BaseAuthoriseResponse() {
+
+            private final String transactionId = randomUUID().toString();
+
+            @Override
+            public AuthoriseStatus authoriseStatus() {
+                return isAuthorised ? AuthoriseStatus.AUTHORISED : AuthoriseStatus.REJECTED;
+            }
+
+            @Override
+            public String getTransactionId() {
+                return transactionId;
+            }
+
+            @Override
+            public String getErrorCode() {
+                return null;
+            }
+
+            @Override
+            public String getErrorMessage() {
+                return null;
+            }
+
+            @Override
+            public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+                return Optional.empty();
+            }
+
+            @Override
+            public String toString() {
+                return "Sandbox authorisation response (transactionId: " + getTransactionId()
+                        + ", isAuthorised: " + isAuthorised + ')';
+            }
+        }).build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -181,6 +181,17 @@ public class WorldpayPaymentProvider implements PaymentProvider<String> {
                 .build();
     }
 
+    private GatewayOrder buildApplePayAuthoriseOrder(ApplePayAuthorisationGatewayRequest request) {
+        return aWorldpayAuthoriseApplePayOrderRequestBuilder()
+                .withApplePayTemplateData(ApplePayTemplateData.from(request.getAppleDecryptedPaymentData()))
+                .withSessionId(request.getChargeExternalId())
+                .withTransactionId(request.getTransactionId().orElse(""))
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withDescription(request.getDescription())
+                .withAmount(request.getAmount())
+                .build();
+    }
+
     private GatewayOrder build3dsResponseAuthOrder(Auth3dsResponseGatewayRequest request) {
         return aWorldpay3dsResponseAuthOrderRequestBuilder()
                 .withPaResponse3ds(request.getAuth3DsDetails().getPaResponse())

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayApplePayAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayApplePayAuthorisationHandler.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.gateway.worldpay.applepay;
+
+import fj.data.Either;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationHandler;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseApplePayOrderRequestBuilder;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+
+public class WorldpayApplePayAuthorisationHandler implements ApplePayAuthorisationHandler {
+
+    private final GatewayClient authoriseClient;
+
+    public WorldpayApplePayAuthorisationHandler(GatewayClient authoriseClient) {
+        this.authoriseClient = authoriseClient;
+    }
+
+    @Override
+    public GatewayResponse<BaseAuthoriseResponse> authorise(ApplePayAuthorisationGatewayRequest request) {
+        Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), buildApplePayAuthoriseOrder(request));
+        return GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
+    }
+
+    private GatewayOrder buildApplePayAuthoriseOrder(ApplePayAuthorisationGatewayRequest request) {
+        return aWorldpayAuthoriseApplePayOrderRequestBuilder()
+                .withApplePayTemplateData(ApplePayTemplateData.from(request.getAppleDecryptedPaymentData()))
+                .withSessionId(request.getChargeExternalId())
+                .withTransactionId(request.getTransactionId().orElse(""))
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withDescription(request.getDescription())
+                .withAmount(request.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -32,7 +32,7 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity chargeEntity, Auth3dsDetails auth3DsDetails) {
-        return getPaymentProviderFor(chargeEntity)
+        return providers.byName(chargeEntity.getPaymentGatewayName())
                 .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(chargeEntity, auth3DsDetails));
     }
     

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.paymentprocessor.service;
 
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,16 +30,17 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 
 public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
 
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    
     private final CardExecutorService cardExecutorService;
     protected final ChargeService chargeService;
-    private final PaymentProviders providers;
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    protected final PaymentProviders providers;
     protected MetricRegistry metricRegistry;
 
-    CardAuthoriseBaseService(PaymentProviders providers,
-                                    CardExecutorService cardExecutorService,
-                                    ChargeService chargeService,
-                                    Environment environment) {
+    protected CardAuthoriseBaseService(PaymentProviders providers,
+                             CardExecutorService cardExecutorService,
+                             ChargeService chargeService,
+                             Environment environment) {
         this.providers = providers;
         this.cardExecutorService = cardExecutorService;
         this.chargeService = chargeService;
@@ -54,7 +56,6 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
                     ChargeStatus.fromString(charge.getStatus()),
                     gatewayAuthRequest,
                     operationResponse);
-            
             return operationResponse;
         };
 
@@ -70,14 +71,14 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
         }
     }
 
-    abstract ChargeEntity prepareChargeForAuthorisation(String chargeId, T gatewayAuthRequest);
+    protected abstract ChargeEntity prepareChargeForAuthorisation(String chargeId, T gatewayAuthRequest);
 
-    abstract void processGatewayAuthorisationResponse(String chargeExternalId, ChargeStatus oldStatus, T gatewayAuthRequest, GatewayResponse<BaseAuthoriseResponse> operationResponse);
+    protected abstract void processGatewayAuthorisationResponse(String chargeExternalId, ChargeStatus oldStatus, T gatewayAuthRequest, GatewayResponse<BaseAuthoriseResponse> operationResponse);
 
-    abstract GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, T gatewayAuthRequest);
+    protected abstract GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, T gatewayAuthRequest);
 
-    ChargeStatus extractChargeStatus(Optional<BaseAuthoriseResponse> baseResponse,
-                                     Optional<GatewayError> gatewayError) {
+    protected ChargeStatus extractChargeStatus(Optional<BaseAuthoriseResponse> baseResponse,
+                                               Optional<GatewayError> gatewayError) {
 
         return baseResponse
                 .map(BaseAuthoriseResponse::authoriseStatus)
@@ -89,6 +90,18 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
 
     PaymentProvider<?> getPaymentProviderFor(ChargeEntity chargeEntity) {
         return providers.byName(chargeEntity.getPaymentGatewayName());
+    }
+    
+    protected Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> operationResponse) {
+        Optional<String> transactionId = operationResponse.getBaseResponse()
+                .map(BaseAuthoriseResponse::getTransactionId);
+
+        if (!transactionId.isPresent() || StringUtils.isBlank(transactionId.get())) {
+            logger.warn("AuthCardDetails authorisation response received with no transaction id. -  charge_external_id={}",
+                    chargeExternalId);
+        }
+
+        return transactionId;
     }
 
     private ChargeStatus mapError(GatewayError gatewayError) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -10,7 +10,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.gateway.model.AuthorisationDetails;
@@ -86,10 +85,6 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
                 .orElseGet(() -> gatewayError
                         .map(this::mapError)
                         .orElse(ChargeStatus.AUTHORISATION_ERROR));
-    }
-
-    PaymentProvider<?> getPaymentProviderFor(ChargeEntity chargeEntity) {
-        return providers.byName(chargeEntity.getPaymentGatewayName());
     }
     
     protected Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> operationResponse) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
+import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
@@ -108,18 +109,6 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
                 updatedCharge.getGatewayAccount().getType(),
                 updatedCharge.getGatewayAccount().getId(),
                 status.toString())).inc();
-    }
-
-    private Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> operationResponse) {
-        Optional<String> transactionId = operationResponse.getBaseResponse()
-                .map(BaseAuthoriseResponse::getTransactionId);
-
-        if (!transactionId.isPresent() || StringUtils.isBlank(transactionId.get())) {
-            logger.warn("AuthCardDetails authorisation response received with no transaction id. -  charge_external_id={}",
-                    chargeExternalId);
-        }
-        
-        return transactionId;
     }
 
     private Optional<Auth3dsDetailsEntity> extractAuth3dsDetails(GatewayResponse<BaseAuthoriseResponse> operationResponse) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
-import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
@@ -83,7 +82,8 @@ public class CardCaptureService {
     }
 
     private GatewayResponse<BaseCaptureResponse> capture(ChargeEntity chargeEntity) {
-        return getPaymentProviderFor(chargeEntity).capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        return providers.byName(chargeEntity.getPaymentGatewayName())
+                .capture(CaptureGatewayRequest.valueOf(chargeEntity));
     }
 
     @Transactional
@@ -125,9 +125,5 @@ public class CardCaptureService {
                     .map(timeoutError -> CAPTURE_APPROVED_RETRY)
                     .orElse(CAPTURE_ERROR);
         }
-    }
-
-    PaymentProvider<?> getPaymentProviderFor(ChargeEntity chargeEntity) {
-        return providers.byName(chargeEntity.getPaymentGatewayName());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -15,7 +15,6 @@ import uk.gov.pay.connector.charge.service.transaction.TransactionalOperation;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
@@ -136,7 +135,7 @@ public class ChargeRefundService {
     private NonTransactionalOperation<TransactionContext, GatewayResponse> doGatewayRefund(PaymentProviders providers) {
         return context -> {
             RefundEntity refundEntity = context.get(RefundEntity.class);
-            return getPaymentProviderFor(providers, refundEntity.getChargeEntity()).refund(RefundGatewayRequest.valueOf(refundEntity));
+            return providers.byName(refundEntity.getChargeEntity().getPaymentGatewayName()).refund(RefundGatewayRequest.valueOf(refundEntity));
         };
     }
 
@@ -231,10 +230,5 @@ public class ChargeRefundService {
          * no refund has not gone through and no reference returned(or needed) to be stored.
          */
         return "";
-    }
-
-    public PaymentProvider<?> getPaymentProviderFor(PaymentProviders providers, ChargeEntity chargeEntity) {
-        PaymentProvider<?> paymentProvider = providers.byName(chargeEntity.getPaymentGatewayName());
-        return paymentProvider;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
@@ -1,6 +1,9 @@
 package uk.gov.pay.connector.util;
 
-import java.time.*;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;

--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -9,8 +9,16 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 
 import static java.lang.String.format;
-import static javax.ws.rs.core.Response.*;
-import static javax.ws.rs.core.Response.Status.*;
+import static javax.ws.rs.core.Response.Status;
+import static javax.ws.rs.core.Response.Status.ACCEPTED;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static javax.ws.rs.core.Response.noContent;
+import static javax.ws.rs.core.Response.status;
 
 public class ResponseUtil {
     protected static final Logger logger = LoggerFactory.getLogger(ResponseUtil.class);
@@ -57,7 +65,7 @@ public class ResponseUtil {
     }
 
     public static Response preconditionFailedResponse(String message) {
-        logger.info(message.toString());
+        logger.info(message);
         return responseWithMessageMap(PRECONDITION_FAILED, message);
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -36,7 +36,6 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -202,8 +201,7 @@ public abstract class BaseEpdqPaymentProviderTest {
         return TestTemplateResourceLoader.load(EPDQ_DELETE_SUCCESS_RESPONSE);
     }
 
-    String notificationPayloadForTransaction(String status, String payId, String payIdSub, String shaSign)
-            throws IOException {
+    String notificationPayloadForTransaction(String status, String payId, String payIdSub, String shaSign) {
         return TestTemplateResourceLoader.load(EPDQ_NOTIFICATION_TEMPLATE)
                 .replace("{{status}}", status)
                 .replace("{{payId}}", payId)

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -50,6 +50,11 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrow_IfTryingToAuthoriseAnApplePayPayment() {
+        provider.authoriseApplePay(null);
+    }
+    
     @Test
     public void shouldNotAuthoriseIfPaymentProviderReturnsUnexpectedStatusCode() {
         mockPaymentProviderResponse(200, errorAuthResponse());

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -7,8 +7,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
-import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -22,7 +20,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
-import uk.gov.pay.connector.util.AuthUtils;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -41,9 +38,6 @@ public class SandboxPaymentProviderTest {
     private static final String AUTH_SUCCESS_CARD_NUMBER = "4242424242424242";
     private static final String AUTH_REJECTED_CARD_NUMBER = "4000000000000069";
     private static final String AUTH_ERROR_CARD_NUMBER = "4000000000000119";
-    private static final String AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "4242";
-    private static final String AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0002";
-    private static final String AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0119";
     
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -85,57 +79,8 @@ public class SandboxPaymentProviderTest {
         provider.parseNotification(notification);
     }
     
-    @Test
-    public void authorise_shouldBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToSucceedForAuthorisation_forApplePay() {
-        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
 
-        GatewayResponse gatewayResponse = provider.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
-
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
-        assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
-
-        BaseAuthoriseResponse authoriseResponse = (BaseAuthoriseResponse) gatewayResponse.getBaseResponse().get();
-        assertThat(authoriseResponse.authoriseStatus(), is(AuthoriseStatus.AUTHORISED));
-        assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
-        assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
-        assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
-    }
-
-    @Test
-    public void authorise_shouldNotBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToBeRejectedForAuthorisation_forApplePay() {
-        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
-
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
-        assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
-
-        BaseAuthoriseResponse authoriseResponse = (BaseAuthoriseResponse) gatewayResponse.getBaseResponse().get();
-        assertThat(authoriseResponse.authoriseStatus(), is(AuthoriseStatus.REJECTED));
-        assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
-        assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
-        assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
-    }
-
-    @Test
-    public void authorise_shouldGetGatewayErrorWhenLastDigitsCardNumbersAreExpectedToFailForAuthorisation_forApplePay() {
-        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
-
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
-
-        GatewayError gatewayError = (GatewayError) gatewayResponse.getGatewayError().get();
-        assertThat(gatewayError.getErrorType(), is(GENERIC_GATEWAY_ERROR));
-        assertThat(gatewayError.getMessage(), is("This transaction could be not be processed."));
-    }
+ 
     
     @Test
     public void authorise_shouldBeAuthorisedWhenCardNumIsExpectedToSucceedForAuthorisation() {

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandlerTest.java
@@ -1,0 +1,83 @@
+package uk.gov.pay.connector.gateway.sandbox.applepay;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.util.AuthUtils;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+
+public class SandboxApplePayAuthorisationHandlerTest {
+
+    private SandboxApplePayAuthorisationHandler sandboxApplePayAuthorisationHandler;
+
+    private static final String AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "4242";
+    private static final String AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0002";
+    private static final String AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0119";
+
+    @Before
+    public void setup() {
+        sandboxApplePayAuthorisationHandler = new SandboxApplePayAuthorisationHandler();
+    }
+
+    @Test
+    public void authorise_shouldBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToSucceedForAuthorisation_forApplePay() {
+        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
+
+        GatewayResponse gatewayResponse = sandboxApplePayAuthorisationHandler.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
+
+        assertThat(gatewayResponse.isSuccessful(), is(true));
+        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
+
+        BaseAuthoriseResponse authoriseResponse = (BaseAuthoriseResponse) gatewayResponse.getBaseResponse().get();
+        assertThat(authoriseResponse.authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
+        assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
+        assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
+        assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
+    }
+
+    @Test
+    public void authorise_shouldNotBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToBeRejectedForAuthorisation_forApplePay() {
+        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
+        GatewayResponse gatewayResponse = sandboxApplePayAuthorisationHandler.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
+
+        assertThat(gatewayResponse.isSuccessful(), is(true));
+        assertThat(gatewayResponse.isFailed(), is(false));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
+
+        BaseAuthoriseResponse authoriseResponse = (BaseAuthoriseResponse) gatewayResponse.getBaseResponse().get();
+        assertThat(authoriseResponse.authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REJECTED));
+        assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
+        assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
+        assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
+    }
+
+    @Test
+    public void authorise_shouldGetGatewayErrorWhenLastDigitsCardNumbersAreExpectedToFailForAuthorisation_forApplePay() {
+        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
+        GatewayResponse gatewayResponse = sandboxApplePayAuthorisationHandler.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
+
+        assertThat(gatewayResponse.isSuccessful(), is(false));
+        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+
+        GatewayError gatewayError = (GatewayError) gatewayResponse.getGatewayError().get();
+        assertThat(gatewayError.getErrorType(), is(GENERIC_GATEWAY_ERROR));
+        assertThat(gatewayError.getMessage(), is("This transaction could be not be processed."));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -113,7 +112,12 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
         assertThat(smartpayAuthorisationResponse.getPaRequest(), is(not(nullValue())));
 
     }
-
+    
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrow_IfTryingToAuthoriseAnApplePayPayment() {
+        provider.authoriseApplePay(null);
+    }
+    
     @Test
     public void shouldSuccess3DSAuthorisation() {
         GatewayAccountEntity gatewayAccountEntity = aServiceAccount();

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -51,7 +51,7 @@ public class StripePaymentProviderTest extends BaseStripePaymentProviderTest {
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS));
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("src_1DXAxYC6H5MjhE5Y4jZVJwNV")); // id from templates/stripe/create_3ds_sources_response.json
-        
+
         Optional<StripeParamsFor3ds> stripeParamsFor3ds = (Optional<StripeParamsFor3ds>) response.getBaseResponse().get().getGatewayParamsFor3ds();
         assertThat(stripeParamsFor3ds.isPresent(), is(true));
         assertThat(stripeParamsFor3ds.get().toAuth3dsDetailsEntity().getIssuerUrl(), containsString("https://hooks.stripe.com")); //from templates/stripe/create_3ds_sources_response.json
@@ -68,6 +68,11 @@ public class StripePaymentProviderTest extends BaseStripePaymentProviderTest {
         assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
         assertEquals(authoriseResponse.getGatewayError().get(), new GatewayError("javax.ws.rs.ProcessingException",
                 GENERIC_GATEWAY_ERROR));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void shouldThrow_IfTryingToAuthoriseAnApplePayPayment() {
+        provider.authoriseApplePay(null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -19,8 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -50,7 +50,7 @@ public class WorldpayNotificationServiceTest {
     private final String transactionId = "transaction-reference";
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         notificationService = new WorldpayNotificationService(
                 mockChargeDao,
                 mockWorldpayConfiguration,

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -164,7 +164,7 @@ public class WorldpayOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidAuthoriseApplePayOrderRequest() throws Exception {
-        AppleDecryptedPaymentData data = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", "4818528840010767");
+        AppleDecryptedPaymentData data = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", "4242");
         
         GatewayOrder actualRequest = aWorldpayAuthoriseApplePayOrderRequestBuilder()
                 .withApplePayTemplateData(ApplePayTemplateData.from(data))
@@ -183,7 +183,7 @@ public class WorldpayOrderRequestBuilderTest {
     
     @Test
     public void shouldGenerateValidAuthoriseApplePayOrderRequest_withMinData() throws Exception {
-        AppleDecryptedPaymentData data = AuthUtils.ApplePay.buildDecryptedMinimalPaymentData("4242424242424242");
+        AppleDecryptedPaymentData data = AuthUtils.ApplePay.buildDecryptedMinimalPaymentData("4242");
 
         GatewayOrder actualRequest = aWorldpayAuthoriseApplePayOrderRequestBuilder()
                 .withApplePayTemplateData(ApplePayTemplateData.from(data))

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -259,7 +259,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
     }
 
     @Test
-    public void shouldSendSuccessfullyAnOrderForMerchant() throws Exception {
+    public void shouldSendSuccessfullyAnOrderForMerchant() {
         GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(getCardAuthorisationRequest());
         assertTrue(response.isSuccessful());
         assertTrue(response.getSessionIdentifier().isPresent());
@@ -318,7 +318,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
             String status,
             String bookingDateDay,
             String bookingDateMonth,
-            String bookingDateYear) throws IOException {
+            String bookingDateYear) {
         return TestTemplateResourceLoader.load(WORLDPAY_NOTIFICATION)
                 .replace("{{transactionId}}", transactionId)
                 .replace("{{refund-ref}}", referenceId)

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayApplePayAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayApplePayAuthorisationHandlerTest.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.connector.gateway.worldpay.applepay;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.xml.sax.SAXException;
+import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
+import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
+import uk.gov.pay.connector.applepay.api.ApplePaymentInfo;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import static fj.data.Either.left;
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.GatewayError.unexpectedStatusCodeFromGateway;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorldpayApplePayAuthorisationHandlerTest {
+
+    
+    @Mock
+    private GatewayClient mockGatewayClient;
+    @Mock
+    private GatewayAccountEntity mockGatewayAccountEntity;
+    private WorldpayApplePayAuthorisationHandler worldpayApplePayAuthorisationHandler;
+    
+    
+    @Before
+    public void setUp() {
+        worldpayApplePayAuthorisationHandler = new WorldpayApplePayAuthorisationHandler(mockGatewayClient);
+    }
+    
+    @Test
+    public void shouldSendApplePayRequestWhenApplePayDetailsArePresent() throws IOException, SAXException {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+                .withDescription("This is the description").build();
+        chargeEntity.setGatewayTransactionId("MyUniqueTransactionId!");
+        chargeEntity.setGatewayAccount(mockGatewayAccountEntity);
+
+        Map<String, String> credentialsMap = ImmutableMap.of("merchant_id", "MERCHANTCODE");
+        when(mockGatewayAccountEntity.getCredentials()).thenReturn(credentialsMap);
+        when(mockGatewayClient.postRequestFor(isNull(), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+                .thenReturn(left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway")));
+
+        worldpayApplePayAuthorisationHandler.authorise(getApplePayAuthorisationRequest(chargeEntity));
+
+        ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
+
+        verify(mockGatewayClient).postRequestFor(eq(null), eq(mockGatewayAccountEntity), gatewayOrderArgumentCaptor.capture());
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
+    }
+
+    private ApplePayAuthorisationGatewayRequest getApplePayAuthorisationRequest(ChargeEntity chargeEntity) {
+        AppleDecryptedPaymentData data = new AppleDecryptedPaymentData(
+                new ApplePaymentInfo(
+                        "4242",
+                        "visa",
+                        PayersCardType.DEBIT,
+                        "Mr. Payment",
+                        "aaa@bbb.test"
+                ),
+                "4818528840010767",
+                LocalDate.of(2023, 12, 31),
+                "643",
+                10L,
+                "040010030273",
+                "3DSecure",
+                new AppleDecryptedPaymentData.PaymentData(
+                        "Ao/fzpIAFvp1eB9y8WVDMAACAAA=",
+                        "7"
+                )
+        );
+        return new ApplePayAuthorisationGatewayRequest(chargeEntity, data);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources.worldpay;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,7 +67,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldAuthoriseChargeWithoutBillingAddress() throws JsonProcessingException {
+    public void shouldAuthoriseChargeWithoutBillingAddress()  {
 
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         worldpayMockClient.mockAuthorisationSuccess();

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -5,13 +5,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
@@ -93,7 +90,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldRespondAuthorisationSuccess() throws Exception {
+    public void doAuthorise_shouldRespondAuthorisationSuccess() {
 
         Auth3dsDetails auth3dsDetails = AuthUtils.buildAuth3dsDetails();
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
@@ -117,7 +114,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldRetainGeneratedTransactionId_evenIfAuthorisationAborted() throws Exception {
+    public void doAuthorise_shouldRetainGeneratedTransactionId_evenIfAuthorisationAborted()  {
 
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
@@ -157,7 +154,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void shouldRespondAuthorisationRejected() throws Exception {
+    public void shouldRespondAuthorisationRejected()  {
         ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
 
@@ -172,7 +169,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void shouldRespondAuthorisationCancelled() throws Exception {
+    public void shouldRespondAuthorisationCancelled()  {
         ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
 
@@ -186,17 +183,15 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void shouldRespondAuthorisationError() throws Exception {
+    public void shouldRespondAuthorisationError()  {
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
         GatewayResponse response = anAuthorisationErrorResponse(charge, argumentCaptor);
 
         assertThat(response.isFailed(), is(true));
-        //  assertThat(reloadedCharge.getStatus(), is(AUTHORISATION_ERROR.toString()));
-        //  assertThat(reloadedCharge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
     }
 
     @Test
-    public void authoriseShouldThrowAnOperationAlreadyInProgressRuntimeExceptionWhenTimeout() throws Exception {
+    public void authoriseShouldThrowAnOperationAlreadyInProgressRuntimeExceptionWhenTimeout()  {
         when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
@@ -233,7 +228,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test(expected = IllegalStateRuntimeException.class)
-    public void shouldThrowAnIllegalStateRuntimeExceptionWhenInvalidStatus() throws Exception {
+    public void shouldThrowAnIllegalStateRuntimeExceptionWhenInvalidStatus()  {
 
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.AUTHORISATION_READY);
 
@@ -292,19 +287,5 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
         return card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
-    }
-
-
-    private HamcrestArgumentMatcher<ChargeEntity> chargeWithStatus(String externalId, ChargeStatus status) {
-        return new HamcrestArgumentMatcher<>(new TypeSafeMatcher<ChargeEntity>() {
-            @Override
-            protected boolean matchesSafely(ChargeEntity chargeEntity) {
-                return chargeEntity.getExternalId().equals(externalId) && ChargeStatus.fromString(chargeEntity.getStatus()) == status;
-            }
-
-            @Override
-            public void describeTo(Description description) {
-            }
-        });
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/PaymentProvidersTest.java
@@ -19,7 +19,6 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
+++ b/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
@@ -16,16 +16,16 @@ public class AuthUtils {
 
 
     public static class ApplePay {
-        private static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String tokenNumber, AppleDecryptedPaymentData.PaymentData paymentData) {
+        private static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String lastFourDigitsCardNumber, AppleDecryptedPaymentData.PaymentData paymentData) {
             return new AppleDecryptedPaymentData(
                     new ApplePaymentInfo(
-                            "4242",
+                            lastFourDigitsCardNumber,
                             "visa",
                             PayersCardType.DEBIT,
                             cardHolderName,
                             email
                     ),
-                    tokenNumber,
+                    "4818528840010767",
                     LocalDate.of(2023, 12, 31),
                     "643",
                     10L,
@@ -35,14 +35,14 @@ public class AuthUtils {
             );
         }
 
-        public static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String tokenNumber) {
-            return buildDecryptedPaymentData(cardHolderName, email, tokenNumber, new AppleDecryptedPaymentData.PaymentData(
+        public static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String lastFourDigitsCardNumber) {
+            return buildDecryptedPaymentData(cardHolderName, email, lastFourDigitsCardNumber, new AppleDecryptedPaymentData.PaymentData(
                     "Ao/fzpIAFvp1eB9y8WVDMAACAAA=",
                     "7"
             ));
         }
-        public static AppleDecryptedPaymentData buildDecryptedMinimalPaymentData(String tokenNumber) {
-            return buildDecryptedPaymentData(null, null, tokenNumber, new AppleDecryptedPaymentData.PaymentData(
+        public static AppleDecryptedPaymentData buildDecryptedMinimalPaymentData(String lastFourDigitsCardNumber) {
+            return buildDecryptedPaymentData(null, null, lastFourDigitsCardNumber, new AppleDecryptedPaymentData.PaymentData(
                     "Ao/fzpIAFvp1eB9y8WVDMAACAAA=",
                     null
             ));

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-apple-pay-min-data.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-apple-pay-min-data.xml
@@ -8,7 +8,7 @@
             <amount currencyCode="GBP" exponent="2" value="500"/>
             <paymentDetails>
                 <EMVCO_TOKEN-SSL type="APPLEPAY">
-                    <tokenNumber>4242424242424242</tokenNumber>
+                    <tokenNumber>4818528840010767</tokenNumber>
                     <expiryDate><date month="12" year="2023"/></expiryDate>
                     <cryptogram>Ao/fzpIAFvp1eB9y8WVDMAACAAA=</cryptogram>
                 </EMVCO_TOKEN-SSL>


### PR DESCRIPTION
 - Apple pay orders are authorised similarly to how "normal" card orders are authorised, but the payload we send to worldpay is different. With the introduction of apple pay there are basically two ways to move forward: either by shoeorning an apple pay auth order in the normal "card" authorise path, or by creating a separate interface.
 - As we are currently refactoring connector and will probably get rid of the `PaymentProviders` interface, I have opted for separating the two paths. We are currently splitting the capabilities of a payment provider using multiple handlers (ie. CaptureHandler). This follows the same pattern, by introducing an `ApplePayAuthorisationHandler`. 
Unfortunately we are bringing in a bit of duplication which will hopefully be extracted away as we move forward with the refactoring.
- Made so that the Sandbox provider switches on the last 4 digits of card rather than the token number, as the latter is encrypted so it would be a bit clunky to generate proper payloads with

