### PR TITLE
PP-4352: Refactor capture contract

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -106,4 +106,9 @@ public class ConnectorModule extends AbstractModule {
     public StripeGatewayClient stripeGatewayClient(GatewayClientFactory gatewayClientFactory) {
         return gatewayClientFactory.createStripeGatewayClient(STRIPE, environment.metrics());
     }
+    
+    @Provides
+    public StripeGatewayConfig stripeGatewayConfig(ConnectorConfiguration connectorConfiguration) {
+        return connectorConfiguration.getStripeConfig();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -4,12 +4,13 @@ import fj.data.Either;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -30,7 +31,7 @@ public interface PaymentProvider<R> {
 
     GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 
-    CaptureHandler getCaptureHandler();
+    GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request);
 
     GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -22,11 +21,13 @@ import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
@@ -163,8 +164,8 @@ public class EpdqPaymentProvider implements PaymentProvider<String> {
     }
 
     @Override
-    public CaptureHandler getCaptureHandler() {
-        return epdqCaptureHandler;
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
+        return epdqCaptureHandler.capture(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -3,18 +3,19 @@ package uk.gov.pay.connector.gateway.sandbox;
 import fj.data.Either;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -72,8 +73,8 @@ public class SandboxPaymentProvider implements PaymentProvider<String> {
     }
 
     @Override
-    public CaptureHandler getCaptureHandler() {
-        return sandboxCaptureHandler;
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
+        return sandboxCaptureHandler.capture(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -16,12 +16,14 @@ import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
@@ -85,8 +87,8 @@ public class SmartpayPaymentProvider implements PaymentProvider<Pair<String, Boo
     }
 
     @Override
-    public CaptureHandler getCaptureHandler() {
-        return smartpayCaptureHandler;
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
+        return smartpayCaptureHandler.capture(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -10,17 +10,18 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -216,8 +217,8 @@ public class StripePaymentProvider implements PaymentProvider<String> {
     }
 
     @Override
-    public CaptureHandler getCaptureHandler() {
-        return stripeCaptureHandler;
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
+        return stripeCaptureHandler.capture(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -5,7 +5,6 @@ import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -15,10 +14,12 @@ import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
@@ -101,8 +102,8 @@ public class WorldpayPaymentProvider implements PaymentProvider<String> {
     }
 
     @Override
-    public CaptureHandler getCaptureHandler() {
-        return worldpayCaptureHandler;
+    public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
+        return worldpayCaptureHandler.capture(request);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -37,7 +37,8 @@ public class CardCaptureService {
     protected MetricRegistry metricRegistry;
 
     @Inject
-    public CardCaptureService(ChargeService chargeService, PaymentProviders providers,
+    public CardCaptureService(ChargeService chargeService, 
+                              PaymentProviders providers, 
                               UserNotificationService userNotificationService,
                               Environment environment) {
         this.chargeService = chargeService;
@@ -82,9 +83,7 @@ public class CardCaptureService {
     }
 
     private GatewayResponse<BaseCaptureResponse> capture(ChargeEntity chargeEntity) {
-        return getPaymentProviderFor(chargeEntity)
-                .getCaptureHandler()
-                .capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        return getPaymentProviderFor(chargeEntity).capture(CaptureGatewayRequest.valueOf(chargeEntity));
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -20,9 +20,9 @@ import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -62,8 +62,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORIS
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CANCEL_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CANCEL_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CANCEL_SUCCESS_RESPONSE;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CAPTURE_ERROR_RESPONSE;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_DELETE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_NOTIFICATION_TEMPLATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_REFUND_ERROR_RESPONSE;
@@ -76,7 +74,7 @@ public abstract class BaseEpdqPaymentProviderTest {
     static final String NOTIFICATION_PAY_ID_SUB = "2";
     static final String NOTIFICATION_SHA_SIGN = "9537B9639F108CDF004459D8A690C598D97506CDF072C3926A60E39759A6402C5089161F6D7A8EA12BBC0FD6F899CE72D5A0C4ACC2913C56ACF6D01B034protected";
 
-    protected GatewayClientFactory gatewayClientFactory;
+    protected GatewayClientFactory gatewayClientFactory;    
     protected EpdqPaymentProvider provider;
 
 
@@ -176,18 +174,6 @@ public abstract class BaseEpdqPaymentProviderTest {
         return TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_ERROR_RESPONSE);
     }
 
-    String successCaptureResponse() {
-        return TestTemplateResourceLoader.load(EPDQ_CAPTURE_SUCCESS_RESPONSE);
-    }
-
-    String errorCaptureResponse() {
-        return TestTemplateResourceLoader.load(EPDQ_CAPTURE_ERROR_RESPONSE);
-    }
-
-    String successCaptureRequest() {
-        return TestTemplateResourceLoader.load(TestTemplateResourceLoader.EPDQ_CAPTURE_REQUEST);
-    }
-
     String successCancelResponse() {
         return TestTemplateResourceLoader.load(EPDQ_CANCEL_SUCCESS_RESPONSE);
     }
@@ -229,10 +215,6 @@ public abstract class BaseEpdqPaymentProviderTest {
         return new CardAuthorisationGatewayRequest(chargeEntity, buildTestAuthCardDetails());
     }
 
-    CaptureGatewayRequest buildTestCaptureRequest(ChargeEntity chargeEntity) {
-        return CaptureGatewayRequest.valueOf(chargeEntity);
-    }
-
     CancelGatewayRequest buildTestCancelRequest(ChargeEntity chargeEntity) {
         return CancelGatewayRequest.valueOf(chargeEntity);
     }
@@ -271,10 +253,6 @@ public abstract class BaseEpdqPaymentProviderTest {
         return new Auth3dsResponseGatewayRequest(chargeEntity, auth3DsDetails);
     }
 
-    CaptureGatewayRequest buildTestCaptureRequest() {
-        return buildTestCaptureRequest(buildTestGatewayAccountEntity());
-    }
-
     CancelGatewayRequest buildTestCancelRequest() {
         return buildTestCancelRequest(buildTestGatewayAccountEntity());
     }
@@ -289,14 +267,6 @@ public abstract class BaseEpdqPaymentProviderTest {
                 .withGatewayAccountEntity(accountEntity)
                 .build();
         return buildTestAuthorisationRequest(chargeEntity);
-    }
-
-    private CaptureGatewayRequest buildTestCaptureRequest(GatewayAccountEntity accountEntity) {
-        ChargeEntity chargeEntity = aValidChargeEntity()
-                .withGatewayAccountEntity(accountEntity)
-                .withTransactionId("payId")
-                .build();
-        return buildTestCaptureRequest(chargeEntity);
     }
 
     private CancelGatewayRequest buildTestCancelRequest(GatewayAccountEntity accountEntity) {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -1,54 +1,137 @@
 package uk.gov.pay.connector.gateway.epdq;
 
+import com.google.common.collect.ImmutableMap;
+import fj.data.Either;
+import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import javax.ws.rs.core.Response;
+
+import static fj.data.Either.left;
+import static fj.data.Either.right;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
+import static uk.gov.pay.connector.gateway.model.GatewayError.unexpectedStatusCodeFromGateway;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CAPTURE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @RunWith(MockitoJUnitRunner.class)
-public class EpdqCaptureHandlerTest extends BaseEpdqPaymentProviderTest {
+public class EpdqCaptureHandlerTest {
 
-    protected EpdqCaptureHandler epdqCaptureHandler;
+    private EpdqCaptureHandler epdqCaptureHandler;
+
+    @Mock 
+    private GatewayClient client;
+    @Mock
+    private Response response;
 
     @Before
     public void setup() {
-        super.setup();
-        epdqCaptureHandler = (EpdqCaptureHandler) provider.getCaptureHandler();
+        epdqCaptureHandler = new EpdqCaptureHandler(client);
     }
 
     @Test
-    public void shouldCapture() {
-        mockPaymentProviderResponse(200, successCaptureResponse());
-        GatewayResponse<BaseCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
-        verifyPaymentProviderRequest(successCaptureRequest());
-        assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
+    public void shouldCapture() throws Exception {
+        //mock client.postRequestFor
+        when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
+        Either<GatewayError, GatewayClient.Response> response = right(new TestResponse(this.response));
+        when(client.postRequestFor(anyString(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(response);
+
+        //mock client.unmarshallResponse
+        Either<GatewayError, EpdqCaptureResponse> unmarshalledResponse = right(XMLUnmarshaller.unmarshall(load(EPDQ_CAPTURE_SUCCESS_RESPONSE), EpdqCaptureResponse.class));
+        when(client.unmarshallResponse(any(TestResponse.class), any(Class.class))).thenReturn(unmarshalledResponse);
+        
+        GatewayResponse<BaseCaptureResponse> gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        assertTrue(gatewayResponse.isSuccessful());
+        assertThat(gatewayResponse.getBaseResponse().get().getTransactionId(), is("3014644340"));
+    }
+
+    private class TestResponse extends GatewayClient.Response {
+
+        protected TestResponse(Response delegate) {
+            super(delegate);
+        }
     }
 
     @Test
-    public void shouldNotCaptureIfPaymentProviderReturnsUnexpectedStatusCode() {
-        mockPaymentProviderResponse(200, errorCaptureResponse());
-        GatewayResponse<BaseCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
+    public void shouldNotCaptureIfPaymentProviderReturnsUnexpectedStatusCode() throws Exception{
+        //mock client.postRequestFor
+        when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
+        Either<GatewayError, GatewayClient.Response> response = right(new TestResponse(this.response));
+        when(client.postRequestFor(anyString(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(response);
+
+        //mock client.unmarshallResponse
+        Either<GatewayError, EpdqCaptureResponse> unmarshalledResponse = right(XMLUnmarshaller.unmarshall(load(EPDQ_CAPTURE_ERROR_RESPONSE), EpdqCaptureResponse.class));
+        when(client.unmarshallResponse(any(TestResponse.class), any(Class.class))).thenReturn(unmarshalledResponse);
+        
+        GatewayResponse<BaseCaptureResponse> gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
     }
 
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() {
-        mockPaymentProviderResponse(400, errorCaptureResponse());
-        GatewayResponse<BaseCaptureResponse> response = epdqCaptureHandler.capture(buildTestCaptureRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
-                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
+        //mock client.postRequestFor
+        Either<GatewayError, GatewayClient.Response> response = left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway"));
+        when(client.postRequestFor(anyString(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(response);
+        
+        GatewayResponse<BaseCaptureResponse> gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());
+        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is("Unexpected HTTP status code 400 from gateway"));
+        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
+    private CaptureGatewayRequest buildTestCaptureRequest() {
+        return buildTestCaptureRequest(buildTestGatewayAccountEntity());
+    }
+
+    private GatewayAccountEntity buildTestGatewayAccountEntity() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("epdq");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(ImmutableMap.of(
+                CREDENTIALS_MERCHANT_ID, "merchant-id",
+                CREDENTIALS_USERNAME, "username",
+                CREDENTIALS_PASSWORD, "password",
+                CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphrase"
+        ));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
+    }
+
+    private CaptureGatewayRequest buildTestCaptureRequest(GatewayAccountEntity accountEntity) {
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(accountEntity)
+                .withTransactionId("payId")
+                .build();
+        return CaptureGatewayRequest.valueOf(chargeEntity);
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCaptureHandlerTest.java
@@ -18,12 +18,10 @@ import static org.hamcrest.core.Is.is;
 public class SandboxCaptureHandlerTest {
 
     private SandboxCaptureHandler sandboxCaptureHandler;
-    private SandboxPaymentProvider sandboxPaymentProvider;
 
     @Before
     public void setup() {
-        SandboxPaymentProvider sandboxPaymentProvider = new SandboxPaymentProvider();
-        sandboxCaptureHandler = (SandboxCaptureHandler) sandboxPaymentProvider.getCaptureHandler();
+        sandboxCaptureHandler = new SandboxCaptureHandler();
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
@@ -1,45 +1,92 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
+import com.google.common.collect.ImmutableMap;
+import fj.data.Either;
+import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
+import javax.ws.rs.core.Response;
+
+import static fj.data.Either.right;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_SUCCESS_RESPONSE;
 
 @RunWith(MockitoJUnitRunner.class)
-public class SmartpayCaptureHandlerTest extends BaseSmartpayPaymentProviderTest {
+public class SmartpayCaptureHandlerTest {
 
     private SmartpayCaptureHandler smartpayCaptureHandler;
 
+    @Mock
+    private GatewayClient client;
+    @Mock
+    private Response response;
+
     @Before
     public void setup() {
-        super.setup();
-        smartpayCaptureHandler = (SmartpayCaptureHandler) provider.getCaptureHandler();
+        smartpayCaptureHandler = new SmartpayCaptureHandler(client);
     }
 
     @Test
     public void shouldCaptureAPaymentSuccessfully() {
-
-        mockSmartpayResponse(200, successCaptureResponse());
-
+        //mock client.postRequestFor
+        when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
+        when(response.readEntity(String.class)).thenReturn(successCaptureResponse());
+        Either<GatewayError, GatewayClient.Response> response = right(new TestResponse(this.response));
+        when(client.postRequestFor(isNull(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(response);
+        
+        //mock client.unmarshallResponse
+        Either<GatewayError, SmartpayCaptureResponse> unmarshalledResponse = right(new SmartpayCaptureResponse());
+        when(client.unmarshallResponse(any(TestResponse.class), any(Class.class))).thenReturn(unmarshalledResponse);
+        
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(aServiceAccount())
                 .build();
 
-        GatewayResponse<BaseCaptureResponse> response = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
-        assertTrue(response.isSuccessful());
+        CaptureGatewayRequest request = CaptureGatewayRequest.valueOf(chargeEntity);
+        GatewayResponse gatewayResponse = smartpayCaptureHandler.capture(request);
+        assertTrue(gatewayResponse.isSuccessful());
     }
 
     private String successCaptureResponse() {
         return TestTemplateResourceLoader.load(SMARTPAY_CAPTURE_SUCCESS_RESPONSE).replace("{{pspReference}}", "8614440510830227");
     }
 
+    private GatewayAccountEntity aServiceAccount() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("smartpay");
+        gatewayAccount.setCredentials(ImmutableMap.of(
+                "username", "theUsername",
+                "password", "thePassword",
+                "merchant_id", "theMerchantCode"
+        ));
+        gatewayAccount.setType(TEST);
+
+        return gatewayAccount;
+    }
+    
+    private class TestResponse extends GatewayClient.Response {
+
+        protected TestResponse(Response delegate) {
+            super(delegate);
+        }
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
@@ -29,8 +29,6 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -41,7 +39,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_3DS_SOURCES_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
@@ -90,10 +87,6 @@ public abstract class BaseStripePaymentProviderTest {
         provider = new StripePaymentProvider(stripeGatewayClient, configuration);
     }
 
-    String successCaptureResponse() {
-        return TestTemplateResourceLoader.load(STRIPE_CAPTURE_SUCCESS_RESPONSE);
-    }
-
     String successTokenResponse() {
         return TestTemplateResourceLoader.load(STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE);
     }
@@ -106,18 +99,6 @@ public abstract class BaseStripePaymentProviderTest {
         return TestTemplateResourceLoader.load(STRIPE_CREATE_3DS_SOURCES_RESPONSE);
     }
 
-    String errorCaptureResponse() {
-        return TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
-    }
-
-    String stripeInternalServerError() {
-        return TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE_GENERAL);
-    }
-
-    CaptureGatewayRequest buildTestCaptureRequest() {
-        return buildTestCaptureRequest(buildTestGatewayAccountEntity());
-    }
-
     CardAuthorisationGatewayRequest buildTestAuthorisationRequest() {
         return buildTestAuthorisationRequest(buildTestGatewayAccountEntity());
     }
@@ -126,12 +107,6 @@ public abstract class BaseStripePaymentProviderTest {
         assertNotNull(actual);
         assertThat(actual.getMessage(), is(expected.getMessage()));
         assertThat(actual.getErrorType(), is(expected.getErrorType()));
-    }
-
-    void mockPaymentProviderCaptureResponse(int responseHttpStatus, String responsePayload) throws IOException {
-        Response response = mockResponseWithPayload(responseHttpStatus);
-        Map<String, Object> responsePayloadMap = new ObjectMapper().readValue(responsePayload, HashMap.class);
-        when(response.readEntity(Map.class)).thenReturn(responsePayloadMap);
     }
 
     @NotNull

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -1,61 +1,118 @@
 package uk.gov.pay.connector.gateway.stripe;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
+import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
-import java.io.IOException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @RunWith(MockitoJUnitRunner.class)
-public class StripeCaptureHandlerTest extends BaseStripePaymentProviderTest {
+public class StripeCaptureHandlerTest {
 
-    protected StripeCaptureHandler stripeCaptureHandler;
+    private StripeCaptureHandler stripeCaptureHandler;
 
+    @Mock
+    private StripeGatewayConfig stripeGatewayConfig;
+    @Mock
+    private StripeGatewayClient stripeGatewayClient;
+    @Mock
+    private Response response;
+    
+    private CaptureGatewayRequest captureGatewayRequest;
+    
     @Before
     public void setup() {
-        super.setup();
-        stripeCaptureHandler = (StripeCaptureHandler) provider.getCaptureHandler();
+        when(stripeGatewayConfig.getUrl()).thenReturn("http://stripe.url");
+        stripeCaptureHandler = new StripeCaptureHandler(stripeGatewayClient, stripeGatewayConfig);
+
+        GatewayAccountEntity gatewayAccount = buildGatewayAccountEntity();
+        
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withTransactionId("ch_1231231123123")
+                .build();
+        
+        captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
     }
 
     @Test
-    public void shouldCapture() throws IOException {
-        mockPaymentProviderCaptureResponse(200, successCaptureResponse());
+    public void shouldCapture() throws Exception {
+        Map<String, Object> responsePayloadMap = new ObjectMapper().readValue(load(STRIPE_CAPTURE_SUCCESS_RESPONSE), HashMap.class);
+        when(response.readEntity(Map.class)).thenReturn(responsePayloadMap);
 
-        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+        when(stripeGatewayClient.postRequest(any(URI.class), anyString(), any(Map.class), any(MediaType.class), anyString())).thenReturn(response);
+
+        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(captureGatewayRequest);
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("ch_123456"));
     }
 
     @Test
-    public void shouldNotCaptureIfPaymentProviderReturns4xxHttpStatusCode() throws IOException {
-        mockPaymentProviderErrorResponse(400, errorCaptureResponse());
-        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+    public void shouldNotCaptureIfPaymentProviderReturns4xxHttpStatusCode() throws Exception {
+        StripeErrorResponse stripeErrorResponse = new ObjectMapper().readValue(load(STRIPE_ERROR_RESPONSE), StripeErrorResponse.class);
+        when(response.readEntity(StripeErrorResponse.class)).thenReturn(stripeErrorResponse);
+
+        GatewayClientException gatewayClientException = new GatewayClientException("Unexpected HTTP status code 402 from gateway", response);
+        when(stripeGatewayClient.postRequest(any(URI.class), anyString(), any(Map.class), any(MediaType.class), anyString())).thenThrow(gatewayClientException);
+        
+        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(captureGatewayRequest);
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("No such charge: ch_123456 or something similar",
-                GENERIC_GATEWAY_ERROR));
+        assertThat(response.getGatewayError().get().getMessage(), is("No such charge: ch_123456 or something similar"));
+        assertThat(response.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
     }
 
     @Test
-    public void shouldNotCaptureIfPaymentProviderReturns5xxHttpStatusCode() throws IOException {
-        mockPaymentProviderErrorResponse(500, stripeInternalServerError());
-        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(buildTestCaptureRequest());
+    public void shouldNotCaptureIfPaymentProviderReturns5xxHttpStatusCode() throws Exception {
+        DownstreamException downstreamException = new DownstreamException(HttpStatus.INTERNAL_SERVER_ERROR_500, "Problem with Stripe servers");
+        when(stripeGatewayClient.postRequest(any(URI.class), anyString(), any(Map.class), any(MediaType.class), anyString())).thenThrow(downstreamException);
+
+        GatewayResponse<BaseCaptureResponse> response = stripeCaptureHandler.capture(captureGatewayRequest);
         assertThat(response.isFailed(), is(true));
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertThat(response.getGatewayError().get().getMessage(), containsString("An internal server error occurred. ErrorId:"));
         assertThat(response.getGatewayError().get().getErrorType(), is(UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
+    private GatewayAccountEntity buildGatewayAccountEntity() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("stripe");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -1,63 +1,109 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import com.google.common.collect.ImmutableMap;
+import fj.data.Either;
+import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import javax.ws.rs.core.Response;
+
+import static fj.data.Either.left;
+import static fj.data.Either.right;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
+import static uk.gov.pay.connector.gateway.model.GatewayError.unexpectedStatusCodeFromGateway;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 
 @RunWith(MockitoJUnitRunner.class)
-public class WorldpayCaptureHandlerTest extends WorldpayBasePaymentProviderTest {
+public class WorldpayCaptureHandlerTest {
 
     private WorldpayCaptureHandler worldpayCaptureHandler;
 
+    @Mock
+    private GatewayClient client;
+    @Mock
+    private Response response;
+
     @Before
     public void setup() {
-        super.setup();
-        worldpayCaptureHandler = (WorldpayCaptureHandler) provider.getCaptureHandler();
+        worldpayCaptureHandler = new WorldpayCaptureHandler(client);
     }
 
     @Test
     public void shouldCaptureAPaymentSuccessfully() throws Exception {
-        mockWorldpaySuccessfulCaptureResponse();
+        //mock client.postRequestFor
+        when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
+        Either<GatewayError, GatewayClient.Response> response = right(new TestResponse(this.response));
+        when(client.postRequestFor(isNull(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(response);
 
-        GatewayResponse response = worldpayCaptureHandler.capture(getCaptureRequest());
-        assertTrue(response.isSuccessful());
+        //mock client.unmarshallResponse
+        Either<GatewayError, WorldpayCaptureResponse> unmarshalledResponse = right(XMLUnmarshaller.unmarshall(successCaptureResponse(), WorldpayCaptureResponse.class));
+        when(client.unmarshallResponse(any(TestResponse.class), any(Class.class))).thenReturn(unmarshalledResponse);
+
+        GatewayResponse gatewayResponse = worldpayCaptureHandler.capture(getCaptureRequest());
+        assertTrue(gatewayResponse.isSuccessful());
+    }
+
+    private class TestResponse extends GatewayClient.Response {
+
+        protected TestResponse(Response delegate) {
+            super(delegate);
+        }
     }
 
     @Test
-    public void shouldErrorIfOrderReferenceNotKnownInCapture() {
-        mockWorldpayErrorResponse(200);
-        GatewayResponse<BaseCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
+    public void shouldErrorIfOrderReferenceNotKnownInCapture() throws Exception {
+        //mock client.postRequestFor
+        when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
+        Either<GatewayError, GatewayClient.Response> response = right(new TestResponse(this.response));
+        when(client.postRequestFor(isNull(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(response);
 
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Worldpay capture response (error code: 5, error: Order has already been paid)", GENERIC_GATEWAY_ERROR));
+        //mock client.unmarshallResponse
+        Either<GatewayError, WorldpayCaptureResponse> unmarshalledResponse = right(XMLUnmarshaller.unmarshall(errorResponse(), WorldpayCaptureResponse.class));
+        when(client.unmarshallResponse(any(TestResponse.class), any(Class.class))).thenReturn(unmarshalledResponse);
+
+        GatewayResponse<BaseCaptureResponse> gatewayResponse = worldpayCaptureHandler.capture(getCaptureRequest());
+
+        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is("Worldpay capture response (error code: 5, error: Order has already been paid)"));
+        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
     }
 
     @Test
     public void shouldErrorIfWorldpayResponseIsNot200() {
-        mockWorldpayErrorResponse(400);
-        GatewayResponse<BaseCaptureResponse> response = worldpayCaptureHandler.capture(getCaptureRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
-                UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
-    }
-
-    private void mockWorldpaySuccessfulCaptureResponse() {
-        mockWorldpayResponse(200, successCaptureResponse());
+        //mock client.postRequestFor
+        Either<GatewayError, GatewayClient.Response> response = left(unexpectedStatusCodeFromGateway("Unexpected HTTP status code 400 from gateway"));
+        when(client.postRequestFor(isNull(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(response);
+        
+        GatewayResponse<BaseCaptureResponse> gatewayResponse = worldpayCaptureHandler.capture(getCaptureRequest());
+        assertThat(gatewayResponse.isFailed(), is(true));
+        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is("Unexpected HTTP status code 400 from gateway"));
+        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 
     private CaptureGatewayRequest getCaptureRequest() {
@@ -82,5 +128,31 @@ public class WorldpayCaptureHandlerTest extends WorldpayBasePaymentProviderTest 
                 "</paymentService>";
     }
 
+    private String errorResponse() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
+                "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
+                "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
+                "    <reply>\n" +
+                "        <error code=\"5\">\n" +
+                "            <![CDATA[Order has already been paid]]>\n" +
+                "        </error>\n" +
+                "    </reply>\n" +
+                "</paymentService>";
+    }
+
+    private GatewayAccountEntity aServiceAccount() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("worldpay");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(ImmutableMap.of(
+                CREDENTIALS_MERCHANT_ID, "worlpay-merchant",
+                CREDENTIALS_USERNAME, "worldpay-password",
+                CREDENTIALS_PASSWORD, "password"
+        ));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
+    }
 }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -19,15 +19,11 @@ import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.PaymentProvider;
-import uk.gov.pay.connector.gateway.epdq.EpdqCaptureHandler;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
 import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
@@ -196,7 +192,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldCaptureSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        EpdqCaptureHandler epdqCaptureHandler = getCaptureHandler(paymentProvider);
+        
         CardAuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -204,12 +200,8 @@ public class EpdqPaymentProviderTest {
         String transactionId = response.getBaseResponse().get().getTransactionId();
         assertThat(transactionId, is(not(nullValue())));
         CaptureGatewayRequest captureRequest = buildCaptureRequest(chargeEntity, transactionId);
-        GatewayResponse<BaseCaptureResponse> captureResponse = epdqCaptureHandler.capture(captureRequest);
+        GatewayResponse<BaseCaptureResponse> captureResponse = paymentProvider.capture(captureRequest);
         assertThat(captureResponse.isSuccessful(), is(true));
-    }
-
-    private EpdqCaptureHandler getCaptureHandler(PaymentProvider paymentProvider) {
-        return (EpdqCaptureHandler) paymentProvider.getCaptureHandler();
     }
 
     @Test
@@ -229,7 +221,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldRefundSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        EpdqCaptureHandler epdqCaptureHandler = getCaptureHandler(paymentProvider);
+        
         CardAuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -237,7 +229,7 @@ public class EpdqPaymentProviderTest {
         String transactionId = response.getBaseResponse().get().getTransactionId();
         assertThat(transactionId, is(not(nullValue())));
         CaptureGatewayRequest captureRequest = buildCaptureRequest(chargeEntity, transactionId);
-        GatewayResponse<BaseCaptureResponse> captureResponse = epdqCaptureHandler.capture(captureRequest);
+        GatewayResponse captureResponse = paymentProvider.capture(captureRequest);
         assertThat(captureResponse.isSuccessful(), is(true));
 
         RefundGatewayRequest refundGatewayRequest = buildRefundRequest(chargeEntity, (chargeEntity.getAmount() - 100));

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -20,14 +20,13 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayAuthorisationResponse;
-import uk.gov.pay.connector.gateway.smartpay.SmartpayCaptureHandler;
+import uk.gov.pay.connector.gateway.smartpay.SmartpayCaptureResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -180,7 +179,6 @@ public class SmartpayPaymentProviderTest {
     @Test
     public void shouldSuccessfullySendACaptureRequest() {
         PaymentProvider paymentProvider = getSmartpayPaymentProvider();
-        SmartpayCaptureHandler smartpayCaptureHandler = (SmartpayCaptureHandler) paymentProvider.getCaptureHandler();
 
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
         GatewayResponse<SmartpayAuthorisationResponse> response = paymentProvider.authorise(request);
@@ -192,7 +190,7 @@ public class SmartpayPaymentProviderTest {
 
         chargeEntity.setGatewayTransactionId(transactionId);
 
-        GatewayResponse<BaseCaptureResponse> captureGatewayResponse = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse<SmartpayCaptureResponse> captureGatewayResponse = paymentProvider.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(captureGatewayResponse.isSuccessful());
     }
 
@@ -218,13 +216,12 @@ public class SmartpayPaymentProviderTest {
     public void shouldRefundToAnExistingPaymentSuccessfully() {
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(chargeEntity);
         PaymentProvider smartpay = getSmartpayPaymentProvider();
-        SmartpayCaptureHandler smartpayCaptureHandler = (SmartpayCaptureHandler) smartpay.getCaptureHandler();
         GatewayResponse<SmartpayAuthorisationResponse> authoriseResponse = smartpay.authorise(request);
         assertTrue(authoriseResponse.isSuccessful());
 
         chargeEntity.setGatewayTransactionId(authoriseResponse.getBaseResponse().get().getPspReference());
 
-        GatewayResponse<BaseCaptureResponse> captureGatewayResponse = smartpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse<SmartpayCaptureResponse> captureGatewayResponse = smartpay.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(captureGatewayResponse.isSuccessful());
 
         RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -17,18 +17,14 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayCaptureHandler;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -186,10 +182,9 @@ public class WorldpayPaymentProviderTest {
      * It simply accepts anything as long as the request is well formed. (And ignores it silently)
      */
     @Test
-    public void shouldBeAbleToSendCaptureRequestForMerchant() throws Exception {
+    public void shouldBeAbleToSendCaptureRequestForMerchant() {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
-        WorldpayCaptureHandler worldpayCaptureHandler = (WorldpayCaptureHandler) paymentProvider.getCaptureHandler();
-        GatewayResponse response = worldpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse response = paymentProvider.capture(CaptureGatewayRequest.valueOf(chargeEntity));
 
         assertTrue(response.isSuccessful());
         assertTrue(response.getSessionIdentifier().isPresent());
@@ -198,7 +193,6 @@ public class WorldpayPaymentProviderTest {
     @Test
     public void shouldBeAbleToSubmitAPartialRefundAfterACaptureHasBeenSubmitted() throws InterruptedException {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
-        WorldpayCaptureHandler worldpayCaptureHandler = (WorldpayCaptureHandler) paymentProvider.getCaptureHandler();
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
@@ -210,7 +204,7 @@ public class WorldpayPaymentProviderTest {
         assertThat(transactionId, is(not(nullValue())));
 
         chargeEntity.setGatewayTransactionId(transactionId);
-        GatewayResponse<BaseCaptureResponse> captureResponse = worldpayCaptureHandler.capture(CaptureGatewayRequest.valueOf(chargeEntity));
+        GatewayResponse captureResponse = paymentProvider.capture(CaptureGatewayRequest.valueOf(chargeEntity));
 
         assertThat(captureResponse.isSuccessful(), is(true));
 

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -53,7 +53,7 @@ public class StripeMockClient {
 
     public void mockCaptureError(String gatewayTransactionId) {
         String payload = TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
-        setupResponse(payload, "/v1/charges/" + gatewayTransactionId + "/capture", 401);
+        setupResponse(payload, "/v1/charges/" + gatewayTransactionId + "/capture", 402);
     }
 
     public void mockUnauthorizedResponse() {


### PR DESCRIPTION
Given the PaymentProvider interface has methods with verbs like 'authorise',
'cancel', 'refund', it seemed weird to have a 'getCaptureHandler'. This PR
reverts it back to the original 'capture'.

@oswaldquek

