### PR TITLE
PP-4373 Refactor authorisation services to remove base authorise service

### DIFF
--- a/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
@@ -1,11 +1,16 @@
 package uk.gov.pay.connector.applepay;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -17,35 +22,58 @@ import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
-public class AppleAuthoriseService extends CardAuthoriseBaseService<AppleDecryptedPaymentData> {
+public class AppleAuthoriseService {
     private static final DateTimeFormatter EXPIRY_DATE_FORMAT = DateTimeFormatter.ofPattern("MM/yy");
-
+    private final CardAuthoriseBaseService cardAuthoriseBaseService;
+    private final ChargeService chargeService;
+    private final PaymentProviders paymentProviders;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private MetricRegistry metricRegistry;
+    
     @Inject
-    AppleAuthoriseService(PaymentProviders paymentProviders, CardExecutorService cardExecutorService, ChargeService chargeService, Environment environment) {
-        super(paymentProviders, cardExecutorService, chargeService, environment);
+    AppleAuthoriseService(PaymentProviders paymentProviders,
+                          ChargeService chargeService,
+                          CardAuthoriseBaseService cardAuthoriseBaseService,
+                          Environment environment) {
+        this.paymentProviders = paymentProviders;
+        this.cardAuthoriseBaseService = cardAuthoriseBaseService;
+        this.chargeService = chargeService;
+        this.metricRegistry = environment.metrics();
     }
 
-    @Override
-    @Transactional
-    public ChargeEntity prepareChargeForAuthorisation(String chargeId, AppleDecryptedPaymentData applePaymentData) {
+    GatewayResponse<BaseAuthoriseResponse> doAuthorise(String chargeId, AppleDecryptedPaymentData authCardDetails) {
+        return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
+            final ChargeEntity charge = prepareChargeForAuthorisation(chargeId);
+            GatewayResponse<BaseAuthoriseResponse> operationResponse = authorise(charge, authCardDetails);
+            processGatewayAuthorisationResponse(
+                    charge.getExternalId(),
+                    ChargeStatus.fromString(charge.getStatus()),
+                    authCardDetails,
+                    operationResponse);
+
+            return operationResponse;
+        });
+    }
+
+    private ChargeEntity prepareChargeForAuthorisation(String chargeId) {
         ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
-        providers.byName(charge.getPaymentGatewayName())
+        getPaymentProviderFor(charge)
                 .generateTransactionId()
                 .ifPresent(charge::setGatewayTransactionId);
         return charge;
     }
 
-    @Override
-    @Transactional
-    public void processGatewayAuthorisationResponse(
+    private void processGatewayAuthorisationResponse(
             String chargeExternalId,
             ChargeStatus oldChargeStatus,
             AppleDecryptedPaymentData applePaymentData,
             GatewayResponse<BaseAuthoriseResponse> operationResponse) {
 
         logger.info("Processing gateway auth response for apple pay");
-        Optional<String> transactionId = extractTransactionId(chargeExternalId, operationResponse);
-        ChargeStatus status = extractChargeStatus(operationResponse.getBaseResponse(), operationResponse.getGatewayError());
+        Optional<String> transactionId = cardAuthoriseBaseService.extractTransactionId(chargeExternalId, operationResponse);
+        ChargeStatus status = cardAuthoriseBaseService.extractChargeStatus(
+                operationResponse.getBaseResponse(),
+                operationResponse.getGatewayError());
 
         AuthCardDetails authCardDetailsToBePersisted = authCardDetailsFor(applePaymentData);
         ChargeEntity updatedCharge = chargeService.updateChargePostApplePayAuthorisation(
@@ -70,11 +98,10 @@ public class AppleAuthoriseService extends CardAuthoriseBaseService<AppleDecrypt
                 status.toString())).inc();
     }
 
-    @Override
     protected GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity chargeEntity, AppleDecryptedPaymentData applePaymentData) {
         logger.info("Authorising charge for apple pay");
         ApplePayAuthorisationGatewayRequest authorisationGatewayRequest = ApplePayAuthorisationGatewayRequest.valueOf(chargeEntity, applePaymentData);
-        return providers.byName(chargeEntity.getPaymentGatewayName())
+        return getPaymentProviderFor(chargeEntity)
                 .authoriseApplePay(authorisationGatewayRequest);
     }
     
@@ -87,6 +114,10 @@ public class AppleAuthoriseService extends CardAuthoriseBaseService<AppleDecrypt
         authCardDetails.setEndDate(applePaymentData.getApplicationExpirationDate().format(EXPIRY_DATE_FORMAT));
         authCardDetails.setCorporateCard(false);
         return authCardDetails;
+    }
+
+    private PaymentProvider<BaseAuthoriseResponse> getPaymentProviderFor(ChargeEntity chargeEntity) {
+        return paymentProviders.byName(chargeEntity.getPaymentGatewayName());
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -233,6 +233,7 @@ public class ChargeService {
         return builderOfResponse;
     }
 
+    @Transactional
     public ChargeEntity updateChargePostAuthorisation(String chargeExternalId,
                                                       ChargeStatus status,
                                                       Optional<String> transactionId,
@@ -257,6 +258,7 @@ public class ChargeService {
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
     }
 
+    @Transactional
     public ChargeEntity updateChargePostApplePayAuthorisation(String chargeExternalId,
                                                       ChargeStatus status,
                                                       Optional<String> transactionId,
@@ -268,6 +270,7 @@ public class ChargeService {
         return charge;
     }
     
+    @Transactional
     public ChargeEntity updateChargePost3dsAuthorisation(String chargeExternalId, ChargeStatus status,
                                                          Optional<String> transactionId) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
@@ -303,6 +306,7 @@ public class ChargeService {
         });
     }
 
+    @Transactional
     public ChargeEntity lockChargeForProcessing(String chargeId, OperationType operationType) {
         return chargeDao.findByExternalId(chargeId).map(chargeEntity -> {
             try {

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProviders.java
@@ -30,7 +30,7 @@ public class PaymentProviders {
 
     }
 
-    public PaymentProvider<BaseResponse> byName(PaymentGatewayName gateway) {
+    public PaymentProvider byName(PaymentGatewayName gateway) {
         return paymentProviders.get(gateway);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -71,7 +71,7 @@ public class CardResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     public Response authorise3dsCharge(@PathParam("chargeId") String chargeId, Auth3dsDetails auth3DsDetails) {
-        GatewayResponse<BaseAuthoriseResponse> response = card3dsResponseAuthService.doAuthorise(chargeId, auth3DsDetails);
+        GatewayResponse<BaseAuthoriseResponse> response = card3dsResponseAuthService.process3DSecure(chargeId, auth3DsDetails);
         return isAuthorisationDeclined(response) ? badRequestResponse("This transaction was declined.") : handleGatewayAuthoriseResponse(response);
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -1,10 +1,14 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import com.google.inject.persist.Transactional;
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.Inject;
 import io.dropwizard.setup.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -12,40 +16,55 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
-import javax.inject.Inject;
 import java.util.Optional;
+import java.util.function.Supplier;
 
-public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3dsDetails> {
+public class Card3dsResponseAuthService {
+    private final ChargeService chargeService;
+    private final CardAuthoriseBaseService cardAuthoriseBaseService;
+    private final PaymentProviders providers;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final MetricRegistry metricRegistry;
+    
     @Inject
     public Card3dsResponseAuthService(PaymentProviders providers,
-                                      CardExecutorService cardExecutorService,
                                       ChargeService chargeService,
+                                      CardAuthoriseBaseService cardAuthoriseBaseService,
                                       Environment environment) {
-        super(providers, cardExecutorService, chargeService, environment);
+        this.providers = providers;
+        this.chargeService = chargeService;
+        this.metricRegistry = environment.metrics();
+        this.cardAuthoriseBaseService = cardAuthoriseBaseService;
     }
 
-    @Override
-    @Transactional
-    public ChargeEntity prepareChargeForAuthorisation(String chargeId, Auth3dsDetails auth3DsDetails) {
-        return chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION_3DS);
+    public GatewayResponse<BaseAuthoriseResponse> process3DSecure(String chargeId, Auth3dsDetails auth3DsDetails) {
+        Supplier authorisationSupplier = () -> {
+            final ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION_3DS);
+            GatewayResponse<BaseAuthoriseResponse> operationResponse = process3DSecure(charge, auth3DsDetails);
+            processGateway3DSecureResponse(
+                    charge.getExternalId(),
+                    ChargeStatus.fromString(charge.getStatus()),
+                    operationResponse);
+
+            return operationResponse;
+        };
+
+        return cardAuthoriseBaseService.executeAuthorise(chargeId, authorisationSupplier);
     }
 
-    @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity chargeEntity, Auth3dsDetails auth3DsDetails) {
-        return providers.byName(chargeEntity.getPaymentGatewayName())
+
+    private GatewayResponse<BaseAuthoriseResponse> process3DSecure(ChargeEntity chargeEntity, Auth3dsDetails auth3DsDetails) {
+        return getPaymentProviderFor(chargeEntity)
                 .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(chargeEntity, auth3DsDetails));
     }
-    
-    @Override
-    @Transactional
-    public void processGatewayAuthorisationResponse(
+
+    private void processGateway3DSecureResponse(
             String chargeExternalId,
             ChargeStatus oldChargeStatus, 
-            Auth3dsDetails auth3DsDetails, 
             GatewayResponse<BaseAuthoriseResponse> operationResponse) {
         
             Optional<String> transactionId = operationResponse.getBaseResponse().map(BaseAuthoriseResponse::getTransactionId);
-            ChargeStatus status = extractChargeStatus(operationResponse.getBaseResponse(), Optional.empty());
+            ChargeStatus status = cardAuthoriseBaseService.extractChargeStatus(operationResponse.getBaseResponse(), Optional.empty());
             ChargeEntity updatedCharge = chargeService.updateChargePost3dsAuthorisation(chargeExternalId, status, transactionId);
 
             logger.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
@@ -57,11 +76,14 @@ public class Card3dsResponseAuthService extends CardAuthoriseBaseService<Auth3ds
                     operationResponse, oldChargeStatus, 
                     status);
 
-
             metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.authorise-3ds.result.%s",
                     updatedCharge.getGatewayAccount().getGatewayName(),
                     updatedCharge.getGatewayAccount().getType(),
                     updatedCharge.getGatewayAccount().getId(),
                     status.toString())).inc();
+    }
+
+    private PaymentProvider<BaseAuthoriseResponse> getPaymentProviderFor(ChargeEntity chargeEntity) {
+        return providers.byName(chargeEntity.getPaymentGatewayName());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -1,24 +1,19 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.setup.Environment;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
-import uk.gov.pay.connector.gateway.model.AuthorisationDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
+import javax.inject.Inject;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -27,38 +22,18 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus;
 
-public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
-
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
-    
+public class CardAuthoriseBaseService {
     private final CardExecutorService cardExecutorService;
-    protected final ChargeService chargeService;
-    protected final PaymentProviders providers;
-    protected MetricRegistry metricRegistry;
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-    protected CardAuthoriseBaseService(PaymentProviders providers,
-                             CardExecutorService cardExecutorService,
-                             ChargeService chargeService,
-                             Environment environment) {
-        this.providers = providers;
+    @Inject
+    public CardAuthoriseBaseService(CardExecutorService cardExecutorService) {
         this.cardExecutorService = cardExecutorService;
-        this.chargeService = chargeService;
-        this.metricRegistry = environment.metrics();
     }
 
-    public GatewayResponse<BaseAuthoriseResponse> doAuthorise(String chargeId, T gatewayAuthRequest) {
-        Supplier authorisationSupplier = () -> {
-            final ChargeEntity charge = prepareChargeForAuthorisation(chargeId, gatewayAuthRequest);
-            GatewayResponse<BaseAuthoriseResponse> operationResponse = authorise(charge, gatewayAuthRequest);
-            processGatewayAuthorisationResponse(
-                    charge.getExternalId(),
-                    ChargeStatus.fromString(charge.getStatus()),
-                    gatewayAuthRequest,
-                    operationResponse);
-            return operationResponse;
-        };
-
-        Pair<ExecutionStatus, GatewayResponse> executeResult = cardExecutorService.execute(authorisationSupplier);
+ 
+    public GatewayResponse<BaseAuthoriseResponse> executeAuthorise(String chargeId, Supplier<GatewayResponse<BaseAuthoriseResponse>> authorisationSupplier) {
+        Pair<ExecutionStatus, GatewayResponse<BaseAuthoriseResponse>> executeResult = cardExecutorService.execute(authorisationSupplier);
 
         switch (executeResult.getLeft()) {
             case COMPLETED:
@@ -70,24 +45,18 @@ public abstract class CardAuthoriseBaseService<T extends AuthorisationDetails> {
         }
     }
 
-    protected abstract ChargeEntity prepareChargeForAuthorisation(String chargeId, T gatewayAuthRequest);
-
-    protected abstract void processGatewayAuthorisationResponse(String chargeExternalId, ChargeStatus oldStatus, T gatewayAuthRequest, GatewayResponse<BaseAuthoriseResponse> operationResponse);
-
-    protected abstract GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, T gatewayAuthRequest);
-
-    protected ChargeStatus extractChargeStatus(Optional<BaseAuthoriseResponse> baseResponse,
-                                               Optional<GatewayError> gatewayError) {
-
+    
+    public ChargeStatus extractChargeStatus(Optional<BaseAuthoriseResponse> baseResponse,
+                                     Optional<GatewayError> gatewayError) {
         return baseResponse
                 .map(BaseAuthoriseResponse::authoriseStatus)
-                .map(AuthoriseStatus::getMappedChargeStatus)
+                .map(BaseAuthoriseResponse.AuthoriseStatus::getMappedChargeStatus)
                 .orElseGet(() -> gatewayError
                         .map(this::mapError)
                         .orElse(ChargeStatus.AUTHORISATION_ERROR));
     }
     
-    protected Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> operationResponse) {
+    public Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> operationResponse) {
         Optional<String> transactionId = operationResponse.getBaseResponse()
                 .map(BaseAuthoriseResponse::getTransactionId);
 

--- a/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
 
@@ -94,12 +95,13 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
 
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         appleAuthoriseService = new AppleAuthoriseService(
                 mockedProviders,
-                mockExecutorService,
                 chargeService,
+                cardAuthoriseBaseService,
                 mockEnvironment);
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -69,7 +69,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, mockConfiguration, null);
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, mockExecutorService, chargeService, mockEnvironment);
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
+
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService, mockEnvironment);
     }
 
     public void setupMockExecutorServiceMock() {
@@ -103,7 +105,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        GatewayResponse response = card3dsResponseAuthService.doAuthorise(charge.getExternalId(), auth3dsDetails);
+        GatewayResponse response = card3dsResponseAuthService.process3DSecure(charge.getExternalId(), auth3dsDetails);
 
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -123,7 +125,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         setupMockExecutorServiceMock();
 
         try {
-            card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+            card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
             fail("Won’t get this far");
         } catch (RuntimeException e) {
             assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
@@ -147,7 +149,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        card3dsResponseAuthService.doAuthorise(charge.getExternalId(), auth3dsDetails);
+        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), auth3dsDetails);
 
         assertTrue(argumentCaptor.getValue().getProviderSessionId().isPresent());
         assertThat(argumentCaptor.getValue().getProviderSessionId().get(), is(providerSessionId));
@@ -195,7 +197,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
-            card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+            card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
             fail("Exception not thrown.");
         } catch (OperationAlreadyInProgressRuntimeException e) {
             Map<String, String> expectedMessage = ImmutableMap.of("message", format("Authorisation for charge already in progress, %s", charge.getExternalId()));
@@ -212,7 +214,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockedChargeDao.findByExternalId(chargeId))
                 .thenReturn(Optional.empty());
 
-        card3dsResponseAuthService.doAuthorise(chargeId, AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecure(chargeId, AuthUtils.buildAuth3dsDetails());
     }
 
     @Test(expected = OperationAlreadyInProgressRuntimeException.class)
@@ -223,7 +225,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         setupMockExecutorServiceMock();
 
-        card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
@@ -236,7 +238,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         setupMockExecutorServiceMock();
 
-        card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
     
@@ -248,7 +250,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         setupMockExecutorServiceMock();
 
-        card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
@@ -274,7 +276,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        return card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        return card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
     }
 
     private GatewayResponse anAuthorisationErrorResponse(ChargeEntity charge,
@@ -286,6 +288,6 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        return card3dsResponseAuthService.doAuthorise(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        return card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -96,7 +96,13 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
-        cardAuthorisationService = new CardAuthoriseService(mockedCardTypeDao, mockedProviders, mockExecutorService, chargeService,
+        
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
+        cardAuthorisationService = new CardAuthoriseService(
+                mockedCardTypeDao, 
+                mockedProviders,
+                cardAuthoriseBaseService,
+                chargeService,
                 mockEnvironment);
     }
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -55,7 +55,7 @@ stripe:
   authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
 
 executorServiceConfig:
-  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
+  timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}
   threadsPerCpu: ${NUMBER_OF_THREADS_PER_CPU:-100}
 
 captureProcessConfig:


### PR DESCRIPTION
This commit reconfigures the services that do something authorisation related,
so that they no longer inherit from a base class, but instead use that base
class as an injected dependency. This makes the services more flexible - they
no longer have to aobey the same contract, so can do what they actually need
to do. There is still some duplication or near duplication which I will
try to address in future PRs.
One thing I have done which is worth being aware of is moving all `@Transactional`
annotations into charge service - this feels like where they really belong,
but does lead to transaction nesting in some cases. From my understanding, Guice
basically ignores all but the top level of the transaction, so I think this is
fine.