### PR TITLE
BAU remove logic from charge entity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -42,7 +42,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -55,7 +54,7 @@ import static uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransi
 @SequenceGenerator(name = "charges_charge_id_seq",
         sequenceName = "charges_charge_id_seq", allocationSize = 1)
 public class ChargeEntity extends AbstractVersionedEntity {
-    private final static Logger logger = LoggerFactory.getLogger(ChargeEntity.class);
+    private static final Logger logger = LoggerFactory.getLogger(ChargeEntity.class);
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "charges_charge_id_seq")
@@ -214,14 +213,14 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.externalId = externalId;
     }
 
-    public void setStatus(ChargeStatus targetStatus)  {
+    public void setStatus(ChargeStatus targetStatus) {
         if (isValidTransition(fromString(this.status), targetStatus)) {
             logger.info("Changing charge status for externalId [{}] [{}]->[{}]",
                     externalId, this.status, targetStatus.getValue());
-            
+
             this.status = targetStatus.getValue();
         } else {
-            logger.warn("Charge with state {} cannot proceed to {} [charge_external_id={}, charge_status={}]", 
+            logger.warn("Charge with state {} cannot proceed to {} [charge_external_id={}, charge_status={}]",
                     this.status, targetStatus, this.externalId, targetStatus);
             throw new InvalidStateTransitionException(this.status, targetStatus.getValue());
         }
@@ -245,14 +244,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void setProviderSessionId(String providerSessionId) {
         this.providerSessionId = providerSessionId;
-    }
-
-    public boolean hasStatus(ChargeStatus... status) {
-        return Arrays.stream(status).anyMatch(s -> equalsIgnoreCase(s.getValue(), getStatus()));
-    }
-
-    public boolean hasStatus(List<ChargeStatus> status) {
-        return hasStatus(status.toArray(new ChargeStatus[0]));
     }
 
     public boolean hasExternalStatus(ExternalChargeState... state) {

--- a/src/main/java/uk/gov/pay/connector/charge/service/CancelServiceFunctions.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/CancelServiceFunctions.java
@@ -60,7 +60,7 @@ class CancelServiceFunctions {
     ) {
         return context -> chargeDao.findByExternalId(chargeId).map(chargeEntity -> {
             ChargeStatus newStatus = statusFlow.getLockState();
-            if (!statusFlow.getTerminatableStatuses().contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
+            if (!chargeIsInTerminatableStatus(statusFlow, chargeEntity)) {
                 if (newStatus.equals(ChargeStatus.fromString(chargeEntity.getStatus()))) {
                     throw new OperationAlreadyInProgressRuntimeException(statusFlow.getName(), chargeId);
                 } else if (Arrays.asList(AUTHORISATION_READY, AUTHORISATION_3DS_READY).contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
@@ -101,7 +101,12 @@ class CancelServiceFunctions {
         };
     }
 
-    static String getLegalStatusNames(List<ChargeStatus> legalStatuses) {
+    private static String getLegalStatusNames(List<ChargeStatus> legalStatuses) {
         return legalStatuses.stream().map(ChargeStatus::toString).collect(Collectors.joining(", "));
     }
+
+    private static boolean chargeIsInTerminatableStatus(StatusFlow statusFlow, ChargeEntity chargeEntity) {
+        return statusFlow.getTerminatableStatuses().contains(ChargeStatus.fromString(chargeEntity.getStatus()));
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/CancelServiceFunctions.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/CancelServiceFunctions.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
 
 /**
  * Bunch of reusable functions and possibly sharable between Cancel/Expire
@@ -38,7 +37,6 @@ class CancelServiceFunctions {
     private static final Logger logger = LoggerFactory.getLogger(CancelServiceFunctions.class);
 
     private CancelServiceFunctions() {
-        // prevent people to instantiate this class, as it has only static methods
     }
 
     static TransactionalOperation<TransactionContext, ChargeEntity> changeStatusTo(ChargeDao chargeDao, ChargeEventDao chargeEventDao, String chargeId, ChargeStatus targetStatus, Optional<ZonedDateTime> generationTimeOptional) {
@@ -60,10 +58,11 @@ class CancelServiceFunctions {
     ) {
         return context -> chargeDao.findByExternalId(chargeId).map(chargeEntity -> {
             ChargeStatus newStatus = statusFlow.getLockState();
-            if (!chargeIsInTerminatableStatus(statusFlow, chargeEntity)) {
-                if (newStatus.equals(ChargeStatus.fromString(chargeEntity.getStatus()))) {
+            final ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+            if (!chargeIsInTerminatableStatus(statusFlow, chargeStatus)) {
+                if (newStatus.equals(chargeStatus)) {
                     throw new OperationAlreadyInProgressRuntimeException(statusFlow.getName(), chargeId);
-                } else if (Arrays.asList(AUTHORISATION_READY, AUTHORISATION_3DS_READY).contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
+                } else if (Arrays.asList(AUTHORISATION_READY, AUTHORISATION_3DS_READY).contains(chargeStatus)) {
                     throw new ConflictRuntimeException(chargeEntity.getExternalId());
                 }
 
@@ -78,7 +77,7 @@ class CancelServiceFunctions {
 
             logger.info("Card cancel request sent - charge_external_id={}, charge_status={}, account_id={}, transaction_id={}, amount={}, operation_type={}, provider={}, provider_type={}, locking_status={}",
                     chargeEntity.getExternalId(),
-                    fromString(chargeEntity.getStatus()),
+                    chargeStatus,
                     gatewayAccount.getId(),
                     chargeEntity.getGatewayTransactionId(),
                     chargeEntity.getAmount(),
@@ -105,8 +104,8 @@ class CancelServiceFunctions {
         return legalStatuses.stream().map(ChargeStatus::toString).collect(Collectors.joining(", "));
     }
 
-    private static boolean chargeIsInTerminatableStatus(StatusFlow statusFlow, ChargeEntity chargeEntity) {
-        return statusFlow.getTerminatableStatuses().contains(ChargeStatus.fromString(chargeEntity.getStatus()));
+    private static boolean chargeIsInTerminatableStatus(StatusFlow statusFlow, ChargeStatus chargeStatus) {
+        return statusFlow.getTerminatableStatuses().contains(chargeStatus);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -73,7 +73,7 @@ public class ChargeCancelService {
 
     private Function<ChargeEntity, Optional<GatewayResponse<BaseCancelResponse>>> doCancel(String chargeId, StatusFlow statusFlow) {
         return chargeEntity -> {
-            if (chargeEntity.hasStatus(nonGatewayStatuses)) {
+            if (nonGatewayStatuses.contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
                 return Optional.of(nonGatewayCancel(chargeId, statusFlow));
             } else {
                 return cancelChargeWithGatewayCleanup(chargeId, statusFlow);

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -73,7 +73,7 @@ public class ChargeCancelService {
 
     private Function<ChargeEntity, Optional<GatewayResponse<BaseCancelResponse>>> doCancel(String chargeId, StatusFlow statusFlow) {
         return chargeEntity -> {
-            if (nonGatewayStatuses.contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
+            if (gatewayIsNotAwareOfCharge(chargeEntity)) {
                 return Optional.of(nonGatewayCancel(chargeId, statusFlow));
             } else {
                 return cancelChargeWithGatewayCleanup(chargeId, statusFlow);
@@ -144,4 +144,7 @@ public class ChargeCancelService {
         }
     }
 
+    private boolean gatewayIsNotAwareOfCharge(ChargeEntity chargeEntity) {
+        return nonGatewayStatuses.contains(ChargeStatus.fromString(chargeEntity.getStatus()));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -300,7 +300,7 @@ public class ChargeService {
             try {
                 chargeEntity.setStatus(operationType.getLockingStatus());
             } catch (InvalidStateTransitionException e) {
-                if (operationType.getLockingStatus().equals(ChargeStatus.fromString(chargeEntity.getStatus()))) {
+                if (chargeIsInLockedStatus(operationType, chargeEntity)) {
                     throw new OperationAlreadyInProgressRuntimeException(operationType.getValue(), chargeEntity.getExternalId());
                 }
                 throw new IllegalStateRuntimeException(chargeEntity.getExternalId());
@@ -340,7 +340,7 @@ public class ChargeService {
 
             ChargeStatus currentStatus = fromString(charge.getStatus());
 
-            if (IGNORABLE_CAPTURE_STATES.contains(ChargeStatus.fromString(charge.getStatus()))) {
+            if (chargeCanBeSkipped(charge)) {
                 logger.info("Skipping charge [charge_external_id={}] with status [{}] from marking as CAPTURE APPROVED", currentStatus, externalId);
                 return charge;
             }
@@ -434,5 +434,13 @@ public class ChargeService {
         return UriBuilder.fromUri(linksConfig.getFrontendUrl())
                 .path("secure")
                 .build();
+    }
+
+    private boolean chargeIsInLockedStatus(OperationType operationType, ChargeEntity chargeEntity) {
+        return operationType.getLockingStatus().equals(ChargeStatus.fromString(chargeEntity.getStatus()));
+    }
+
+    private boolean chargeCanBeSkipped(ChargeEntity charge) {
+        return IGNORABLE_CAPTURE_STATES.contains(ChargeStatus.fromString(charge.getStatus()));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -300,7 +300,7 @@ public class ChargeService {
             try {
                 chargeEntity.setStatus(operationType.getLockingStatus());
             } catch (InvalidStateTransitionException e) {
-                if (chargeEntity.hasStatus(operationType.getLockingStatus())) {
+                if (operationType.getLockingStatus().equals(ChargeStatus.fromString(chargeEntity.getStatus()))) {
                     throw new OperationAlreadyInProgressRuntimeException(operationType.getValue(), chargeEntity.getExternalId());
                 }
                 throw new IllegalStateRuntimeException(chargeEntity.getExternalId());
@@ -340,7 +340,7 @@ public class ChargeService {
 
             ChargeStatus currentStatus = fromString(charge.getStatus());
 
-            if (charge.hasStatus(IGNORABLE_CAPTURE_STATES)) {
+            if (IGNORABLE_CAPTURE_STATES.contains(ChargeStatus.fromString(charge.getStatus()))) {
                 logger.info("Skipping charge [charge_external_id={}] with status [{}] from marking as CAPTURE APPROVED", currentStatus, externalId);
                 return charge;
             }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
@@ -49,9 +49,9 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
 
     protected ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<ChargeStatus> statusesThatMapToExternalPending,
                                                          List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull) {
-        if (chargeEntity.hasStatus(statusesThatMapToExternalPending)) {
+        if (statusesThatMapToExternalPending.contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
             return EXTERNAL_PENDING;
-        } else if (chargeEntity.hasStatus(statusesThatMapToExternalAvailableOrExternalFull)) {
+        } else if (statusesThatMapToExternalAvailableOrExternalFull.contains(ChargeStatus.fromString(chargeEntity.getStatus()))) {
             if (RefundCalculator.getTotalAmountAvailableToBeRefunded(chargeEntity) > 0) {
                 return EXTERNAL_AVAILABLE;
             } else {

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityTest.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -21,15 +22,15 @@ public class ChargeEntityTest {
 
     @Test
     public void shouldHaveTheGivenStatus() {
-        assertTrue(aValidChargeEntity().withStatus(CREATED).build().hasStatus(CREATED));
-        assertTrue(aValidChargeEntity().withStatus(ENTERING_CARD_DETAILS).build().hasStatus(ENTERING_CARD_DETAILS));
+        assertEquals(aValidChargeEntity().withStatus(CREATED).build().getStatus(), CREATED.toString());
+        assertEquals(aValidChargeEntity().withStatus(ENTERING_CARD_DETAILS).build().getStatus(), ENTERING_CARD_DETAILS.toString());
     }
 
 
     @Test
     public void shouldHaveAtLeastOneOfTheGivenStatuses() {
-        assertTrue(aValidChargeEntity().withStatus(CREATED).build().hasStatus(CREATED, ENTERING_CARD_DETAILS));
-        assertTrue(aValidChargeEntity().withStatus(ENTERING_CARD_DETAILS).build().hasStatus(CAPTURED, ENTERING_CARD_DETAILS));
+        assertEquals(aValidChargeEntity().withStatus(CREATED).build().getStatus(), CREATED.toString());
+        assertEquals(aValidChargeEntity().withStatus(ENTERING_CARD_DETAILS).build().getStatus(), ENTERING_CARD_DETAILS.toString());
     }
 
 
@@ -53,17 +54,15 @@ public class ChargeEntityTest {
     }
 
     @Test
-    public void shouldAllowAValidStatusTransition() throws Exception {
-        ChargeEntity chargeCreated = ChargeEntityFixture.aValidChargeEntity()
-                .withStatus(CREATED).build();
+    public void shouldAllowAValidStatusTransition() {
+        ChargeEntity chargeCreated = ChargeEntityFixture.aValidChargeEntity().withStatus(CREATED).build();
         chargeCreated.setStatus(ENTERING_CARD_DETAILS);
-        assertThat(chargeCreated.getStatus(), is(ENTERING_CARD_DETAILS.getValue()));
+        assertThat(chargeCreated.getStatus(), is(ENTERING_CARD_DETAILS.toString()));
     }
 
     @Test(expected = InvalidStateTransitionException.class)
-    public void shouldRejectAnInvalidStatusTransition() throws Exception {
-        ChargeEntity chargeCreated = ChargeEntityFixture.aValidChargeEntity()
-                .withStatus(CREATED).build();
+    public void shouldRejectAnInvalidStatusTransition() {
+        ChargeEntity chargeCreated = ChargeEntityFixture.aValidChargeEntity().withStatus(CREATED).build();
         chargeCreated.setStatus(CAPTURED);
     }
 }


### PR DESCRIPTION
## WHAT
* Removed logic from `ChargeEntity`
* Refactored long conditionals into smaller and meaningful methods

## HOW 
BAU - Extract conditionals into smaller methods

    - Long if statements can be expressed better by encapsulating them into
    one line methods. Beside making the line shorter, the name of the
    method is meaningful in the context of the if statement, instead of trying
    to figure out what's going on with status mappers, equality etc.

BAU - Remove logic from `ChargeEntity`

    - I removed the two methods `hasStatus` from the `ChargeEntity` as this feels wrong.
    The entity already has a `getStatus()` method which returns the current status, while
    the two methods were used to actually check that the current status is in a list of
    already known states. This can be easily accomplished by just using `contains` of
    Collections framework
    - Added a private constructor on `CancelServiceFunctions` to prevent people from
    instantiating it as this class has only static methods
    - Updated relevant tests to test on the actual String value that gets returned by the
    `getStatus()` method, instead trying to compare a String (returned by the entity) with
    a ChargeStatus value. Assert on the value you get and not on some other object.
    - Reordered modifiers to comply with JLS. Will make it easier for future reading and
    understanding of the code.

