### PR TITLE
PP-4399 - Remove Optional as argument

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/CancelServiceFunctions.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/CancelServiceFunctions.java
@@ -20,10 +20,8 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
@@ -39,13 +37,13 @@ class CancelServiceFunctions {
     private CancelServiceFunctions() {
     }
 
-    static TransactionalOperation<TransactionContext, ChargeEntity> changeStatusTo(ChargeDao chargeDao, ChargeEventDao chargeEventDao, String chargeId, ChargeStatus targetStatus, Optional<ZonedDateTime> generationTimeOptional) {
+    static TransactionalOperation<TransactionContext, ChargeEntity> changeStatusTo(ChargeDao chargeDao, ChargeEventDao chargeEventDao, String chargeId, ChargeStatus targetStatus) {
         return context -> chargeDao.findByExternalId(chargeId)
                 .map(chargeEntity -> {
                     logger.info("Charge status to update - charge_external_id={}, status={}, to_status={}",
                             chargeEntity.getExternalId(), chargeEntity.getStatus(), targetStatus);
                     chargeEntity.setStatus(targetStatus);
-                    chargeEventDao.persistChargeEventOf(chargeEntity, generationTimeOptional);
+                    chargeEventDao.persistChargeEventOf(chargeEntity);
                     return chargeEntity;
                 })
                 .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
@@ -86,7 +84,7 @@ class CancelServiceFunctions {
                     gatewayAccount.getType(),
                     newStatus);
 
-            chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+            chargeEventDao.persistChargeEventOf(chargeEntity);
 
             return chargeEntity;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -101,7 +101,7 @@ public class ChargeCancelService {
                     cancelResponse, chargeEntity.getStatus(), status);
 
             chargeEntity.setStatus(status);
-            chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+            chargeEventDao.persistChargeEventOf(chargeEntity);
             return cancelResponse;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
@@ -122,7 +122,7 @@ public class ChargeCancelService {
     private GatewayResponse<BaseCancelResponse> nonGatewayCancel(String chargeId, StatusFlow statusFlow) {
         ChargeStatus completeStatus = statusFlow.getSuccessTerminalState();
         ChargeEntity processedCharge = transactionFlowProvider.get()
-                .executeNext(changeStatusTo(chargeDao, chargeEventDao, chargeId, completeStatus, Optional.empty()))
+                .executeNext(changeStatusTo(chargeDao, chargeEventDao, chargeId, completeStatus))
                 .complete()
                 .get(ChargeEntity.class);
         GatewayResponseBuilder<BaseCancelResponse> gatewayResponseBuilder = responseBuilder();

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -130,7 +130,7 @@ public class ChargeService {
                     chargeRequest.isDelayedCapture());
             chargeDao.persist(chargeEntity);
 
-            chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+            chargeEventDao.persistChargeEventOf(chargeEntity);
             return Optional.of(populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity).build());
         }).orElseGet(Optional::empty);
     }
@@ -138,7 +138,7 @@ public class ChargeService {
     @Transactional
     public void abortCharge(ChargeEntity charge) {
         charge.setStatus(AUTHORISATION_ABORTED);
-        chargeEventDao.persistChargeEventOf(charge, Optional.empty());
+        chargeEventDao.persistChargeEventOf(charge);
     }
 
     @Transactional
@@ -167,7 +167,7 @@ public class ChargeService {
                     final ChargeStatus oldChargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
                     if (CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS.contains(oldChargeStatus)) {
                         chargeEntity.setStatus(newChargeStatus);
-                        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+                        chargeEventDao.persistChargeEventOf(chargeEntity);
                         return Optional.of(chargeEntity);
                     }
                     return Optional.<ChargeEntity>empty();
@@ -248,7 +248,7 @@ public class ChargeService {
             CardDetailsEntity detailsEntity = buildCardDetailsEntity(authCardDetails);
             charge.setCardDetails(detailsEntity);
 
-            chargeEventDao.persistChargeEventOf(charge, Optional.empty());
+            chargeEventDao.persistChargeEventOf(charge);
 
             logger.info("Stored confirmation details for charge - charge_external_id={}",
                     chargeExternalId);
@@ -264,7 +264,7 @@ public class ChargeService {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             charge.setStatus(status);
             setTransactionId(charge, transactionId);
-            chargeEventDao.persistChargeEventOf(charge, Optional.empty());
+            chargeEventDao.persistChargeEventOf(charge);
 
             return charge;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
@@ -279,8 +279,7 @@ public class ChargeService {
                     //for sandbox, immediately move from CAPTURE_SUBMITTED to CAPTURED, as there will be no external notification
                     if (chargeEntity.getPaymentGatewayName() == PaymentGatewayName.SANDBOX) {
                         chargeEntity.setStatus(CAPTURED);
-                        ZonedDateTime gatewayEventTime = ZonedDateTime.now();
-                        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.of(gatewayEventTime));
+                        chargeEventDao.persistChargeEventOf(chargeEntity, ZonedDateTime.now());
                     }
                     return chargeEntity;
                 })
@@ -311,7 +310,7 @@ public class ChargeService {
 
     private ChargeEntity updateChargeStatus(ChargeEntity chargeEntity, ChargeStatus chargeStatus) {
         chargeEntity.setStatus(chargeStatus);
-        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.empty());
+        chargeEventDao.persistChargeEventOf(chargeEntity);
         return chargeEntity;
     }
 

--- a/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
@@ -3,9 +3,9 @@ package uk.gov.pay.connector.chargeevent.dao;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.common.dao.JpaDao;
-import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.common.dao.JpaDao;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -20,8 +20,12 @@ public class ChargeEventDao extends JpaDao<ChargeEventEntity> {
         super(entityManager);
     }
 
-    public void persistChargeEventOf(ChargeEntity chargeEntity, Optional<ZonedDateTime> gatewayEventDate) {
+    public void persistChargeEventOf(ChargeEntity chargeEntity) {
+        this.persistChargeEventOf(chargeEntity, null);
+    }
+
+    public void persistChargeEventOf(ChargeEntity chargeEntity, ZonedDateTime gatewayEventDate) {
         this.persist(ChargeEventEntity.from(chargeEntity, ChargeStatus.fromString(chargeEntity.getStatus()),
-                ZonedDateTime.now(), gatewayEventDate));
+                ZonedDateTime.now(), Optional.ofNullable(gatewayEventDate)));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -10,7 +10,6 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
-import java.util.Optional;
 
 public class ChargeNotificationProcessor {
 
@@ -50,6 +49,6 @@ public class ChargeNotificationProcessor {
                 gatewayAccount.getGatewayName(),
                 gatewayAccount.getType());
 
-        chargeEventDao.persistChargeEventOf(chargeEntity, Optional.ofNullable(gatewayEventDate));
+        chargeEventDao.persistChargeEventOf(chargeEntity, gatewayEventDate);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/webhook/service/NotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/webhook/service/NotificationService.java
@@ -219,7 +219,7 @@ public class NotificationService {
                     gatewayAccount.getGatewayName(),
                     gatewayAccount.getType());
 
-            chargeEventDao.persistChargeEventOf(chargeEntity, Optional.ofNullable(notification.getGatewayEventDate()));
+            chargeEventDao.persistChargeEventOf(chargeEntity, notification.getGatewayEventDate());
         }
 
         private <T> void updateRefundStatus(EvaluatedRefundStatusNotification<T> notification) {
@@ -241,7 +241,7 @@ public class NotificationService {
             RefundStatus newStatus = notification.getRefundStatus();
 
             refundEntity.setStatus(newStatus);
-            
+
             if (newStatus.equals(RefundStatus.REFUNDED)) {
                 userNotificationService.sendRefundIssuedEmail(refundEntity);
             }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -79,7 +78,7 @@ public class ChargeCancelServiceTest {
     }
 
     @Test
-    public void doSystemCancel_shouldCancel_withStatusThatDoesNotNeedCancellationInGatewayProvider() throws Exception {
+    public void doSystemCancel_shouldCancel_withStatusThatDoesNotNeedCancellationInGatewayProvider() {
 
         String externalChargeId = "external-charge-id";
         Long gatewayAccountId = nextLong();
@@ -97,11 +96,11 @@ public class ChargeCancelServiceTest {
         assertThat(response.get().isSuccessful(), is(true));
         assertThat(chargeEntity.getStatus(), is(SYSTEM_CANCELLED.getValue()));
 
-        verify(mockChargeEventDao).persistChargeEventOf(chargeEntity, Optional.empty());
+        verify(mockChargeEventDao).persistChargeEventOf(chargeEntity);
     }
 
     @Test
-    public void doSystemCancel_shouldCancel_havingChargeStatusThatNeedsCancellationInGatewayProvider_withCancelledGatewayResponse() throws Exception {
+    public void doSystemCancel_shouldCancel_havingChargeStatusThatNeedsCancellationInGatewayProvider_withCancelledGatewayResponse() {
 
         String externalChargeId = "external-charge-id";
         Long gatewayAccountId = nextLong();
@@ -118,7 +117,7 @@ public class ChargeCancelServiceTest {
 
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class), eq(Optional.empty()));
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
 
@@ -130,13 +129,13 @@ public class ChargeCancelServiceTest {
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId);
         verify(mockChargeDao, times(2)).findByExternalId(externalChargeId);
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)), eq(Optional.empty()));
+        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
 
         verifyNoMoreInteractions(mockChargeDao);
     }
 
     @Test(expected = ChargeNotFoundRuntimeException.class)
-    public void doSystemCancel_shouldFail_whenChargeNotFound() throws Exception {
+    public void doSystemCancel_shouldFail_whenChargeNotFound() {
 
         String externalChargeId = "external-charge-id";
         Long gatewayAccountId = nextLong();
@@ -147,7 +146,7 @@ public class ChargeCancelServiceTest {
     }
 
     @Test
-    public void doUserCancel_shouldCancel_withStatusThatDoesNotNeedCancellationInGatewayProvider() throws Exception {
+    public void doUserCancel_shouldCancel_withStatusThatDoesNotNeedCancellationInGatewayProvider() {
 
         String externalChargeId = "external-charge-id";
         ChargeEntity chargeEntity = aValidChargeEntity()
@@ -163,11 +162,11 @@ public class ChargeCancelServiceTest {
         assertThat(response.get().isSuccessful(), is(true));
         assertThat(chargeEntity.getStatus(), is(USER_CANCELLED.getValue()));
 
-        verify(mockChargeEventDao).persistChargeEventOf(chargeEntity, Optional.empty());
+        verify(mockChargeEventDao).persistChargeEventOf(chargeEntity);
     }
 
     @Test
-    public void doUserCancel_shouldCancel_havingChargeStatusThatNeedsCancellationInGatewayProvider_withCancelledGatewayResponse() throws Exception {
+    public void doUserCancel_shouldCancel_havingChargeStatusThatNeedsCancellationInGatewayProvider_withCancelledGatewayResponse() {
 
         String externalChargeId = "external-charge-id";
         ChargeEntity chargeEntity = aValidChargeEntity()
@@ -182,7 +181,7 @@ public class ChargeCancelServiceTest {
         GatewayResponse cancelResponse = gatewayResponseBuilder.withResponse(worldpayResponse).build();
 
         when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class), eq(Optional.empty()));
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
 
@@ -193,13 +192,13 @@ public class ChargeCancelServiceTest {
         assertThat(chargeEntity.getStatus(), is(USER_CANCELLED.getValue()));
 
         verify(mockChargeDao, times(3)).findByExternalId(externalChargeId);
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(USER_CANCELLED)), eq(Optional.empty()));
+        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(USER_CANCELLED)));
 
         verifyNoMoreInteractions(mockChargeDao);
     }
 
     @Test(expected = ChargeNotFoundRuntimeException.class)
-    public void doUserCancel_shouldFail_whenChargeNotFound() throws Exception {
+    public void doUserCancel_shouldFail_whenChargeNotFound() {
 
         String externalChargeId = "external-charge-id";
 
@@ -226,7 +225,7 @@ public class ChargeCancelServiceTest {
 
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class), eq(Optional.empty()));
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
 
@@ -238,7 +237,7 @@ public class ChargeCancelServiceTest {
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId);
         verify(mockChargeDao, times(2)).findByExternalId(externalChargeId);
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)), eq(Optional.empty()));
+        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
 
         verifyNoMoreInteractions(mockChargeDao);
     }
@@ -261,7 +260,7 @@ public class ChargeCancelServiceTest {
 
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class), eq(Optional.empty()));
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
 
@@ -273,7 +272,7 @@ public class ChargeCancelServiceTest {
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId);
         verify(mockChargeDao, times(2)).findByExternalId(externalChargeId);
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)), eq(Optional.empty()));
+        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
 
         verifyNoMoreInteractions(mockChargeDao);
     }
