### PR TITLE
PP-4315 Add WalletType enum

### DIFF
--- a/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AsymmetricKeyVerifier.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.connector.applepay;
 
-import org.apache.commons.lang3.RandomUtils;
-
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;

--- a/src/main/java/uk/gov/pay/connector/applepay/WalletType.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/WalletType.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.connector.applepay;
+
+public enum WalletType {
+    APPLE_PAY
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.SupportedLanguageJpaConverter;
+import uk.gov.pay.connector.applepay.WalletType;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
@@ -25,6 +26,8 @@ import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -122,6 +125,10 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Column(name = "delayed_capture")
     private boolean delayedCapture;
 
+    @Column(name = "wallet")
+    @Enumerated(EnumType.STRING)
+    private WalletType walletType;
+    
     public ChargeEntity() {
         //for jpa
     }
@@ -244,6 +251,14 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void setProviderSessionId(String providerSessionId) {
         this.providerSessionId = providerSessionId;
+    }
+
+    public WalletType getWalletType() {
+        return walletType;
+    }
+
+    public void setWalletType(WalletType walletType) {
+        this.walletType = walletType;
     }
 
     public boolean hasExternalStatus(ExternalChargeState... state) {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -164,6 +164,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
         assertThat(createdChargeEntity.isDelayedCapture(), is(false));
         assertThat(createdChargeEntity.getCorporateSurcharge().isPresent(), is(false));
+        assertThat(createdChargeEntity.getWalletType(), is(nullValue()));
 
         verify(mockedChargeEventDao).persistChargeEventOf(createdChargeEntity);
     }

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.model.domain;
 
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.connector.applepay.WalletType;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -43,7 +44,8 @@ public class ChargeEntityFixture {
     private SupportedLanguage language = SupportedLanguage.ENGLISH;
     private boolean delayedCapture = false;
     private Long corporateSurcharge = null;
-
+    private WalletType walletType = null;
+    
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
     }
@@ -150,6 +152,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withCorporateSurcharge(Long corporateSurcharge) {
         this.corporateSurcharge = corporateSurcharge;
+        return this;
+    }
+    
+    public ChargeEntityFixture withWalletType(WalletType walletType) {
+        this.walletType = walletType;
         return this;
     }
 


### PR DESCRIPTION
## WHAT
 - This will be used to populate the newly created wallet db column, null for non wallets payments
 - We are supporting just `APPLE_PAY` payments for now
