### PR TITLE
PP-4314 Add ApplePayService to authorise an apple pay charge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.connector.applepay;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import io.dropwizard.setup.Environment;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.model.OperationType;
+import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
+import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+public class AppleAuthoriseService extends CardAuthoriseBaseService<AppleDecryptedPaymentData> {
+    private static final DateTimeFormatter EXPIRY_DATE_FORMAT = DateTimeFormatter.ofPattern("MM/yy");
+
+    @Inject
+    AppleAuthoriseService(PaymentProviders paymentProviders, CardExecutorService cardExecutorService, ChargeService chargeService, Environment environment) {
+        super(paymentProviders, cardExecutorService, chargeService, environment);
+    }
+
+    @Override
+    @Transactional
+    public ChargeEntity prepareChargeForAuthorisation(String chargeId, AppleDecryptedPaymentData applePaymentData) {
+        ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
+        providers.byName(charge.getPaymentGatewayName())
+                .generateTransactionId()
+                .ifPresent(charge::setGatewayTransactionId);
+        return charge;
+    }
+
+    @Override
+    @Transactional
+    public void processGatewayAuthorisationResponse(
+            String chargeExternalId,
+            ChargeStatus oldChargeStatus,
+            AppleDecryptedPaymentData applePaymentData,
+            GatewayResponse<BaseAuthoriseResponse> operationResponse) {
+
+        logger.info("Processing gateway auth response for apple pay");
+        Optional<String> transactionId = extractTransactionId(chargeExternalId, operationResponse);
+        ChargeStatus status = extractChargeStatus(operationResponse.getBaseResponse(), operationResponse.getGatewayError());
+
+        AuthCardDetails authCardDetailsToBePersisted = new AuthCardDetails();
+        authCardDetailsToBePersisted.setCardHolder(applePaymentData.getPaymentInfo().getCardholderName());
+        authCardDetailsToBePersisted.setCardNo(applePaymentData.getPaymentInfo().getLastDigitsCardNumber());
+        authCardDetailsToBePersisted.setPayersCardType(applePaymentData.getPaymentInfo().getCardType());
+        authCardDetailsToBePersisted.setCardBrand(applePaymentData.getPaymentInfo().getBrand());
+        authCardDetailsToBePersisted.setEndDate(applePaymentData.getApplicationExpirationDate().format(EXPIRY_DATE_FORMAT));
+        authCardDetailsToBePersisted.setCorporateCard(false);
+        ChargeEntity updatedCharge = chargeService.updateChargePostAuthorisation(
+                chargeExternalId,
+                status,
+                transactionId,
+                Optional.empty(),
+                operationResponse.getSessionIdentifier(),
+                authCardDetailsToBePersisted,
+                Optional.of(WalletType.APPLE_PAY));
+
+        logger.info("Authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
+                updatedCharge.getExternalId(), updatedCharge.getPaymentGatewayName().getName(),
+                transactionId.orElse("missing transaction ID"),
+                updatedCharge.getGatewayAccount().getAnalyticsId(), updatedCharge.getGatewayAccount().getId(),
+                operationResponse, oldChargeStatus, status);
+
+        metricRegistry.counter(String.format(
+                "gateway-operations.%s.%s.%s.authorise.result.%s",
+                updatedCharge.getGatewayAccount().getGatewayName(),
+                updatedCharge.getGatewayAccount().getType(),
+                updatedCharge.getGatewayAccount().getId(),
+                status.toString())).inc();
+    }
+
+    @Override
+    protected GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity chargeEntity, AppleDecryptedPaymentData applePaymentData) {
+        logger.info("Authorising charge for apple pay");
+        ApplePayAuthorisationGatewayRequest authorisationGatewayRequest = ApplePayAuthorisationGatewayRequest.valueOf(chargeEntity, applePaymentData);
+        return providers.byName(chargeEntity.getPaymentGatewayName())
+                .authoriseApplePay(authorisationGatewayRequest);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/applepay/ApplePayService.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/ApplePayService.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.applepay;
+
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.applepay.api.ApplePayToken;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.util.ResponseUtil;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
+import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
+
+public class ApplePayService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApplePayService.class);
+
+    private ApplePayDecrypter applePayDecrypter;
+    private AppleAuthoriseService authoriseService;
+
+    @Inject
+    public ApplePayService(ApplePayDecrypter applePayDecrypter, AppleAuthoriseService authoriseService) {
+        this.applePayDecrypter = applePayDecrypter;
+        this.authoriseService = authoriseService;
+    }
+
+    public Response authorise(String chargeId, ApplePayToken applePayToken) {
+        LOGGER.info("Decrypting apple pay payload for charge with id {} ", chargeId);
+
+        AppleDecryptedPaymentData data = applePayDecrypter.performDecryptOperation(applePayToken);
+        data.setPaymentInfo(applePayToken.getApplePaymentInfo());
+
+        LOGGER.info("Authorising apple pay charge with id {} ", chargeId);
+        GatewayResponse<BaseAuthoriseResponse> response = authoriseService.doAuthorise(chargeId, data);
+        return handleGatewayAuthoriseResponse(response);
+    }
+
+
+    //PP-4314 This is duplicated from the CardResource. This kind of handling shouldn't be there in the first place, so will refactor to be embedded in services rather than at resource level
+    private Response handleGatewayAuthoriseResponse(GatewayResponse<? extends BaseAuthoriseResponse> response) {
+        return response.getGatewayError()
+                .map(this::handleError)
+                .orElseGet(() -> response.getBaseResponse()
+                        .map(r -> ResponseUtil.successResponseWithEntity(ImmutableMap.of("status", r.authoriseStatus().getMappedChargeStatus().toString())))
+                        .orElseGet(() -> ResponseUtil.serviceErrorResponse("InterpretedStatus not found for Gateway response")));
+    }
+    private Response handleError(GatewayError error) {
+        switch (error.getErrorType()) {
+            case UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY:
+            case MALFORMED_RESPONSE_RECEIVED_FROM_GATEWAY:
+            case GATEWAY_URL_DNS_ERROR:
+            case GATEWAY_CONNECTION_TIMEOUT_ERROR:
+            case GATEWAY_CONNECTION_SOCKET_ERROR:
+                return serviceErrorResponse(error.getMessage());
+            default:
+                return badRequestResponse(error.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -238,15 +238,13 @@ public class ChargeService {
                                                       Optional<String> transactionId,
                                                       Optional<Auth3dsDetailsEntity> auth3dsDetails,
                                                       Optional<String> sessionIdentifier,
-                                                      AuthCardDetails authCardDetails,
-                                                      Optional<WalletType> walletType) {
+                                                      AuthCardDetails authCardDetails) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             charge.setStatus(status);
             
             setTransactionId(charge, transactionId);
             sessionIdentifier.ifPresent(charge::setProviderSessionId);
             auth3dsDetails.ifPresent(charge::set3dsDetails);
-            walletType.ifPresent(charge::setWalletType);
             CardDetailsEntity detailsEntity = buildCardDetailsEntity(authCardDetails);
             charge.setCardDetails(detailsEntity);
 
@@ -257,10 +255,19 @@ public class ChargeService {
 
             return charge;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
-
-
     }
 
+    public ChargeEntity updateChargePostApplePayAuthorisation(String chargeExternalId,
+                                                      ChargeStatus status,
+                                                      Optional<String> transactionId,
+                                                      Optional<Auth3dsDetailsEntity> auth3dsDetails,
+                                                      Optional<String> sessionIdentifier,
+                                                      AuthCardDetails authCardDetails) {
+        ChargeEntity charge = updateChargePostAuthorisation(chargeExternalId, status, transactionId, auth3dsDetails, sessionIdentifier, authCardDetails);
+        charge.setWalletType(WalletType.APPLE_PAY);
+        return charge;
+    }
+    
     public ChargeEntity updateChargePost3dsAuthorisation(String chargeExternalId, ChargeStatus status,
                                                          Optional<String> transactionId) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -143,7 +143,7 @@ public class EpdqPaymentProvider implements PaymentProvider<String> {
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
-        throw new UnsupportedOperationException("Apple Pay is not supported for EPDQ");
+        throw new UnsupportedOperationException("Apple Pay is not supported for ePDQ");
     }
     
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -1,13 +1,14 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toMap;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 
 public class SandboxCardNumbers {
 
@@ -17,27 +18,15 @@ public class SandboxCardNumbers {
     }
 
     public static boolean isRejectedCard(String cardNumber) {
-        return REJECTED_CARDS
-                .keySet()
-                .stream()
-                .anyMatch(rejectedCards -> rejectedCards.contains(cardNumber));
+        return REJECTED_CARDS.contains(cardNumber);
     }
 
     public static boolean isErrorCard(String cardNumber) {
-        return ERROR_CARDS
-                .keySet()
-                .stream()
-                .anyMatch(errorCards -> errorCards.contains(cardNumber));
+        return ERROR_CARDS.containsKey(cardNumber);
     }
 
     public static CardError cardErrorFor(String cardNumber) {
-        return ERROR_CARDS
-                .entrySet()
-                .stream()
-                .filter(errorCards -> errorCards.getKey().contains(cardNumber))
-                .findFirst()
-                .map(Map.Entry::getValue)
-                .orElse(null);
+        return ERROR_CARDS.get(cardNumber);
     }
 
     private static final List<String> GOOD_CARDS = ImmutableList.of(
@@ -64,15 +53,13 @@ public class SandboxCardNumbers {
     private static final String PROCESSING_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0119";
     private static final String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
 
-    private static final Map<List<String>, CardError> ERROR_CARDS = ImmutableMap.of(
-            ImmutableList.of(PROCESSING_ERROR_CARD_NUMBER,PROCESSING_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
-            new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
+    private static Map<String, CardError> ERROR_CARDS = Stream.of(
+            PROCESSING_ERROR_CARD_NUMBER,
+            PROCESSING_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
+            .collect(toMap(
+                    Function.identity(),
+                    cardNumber -> new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed.")));
 
-    private static final Map<List<String>, CardError> REJECTED_CARDS = ImmutableMap.of(
-            ImmutableList.of(DECLINED_CARD_NUMBER, DECLINED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
-            new CardError(AUTHORISATION_REJECTED, "This transaction was declined."),
-            ImmutableList.of(EXPIRED_CARD_NUMBER, EXPIRED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
-            new CardError(AUTHORISATION_REJECTED, "The card is expired."),
-            ImmutableList.of(CVC_ERROR_CARD_NUMBER, CVC_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER),
-            new CardError(AUTHORISATION_REJECTED, "The CVC code is incorrect."));
+    private static final List<String>REJECTED_CARDS = ImmutableList.of(DECLINED_CARD_NUMBER, DECLINED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER, EXPIRED_CARD_NUMBER, EXPIRED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER, CVC_ERROR_CARD_NUMBER,
+            CVC_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandler.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.connector.gateway.sandbox.applepay;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.applepay.ApplePayAuthorisationHandler;
 import uk.gov.pay.connector.gateway.model.GatewayError;
@@ -15,11 +13,8 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
 public class SandboxApplePayAuthorisationHandler implements ApplePayAuthorisationHandler {
-    private final static Logger LOGGER = LoggerFactory.getLogger(SandboxApplePayAuthorisationHandler.class);
-
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(ApplePayAuthorisationGatewayRequest request) {
-        LOGGER.info("sandbox apple pay auth");
         String lastDigitsCardNumber = request.getAppleDecryptedPaymentData().getPaymentInfo().getLastDigitsCardNumber();        
         GatewayResponse.GatewayResponseBuilder<BaseAuthoriseResponse> gatewayResponseBuilder = responseBuilder();
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -93,7 +93,8 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
                 transactionId,
                 extractAuth3dsDetails(operationResponse), 
                 operationResponse.getSessionIdentifier(),
-                authCardDetails);
+                authCardDetails,
+                Optional.empty());
         
         logger.info("Authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                 updatedCharge.getExternalId(), updatedCharge.getPaymentGatewayName().getName(),

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -93,8 +93,7 @@ public class CardAuthoriseService extends CardAuthoriseBaseService<AuthCardDetai
                 transactionId,
                 extractAuth3dsDetails(operationResponse), 
                 operationResponse.getSessionIdentifier(),
-                authCardDetails,
-                Optional.empty());
+                authCardDetails);
         
         logger.info("Authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                 updatedCharge.getExternalId(), updatedCharge.getPaymentGatewayName().getName(),

--- a/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
@@ -25,7 +25,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
-import uk.gov.pay.connector.util.AuthUtils;
 
 import java.util.Map;
 import java.util.Optional;
@@ -77,7 +76,8 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
     private Counter mockCounter;
 
     private AppleAuthoriseService appleAuthoriseService;
-    private AppleDecryptedPaymentData validApplePayDetails =
+    
+    private final AppleDecryptedPaymentData validApplePayDetails =
             anApplePayDecryptedPaymentData()
                     .withApplePaymentInfo(
                             anApplePayPaymentInfo().build())
@@ -91,6 +91,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
 
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
@@ -102,34 +103,10 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
                 mockEnvironment);
     }
 
-    public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
-        doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
-                .when(mockExecutorService).execute(any(Supplier.class));
-    }
-
-    private GatewayResponse mockAuthResponse(String TRANSACTION_ID, AuthoriseStatus authoriseStatus, String errorCode) {
-        WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
-        when(worldpayResponse.getTransactionId()).thenReturn(TRANSACTION_ID);
-        when(worldpayResponse.authoriseStatus()).thenReturn(authoriseStatus);
-        when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
-        GatewayResponseBuilder<WorldpayOrderStatusResponse> gatewayResponseBuilder = responseBuilder();
-        return gatewayResponseBuilder
-                .withResponse(worldpayResponse)
-                .withSessionIdentifier(SESSION_IDENTIFIER)
-                .build();
-    }
-
-    private void setupPaymentProviderMock(GatewayError gatewayError) {
-        GatewayResponseBuilder<WorldpayOrderStatusResponse> gatewayResponseBuilder = responseBuilder();
-        GatewayResponse authorisationResponse = gatewayResponseBuilder
-                .withGatewayError(gatewayError)
-                .build();
-        when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(authorisationResponse);
-    }
-
     @Test
     public void doAuthoriseCard_shouldRespondAuthorisationSuccess() {
         providerWillAuthorise();
+        
         GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
         assertThat(response.isSuccessful(), is(true));
@@ -142,32 +119,12 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
         verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
+        assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
     }
 
     @Test
-    public void doAuthorise_shouldRespondAuthorisationSuccess_overridingGeneratedTransactionId() {
-
-        providerWillAuthorise();
-
-        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
-
-        assertThat(response.isSuccessful(), is(true));
-        assertThat(response.getSessionIdentifier().isPresent(), is(true));
-        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
-
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
-        assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
-        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
-        assertThat(charge.get3dsDetails(), is(nullValue()));
-        assertThat(charge.getGatewayTransactionId(), is(notNullValue()));
-        assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
-        verify(mockedChargeEventDao).persistChargeEventOf(charge);
-    }
-
-    @Test
     public void doAuthorise_shouldRespondAuthorisationRejected_whenProviderAuthorisationIsRejected() {
-
         providerWillReject();
 
         GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -180,10 +137,8 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldRespondAuthorisationCancelled_whenProviderAuthorisationIsCancelled() {
-
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.CANCELLED, null);
-        providerWillRespondToAuthoriseWith(authResponse);
+        when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(authResponse);
 
         GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
@@ -195,7 +150,6 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void shouldRespondAuthorisationError() {
-
         providerWillError();
 
         GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -209,6 +163,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
     @Test
     public void doAuthorise_shouldStoreExpectedCardDetails_whenAuthorisationSuccess() {
         providerWillAuthorise();
+        
         appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
         CardDetailsEntity cardDetails = charge.getCardDetails();
@@ -223,7 +178,6 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldStoreCardDetails_evenIfAuthorisationRejected() {
-
         providerWillReject();
 
         appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -234,7 +188,6 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldStoreCardDetails_evenIfInAuthorisationError() {
-
         providerWillError();
 
         appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -245,7 +198,6 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldStoreProviderSessionId_evenIfAuthorisationRejected() {
-
         providerWillReject();
 
         appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -254,8 +206,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldNotProviderSessionId_whenAuthorisationError() {
-
+    public void doAuthorise_shouldNotStoreProviderSessionId_whenAuthorisationError() {
         providerWillError();
 
         appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
@@ -265,7 +216,6 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenTimeout() {
-
         when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
@@ -279,11 +229,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test(expected = ChargeNotFoundRuntimeException.class)
     public void doAuthorise_shouldThrowAChargeNotFoundRuntimeException_whenChargeDoesNotExist() {
-
         String chargeId = "jgk3erq5sv2i4cds6qqa9f1a8a";
-
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
-
         when(mockedChargeDao.findByExternalId(chargeId))
                 .thenReturn(Optional.empty());
 
@@ -292,7 +238,6 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test(expected = OperationAlreadyInProgressRuntimeException.class)
     public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenStatusIsAuthorisationReady() {
-
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.AUTHORISATION_READY);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
@@ -304,7 +249,6 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test(expected = IllegalStateRuntimeException.class)
     public void doAuthorise_shouldThrowAnIllegalStateRuntimeException_whenInvalidStatus() {
-
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.CREATED);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
@@ -316,8 +260,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldReportAuthorisationTimeout_whenProviderTimeout() {
-        GatewayError gatewayError = gatewayConnectionTimeoutException("Connection timed out");
-        providerWillRespondWithError(gatewayError);
+        providerWillRespondWithError(gatewayConnectionTimeoutException("Connection timed out"));
 
         GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
@@ -327,9 +270,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldReportUnexpectedError_whenProviderError() {
-
-        GatewayError gatewayError = malformedResponseReceivedFromGateway("Malformed response received");
-        providerWillRespondWithError(gatewayError);
+        providerWillRespondWithError(malformedResponseReceivedFromGateway("Malformed response received"));
 
         GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
@@ -337,30 +278,41 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
     }
 
-    private void providerWillRespondToAuthoriseWith(GatewayResponse value) {
-        when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(value);
+    private GatewayResponse mockAuthResponse(String TRANSACTION_ID, AuthoriseStatus authoriseStatus, String errorCode) {
+        WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
+        when(worldpayResponse.getTransactionId()).thenReturn(TRANSACTION_ID);
+        when(worldpayResponse.authoriseStatus()).thenReturn(authoriseStatus);
+        when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
+        return responseBuilder()
+                .withResponse(worldpayResponse)
+                .withSessionIdentifier(SESSION_IDENTIFIER)
+                .build();
     }
 
+    public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
+        doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
+                .when(mockExecutorService).execute(any(Supplier.class));
+    }
+    
     private void providerWillAuthorise() {
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.AUTHORISED, null);
-        providerWillRespondToAuthoriseWith(authResponse);
+        when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(authResponse);
     }
 
     private void providerWillReject() {
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.REJECTED, null);
-        providerWillRespondToAuthoriseWith(authResponse);
+         when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(authResponse);
     }
 
     private void providerWillError() {
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         GatewayResponse authResponse = mockAuthResponse(null, AuthoriseStatus.ERROR, "error-code");
-        providerWillRespondToAuthoriseWith(authResponse);
+         when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(authResponse);
     }
 
     private void providerWillRespondWithError(GatewayError gatewayError) {
-        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
-        setupPaymentProviderMock(gatewayError);
+        GatewayResponse authorisationResponse = responseBuilder()
+                .withGatewayError(gatewayError)
+                .build();
+        when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(authorisationResponse);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
@@ -1,0 +1,366 @@
+package uk.gov.pay.connector.applepay;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.CardDetailsEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
+import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
+import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
+import uk.gov.pay.connector.util.AuthUtils;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionTimeoutException;
+import static uk.gov.pay.connector.gateway.model.GatewayError.malformedResponseReceivedFromGateway;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
+import static uk.gov.pay.connector.model.domain.applepay.ApplePayDecryptedPaymentDataFixture.anApplePayDecryptedPaymentData;
+import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixture.anApplePayPaymentInfo;
+import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
+import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.IN_PROGRESS;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AppleAuthoriseServiceTest extends CardServiceTest {
+
+    private static final String SESSION_IDENTIFIER = "session-identifier";
+    private static final String TRANSACTION_ID = "transaction-id";
+
+    private final ChargeEntity charge = createNewChargeWith(1L, ENTERING_CARD_DETAILS);
+
+    @Mock
+    private CardExecutorService mockExecutorService;
+
+    @Mock
+    private Environment mockEnvironment;
+
+    @Mock
+    private Counter mockCounter;
+
+    private AppleAuthoriseService appleAuthoriseService;
+    private AppleDecryptedPaymentData validApplePayDetails =
+            anApplePayDecryptedPaymentData()
+                    .withApplePaymentInfo(
+                            anApplePayPaymentInfo().build())
+                    .build();
+
+    @Before
+    public void setUpAppleAuthorisationService() {
+        mockMetricRegistry = mock(MetricRegistry.class);
+        when(mockedProviders.byName(any())).thenReturn(mockedPaymentProvider);
+        when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(TRANSACTION_ID));
+        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
+        when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+        when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
+        ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
+
+        ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
+                null, null, mockConfiguration, null);
+        appleAuthoriseService = new AppleAuthoriseService(
+                mockedProviders,
+                mockExecutorService,
+                chargeService,
+                mockEnvironment);
+    }
+
+    public void mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue() {
+        doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
+                .when(mockExecutorService).execute(any(Supplier.class));
+    }
+
+    private GatewayResponse mockAuthResponse(String TRANSACTION_ID, AuthoriseStatus authoriseStatus, String errorCode) {
+        WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
+        when(worldpayResponse.getTransactionId()).thenReturn(TRANSACTION_ID);
+        when(worldpayResponse.authoriseStatus()).thenReturn(authoriseStatus);
+        when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
+        GatewayResponseBuilder<WorldpayOrderStatusResponse> gatewayResponseBuilder = responseBuilder();
+        return gatewayResponseBuilder
+                .withResponse(worldpayResponse)
+                .withSessionIdentifier(SESSION_IDENTIFIER)
+                .build();
+    }
+
+    private void setupPaymentProviderMock(GatewayError gatewayError) {
+        GatewayResponseBuilder<WorldpayOrderStatusResponse> gatewayResponseBuilder = responseBuilder();
+        GatewayResponse authorisationResponse = gatewayResponseBuilder
+                .withGatewayError(gatewayError)
+                .build();
+        when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(authorisationResponse);
+    }
+
+    @Test
+    public void doAuthoriseCard_shouldRespondAuthorisationSuccess() {
+        providerWillAuthorise();
+        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getSessionIdentifier().isPresent(), is(true));
+        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
+        assertThat(charge.get3dsDetails(), is(nullValue()));
+        assertThat(charge.getCardDetails(), is(notNullValue()));
+        assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
+    }
+
+    @Test
+    public void doAuthorise_shouldRespondAuthorisationSuccess_overridingGeneratedTransactionId() {
+
+        providerWillAuthorise();
+
+        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.getSessionIdentifier().isPresent(), is(true));
+        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        assertThat(charge.get3dsDetails(), is(nullValue()));
+        assertThat(charge.getGatewayTransactionId(), is(notNullValue()));
+        assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
+    }
+
+    @Test
+    public void doAuthorise_shouldRespondAuthorisationRejected_whenProviderAuthorisationIsRejected() {
+
+        providerWillReject();
+
+        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
+    }
+
+    @Test
+    public void doAuthorise_shouldRespondAuthorisationCancelled_whenProviderAuthorisationIsCancelled() {
+
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+        GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.CANCELLED, null);
+        providerWillRespondToAuthoriseWith(authResponse);
+
+        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isSuccessful(), is(true));
+        assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
+    }
+
+    @Test
+    public void shouldRespondAuthorisationError() {
+
+        providerWillError();
+
+        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isFailed(), is(true));
+        assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        assertThat(charge.getWalletType(), is(WalletType.APPLE_PAY));
+    }
+
+    @Test
+    public void doAuthorise_shouldStoreExpectedCardDetails_whenAuthorisationSuccess() {
+        providerWillAuthorise();
+        appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        CardDetailsEntity cardDetails = charge.getCardDetails();
+
+        assertThat(cardDetails.getCardHolderName(), is("Mr. Payment"));
+        assertThat(cardDetails.getCardBrand(), is("visa"));
+        assertThat(cardDetails.getExpiryDate(), is("12/23"));
+        assertThat(cardDetails.getLastDigitsCardNumber().toString(), is("4242"));
+        assertThat(cardDetails.getFirstDigitsCardNumber(), is(nullValue()));
+        assertThat(cardDetails.getBillingAddress().isPresent(), is(false));
+    }
+
+    @Test
+    public void doAuthorise_shouldStoreCardDetails_evenIfAuthorisationRejected() {
+
+        providerWillReject();
+
+        appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        CardDetailsEntity cardDetails = charge.getCardDetails();
+        assertThat(cardDetails, is(notNullValue()));
+    }
+
+    @Test
+    public void doAuthorise_shouldStoreCardDetails_evenIfInAuthorisationError() {
+
+        providerWillError();
+
+        appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        CardDetailsEntity cardDetails = charge.getCardDetails();
+        assertThat(cardDetails, is(notNullValue()));
+    }
+
+    @Test
+    public void doAuthorise_shouldStoreProviderSessionId_evenIfAuthorisationRejected() {
+
+        providerWillReject();
+
+        appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+    }
+
+    @Test
+    public void doAuthorise_shouldNotProviderSessionId_whenAuthorisationError() {
+
+        providerWillError();
+
+        appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(charge.getProviderSessionId(), is(nullValue()));
+    }
+
+    @Test
+    public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenTimeout() {
+
+        when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
+
+        try {
+            appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+            fail("Exception not thrown.");
+        } catch (OperationAlreadyInProgressRuntimeException e) {
+            Map<String, String> expectedMessage = ImmutableMap.of("message", format("Authorisation for charge already in progress, %s", charge.getExternalId()));
+            assertThat(e.getResponse().getEntity(), is(expectedMessage));
+        }
+    }
+
+    @Test(expected = ChargeNotFoundRuntimeException.class)
+    public void doAuthorise_shouldThrowAChargeNotFoundRuntimeException_whenChargeDoesNotExist() {
+
+        String chargeId = "jgk3erq5sv2i4cds6qqa9f1a8a";
+
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+
+        when(mockedChargeDao.findByExternalId(chargeId))
+                .thenReturn(Optional.empty());
+
+        appleAuthoriseService.doAuthorise(chargeId, validApplePayDetails);
+    }
+
+    @Test(expected = OperationAlreadyInProgressRuntimeException.class)
+    public void doAuthorise_shouldThrowAnOperationAlreadyInProgressRuntimeException_whenStatusIsAuthorisationReady() {
+
+        ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.AUTHORISATION_READY);
+        when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+
+        appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
+    }
+
+    @Test(expected = IllegalStateRuntimeException.class)
+    public void doAuthorise_shouldThrowAnIllegalStateRuntimeException_whenInvalidStatus() {
+
+        ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.CREATED);
+        when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+
+        appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
+    }
+
+    @Test
+    public void doAuthorise_shouldReportAuthorisationTimeout_whenProviderTimeout() {
+        GatewayError gatewayError = gatewayConnectionTimeoutException("Connection timed out");
+        providerWillRespondWithError(gatewayError);
+
+        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isFailed(), is(true));
+        assertThat(charge.getStatus(), is(AUTHORISATION_TIMEOUT.getValue()));
+    }
+
+    @Test
+    public void doAuthorise_shouldReportUnexpectedError_whenProviderError() {
+
+        GatewayError gatewayError = malformedResponseReceivedFromGateway("Malformed response received");
+        providerWillRespondWithError(gatewayError);
+
+        GatewayResponse response = appleAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
+
+        assertThat(response.isFailed(), is(true));
+        assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
+    }
+
+    private void providerWillRespondToAuthoriseWith(GatewayResponse value) {
+        when(mockedPaymentProvider.authoriseApplePay(any(ApplePayAuthorisationGatewayRequest.class))).thenReturn(value);
+    }
+
+    private void providerWillAuthorise() {
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+        GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.AUTHORISED, null);
+        providerWillRespondToAuthoriseWith(authResponse);
+    }
+
+    private void providerWillReject() {
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+        GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.REJECTED, null);
+        providerWillRespondToAuthoriseWith(authResponse);
+    }
+
+    private void providerWillError() {
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+        GatewayResponse authResponse = mockAuthResponse(null, AuthoriseStatus.ERROR, "error-code");
+        providerWillRespondToAuthoriseWith(authResponse);
+    }
+
+    private void providerWillRespondWithError(GatewayError gatewayError) {
+        mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
+        setupPaymentProviderMock(gatewayError);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/ApplePayServiceTest.java
@@ -1,0 +1,90 @@
+package uk.gov.pay.connector.applepay;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.applepay.api.ApplePayToken;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.util.AuthUtils;
+
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_URL_DNS_ERROR;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
+import static uk.gov.pay.connector.model.domain.applepay.ApplePayDecryptedPaymentDataFixture.anApplePayDecryptedPaymentData;
+import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixture.anApplePayPaymentInfo;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApplePayServiceTest {
+
+    @Mock
+    private ApplePayDecrypter mockedApplePayDecrypter;
+
+    @Mock
+    private AppleAuthoriseService mockedApplePayAuthoriseService;
+
+    private ApplePayService applePayService;
+    private AppleDecryptedPaymentData validData =
+            anApplePayDecryptedPaymentData()
+                    .withApplePaymentInfo(
+                            anApplePayPaymentInfo().build())
+                    .build();
+    @Before
+    public void setUp() {
+        applePayService = new ApplePayService(mockedApplePayDecrypter, mockedApplePayAuthoriseService);
+    }
+    
+    @Test
+    public void shouldDecryptAndAuthoriseAValidCharge() throws IOException {
+        String externalChargeId = "external-charge-id";
+        ApplePayToken applePayToken = ApplePayTokenBuilder.anApplePayToken().build();
+                
+        WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
+        GatewayResponse gatewayResponse = responseBuilder()
+                .withResponse(worldpayResponse)
+                .withSessionIdentifier("234")
+                .build();
+        when(worldpayResponse.authoriseStatus()).thenReturn(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
+        when(mockedApplePayDecrypter.performDecryptOperation(applePayToken)).thenReturn(validData);
+        when(mockedApplePayAuthoriseService.doAuthorise(externalChargeId, validData)).thenReturn(gatewayResponse);
+
+        Response authorisationResponse = applePayService.authorise(externalChargeId, applePayToken);
+
+        verify(mockedApplePayAuthoriseService).doAuthorise(externalChargeId, validData);
+        assertThat(authorisationResponse.getStatus(), is(200));
+        assertThat(authorisationResponse.getEntity(), is(ImmutableMap.of("status", "AUTHORISATION SUCCESS")));
+    }
+
+    @Test
+    public void shouldReturnInternalServerError_ifGatewayErrors() throws IOException {
+        String externalChargeId = "external-charge-id";
+        ApplePayToken applePayToken = ApplePayTokenBuilder.anApplePayToken().build();
+        GatewayError gatewayError = mock(GatewayError.class);
+        GatewayResponse gatewayResponse = responseBuilder()
+                .withGatewayError(gatewayError)
+                .withSessionIdentifier("234")
+                .build();
+        when(gatewayError.getErrorType()).thenReturn(GATEWAY_URL_DNS_ERROR);
+        when(gatewayError.getMessage()).thenReturn("oops");
+        when(mockedApplePayDecrypter.performDecryptOperation(applePayToken)).thenReturn(validData);
+        when(mockedApplePayAuthoriseService.doAuthorise(externalChargeId, validData)).thenReturn(gatewayResponse);
+
+        Response authorisationResponse = applePayService.authorise(externalChargeId, applePayToken);
+
+        verify(mockedApplePayAuthoriseService).doAuthorise(externalChargeId, validData);
+        assertThat(authorisationResponse.getStatus(), is(500));
+        assertThat(authorisationResponse.getEntity(), is(ImmutableMap.of("message", "oops")));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbersTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbersTest.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxCardNumbers.cardErrorFor;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxCardNumbers.isErrorCard;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxCardNumbers.isRejectedCard;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxCardNumbers.isValidCard;
+
+public class SandboxCardNumbersTest {
+
+    @Test
+    public void shouldDetectValidCards() {
+        assertThat(isValidCard("4444333322221111"), is (true));
+        assertThat(isValidCard("4000180000000002"), is (true));
+        assertThat(isValidCard("4242"), is (true));
+    }
+
+    @Test
+    public void shouldDetectErrorCards() {
+        assertThat(isErrorCard("4000000000000119"), is (true));
+        assertThat(isErrorCard("0119"), is (true));
+    }
+
+    @Test
+    public void shouldDetectRejectedCards() {
+        assertThat(isRejectedCard("4000000000000002"), is (true));
+        assertThat(isRejectedCard("0002"), is (true));
+        assertThat(isRejectedCard("4000000000000069"), is (true));
+        assertThat(isRejectedCard("0069"), is (true));
+        assertThat(isRejectedCard("4000000000000127"), is (true));
+        assertThat(isRejectedCard("0127"), is (true));
+    }
+
+    @Test
+    public void shouldRetrieveStatusForErrorCards() {
+        assertThat(cardErrorFor("4000000000000119").getNewErrorStatus(), is(AUTHORISATION_ERROR));
+        assertThat(cardErrorFor("0119").getNewErrorStatus(), is(AUTHORISATION_ERROR));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxApplePayAuthorisationHandlerTest.java
@@ -8,13 +8,14 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.util.AuthUtils;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.model.domain.applepay.ApplePayDecryptedPaymentDataFixture.anApplePayDecryptedPaymentData;
+import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixture.anApplePayPaymentInfo;
 
 public class SandboxApplePayAuthorisationHandlerTest {
 
@@ -31,8 +32,13 @@ public class SandboxApplePayAuthorisationHandlerTest {
 
     @Test
     public void authorise_shouldBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToSucceedForAuthorisation_forApplePay() {
-        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
-
+        AppleDecryptedPaymentData applePaymentData =
+                anApplePayDecryptedPaymentData()
+                        .withApplePaymentInfo(
+                                anApplePayPaymentInfo()
+                                        .withLastDigitsCardNumber(AUTH_SUCCESS_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
+                                        .build())
+                        .build();
         GatewayResponse gatewayResponse = sandboxApplePayAuthorisationHandler.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
@@ -50,7 +56,13 @@ public class SandboxApplePayAuthorisationHandlerTest {
 
     @Test
     public void authorise_shouldNotBeAuthorisedWhenLastDigitsCardNumbersAreExpectedToBeRejectedForAuthorisation_forApplePay() {
-        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
+        AppleDecryptedPaymentData applePaymentData =
+                anApplePayDecryptedPaymentData()
+                        .withApplePaymentInfo(
+                                anApplePayPaymentInfo()
+                                        .withLastDigitsCardNumber(AUTH_REJECTED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
+                                        .build())
+                        .build();
         GatewayResponse gatewayResponse = sandboxApplePayAuthorisationHandler.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
 
         assertThat(gatewayResponse.isSuccessful(), is(true));
@@ -68,7 +80,13 @@ public class SandboxApplePayAuthorisationHandlerTest {
 
     @Test
     public void authorise_shouldGetGatewayErrorWhenLastDigitsCardNumbersAreExpectedToFailForAuthorisation_forApplePay() {
-        AppleDecryptedPaymentData applePaymentData = AuthUtils.ApplePay.buildDecryptedPaymentData("Mr. Payment", "mr@payment.test", AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
+        AppleDecryptedPaymentData applePaymentData =
+                anApplePayDecryptedPaymentData()
+                        .withApplePaymentInfo(
+                                anApplePayPaymentInfo()
+                                        .withLastDigitsCardNumber(AUTH_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
+                                        .build())
+                        .build();
         GatewayResponse gatewayResponse = sandboxApplePayAuthorisationHandler.authorise(new ApplePayAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), applePaymentData));
 
         assertThat(gatewayResponse.isSuccessful(), is(false));

--- a/src/test/java/uk/gov/pay/connector/model/domain/applepay/ApplePayDecryptedPaymentDataFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/applepay/ApplePayDecryptedPaymentDataFixture.java
@@ -1,0 +1,125 @@
+package uk.gov.pay.connector.model.domain.applepay;
+
+import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
+import uk.gov.pay.connector.applepay.api.ApplePaymentInfo;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+
+import java.time.LocalDate;
+
+public final class ApplePayDecryptedPaymentDataFixture {
+    private ApplePaymentInfo applePaymentInfo = new ApplePaymentInfo(
+            "4242",
+            "visa",
+            PayersCardType.DEBIT,
+            "Mr. Payment",
+            "aaa@bbb.test"
+    );
+    private String applicationPrimaryAccountNumber = "4818528840010767";
+    private LocalDate applicationExpirationDate = LocalDate.of(2023, 12, 31);
+    private String currencyCode = "643";
+    private Long transactionAmount = 10L;
+    private String deviceManufacturerIdentifier = "040010030273";
+    private String paymentDataType = "3DSecure";
+    private String onlinePaymentCryptogram = "Ao/fzpIAFvp1eB9y8WVDMAACAAA=";
+    private String eciIndicator = "7";
+
+    private ApplePayDecryptedPaymentDataFixture() {
+    }
+
+    public static ApplePayDecryptedPaymentDataFixture anApplePayDecryptedPaymentData() {
+        return new ApplePayDecryptedPaymentDataFixture();
+    }
+
+    public ApplePaymentInfo getApplePaymentInfo() {
+        return applePaymentInfo;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withApplePaymentInfo(ApplePaymentInfo applePaymentInfo) {
+        this.applePaymentInfo = applePaymentInfo;
+        return this;
+    }
+
+    public String getApplicationPrimaryAccountNumber() {
+        return applicationPrimaryAccountNumber;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withApplicationPrimaryAccountNumber(String applicationPrimaryAccountNumber) {
+        this.applicationPrimaryAccountNumber = applicationPrimaryAccountNumber;
+        return this;
+    }
+
+    public LocalDate getApplicationExpirationDate() {
+        return applicationExpirationDate;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withExpiryDate(LocalDate expiryDate) {
+        this.applicationExpirationDate = expiryDate;
+        return this;
+    }
+
+    public String getCurrencyCode() {
+        return currencyCode;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withConcurrencyCode(String concurrencyCode) {
+        this.currencyCode = concurrencyCode;
+        return this;
+    }
+
+    public Long getTransactionAmount() {
+        return transactionAmount;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withAmount(Long amount) {
+        this.transactionAmount = amount;
+        return this;
+    }
+
+    public String getDeviceManufacturerIdentifier() {
+        return deviceManufacturerIdentifier;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withDeviceManufacturerIdentifier(String deviceManufacturerIdentifier) {
+        this.deviceManufacturerIdentifier = deviceManufacturerIdentifier;
+        return this;
+    }
+
+    public String getPaymentDataType() {
+        return paymentDataType;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withPaymentDataType(String paymentDataType) {
+        this.paymentDataType = paymentDataType;
+        return this;
+    }
+
+    public String getOnlinePaymentCryptogram() {
+        return onlinePaymentCryptogram;
+    }
+
+
+    public String getEciIndicator() {
+        return eciIndicator;
+    }
+
+    public ApplePayDecryptedPaymentDataFixture withEciIndicator(String eciIndicator) {
+        this.eciIndicator = eciIndicator;
+        return this;
+    }
+
+    public AppleDecryptedPaymentData build() {
+        return new AppleDecryptedPaymentData(
+                applePaymentInfo,
+                applicationPrimaryAccountNumber,
+                applicationExpirationDate,
+                currencyCode,
+                transactionAmount,
+                deviceManufacturerIdentifier,
+                paymentDataType,
+                new AppleDecryptedPaymentData.PaymentData(
+                        onlinePaymentCryptogram,
+                        eciIndicator
+                )
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/applepay/ApplePayPaymentInfoFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/applepay/ApplePayPaymentInfoFixture.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.model.domain.applepay;
+
+import uk.gov.pay.connector.applepay.api.ApplePaymentInfo;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+
+public final class ApplePayPaymentInfoFixture {
+    String lastDigitsCardNumber = "4242";
+    String brand = "visa";
+    PayersCardType cardType = PayersCardType.DEBIT;
+    String cardholderName = "Mr. Payment";
+    String email = "mr@payment.test";
+    private ApplePayPaymentInfoFixture() {
+    }
+
+    public static ApplePayPaymentInfoFixture anApplePayPaymentInfo() {
+        return new ApplePayPaymentInfoFixture();
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public ApplePayPaymentInfoFixture withLastDigitsCardNumber(String lastDigitsCardNumber) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        return this;
+    }
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public PayersCardType getCardType() {
+        return cardType;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public ApplePayPaymentInfoFixture withCardholderName(String cardholderName) {
+        this.cardholderName = cardholderName;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public ApplePayPaymentInfoFixture withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public ApplePaymentInfo build() {
+        return new ApplePaymentInfo(
+                lastDigitsCardNumber,
+                brand,
+                cardType,
+                cardholderName,
+                email
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -249,6 +249,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
         assertThat(charge.getCorporateSurcharge().get(), is(50L));
+        assertThat(charge.getWalletType(), is(nullValue()));
     }
 
     @Test
@@ -272,6 +273,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.get3dsDetails(), is(nullValue()));
+        assertThat(charge.getWalletType(), is(nullValue()));
         verify(mockedChargeEventDao).persistChargeEventOf(charge);
     }
 
@@ -302,6 +304,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getStatus(), is(AUTHORISATION_3DS_REQUIRED.getValue()));
         verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails().getHtmlOut(), is(notNullValue()));
+        assertThat(charge.getWalletType(), is(nullValue()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
+++ b/src/test/java/uk/gov/pay/connector/util/AuthUtils.java
@@ -1,11 +1,6 @@
 package uk.gov.pay.connector.util;
 
-import uk.gov.pay.connector.applepay.AppleDecryptedPaymentData;
-import uk.gov.pay.connector.applepay.api.ApplePaymentInfo;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
-import uk.gov.pay.connector.gateway.model.PayersCardType;
-
-import java.time.LocalDate;
 
 public class AuthUtils {
     public static Auth3dsDetails buildAuth3dsDetails() {
@@ -13,40 +8,4 @@ public class AuthUtils {
         auth3dsDetails.setPaResponse("sample-pa-response");
         return auth3dsDetails;
     }
-
-
-    public static class ApplePay {
-        private static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String lastFourDigitsCardNumber, AppleDecryptedPaymentData.PaymentData paymentData) {
-            return new AppleDecryptedPaymentData(
-                    new ApplePaymentInfo(
-                            lastFourDigitsCardNumber,
-                            "visa",
-                            PayersCardType.DEBIT,
-                            cardHolderName,
-                            email
-                    ),
-                    "4818528840010767",
-                    LocalDate.of(2023, 12, 31),
-                    "643",
-                    10L,
-                    "040010030273",
-                    "3DSecure",
-                    paymentData
-            );
-        }
-
-        public static AppleDecryptedPaymentData buildDecryptedPaymentData(String cardHolderName, String email, String lastFourDigitsCardNumber) {
-            return buildDecryptedPaymentData(cardHolderName, email, lastFourDigitsCardNumber, new AppleDecryptedPaymentData.PaymentData(
-                    "Ao/fzpIAFvp1eB9y8WVDMAACAAA=",
-                    "7"
-            ));
-        }
-        public static AppleDecryptedPaymentData buildDecryptedMinimalPaymentData(String lastFourDigitsCardNumber) {
-            return buildDecryptedPaymentData(null, null, lastFourDigitsCardNumber, new AppleDecryptedPaymentData.PaymentData(
-                    "Ao/fzpIAFvp1eB9y8WVDMAACAAA=",
-                    null
-            ));
-        }
-    }
-
 }


### PR DESCRIPTION
## WHAT
- Adding `ApplePayService` which decrypts a payload and then delegates to `AppleAuthoriseService` to authorise an apple pay charge. There is some duplication with CardResource on handling the response from the authorise service - another refactor will follow in which we embed that logic in services and move it out of the resource (also, using better practices like exception mappers).
- The logic is extremely similar to CardAuthoriseService - we can definitely extract commonalities / use one service. As this area is going through a big refactoring, I am introducing a bit of duplication in the hope of not interfering (right now) with it
- A charge is marked with WalletType of `APPLE_PAY` when authorised through this new service
- The tests are very verbose (are similar to ones in the card authorise service). The pending refactoring should help shrinking those tests.
- Simplified logic for SandboxCardNumbers