@@ -296,7 +295,7 @@ public class ChargeCancelServiceTest {
 
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class), eq(Optional.empty()));
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
 
@@ -308,7 +307,7 @@ public class ChargeCancelServiceTest {
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId);
         verify(mockChargeDao, times(2)).findByExternalId(externalChargeId);
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)), eq(Optional.empty()));
+        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
 
         verifyNoMoreInteractions(mockChargeDao);
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -63,13 +63,13 @@ public class ChargeExpiryServiceTest {
 
     @Mock
     private WorldpayCancelResponse mockWorldpayCancelResponse;
-    
+
     @Mock
     private ChargeSweepConfig mockedChargeSweepConfig;
 
     @Mock
     private ConnectorConfiguration mockedConfig;
-    
+
     private GatewayResponse<BaseCancelResponse> gatewayResponse;
     private GatewayAccountEntity gatewayAccount;
 
@@ -99,7 +99,7 @@ public class ChargeExpiryServiceTest {
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
         ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
         ArgumentCaptor<CancelGatewayRequest> cancelCaptor = ArgumentCaptor.forClass(CancelGatewayRequest.class);
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture(), any());
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture());
 
         chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -123,7 +123,7 @@ public class ChargeExpiryServiceTest {
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
         ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
         ArgumentCaptor<CancelGatewayRequest> cancelCaptor = ArgumentCaptor.forClass(CancelGatewayRequest.class);
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture(), any());
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture());
 
         chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -146,7 +146,7 @@ public class ChargeExpiryServiceTest {
                     ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
 
                     when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
-                    doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture(), any());
+                    doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture());
 
                     chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -173,7 +173,7 @@ public class ChargeExpiryServiceTest {
         when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayErrorResponse);
         ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture(), any());
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture());
 
         chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -201,7 +201,7 @@ public class ChargeExpiryServiceTest {
         when(mockChargeDao.findByExternalId(chargeEntityAwaitingCapture.getExternalId())).thenReturn(Optional.of(chargeEntityAwaitingCapture));
         when(mockChargeDao.findByExternalId(chargeEntityAuthorisationSuccess.getExternalId())).thenReturn(Optional.of(chargeEntityAuthorisationSuccess));
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(), any());
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
         when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(ChargeExpiryService.EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS))).thenReturn(singletonList(chargeEntityAwaitingCapture));
         when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(ChargeExpiryService.EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(chargeEntityAuthorisationSuccess));
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -101,7 +101,7 @@ public class ChargeServiceTest {
     private PaymentProvider mockedPaymentProvider;
 
     private ChargeService service;
-    
+
     private GatewayAccountEntity gatewayAccount;
 
     @Before
@@ -165,7 +165,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.isDelayedCapture(), is(false));
         assertThat(createdChargeEntity.getCorporateSurcharge().isPresent(), is(false));
 
