### PR TITLE
PP-4374 Introduced EpdqNotificationService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
@@ -1,0 +1,182 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.apache.http.NameValuePair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.service.StatusFlow.EXPIRE_FLOW;
+import static uk.gov.pay.connector.charge.service.StatusFlow.SYSTEM_CANCELLATION_FLOW;
+import static uk.gov.pay.connector.charge.service.StatusFlow.USER_CANCELLATION_FLOW;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.SHASIGN_KEY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_ERROR;
+
+public class EpdqNotificationService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final ChargeDao chargeDao;
+    private final SignatureGenerator signatureGenerator;
+    private final ChargeNotificationProcessor chargeNotificationProcessor;
+    private final RefundNotificationProcessor refundNotificationProcessor;
+
+    private static final String PAYMENT_GATEWAY_NAME = PaymentGatewayName.EPDQ.getName();
+
+    @Inject
+    public EpdqNotificationService(ChargeDao chargeDao,
+                                   SignatureGenerator signatureGenerator,
+                                   ChargeNotificationProcessor chargeNotificationProcessor,
+                                   RefundNotificationProcessor refundNotificationProcessor) {
+        this.chargeDao = chargeDao;
+        this.signatureGenerator = signatureGenerator;
+        this.chargeNotificationProcessor = chargeNotificationProcessor;
+        this.refundNotificationProcessor = refundNotificationProcessor;
+    }
+
+    @Transactional
+    public void handleNotificationFor(String payload) {
+        logger.info("Parsing {} notification", PAYMENT_GATEWAY_NAME);
+
+        EpdqNotification notification;
+        try {
+            notification = new EpdqNotification(payload);
+            logger.info("Parsed {} notification: {}", PAYMENT_GATEWAY_NAME, notification);
+        } catch (EpdqParseException e) {
+            logger.error("{} notification parsing failed: {}", PAYMENT_GATEWAY_NAME, e);
+            return;
+        }
+
+        logger.info("Verifying {} notification {}", PAYMENT_GATEWAY_NAME, notification);
+
+        if (isBlank(notification.getTransactionId())) {
+            logger.error("{} notification {} failed verification because it has no transaction ID", PAYMENT_GATEWAY_NAME, notification);
+            return;
+        }
+
+        Optional<ChargeEntity> maybeCharge = chargeDao.findByProviderAndTransactionId(PAYMENT_GATEWAY_NAME, notification.getTransactionId());
+
+        if (!maybeCharge.isPresent()) {
+            logger.error("{} notification {} could not be verified (associated charge entity not found)",
+                    PAYMENT_GATEWAY_NAME, notification);
+            return;
+        }
+
+        ChargeEntity charge = maybeCharge.get();
+        if (!isValidNotificationSignature(notification, charge)) {
+            return;
+        }
+
+        logger.info("Evaluating {} notification {}", PAYMENT_GATEWAY_NAME, notification);
+
+        final Optional<ChargeStatus> newChargeStatus = newChargeStateForChargeNotification(notification.getStatus(), ChargeStatus.fromString(charge.getStatus()));
+        final Optional<RefundStatus> newRefundStatus = newRefundStateForRefundNotification(notification.getStatus());
+
+        if (newChargeStatus.isPresent()) {
+            chargeNotificationProcessor.invoke(notification.getTransactionId(), charge, newChargeStatus.get(), null);
+        } else if (newRefundStatus.isPresent()) {
+            refundNotificationProcessor.invoke(
+                    PaymentGatewayName.EPDQ, newRefundStatus.get(), notification.getReference(), notification.getTransactionId()
+            );
+        }
+    }
+
+    private boolean isValidNotificationSignature(EpdqNotification notification, ChargeEntity charge) {
+        String actualSignature = signatureGenerator.sign(
+                getParams(notification, false),
+                getShaOutPassphrase(charge)
+        );
+
+        final String expectedShaSignature = getExpectedShaSignature(notification);
+        final boolean verified = actualSignature.equalsIgnoreCase(expectedShaSignature);
+        if (!verified) {
+            logger.error("{} notification {} failed verification. Actual signature [{}] expected [{}]",
+                    PAYMENT_GATEWAY_NAME, notification, actualSignature, expectedShaSignature);
+        }
+        return verified;
+    }
+
+    private String getExpectedShaSignature(EpdqNotification notification) {
+        try {
+            return getParams(notification, true).get(0).getValue();
+        } catch (IndexOutOfBoundsException e) {
+            return "";
+        }
+    }
+
+    private List<NameValuePair> getParams(EpdqNotification notification, boolean withShaSignature) {
+        return notification.getParams()
+                .stream()
+                .collect(Collectors.partitioningBy(p -> p.getName().equalsIgnoreCase(SHASIGN_KEY)))
+                .get(withShaSignature);
+    }
+
+    private String getShaOutPassphrase(ChargeEntity charge) {
+        return charge.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE);
+    }
+
+    private static Optional<ChargeStatus> newChargeStateForChargeNotification(String notificationStatus, ChargeStatus chargeStatus) {
+        final EpdqNotification.StatusCode statusCode = EpdqNotification.StatusCode.byCode(notificationStatus);
+
+        switch (statusCode) {
+            case EPDQ_AUTHORISATION_REFUSED:
+                return Optional.of(AUTHORISATION_REJECTED);
+            case EPDQ_AUTHORISED:
+                return Optional.of(AUTHORISATION_SUCCESS);
+
+            case EPDQ_AUTHORISED_CANCELLED:
+                switch (chargeStatus) {
+                    case USER_CANCEL_SUBMITTED:
+                        return Optional.of(USER_CANCELLATION_FLOW.getSuccessTerminalState());
+
+                    case EXPIRE_CANCEL_SUBMITTED:
+                        return Optional.of(EXPIRE_FLOW.getSuccessTerminalState());
+
+                    case SYSTEM_CANCEL_SUBMITTED:
+                    case CREATED:
+                    case ENTERING_CARD_DETAILS:
+                        return Optional.of(SYSTEM_CANCELLATION_FLOW.getSuccessTerminalState());
+                    default:
+                        return Optional.empty();
+                }
+            case EPDQ_PAYMENT_REQUESTED:
+                return Optional.of(CAPTURED);
+            default:
+                return Optional.empty();
+        }
+    }
+
+    private static Optional<RefundStatus> newRefundStateForRefundNotification(String notificationStatus) {
+        final EpdqNotification.StatusCode statusCode = EpdqNotification.StatusCode.byCode(notificationStatus);
+
+        switch (statusCode) {
+            case EPDQ_REFUND:
+            case EPDQ_PAYMENT_DELETED:
+                return Optional.of(REFUNDED);
+
+            case EPDQ_REFUND_REFUSED:
+            case EPDQ_DELETION_REFUSED:
+            case EPDQ_REFUND_DECLINED_BY_ACQUIRER:
+                return Optional.of(REFUND_ERROR);
+            default:
+                return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqParseException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqParseException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+public class EpdqParseException extends Exception {
+    public EpdqParseException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqNotificationServiceTest.java
@@ -1,0 +1,76 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Before;
+import org.mockito.Mock;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
+
+public abstract class BaseEpdqNotificationServiceTest {
+    EpdqNotificationService notificationService;
+
+    @Mock
+    protected ChargeDao mockChargeDao;
+    @Mock
+    protected ChargeNotificationProcessor mockChargeNotificationProcessor;
+    @Mock
+    protected RefundNotificationProcessor mockRefundNotificationProcessor;
+    @Mock
+    protected ChargeEntity mockCharge;
+    @Mock
+    protected GatewayAccountEntity mockGatewayAccountEntity;
+
+    protected final String payId = "transaction-reference";
+    final String payIdSub = "pay-id-sub";
+    private final String shaPhraseOut = "sha-phrase-out";
+
+    @Before
+    public void setup() {
+        notificationService = new EpdqNotificationService(
+                mockChargeDao,
+                new EpdqSha512SignatureGenerator(),
+                mockChargeNotificationProcessor,
+                mockRefundNotificationProcessor
+        );
+        when(mockCharge.getStatus()).thenReturn(CAPTURE_APPROVED.getValue());
+        when(mockCharge.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
+        when(mockGatewayAccountEntity.getCredentials()).thenReturn(ImmutableMap.of(CREDENTIALS_SHA_OUT_PASSPHRASE, shaPhraseOut));
+
+        when(mockChargeDao.findByProviderAndTransactionId(EPDQ.getName(), payId)).thenReturn(Optional.of(mockCharge));
+    }
+
+    protected String notificationPayloadForTransaction(String payId, EpdqNotification.StatusCode statusCode) {
+        List<NameValuePair> payloadParameters = buildPayload(payId, statusCode.getCode());
+        return notificationPayloadForTransaction(payloadParameters);
+    }
+
+    private List<NameValuePair> buildPayload(String payId, String status) {
+        return Lists.newArrayList(
+                new BasicNameValuePair("STATUS", status),
+                new BasicNameValuePair("PAYID", payId),
+                new BasicNameValuePair("PAYIDSUB", "pay-id-sub"));
+    }
+
+    protected String notificationPayloadForTransaction(List<NameValuePair> payloadParameters) {
+        String signature = new EpdqSha512SignatureGenerator().sign(payloadParameters, shaPhraseOut);
+
+        payloadParameters.add(new BasicNameValuePair("SHASIGN", signature));
+        return URLEncodedUtils.format(payloadParameters, StandardCharsets.UTF_8.toString());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -1,0 +1,166 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.charge.service.StatusFlow.EXPIRE_FLOW;
+import static uk.gov.pay.connector.charge.service.StatusFlow.SYSTEM_CANCELLATION_FLOW;
+import static uk.gov.pay.connector.charge.service.StatusFlow.USER_CANCELLATION_FLOW;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_AUTHORISATION_REFUSED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_AUTHORISED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_AUTHORISED_CANCELLED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_DELETION_REFUSED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_PAYMENT_DELETED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_PAYMENT_REQUESTED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_REFUND;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_REFUND_DECLINED_BY_ACQUIRER;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_REFUND_REFUSED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.UNKNOWN;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_ERROR;
+
+public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTest {
+
+    @Before
+    public void setup() {
+        super.setup();
+    }
+
+    @Test
+    public void shouldUpdateChargeToAuthorisationRejected_IfEpdqStatusIs2() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISATION_REFUSED);
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor).invoke(payId, mockCharge, AUTHORISATION_REJECTED, null);
+    }
+
+    @Test
+    public void shouldUpdateChargeToAuthorisationSuccess_IfEpdqStatusIs5() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED);
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor).invoke(payId, mockCharge, AUTHORISATION_SUCCESS, null);
+    }
+
+    @Test
+    public void shouldUpdateChargeToCaptured_IfEpdqStatusIs9() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_PAYMENT_REQUESTED);
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor).invoke(payId, mockCharge, CAPTURED, null);
+    }
+
+    @Test
+    public void shouldUpdateChargeToSystemCancel_IfEpdqStatusIs6WithRelevantChargeStatus() {
+
+        List<ChargeStatus> ChargeStatuses = ImmutableList.of(SYSTEM_CANCEL_SUBMITTED, CREATED, ENTERING_CARD_DETAILS);
+
+        for (ChargeStatus chargeStatus : ChargeStatuses) {
+            when(mockCharge.getStatus()).thenReturn(chargeStatus.getValue());
+            final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
+            notificationService.handleNotificationFor(payload);
+        }
+        verify(mockChargeNotificationProcessor, times(3)).invoke(payId, mockCharge, SYSTEM_CANCELLATION_FLOW.getSuccessTerminalState(), null);
+    }
+
+    @Test
+    public void shouldUpdateChargeToUserCancel_IfEpdqStatusIs6WithRelevantChargeStatus() {
+        when(mockCharge.getStatus()).thenReturn(USER_CANCEL_SUBMITTED.getValue());
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockChargeNotificationProcessor).invoke(payId, mockCharge, USER_CANCELLATION_FLOW.getSuccessTerminalState(), null);
+    }
+
+    @Test
+    public void shouldUpdateChargeToExpire_IfEpdqStatusIs6WithRelevantChargeStatus() {
+        when(mockCharge.getStatus()).thenReturn(EXPIRE_CANCEL_SUBMITTED.getValue());
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockChargeNotificationProcessor).invoke(payId, mockCharge, EXPIRE_FLOW.getSuccessTerminalState(), null);
+    }
+
+    @Test
+    public void shouldUpdateChargeToSystemCancel_IfEpdqStatusIs6AndChargeStatusIsNotRelevant() {
+        when(mockCharge.getStatus()).thenReturn(CAPTURED.getValue());
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotUpdateCharge_IfEpdqStatusIsUnknown() {
+        final String payload = notificationPayloadForTransaction(payId, UNKNOWN);
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldRefund_IfEpdqStatusIs7() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_PAYMENT_DELETED);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockRefundNotificationProcessor).invoke(PaymentGatewayName.EPDQ, REFUNDED, payId + "/" + payIdSub, payId);
+    }
+
+    @Test
+    public void shouldRefund_IfEpdqStatusIs8() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_REFUND);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockRefundNotificationProcessor).invoke(PaymentGatewayName.EPDQ, REFUNDED, payId + "/" + payIdSub, payId);
+    }
+
+    @Test
+    public void shouldBeARefundError_IfEpdqStatusIs83() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_REFUND_REFUSED);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockRefundNotificationProcessor).invoke(PaymentGatewayName.EPDQ, REFUND_ERROR, payId + "/" + payIdSub, payId);
+    }
+
+    @Test
+    public void shouldBeARefundError_IfEpdqStatusIs73() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_DELETION_REFUSED);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockRefundNotificationProcessor).invoke(PaymentGatewayName.EPDQ, REFUND_ERROR, payId + "/" + payIdSub, payId);
+    }
+
+    @Test
+    public void shouldBeARefundError_IfEpdqStatusIs94() {
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_REFUND_DECLINED_BY_ACQUIRER);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockRefundNotificationProcessor).invoke(PaymentGatewayName.EPDQ, REFUND_ERROR, payId + "/" + payIdSub, payId);
+    }
+
+    @Test
+    public void shouldNotProcessRefund_IfEpdqStatusIsUnknown() {
+        final String payload = notificationPayloadForTransaction(payId, UNKNOWN);
+
+        notificationService.handleNotificationFor(payload);
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
@@ -1,0 +1,131 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_PAYMENT_REQUESTED;
+import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_REFUND;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest{
+   
+    @Before
+    public void setup() {
+        super.setup();
+    }
+
+    @Test
+    public void givenAChargeCapturedNotification_chargeNotificationProcessorInvokedWithNotificationAndCharge() {
+
+        final String payload = notificationPayloadForTransaction(
+                payId,
+                EPDQ_PAYMENT_REQUESTED);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockChargeNotificationProcessor).invoke(payId, mockCharge, CAPTURED, null);
+    }
+
+    @Test
+    public void givenARefundNotification_refundNotificationProcessorInvokedWithNotificationAndCharge() {
+
+        final String payload = notificationPayloadForTransaction(
+                payId,
+                EPDQ_REFUND);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor).invoke(EPDQ, RefundStatus.REFUNDED, payId + "/" + payIdSub, payId);
+    }
+
+    @Test
+    public void ifChargeNotFound_shouldNotInvokeChargeOrRefundNotificationProcessor() {
+        final String payload = notificationPayloadForTransaction(
+                payId,
+                EPDQ_REFUND);
+
+
+        when(mockChargeDao.findByProviderAndTransactionId(EPDQ.getName(), payId)).thenReturn(Optional.empty());
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void ifTransactionIdEmpty_shouldNotInvokeChargeOrRefundNotificationProcessor() {
+        final String payload = notificationPayloadForTransaction(
+                null,
+                EPDQ_REFUND);
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(anyString(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void ifPayloadNotValidXml_shouldIgnoreNotification() {
+        String payload = "not_valid";
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldIgnoreNotificationWhenStatusIsUnknown() {
+        final String payload = notificationPayloadForTransaction(
+                payId,
+                EpdqNotification.StatusCode.UNKNOWN);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(anyString(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotUpdateIfShaPhraseExpectedIsIncorrect() {
+
+        when(mockGatewayAccountEntity.getCredentials())
+                .thenReturn(ImmutableMap.of(CREDENTIALS_SHA_OUT_PASSPHRASE, "sha-phrase-out-expected"));
+
+        final String payload = notificationPayloadForTransaction(payId, EPDQ_PAYMENT_REQUESTED);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(anyString(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationTest.java
@@ -13,14 +13,14 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_NOTIFICA
 
 public class EpdqNotificationTest {
 
-    private static final String CARDHOLDER_NAME = "mr payment"; 
+    private static final String CARDHOLDER_NAME = "mr payment";
     private static final String STATUS = "9";
     private static final String PAY_ID = "3020450409";
     private static final String PAY_ID_SUB = "2";
     private static final String SHA_SIGN = "9537B9639F108CDF004459D8A690C598D97506CDF072C3926A60E39759A6402C5089161F6D7A8EA12BBC0FD6F899CE72D5A0C4ACC2913C56ACF6D01B034EEC32";
 
     @Test
-    public void shouldParsePayload() {
+    public void shouldParsePayload() throws EpdqParseException {
         String payload = notificationPayloadForTransaction(CARDHOLDER_NAME, STATUS, PAY_ID, PAY_ID_SUB, SHA_SIGN);
 
         EpdqNotification epdqNotification = new EpdqNotification(payload);
@@ -32,7 +32,7 @@ public class EpdqNotificationTest {
     }
 
     @Test
-    public void shouldHaveReferenceIfPayIdAndPaySubId() {
+    public void shouldHaveReferenceIfPayIdAndPaySubId() throws EpdqParseException {
         String payload = notificationPayloadForTransaction(CARDHOLDER_NAME, STATUS, PAY_ID, PAY_ID_SUB, SHA_SIGN);
 
         EpdqNotification epdqNotification = new EpdqNotification(payload);
@@ -41,7 +41,7 @@ public class EpdqNotificationTest {
     }
 
     @Test
-    public void shouldHaveNoReferenceIfNoPayId() {
+    public void shouldHaveNoReferenceIfNoPayId() throws EpdqParseException {
         String payload = notificationPayloadForTransaction(CARDHOLDER_NAME, STATUS, "", PAY_ID_SUB, SHA_SIGN);
 
         EpdqNotification epdqNotification = new EpdqNotification(payload);
@@ -50,7 +50,7 @@ public class EpdqNotificationTest {
     }
 
     @Test
-    public void shouldHaveNoReferenceIfNoPayIdSub() {
+    public void shouldHaveNoReferenceIfNoPayIdSub() throws EpdqParseException {
         String payload = notificationPayloadForTransaction(CARDHOLDER_NAME, STATUS, PAY_ID, "", SHA_SIGN);
 
         EpdqNotification epdqNotification = new EpdqNotification(payload);
@@ -58,13 +58,13 @@ public class EpdqNotificationTest {
         assertThat(epdqNotification.getReference(), is(""));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void shouldFailToParseMalformedPayload() {
+    @Test(expected = EpdqParseException.class)
+    public void shouldFailToParseMalformedPayload() throws EpdqParseException {
         new EpdqNotification("malformed");
     }
 
     @Test
-    public void shouldReturnParams() {
+    public void shouldReturnParams() throws EpdqParseException {
         String payload = notificationPayloadForTransaction(CARDHOLDER_NAME, STATUS, PAY_ID, PAY_ID_SUB, SHA_SIGN);
 
         EpdqNotification epdqNotification = new EpdqNotification(payload);
@@ -90,7 +90,7 @@ public class EpdqNotificationTest {
     }
 
     @Test
-    public void shouldDecodeNotificationsAccordingToTheRightEpdqCharset() {
+    public void shouldDecodeNotificationsAccordingToTheRightEpdqCharset() throws EpdqParseException {
         String cardHolderName = "Mr O%92Payment"; // %92 is encoded value for ’ (right single quotation mark)
         String payload = notificationPayloadForTransaction(cardHolderName, STATUS, PAY_ID, PAY_ID_SUB, SHA_SIGN);
 
@@ -99,9 +99,8 @@ public class EpdqNotificationTest {
         assertThat(epdqNotification.getParams(), hasItem(
                 new BasicNameValuePair("CN", "Mr O’Payment")));
     }
-    
-    private String notificationPayloadForTransaction(String cardHolderName, String status, String payId, String payIdSub, String shaSign)
-    {
+
+    private String notificationPayloadForTransaction(String cardHolderName, String status, String payId, String payIdSub, String shaSign) {
         return TestTemplateResourceLoader.load(EPDQ_NOTIFICATION_TEMPLATE)
                 .replace("{{cardHolderName}}", cardHolderName)
                 .replace("{{status}}", status)
@@ -109,5 +108,4 @@ public class EpdqNotificationTest {
                 .replace("{{payIdSub}}", payIdSub)
                 .replace("{{shaSign}}", shaSign);
     }
-
 }


### PR DESCRIPTION
## WHAT

Part of refactoring notification handling (see https://github.com/alphagov/pay-connector/pull/787 for the original full attempt...). Introducing gateway specific service objects to handle notifications instead of generalised notification handler (`NotificationService`). We don't need a generalised `NotificationService` as each gateway notification has dedicated notification resource endpoint. Having separate service object will make it easier to understand and follow through the path.  

- Added `EpdqNotificationService` to delegate EPDQ notification processing to service instead of a generic handler.
- NotificationResource for EPDQ notifications now uses `EpdqNotificationService`

Note that any existing code that handles EPDQ notifications still stays and will be removed in subsequent PRs

## HOW 
- Existing tests in `EpdqNotificationResourceITest` should continue to pass
- All tests in `EpdqNotificationServiceTest`, `EpdqNotificationServiceStatusMapperTest` should pass
