### PR TITLE
PP-4374 Introduced WorldpayNotificationService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/NotificationConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/NotificationConfiguration.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.gateway;
+
+public interface NotificationConfiguration {
+    PaymentGatewayName getPaymentGatewayName();
+
+    Boolean isNotificationEndpointSecured();
+
+    String getNotificationDomain();
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.gateway.processor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
+import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+public class ChargeNotificationProcessor {
+
+    private ChargeEventDao chargeEventDao;
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    ChargeNotificationProcessor(ChargeEventDao chargeEventDao) {
+        this.chargeEventDao = chargeEventDao;
+    }
+
+    public void invoke(String transactionId, ChargeEntity chargeEntity, ChargeStatus newStatus, ZonedDateTime gatewayEventDate) {
+        GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
+        String oldStatus = chargeEntity.getStatus();
+
+        try {
+            chargeEntity.setStatus(newStatus);
+        } catch (InvalidStateTransitionException e) {
+            logger.error("{} ({}) notification '{}' could not be used to update charge: {}",
+                    gatewayAccount.getGatewayName(), gatewayAccount.getId(), transactionId, e.getMessage());
+            return;
+        }
+
+        logger.info("Notification received. Updating charge - " +
+                        "charge_external_id={}, " +
+                        "status={}, " +
+                        "status_to={}, " +
+                        "transaction_id={}, " +
+                        "account_id={}, " +
+                        "provider={}, " +
+                        "provider_type={}",
+                chargeEntity.getExternalId(),
+                oldStatus,
+                newStatus,
+                transactionId,
+                gatewayAccount.getId(),
+                gatewayAccount.getGatewayName(),
+                gatewayAccount.getType());
+
+        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.ofNullable(gatewayEventDate));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.connector.gateway.processor;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class RefundNotificationProcessor {
+    
+    private Logger logger = LoggerFactory.getLogger(getClass());
+    private RefundDao refundDao;
+
+    @Inject
+    RefundNotificationProcessor(RefundDao refundDao) {
+        this.refundDao = refundDao;
+    }
+
+    public void invoke(PaymentGatewayName gatewayName, RefundStatus newStatus, String reference, String transactionId) {
+        if (isBlank(reference)) {
+            logger.error("{} refund notification could not be used to update charge (missing reference)",
+                    gatewayName);
+            return;
+        }
+
+        Optional<RefundEntity> optionalRefundEntity = refundDao.findByProviderAndReference(gatewayName.getName(), reference);
+        if (!optionalRefundEntity.isPresent()) {
+            logger.error("{} notification '{}' could not be used to update refund (associated refund entity not found)",
+                    gatewayName, reference);
+            return;
+        }
+
+        RefundEntity refundEntity = optionalRefundEntity.get();
+        RefundStatus oldStatus = refundEntity.getStatus();
+
+        refundEntity.setStatus(newStatus);
+
+        GatewayAccountEntity gatewayAccount = refundEntity.getChargeEntity().getGatewayAccount();
+        logger.info("Notification received for refund. Updating refund - charge_external_id={}, refund_reference={}, transaction_id={}, status={}, "
+                        + "status_to={}, account_id={}, provider={}, provider_type={}",
+                refundEntity.getChargeEntity().getExternalId(),
+                reference,
+                transactionId,
+                oldStatus,
+                newStatus,
+                gatewayAccount.getId(),
+                gatewayAccount.getGatewayName(),
+                gatewayAccount.getType());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotification.java
@@ -1,15 +1,31 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import org.eclipse.persistence.oxm.annotations.XmlPath;
-import uk.gov.pay.connector.usernotification.model.ChargeStatusRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.usernotification.model.ChargeStatusRequest;
 
 import javax.xml.bind.annotation.XmlRootElement;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 @XmlRootElement(name = "paymentService")
 public class WorldpayNotification implements ChargeStatusRequest {
+
+    public WorldpayNotification() {
+
+    }
+
+    public WorldpayNotification(String merchantCode, String status, int dayOfMonth, int month, int year, String transactionId, String reference) {
+        this.merchantCode = merchantCode;
+        this.status = status;
+        this.dayOfMonth = dayOfMonth;
+        this.month = month;
+        this.year = year;
+        this.transactionId = transactionId;
+        this.reference = reference;
+    }
 
     @XmlPath("@merchantCode")
     private String merchantCode;
@@ -50,6 +66,10 @@ public class WorldpayNotification implements ChargeStatusRequest {
 
     public String getStatus() {
         return status;
+    }
+
+    public ZonedDateTime getGatewayEventDate() {
+        return getBookingDate().atStartOfDay(ZoneOffset.UTC);
     }
 
     public String getMerchantCode() {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationConfiguration.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import com.google.inject.Inject;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.WorldpayConfig;
+import uk.gov.pay.connector.gateway.NotificationConfiguration;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+
+public class WorldpayNotificationConfiguration implements NotificationConfiguration {
+
+    private final WorldpayConfig config;
+
+    @Inject
+    public WorldpayNotificationConfiguration(ConnectorConfiguration config) {
+        this.config = config.getWorldpayConfig();
+    }
+
+    @Override
+    public PaymentGatewayName getPaymentGatewayName() {
+        return PaymentGatewayName.WORLDPAY;
+    }
+
+    @Override
+    public Boolean isNotificationEndpointSecured() {
+        return config.isSecureNotificationEnabled();
+    }
+
+    @Override
+    public String getNotificationDomain() {
+        return config.getNotificationDomain();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -1,0 +1,147 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
+import uk.gov.pay.connector.gateway.util.XMLUnmarshallerException;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.util.DnsUtils;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+
+public class WorldpayNotificationService {
+
+    private static final List<String> IGNORED_STATUSES = ImmutableList.of(
+            "SENT_FOR_AUTHORISATION",
+            "AUTHORISED",
+            "CANCELLED",
+            "EXPIRED",
+            "REFUSED",
+            "REFUSED_BY_BANK",
+            "SETTLED_BY_MERCHANT",
+            "SENT_FOR_REFUND"
+    );
+    private static final List<String> REFUND_STATUSES = ImmutableList.of("REFUNDED", "REFUNDED_BY_MERCHANT", "REFUND_FAILED");
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final ChargeDao chargeDao;
+    private final WorldpayNotificationConfiguration config;
+    private final DnsUtils dnsUtils;
+    private final ChargeNotificationProcessor chargeNotificationProcessor;
+    private final RefundNotificationProcessor refundNotificationProcessor;
+
+    @Inject
+    public WorldpayNotificationService(
+            ChargeDao chargeDao,
+            WorldpayNotificationConfiguration config,
+            DnsUtils dnsUtils,
+            ChargeNotificationProcessor chargeNotificationProcessor,
+            RefundNotificationProcessor refundNotificationProcessor
+    ) {
+        this.chargeDao = chargeDao;
+        this.config = config;
+        this.dnsUtils = dnsUtils;
+
+        this.chargeNotificationProcessor = chargeNotificationProcessor;
+        this.refundNotificationProcessor = refundNotificationProcessor;
+    }
+
+    @Transactional
+    public boolean handleNotificationFor(String ipAddress, String payload) {
+        if (isNotificationRejectedFromIpAddress(ipAddress)) {
+            logger.error("{} notification received from ip '{}' which is not in domain '{}'", gatewayName(), ipAddress, notificationDomain());
+            return false;
+        }
+
+        WorldpayNotification notification;
+        try {
+            logger.info("Parsing {} notification", gatewayName());
+            logger.debug("Payload: {}", payload);
+            notification = XMLUnmarshaller.unmarshall(payload, WorldpayNotification.class);
+            logger.info("Parsed {} notification: {}", gatewayName(), notification);
+        } catch (XMLUnmarshallerException e) {
+            logger.error("{} notification parsing failed: {}", gatewayName(), e.toString());
+            return true;
+        }
+
+        if (isIgnored(notification)) {
+            logger.info("{} notification {} ignored", gatewayName(), notification);
+            return true;
+        }
+
+        if (isTransactionIdBlank(notification)) {
+            logger.error("{} notification {} failed verification because it has no transaction ID", gatewayName(), notification);
+            return true;
+        }
+
+        Optional<ChargeEntity> optionalChargeEntity = chargeDao.findByProviderAndTransactionId(gatewayName(),
+                notification.getTransactionId());
+
+        if (!optionalChargeEntity.isPresent()) {
+            logger.error("{} notification {} could not be evaluated (associated charge entity not found)",
+                    gatewayName(), notification);
+            return true;
+        }
+
+        if (isCaptureNotification(notification)) {
+            chargeNotificationProcessor.invoke(notification.getTransactionId(), optionalChargeEntity.get(), CAPTURED, notification.getGatewayEventDate());
+        } else if (isRefundNotification(notification)) {
+            refundNotificationProcessor.invoke(getPaymentGatewayName(), newRefundStatus(notification), notification.getReference(), notification.getTransactionId());
+        } else {
+            logger.error("{} notification {} unknown", gatewayName(), notification);
+        }
+        return true;
+    }
+
+    private RefundStatus newRefundStatus(WorldpayNotification notification) {
+        return "REFUND_FAILED".equals(notification.getStatus()) ? RefundStatus.REFUND_ERROR : RefundStatus.REFUNDED;
+    }
+
+    private boolean isRefundNotification(WorldpayNotification notification) {
+        return REFUND_STATUSES.contains(notification.getStatus());
+    }
+
+    private boolean isCaptureNotification(WorldpayNotification notification) {
+        return "CAPTURED".equals(notification.getStatus());
+    }
+
+    private boolean isNotificationRejectedFromIpAddress(String ipAddress) {
+        return isNotificationEndpointSecured() && !dnsUtils.ipMatchesDomain(ipAddress, notificationDomain());
+    }
+
+    private boolean isTransactionIdBlank(WorldpayNotification notification) {
+        return isBlank(notification.getTransactionId());
+    }
+
+    private boolean isIgnored(WorldpayNotification notification) {
+        return IGNORED_STATUSES.contains(notification.getStatus());
+    }
+
+    public String notificationDomain() {
+        return config.getNotificationDomain();
+    }
+
+    public Boolean isNotificationEndpointSecured() {
+        return config.isNotificationEndpointSecured();
+    }
+
+    public PaymentGatewayName getPaymentGatewayName() {
+        return PaymentGatewayName.WORLDPAY;
+    }
+
+    public String gatewayName() {
+        return getPaymentGatewayName().getName();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -1,0 +1,227 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.util.DnsUtils;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WorldpayNotificationServiceTest {
+    private WorldpayNotificationService notificationService;
+
+    @Mock
+    private ChargeDao mockChargeDao;
+    @Mock
+    private WorldpayNotificationConfiguration mockWorldpayConfiguration;
+    @Mock
+    private DnsUtils mockDnsUtils;
+    @Mock
+    private ChargeNotificationProcessor mockChargeNotificationProcessor;
+    @Mock
+    private RefundNotificationProcessor mockRefundNotificationProcessor;
+    @Mock
+    private ChargeEntity mockCharge;
+
+    private final String ipAddress = "1.1.1.1";
+    private final String referenceId = "refund-reference";
+    private final String transactionId = "transaction-reference";
+
+    @Before
+    public void setup() throws Exception {
+        notificationService = new WorldpayNotificationService(
+                mockChargeDao,
+                mockWorldpayConfiguration,
+                mockDnsUtils,
+                mockChargeNotificationProcessor,
+                mockRefundNotificationProcessor
+        );
+        when(mockChargeDao.findByProviderAndTransactionId(WORLDPAY.getName(), transactionId)).thenReturn(Optional.of(mockCharge));
+    }
+
+    @Test
+    public void givenAChargeCapturedNotification_chargeNotificationProcessorInvokedWithNotificationAndCharge() {
+        final String payload = sampleWorldpayNotification(
+                transactionId,
+                referenceId,
+                "CAPTURED",
+                "10",
+                "03",
+                "2017");
+
+        final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
+        assertEquals(true, result);
+
+        WorldpayNotification expectedNotification = new WorldpayNotification(
+                "MERCHANTCODE",
+                "CAPTURED",
+                10,
+                03,
+                2017,
+                transactionId,
+                referenceId
+        );
+        verify(mockChargeNotificationProcessor).invoke(expectedNotification.getTransactionId(), mockCharge, CAPTURED, expectedNotification.getGatewayEventDate());
+    }
+
+    @Test
+    public void givenARefundNotification_refundNotificationProcessorInvokedWithNotificationAndCharge() {
+        final String payload = sampleWorldpayNotification(
+                transactionId,
+                referenceId,
+                "REFUNDED",
+                "10",
+                "03",
+                "2017");
+
+        final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
+        assertEquals(true, result);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor).invoke(WORLDPAY, RefundStatus.REFUNDED, referenceId, transactionId);
+    }
+
+    @Test
+    public void ifChargeNotFound_shouldNotInvokeChargeNotificationProcessor() {
+        final String payload = sampleWorldpayNotification(
+                transactionId,
+                referenceId,
+                "CHARGED",
+                "10",
+                "03",
+                "2017");
+
+        when(mockChargeDao.findByProviderAndTransactionId(WORLDPAY.getName(), transactionId)).thenReturn(Optional.empty());
+
+        final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
+        assertEquals(result, true);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void ifTransactionIdEmpty_shouldNotInvokeChargeNotificationProcessor() {
+        final String payload = sampleWorldpayNotification(
+                "",
+                referenceId,
+                "CHARGED",
+                "10",
+                "03",
+                "2017");
+
+        final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
+        assertEquals(result, true);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(anyString(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldIgnoreNotificationWhenStatusIsToBeIgnored() {
+        final List<String> ignoredStatuses = Arrays.asList(
+                "SENT_FOR_AUTHORISATION",
+                "AUTHORISED",
+                "CANCELLED",
+                "EXPIRED",
+                "REFUSED",
+                "REFUSED_BY_BANK",
+                "SETTLED_BY_MERCHANT",
+                "SENT_FOR_REFUND"
+        );
+
+        for (String status : ignoredStatuses) {
+            final String payload = sampleWorldpayNotification(
+                    transactionId,
+                    referenceId,
+                    status);
+
+            assertEquals(true, notificationService.handleNotificationFor(ipAddress, payload));
+
+            verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+            verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        }
+    }
+
+    @Test
+    public void ifIpAddressOutsidePermittedRange_returnFalseAndDontProcessNotification() {
+        final String payload = sampleWorldpayNotification(
+                transactionId,
+                referenceId,
+                "CAPTURED",
+                "10",
+                "03",
+                "2017");
+        when(mockWorldpayConfiguration.isNotificationEndpointSecured()).thenReturn(true);
+        when(mockWorldpayConfiguration.getNotificationDomain()).thenReturn("worldpay.com");
+        when(mockDnsUtils.ipMatchesDomain(ipAddress, "worldpay.com")).thenReturn(false);
+
+        final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
+        assertEquals(false, result);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void ifPayloadNotValidXml_shouldIgnoreNotification() {
+        String payload = "<not></valid>";
+
+        final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
+        assertEquals(true, result);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    private static String sampleWorldpayNotification(
+            String transactionId,
+            String referenceId,
+            String status,
+            String bookingDateDay,
+            String bookingDateMonth,
+            String bookingDateYear) {
+        return TestTemplateResourceLoader.load(WORLDPAY_NOTIFICATION)
+                .replace("{{transactionId}}", transactionId)
+                .replace("{{refund-ref}}", referenceId)
+                .replace("{{status}}", status)
+                .replace("{{bookingDateDay}}", bookingDateDay)
+                .replace("{{bookingDateMonth}}", bookingDateMonth)
+                .replace("{{bookingDateYear}}", bookingDateYear);
+    }
+
+    private static String sampleWorldpayNotification(
+            String transactionId,
+            String referenceId,
+            String status) {
+        return sampleWorldpayNotification(transactionId, referenceId, status, "2017", "10", "22");
+    }
+
+    private static String load(String location, Map<String, String> substitutions) {
+        String template = TestTemplateResourceLoader.load(location);
+        for (Map.Entry<String, String> entry : substitutions.entrySet()) {
+            template = template.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        }
+        return template;
+    }
+}


### PR DESCRIPTION
## WHAT

Part of refactoring notification handling (see https://github.com/alphagov/pay-connector/pull/787 for the original full attempt... we are breaking the changes out into "digestable" size for friendly review).

- Introduced `WorldPayNotificationService` to delegate worldpay notification processing (not yet integrated with notification handling) to service instead of a generic handler.

with @IreneLau-GDS 

## HOW 
All tests in `WorldpayNotificationServiceTest` should pass