-        verify(mockedChargeEventDao).persistChargeEventOf(createdChargeEntity, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(createdChargeEntity);
     }
 
     @Test
@@ -398,9 +398,9 @@ public class ChargeServiceTest {
         service.updateFromInitialStatus(createdChargeEntity.getExternalId(), ENTERING_CARD_DETAILS);
 
     }
-    
+
     @Test
-    public void shouldFindChargeWithCaptureUrlAndNoNextUrl_whenChargeInAwaitingCaptureRequest() throws Exception{
+    public void shouldFindChargeWithCaptureUrlAndNoNextUrl_whenChargeInAwaitingCaptureRequest() throws Exception {
         Long chargeId = 101L;
 
         ChargeEntity newCharge = aValidChargeEntity()

--- a/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/dao/ChargeEventDaoITest.java
@@ -7,18 +7,16 @@ import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.it.dao.DaoITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -68,19 +66,19 @@ public class ChargeEventDaoITest extends DaoITestBase {
         ChargeEntity entity = chargeDao.findById(chargeId).get();
         entity.setStatus(ENTERING_CARD_DETAILS);
 
-        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+        chargeEventDao.persistChargeEventOf(entity);
 
         //move status to AUTHORISED
         entity.setStatus(AUTHORISATION_READY);
         entity.setStatus(AUTHORISATION_SUCCESS);
         entity.setGatewayTransactionId(TRANSACTION_ID_2);
 
-        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+        chargeEventDao.persistChargeEventOf(entity);
 
         entity.setStatus(CAPTURE_READY);
         entity.setGatewayTransactionId(TRANSACTION_ID_3);
 
-        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+        chargeEventDao.persistChargeEventOf(entity);
 
         List<ChargeEventEntity> events = chargeDao.findById(chargeId).get().getEvents();
 
@@ -108,19 +106,19 @@ public class ChargeEventDaoITest extends DaoITestBase {
         ChargeEntity entity = chargeDao.findById(chargeId).get();
         entity.setStatus(ENTERING_CARD_DETAILS);
 
-        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+        chargeEventDao.persistChargeEventOf(entity);
 
         //move status to AUTHORISED
         entity.setStatus(AUTHORISATION_READY);
         entity.setStatus(AUTHORISATION_SUCCESS);
         entity.setGatewayTransactionId(TRANSACTION_ID_2);
 
-        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+        chargeEventDao.persistChargeEventOf(entity);
 
         entity.setStatus(AWAITING_CAPTURE_REQUEST);
         entity.setGatewayTransactionId(TRANSACTION_ID_3);
 
-        chargeEventDao.persistChargeEventOf(entity, Optional.empty());
+        chargeEventDao.persistChargeEventOf(entity);
 
         List<ChargeEventEntity> events = chargeDao.findById(chargeId).get().getEvents();
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -87,8 +87,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     private CardAuthoriseService cardAuthorisationService;
 
-    private ChargeService chargeService;
-
     @Before
     public void setUpCardAuthorisationService() {
         mockMetricRegistry = mock(MetricRegistry.class);
@@ -96,7 +94,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
-        chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
+        ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         cardAuthorisationService = new CardAuthoriseService(mockedCardTypeDao, mockedProviders, mockExecutorService, chargeService,
                 mockEnvironment);
@@ -147,7 +145,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
@@ -170,7 +168,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
         assertThat(charge.getCardDetails().getBillingAddress().isPresent(), is(false));
@@ -197,7 +195,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
@@ -222,7 +220,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
         assertThat(charge.getCorporateSurcharge().get(), is(250L));
@@ -247,7 +245,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
         assertThat(charge.getCorporateSurcharge().get(), is(50L));
@@ -274,7 +272,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.get3dsDetails(), is(nullValue()));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
     }
 
     @Test
@@ -288,7 +286,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.isSuccessful(), is(true));
 
         assertThat(charge.getStatus(), is(AUTHORISATION_3DS_REQUIRED.getValue()));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails().getIssuerUrl(), is(ISSUER_URL_FROM_PROVIDER));
         assertThat(charge.get3dsDetails().getPaRequest(), is(PA_REQ_VALUE_FROM_PROVIDER));
     }
