### PR TITLE
PP-4374 Introduced SmartpayNotificationService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
@@ -1,0 +1,144 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.persist.Transactional;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.status.InterpretedStatus;
+import uk.gov.pay.connector.gateway.model.status.MappedChargeStatus;
+import uk.gov.pay.connector.gateway.model.status.MappedRefundStatus;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+
+public class SmartpayNotificationService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final ChargeDao chargeDao;
+    private final ChargeNotificationProcessor chargeNotificationProcessor;
+    private final RefundNotificationProcessor refundNotificationProcessor;
+
+    private static final String PAYMENT_GATEWAY_NAME = SMARTPAY.getName();
+
+    @Inject
+    public SmartpayNotificationService(ChargeDao chargeDao,
+                                       ChargeNotificationProcessor chargeNotificationProcessor,
+                                       RefundNotificationProcessor refundNotificationProcessor) {
+        this.chargeDao = chargeDao;
+        this.chargeNotificationProcessor = chargeNotificationProcessor;
+        this.refundNotificationProcessor = refundNotificationProcessor;
+    }
+
+    @Transactional
+    public boolean handleNotificationFor(String payload) {
+        List<SmartpayNotification> notifications = parse(payload);
+        for (SmartpayNotification notification : notifications) {
+            handle(notification);
+        }
+        return true;
+    }
+
+    private void handle(SmartpayNotification notification) {
+        if (shouldIgnore(notification)) {
+            logger.info("{} notification {} ignored", PAYMENT_GATEWAY_NAME, notification);
+            return;
+        }
+
+        logger.info("Verifying {} notification {}", PAYMENT_GATEWAY_NAME, notification);
+
+        if (isBlank(notification.getTransactionId())) {
+            logger.error("{} notification {} failed verification because it has no transaction ID", PAYMENT_GATEWAY_NAME, notification);
+            return;
+        }
+
+        logger.info("Evaluating {} notification {}", PAYMENT_GATEWAY_NAME, notification);
+
+        Optional<ChargeEntity> maybeCharge = chargeDao.findByProviderAndTransactionId(PAYMENT_GATEWAY_NAME,
+                notification.getOriginalReference());
+
+        if (!maybeCharge.isPresent()) {
+            logger.error("{} notification {} could not be evaluated (associated charge entity not found)",
+                    PAYMENT_GATEWAY_NAME, notification);
+            return;
+        }
+
+        ChargeEntity charge = maybeCharge.get();
+        InterpretedStatus interpretedStatus = interpretStatus(notification, charge);
+
+        if (interpretedStatus instanceof MappedChargeStatus) {
+            chargeNotificationProcessor.invoke(
+                    notification.getPspReference(),
+                    charge,
+                    interpretedStatus.getChargeStatus(),
+                    notification.getEventDate()
+            );
+        } else if (interpretedStatus instanceof MappedRefundStatus) {
+            refundNotificationProcessor.invoke(
+                    SMARTPAY,
+                    interpretedStatus.getRefundStatus(),
+                    notification.getPspReference(),
+                    notification.getOriginalReference()
+            );
+        } else {
+            logger.error("{} notification {} unknown", PAYMENT_GATEWAY_NAME, notification);
+        }
+    }
+
+    private InterpretedStatus interpretStatus(SmartpayNotification notification, ChargeEntity charge) {
+        return SmartpayStatusMapper.from(
+                notification.getStatus(),
+                ChargeStatus.fromString(charge.getStatus())
+        );
+    }
+
+    private boolean shouldIgnore(SmartpayNotification notification) {
+        return interpretedStatusFrom(notification.getStatus())
+                .getType() == InterpretedStatus.Type.IGNORED;
+    }
+
+    private InterpretedStatus interpretedStatusFrom(Pair<String, Boolean> status) {
+        return SmartpayStatusMapper
+                .from(status);
+    }
+
+    private List<SmartpayNotification> parse(String payload) {
+        logger.info("Parsing {} notification", PAYMENT_GATEWAY_NAME);
+
+        List<SmartpayNotification> result;
+        try {
+            result = parseNotification(payload);
+            logger.info("Parsed {} notification: {}", PAYMENT_GATEWAY_NAME, result);
+        } catch (SmartpayParseException e) {
+            logger.error("{} notification parsing failed: {}", PAYMENT_GATEWAY_NAME, e);
+            result = Collections.emptyList();
+        }
+        return result;
+    }
+
+    private List<SmartpayNotification> parseNotification(String payload) throws SmartpayParseException {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            // TODO for authorisation notifications, this does the wrong thing
+            // Transaction ID is pspReference, not originalReference as the code below assumes
+            // https://www.barclaycard.co.uk/business/files/SmartPay_Notifications_Guide.pdf
+            // We will set the transaction ID to blank, which makes the notification effectively useless
+            // This is OK at the moment because we ignore authorisation notifications for Smartpay
+            return objectMapper.readValue(payload, SmartpayNotificationList.class)
+                    .getNotifications();
+        } catch (Exception e) {
+            throw new SmartpayParseException(e);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayParseException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayParseException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+public class SmartpayParseException extends Exception {
+    public SmartpayParseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayStatusMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayStatusMapper.java
@@ -1,7 +1,9 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
 import org.apache.commons.lang3.tuple.Pair;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.StatusMapper;
+import uk.gov.pay.connector.gateway.model.status.InterpretedStatus;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -10,33 +12,41 @@ import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_ERROR
 
 public class SmartpayStatusMapper {
 
-        private static final StatusMapper<Pair<String, Boolean>> STATUS_MAPPER =
-                StatusMapper
-                        .<Pair<String, Boolean>>builder()
-                        .ignore(Pair.of("AUTHORISATION", true))
-                        .ignore(Pair.of("AUTHORISATION", false))
-                        .map(Pair.of("CAPTURE", true), CAPTURED)
-                        .map(Pair.of("CAPTURE", false), CAPTURE_ERROR)
-                        .ignore(Pair.of("CANCELLATION", true))
-                        .ignore(Pair.of("CANCELLATION", false))
-                        .map(Pair.of("REFUND", true), REFUNDED)
-                        .map(Pair.of("REFUND", false), REFUND_ERROR)
-                        .map(Pair.of("REFUND_FAILED", true), REFUND_ERROR)    // TODO:: Check with Smartpay what is a valid business use case
-                        .map(Pair.of("REFUND_FAILED", false), REFUND_ERROR)
-                        .ignore(Pair.of("REFUND", false))
-                        .ignore(Pair.of("REQUEST_FOR_INFORMATION", true))
-                        .ignore(Pair.of("REQUEST_FOR_INFORMATION", false))
-                        .ignore(Pair.of("NOTIFICATION_OF_CHARGEBACK", true))
-                        .ignore(Pair.of("NOTIFICATION_OF_CHARGEBACK", false))
-                        .ignore(Pair.of("CHARGEBACK", true))
-                        .ignore(Pair.of("CHARGEBACK", false))
-                        .ignore(Pair.of("CHARGEBACK_REVERSED", true))
-                        .ignore(Pair.of("CHARGEBACK_REVERSED", false))
-                        .ignore(Pair.of("REPORT_AVAILABLE", true))
-                        .ignore(Pair.of("REPORT_AVAILABLE", false))
-                        .build();
+    private static final StatusMapper<Pair<String, Boolean>> STATUS_MAPPER =
+            StatusMapper
+                    .<Pair<String, Boolean>>builder()
+                    .ignore(Pair.of("AUTHORISATION", true))
+                    .ignore(Pair.of("AUTHORISATION", false))
+                    .map(Pair.of("CAPTURE", true), CAPTURED)
+                    .map(Pair.of("CAPTURE", false), CAPTURE_ERROR)
+                    .ignore(Pair.of("CANCELLATION", true))
+                    .ignore(Pair.of("CANCELLATION", false))
+                    .map(Pair.of("REFUND", true), REFUNDED)
+                    .map(Pair.of("REFUND", false), REFUND_ERROR)
+                    .map(Pair.of("REFUND_FAILED", true), REFUND_ERROR)    // TODO:: Check with Smartpay what is a valid business use case
+                    .map(Pair.of("REFUND_FAILED", false), REFUND_ERROR)
+                    .ignore(Pair.of("REFUND", false))
+                    .ignore(Pair.of("REQUEST_FOR_INFORMATION", true))
+                    .ignore(Pair.of("REQUEST_FOR_INFORMATION", false))
+                    .ignore(Pair.of("NOTIFICATION_OF_CHARGEBACK", true))
+                    .ignore(Pair.of("NOTIFICATION_OF_CHARGEBACK", false))
+                    .ignore(Pair.of("CHARGEBACK", true))
+                    .ignore(Pair.of("CHARGEBACK", false))
+                    .ignore(Pair.of("CHARGEBACK_REVERSED", true))
+                    .ignore(Pair.of("CHARGEBACK_REVERSED", false))
+                    .ignore(Pair.of("REPORT_AVAILABLE", true))
+                    .ignore(Pair.of("REPORT_AVAILABLE", false))
+                    .build();
 
-        public static StatusMapper<Pair<String, Boolean>> get() {
-                return STATUS_MAPPER;
-        }
+    public static StatusMapper<Pair<String, Boolean>> get() {
+        return STATUS_MAPPER;
+    }
+
+    public static InterpretedStatus from(Pair<String, Boolean> gatewayStatus, ChargeStatus currentStatus) {
+        return get().from(gatewayStatus, currentStatus);
+    }
+
+    public static InterpretedStatus from(Pair<String, Boolean> gatewayStatus) {
+        return get().from(gatewayStatus);
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
@@ -1,0 +1,166 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_MULTIPLE_NOTIFICATIONS_DIFFERENT_DATES;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_NOTIFICATION_AUTHORISATION;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_NOTIFICATION_CAPTURE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_NOTIFICATION_CAPTURE_WITH_UNKNOWN_STATUS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_NOTIFICATION_REFUND;
+import static uk.gov.pay.connector.util.TransactionId.randomId;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SmartpayNotificationServiceTest {
+    private SmartpayNotificationService notificationService;
+
+    @Mock
+    private ChargeDao mockChargeDao;
+    @Mock
+    private ChargeNotificationProcessor mockChargeNotificationProcessor;
+    @Mock
+    private RefundNotificationProcessor mockRefundNotificationProcessor;
+    @Mock
+    private ChargeEntity mockCharge;
+
+    private final String originalReference = "original-reference";
+    private final String pspReference = "psp-reference";
+
+    @Before
+    public void setup() {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        notificationService = new SmartpayNotificationService(
+                mockChargeDao,
+                mockChargeNotificationProcessor,
+                mockRefundNotificationProcessor
+        );
+        when(mockCharge.getStatus()).thenReturn(AUTHORISATION_SUCCESS.getValue());
+
+        when(mockChargeDao.findByProviderAndTransactionId(SMARTPAY.getName(), originalReference)).thenReturn(Optional.of(mockCharge));
+    }
+
+    @Test
+    public void shouldUpdateCharge_WhenNotificationIsForChargeCapture() {
+        final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_CAPTURE,
+                randomId(), originalReference, pspReference);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockChargeNotificationProcessor).invoke(pspReference, mockCharge, CAPTURED,
+                ZonedDateTime.parse("2015-10-08T13:48:30+02:00"));  // from notification-capture.json
+    }
+
+    @Test
+    public void shouldUpdateRefund_WhenNotificationIsForRefund() {
+        final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_REFUND,
+                randomId(), originalReference, pspReference);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor).invoke(SMARTPAY,
+                RefundStatus.REFUNDED, pspReference, originalReference);
+    }
+
+    @Test
+    public void shouldIgnore_WhenNotificationIsForAuthorisation() {
+        final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_AUTHORISATION,
+                randomId(), originalReference, pspReference);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldProcessMultipleNotifications() {
+        final String payload = sampleSmartpayNotification(SMARTPAY_MULTIPLE_NOTIFICATIONS_DIFFERENT_DATES,
+                randomId(), originalReference, pspReference);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, times(1)).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldIgnoreNotificationWhenStatusIsUnknown() {
+        final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_CAPTURE_WITH_UNKNOWN_STATUS,
+                randomId(), originalReference, pspReference);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotUpdateChargeOrRefund_WhenTransactionIdIsNotAvailable() {
+        final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_REFUND,
+                randomId(), originalReference, StringUtils.EMPTY);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotUpdateChargeOrRefund_WhenChargeIsNotFoundForTransactionId() {
+        final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_REFUND,
+                randomId(), "unknown-transaction-id", pspReference);
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    @Test
+    public void shouldNotUpdateChargeOrRefund_WhenPayloadIsInvalid() {
+        final String payload = "invalid-payload";
+
+        notificationService.handleNotificationFor(payload);
+
+        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
+    }
+
+    private static String sampleSmartpayNotification(String location,
+                                                     String merchantReference,
+                                                     String originalReference,
+                                                     String pspReference) {
+        return TestTemplateResourceLoader.load(location)
+                .replace("{{merchantReference}}", merchantReference)
+                .replace("{{originalReference}}", originalReference)
+                .replace("{{transactionId}}", originalReference)
+                .replace("{{transactionId2}}", originalReference)
+                .replace("{{originalReference}}", originalReference)
+                .replace("{{pspReference}}", pspReference);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayStatusMapperTest.java
@@ -19,7 +19,7 @@ public class SmartpayStatusMapperTest {
     @Test
     public void shouldReturnAStatusForCaptureTrue() throws Exception {
         Pair<String, Boolean> value = Pair.of("CAPTURE", true);
-        InterpretedStatus status = SmartpayStatusMapper.get().from(value, CAPTURE_SUBMITTED);
+        InterpretedStatus status = SmartpayStatusMapper.from(value, CAPTURE_SUBMITTED);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.CHARGE_STATUS));
         assertThat(status.getChargeStatus(), is(CAPTURED));
@@ -28,7 +28,7 @@ public class SmartpayStatusMapperTest {
     @Test
     public void shouldReturnAStatusForCaptureFalse() throws Exception {
         Pair<String, Boolean> value = Pair.of("CAPTURE", false);
-        InterpretedStatus status = SmartpayStatusMapper.get().from(value, CAPTURE_SUBMITTED);
+        InterpretedStatus status = SmartpayStatusMapper.from(value, CAPTURE_SUBMITTED);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.CHARGE_STATUS));
         assertThat(status.getChargeStatus(), is(CAPTURE_ERROR));
@@ -37,7 +37,7 @@ public class SmartpayStatusMapperTest {
     @Test
     public void shouldReturnAStatusForRefundedTrue() throws Exception {
         Pair<String, Boolean> value = Pair.of("REFUND", true);
-        InterpretedStatus status = SmartpayStatusMapper.get().from(value, CAPTURED);
+        InterpretedStatus status = SmartpayStatusMapper.from(value, CAPTURED);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.REFUND_STATUS));
         assertThat(((MappedRefundStatus) status).getRefundStatus(), is(REFUNDED));
@@ -46,7 +46,7 @@ public class SmartpayStatusMapperTest {
     @Test
     public void shouldReturnAStatusForRefundedFalse() throws Exception {
         Pair<String, Boolean> value = Pair.of("REFUND", false);
-        InterpretedStatus status = SmartpayStatusMapper.get().from(value, CAPTURED);
+        InterpretedStatus status = SmartpayStatusMapper.from(value, CAPTURED);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.REFUND_STATUS));
         assertThat(status.getRefundStatus(), is(REFUND_ERROR));
@@ -55,7 +55,7 @@ public class SmartpayStatusMapperTest {
     @Test
     public void shouldReturnAStatusForRefundFailedTrue() throws Exception {
         Pair<String, Boolean> value = Pair.of("REFUND_FAILED", true);
-        InterpretedStatus status = SmartpayStatusMapper.get().from(value, CAPTURED);
+        InterpretedStatus status = SmartpayStatusMapper.from(value, CAPTURED);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.REFUND_STATUS));
         assertThat(status.getRefundStatus(), is(REFUND_ERROR));
@@ -64,7 +64,7 @@ public class SmartpayStatusMapperTest {
     @Test
     public void shouldReturnAStatusForRefundFailedFalse() throws Exception {
         Pair<String, Boolean> value = Pair.of("REFUND_FAILED", false);
-        InterpretedStatus status = SmartpayStatusMapper.get().from(value, CAPTURED);
+        InterpretedStatus status = SmartpayStatusMapper.from(value, CAPTURED);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.REFUND_STATUS));
         assertThat(status.getRefundStatus(), is(REFUND_ERROR));
@@ -72,14 +72,14 @@ public class SmartpayStatusMapperTest {
 
     @Test
     public void shouldReturnEmptyWhenStatusIsUnknown() throws Exception {
-        InterpretedStatus status = SmartpayStatusMapper.get().from(Pair.of("UNKNOWN", true), AUTHORISATION_SUCCESS);
+        InterpretedStatus status = SmartpayStatusMapper.from(Pair.of("UNKNOWN", true), AUTHORISATION_SUCCESS);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.UNKNOWN));
     }
 
     @Test
     public void shouldReturnEmptyWhenStatusIsIgnored() throws Exception {
-        InterpretedStatus status = SmartpayStatusMapper.get().from(Pair.of("AUTHORISATION", true), AUTHORISATION_SUCCESS);
+        InterpretedStatus status = SmartpayStatusMapper.from(Pair.of("AUTHORISATION", true), AUTHORISATION_SUCCESS);
 
         assertThat(status.getType(), is(InterpretedStatus.Type.IGNORED));
     }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -69,11 +69,11 @@ public class TestTemplateResourceLoader {
     public static final String SMARTPAY_VALID_CAPTURE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/valid-capture-smartpay-request.xml";
 
     public static final String SMARTPAY_MULTIPLE_NOTIFICATIONS = SMARTPAY_BASE_NAME + "/multiple-notifications.json";
-    public static final String SMARTPAY_MULTIPLE_NOTIFICATIONS_DIFFERENT_DATES = SMARTPAY_BASE_NAME + "/multiple-notifications-different-dates.xml";
-    public static final String SMARTPAY_NOTIFICATION_AUTHORISATION = SMARTPAY_BASE_NAME + "/notification-authorisation.xml";
-    public static final String SMARTPAY_NOTIFICATION_CAPTURE_WITH_UNKNOWN_STATUS = SMARTPAY_BASE_NAME + "/notification-capture-with-unknown-status.xml";
-    public static final String SMARTPAY_NOTIFICATION_CAPTURE = SMARTPAY_BASE_NAME + "/notification-capture.xml";
-    public static final String SMARTPAY_NOTIFICATION_REFUND = SMARTPAY_BASE_NAME + "/notification-refund.xml";
+    public static final String SMARTPAY_MULTIPLE_NOTIFICATIONS_DIFFERENT_DATES = SMARTPAY_BASE_NAME + "/multiple-notifications-different-dates.json";
+    public static final String SMARTPAY_NOTIFICATION_AUTHORISATION = SMARTPAY_BASE_NAME + "/notification-authorisation.json";
+    public static final String SMARTPAY_NOTIFICATION_CAPTURE_WITH_UNKNOWN_STATUS = SMARTPAY_BASE_NAME + "/notification-capture-with-unknown-status.json";
+    public static final String SMARTPAY_NOTIFICATION_CAPTURE = SMARTPAY_BASE_NAME + "/notification-capture.json";
+    public static final String SMARTPAY_NOTIFICATION_REFUND = SMARTPAY_BASE_NAME + "/notification-refund.json";
 
     public static final String SMARTPAY_REFUND_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/refund-error-response.xml";
     public static final String SMARTPAY_REFUND_SUCCESS_RESPONSE = SMARTPAY_BASE_NAME + "/refund-success-response.xml";


### PR DESCRIPTION
## WHAT

Part of refactoring notification handling (see https://github.com/alphagov/pay-connector/pull/787 for the original full attempt...). Introducing gateway specific service objects to handle notifications instead of generalised notification handler (`NotificationService`). We don't need a generalised `NotificationService` as each gateway notification has dedicated notification resource endpoint. Having separate service object will make it easier to understand and follow through the path.  

- Added `SmartpayNotificationService` to delegate Smartpay notification processing to service instead of a generic handler.
- NotificationResource for Smartpay notifications now uses `SmartNotificationService`
- Also removed handleNotification() from NotificationResource as it is no longer required

Note that any existing code that handles Smartpay notifications still stays and will be removed in subsequent PRs

## HOW 
- Existing tests in `SmartpayNotificationResourceWithAccountSpecificAuthITest` should continue to pass
- All tests in `SmartpayNotificationServiceTest` should pass



