### PR TITLE
PP-4315 Add wallet column to charges table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -949,4 +949,12 @@
         </update>
     </changeSet>
 
+    <changeSet id="add wallet column to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="wallet" type="varchar(50)">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
 - This column will be used to flag if the payment has been done using an electronic wallet like `APPLE_PAY`. It will be NULL by default for all of the other payments