@@ -302,7 +300,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_3DS_REQUIRED.getValue()));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails().getHtmlOut(), is(notNullValue()));
     }
 
@@ -317,7 +315,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.isSuccessful(), is(true));
 
         assertThat(charge.getStatus(), is(AUTHORISATION_3DS_REQUIRED.getValue()));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails().getIssuerUrl(), is(ISSUER_URL_FROM_PROVIDER));
         assertThat(charge.get3dsDetails().getPaRequest(), is(PA_REQ_VALUE_FROM_PROVIDER));
     }
@@ -370,7 +368,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
             fail("Expected test to fail with ConflictRuntimeException due to configuration conflicting in 3ds requirements");
         } catch (IllegalStateRuntimeException e) {
             assertThat(charge.getStatus(), is(AUTHORISATION_ABORTED.toString()));
-            verify(mockedChargeEventDao).persistChargeEventOf(charge, Optional.empty());
+            verify(mockedChargeEventDao).persistChargeEventOf(charge);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/webhook/service/NotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/webhook/service/NotificationServiceTest.java
@@ -82,7 +82,7 @@ public class NotificationServiceTest {
 
     @Mock
     private UserNotificationService mockedUserNotificationService;
-    
+
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private ChargeEntity mockedChargeEntity;
 
@@ -329,11 +329,11 @@ public class NotificationServiceTest {
 
         verify(mockedChargeEntity).setStatus(CAPTURED);
 
-        ArgumentCaptor<Optional> generatedTimeCaptor = ArgumentCaptor.forClass(Optional.class);
+        ArgumentCaptor<ZonedDateTime> generatedTimeCaptor = ArgumentCaptor.forClass(ZonedDateTime.class);
         verify(mockedChargeEventDao).persistChargeEventOf(argThat(obj -> mockedChargeEntity.equals(obj)), generatedTimeCaptor.capture());
 
-        assertTrue(ChronoUnit.SECONDS.between((ZonedDateTime) generatedTimeCaptor.getValue().get(), ZonedDateTime.now()) < 10);
-       
+        assertTrue(ChronoUnit.SECONDS.between(generatedTimeCaptor.getValue(), ZonedDateTime.now()) < 10);
+
         verifyNoMoreInteractions(ignoreStubs(mockedChargeDao));
         verifyZeroInteractions(mockedUserNotificationService);
     }
@@ -367,7 +367,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    public void whenSecureNotificationEndpointIsEnabled_shouldRejectNotificationIfIpIsNotValid() throws Exception {
+    public void whenSecureNotificationEndpointIsEnabled_shouldRejectNotificationIfIpIsNotValid() {
         when(mockedPaymentProviders.byName(WORLDPAY)).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.isNotificationEndpointSecured()).thenReturn(true);
         when(mockedPaymentProvider.getNotificationDomain()).thenReturn("something.com");
@@ -377,7 +377,7 @@ public class NotificationServiceTest {
     }
 
     @Test
-    public void whenSecureNotificationEndpointIsEnabled_shouldHandleNotificationIfIpBelongsToDomain() throws Exception {
+    public void whenSecureNotificationEndpointIsEnabled_shouldHandleNotificationIfIpBelongsToDomain() {
         String ipAddress = "ip-address";
         String domain = "worldpay.com";
         Notifications<Pair<String, Boolean>> notifications = createNotificationFor("", null, Pair.of("CAPTURE", true));


### PR DESCRIPTION
## WHAT
- Replaced method argument Optional with method overload. This avoids
having to pass Optional.empty() from many other places just to satisfy
Java's lack of positional or named parameters.
- Removed unnecessary `throws Exception` as those methods don't actually
throw it
- Updated logger to use the built in method and no string concatenation



