### PR TITLE
PP-4373 Simplify auth 3ds interface

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -269,9 +269,10 @@ public class ChargeService {
         charge.setWalletType(WalletType.APPLE_PAY);
         return charge;
     }
-    
+
     @Transactional
     public ChargeEntity updateChargePost3dsAuthorisation(String chargeExternalId, ChargeStatus status,
+                                                         OperationType operationType,
                                                          Optional<String> transactionId) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             charge.setStatus(status);

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import java.util.Optional;
@@ -24,7 +25,7 @@ public interface PaymentProvider {
 
     GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request);
 
-    GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
+    Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 
     GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
@@ -19,7 +19,8 @@ public interface BaseAuthoriseResponse extends BaseResponse {
         REJECTED(ChargeStatus.AUTHORISATION_REJECTED),
         REQUIRES_3DS(ChargeStatus.AUTHORISATION_3DS_REQUIRED),
         CANCELLED(ChargeStatus.AUTHORISATION_CANCELLED),
-        ERROR(ChargeStatus.AUTHORISATION_ERROR);
+        ERROR(ChargeStatus.AUTHORISATION_ERROR),
+        EXCEPTION(ChargeStatus.AUTHORISATION_ERROR);
 
         ChargeStatus mappedChargeStatus;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.gateway.model.response;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+
+import java.util.Optional;
+
+import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION;
+
+public class Gateway3DSAuthorisationResponse {
+    private final BaseAuthoriseResponse.AuthoriseStatus authorisationStatus;
+    private final String transactionId;
+
+    private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
+        this.transactionId = transactionId;
+        this.authorisationStatus = authorisationStatus;
+    }
+
+    public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId);
+    }
+
+    public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null);
+    }
+
+    public static Gateway3DSAuthorisationResponse ofException() {
+        return new Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED, null);
+    }
+
+    public boolean isDeclined() {
+        return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.REJECTED ||
+                authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.ERROR;
+    }
+
+    public boolean isSuccessful() {
+        return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
+    }
+
+    public boolean isException() {
+        return authorisationStatus == EXCEPTION;
+    }
+
+    public ChargeStatus getMappedChargeStatus() {
+        return authorisationStatus.getMappedChargeStatus();
+    }
+
+    public Optional<String> getTransactionId() {
+        return Optional.ofNullable(transactionId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -88,15 +88,15 @@ public class GatewayResponse<T extends BaseResponse> {
             return this;
         }
 
-        public GatewayResponse build() {
+        public GatewayResponse<T> build() {
             if (gatewayError != null) {
-                return new GatewayResponse(gatewayError);
+                return new GatewayResponse<>(gatewayError);
             }
             if (StringUtils.isNotBlank(response.getErrorCode()) ||
                     StringUtils.isNotBlank(response.getErrorMessage())) {
                 return new GatewayResponse<>(genericGatewayError(response.toString()));
             }
-            return new GatewayResponse(response, sessionIdentifier);
+            return new GatewayResponse<>(response, sessionIdentifier);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxApplePayAuthorisationHandler;
@@ -64,11 +65,8 @@ public class SandboxPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        GatewayResponseBuilder<BaseResponse> gatewayResponseBuilder = responseBuilder();
-        return gatewayResponseBuilder
-                .withGatewayError(new GatewayError("3D Secure not implemented for Sandbox", GENERIC_GATEWAY_ERROR))
-                .build();
+    public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+        return Gateway3DSAuthorisationResponse.ofException();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
@@ -69,9 +70,13 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+    public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), build3dsResponseAuthOrderFor(request));
-        return GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayAuthorisationResponse.class);
+        GatewayResponse<BaseAuthoriseResponse> gatewayResponse = GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayAuthorisationResponse.class);
+
+        return gatewayResponse.getBaseResponse().map(
+                baseResponse -> Gateway3DSAuthorisationResponse.of(baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
+                .orElseGet(Gateway3DSAuthorisationResponse::ofException);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCancelHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
@@ -206,7 +207,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+    public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         return null;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -21,6 +21,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
@@ -87,9 +88,13 @@ public class WorldpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+    public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), build3dsResponseAuthOrder(request));
-        return GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
+        GatewayResponse<BaseAuthoriseResponse> gatewayResponse = GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
+
+        return gatewayResponse.getBaseResponse().map(
+                baseResponse -> Gateway3DSAuthorisationResponse.of(baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
+                .orElseGet(Gateway3DSAuthorisationResponse::ofException);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -71,7 +71,7 @@ public class CardResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     public Response authorise3dsCharge(@PathParam("chargeId") String chargeId, Auth3dsDetails auth3DsDetails) {
-        GatewayResponse<BaseAuthoriseResponse> response = card3dsResponseAuthService.process3DSecure(chargeId, auth3DsDetails);
+        GatewayResponse<BaseAuthoriseResponse> response = card3dsResponseAuthService.process3DSecureAuthorisation(chargeId, auth3DsDetails);
         return isAuthorisationDeclined(response) ? badRequestResponse("This transaction was declined.") : handleGatewayAuthoriseResponse(response);
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -1,14 +1,8 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.inject.Inject;
-import io.dropwizard.setup.Environment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -16,74 +10,43 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
+import javax.inject.Inject;
 import java.util.Optional;
-import java.util.function.Supplier;
 
 public class Card3dsResponseAuthService {
     private final ChargeService chargeService;
     private final CardAuthoriseBaseService cardAuthoriseBaseService;
     private final PaymentProviders providers;
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final MetricRegistry metricRegistry;
 
     @Inject
     public Card3dsResponseAuthService(PaymentProviders providers,
                                       ChargeService chargeService,
-                                      CardAuthoriseBaseService cardAuthoriseBaseService,
-                                      Environment environment) {
+                                      CardAuthoriseBaseService cardAuthoriseBaseService
+    ) {
         this.providers = providers;
         this.chargeService = chargeService;
-        this.metricRegistry = environment.metrics();
         this.cardAuthoriseBaseService = cardAuthoriseBaseService;
     }
 
-    public GatewayResponse<BaseAuthoriseResponse> process3DSecure(String chargeId, Auth3dsDetails auth3DsDetails) {
-        Supplier authorisationSupplier = () -> {
+    public GatewayResponse<BaseAuthoriseResponse> process3DSecureAuthorisation(String chargeId, Auth3dsDetails auth3DsDetails) {
+        return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
             final ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION_3DS);
-            GatewayResponse<BaseAuthoriseResponse> operationResponse = process3DSecure(charge, auth3DsDetails);
-            processGateway3DSecureResponse(
-                    charge.getExternalId(),
-                    ChargeStatus.fromString(charge.getStatus()),
-                    operationResponse);
+            GatewayResponse<BaseAuthoriseResponse> operationResponse = providers
+                    .byName(charge.getPaymentGatewayName())
+                    .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(charge, auth3DsDetails));
+            processGateway3DSecureResponse(charge.getExternalId(), ChargeStatus.fromString(charge.getStatus()), operationResponse);
 
             return operationResponse;
-        };
-
-        return cardAuthoriseBaseService.executeAuthorise(chargeId, authorisationSupplier);
+        });
     }
+    
+    private void processGateway3DSecureResponse(String chargeExternalId, ChargeStatus oldChargeStatus, GatewayResponse<BaseAuthoriseResponse> operationResponse) {
+            Optional<String> transactionId = operationResponse.getBaseResponse().map(BaseAuthoriseResponse::getTransactionId);
+            ChargeStatus status = cardAuthoriseBaseService.extractChargeStatus(operationResponse.getBaseResponse(), Optional.empty());
+            
+            ChargeEntity updatedCharge = chargeService.updateChargePost3dsAuthorisation(chargeExternalId, status, transactionId);
 
-
-    private GatewayResponse<BaseAuthoriseResponse> process3DSecure(ChargeEntity chargeEntity, Auth3dsDetails auth3DsDetails) {
-        return getPaymentProviderFor(chargeEntity)
-                .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(chargeEntity, auth3DsDetails));
-    }
-
-    private void processGateway3DSecureResponse(
-            String chargeExternalId,
-            ChargeStatus oldChargeStatus,
-            GatewayResponse<BaseAuthoriseResponse> operationResponse) {
-
-        Optional<String> transactionId = operationResponse.getBaseResponse().map(BaseAuthoriseResponse::getTransactionId);
-        ChargeStatus status = cardAuthoriseBaseService.extractChargeStatus(operationResponse.getBaseResponse(), Optional.empty());
-        ChargeEntity updatedCharge = chargeService.updateChargePost3dsAuthorisation(chargeExternalId, status, transactionId);
-
-        logger.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
-                updatedCharge.getExternalId(),
-                updatedCharge.getPaymentGatewayName().getName(),
-                updatedCharge.getGatewayTransactionId(),
-                updatedCharge.getGatewayAccount().getAnalyticsId(),
-                updatedCharge.getGatewayAccount().getId(),
-                operationResponse, oldChargeStatus,
-                status);
-
-        metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.authorise-3ds.result.%s",
-                updatedCharge.getGatewayAccount().getGatewayName(),
-                updatedCharge.getGatewayAccount().getType(),
-                updatedCharge.getGatewayAccount().getId(),
-                status.toString())).inc();
-    }
-
-    private PaymentProvider getPaymentProviderFor(ChargeEntity chargeEntity) {
-        return providers.byName(chargeEntity.getPaymentGatewayName());
+            cardAuthoriseBaseService.logAuthorisation("3DS response authorisation", updatedCharge, oldChargeStatus, operationResponse);
+            cardAuthoriseBaseService.emitAuthorisationMetric(updatedCharge, "authorise-3ds");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -37,8 +37,8 @@ public class CardAuthoriseBaseService {
     }
 
  
-    public GatewayResponse<BaseAuthoriseResponse> executeAuthorise(String chargeId, Supplier<GatewayResponse<BaseAuthoriseResponse>> authorisationSupplier) {
-        Pair<ExecutionStatus, GatewayResponse<BaseAuthoriseResponse>> executeResult = cardExecutorService.execute(authorisationSupplier);
+    public <T> T executeAuthorise(String chargeId, Supplier<T> authorisationSupplier) {
+        Pair<ExecutionStatus, T> executeResult = (Pair<ExecutionStatus, T>) cardExecutorService.execute(authorisationSupplier);
 
         switch (executeResult.getLeft()) {
             case COMPLETED:
@@ -87,17 +87,15 @@ public class CardAuthoriseBaseService {
     public void logAuthorisation(
             String operationDescription,
             ChargeEntity updatedCharge,
-            ChargeStatus oldChargeStatus,
-            GatewayResponse<BaseAuthoriseResponse> operationResponse
+            ChargeStatus oldChargeStatus
     ) {
-        logger.info("{} for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
+        logger.info("{} for {} ({} {}) for {} ({}) .'. {} -> {}",
                 operationDescription,
                 updatedCharge.getExternalId(),
                 updatedCharge.getPaymentGatewayName().getName(),
                 updatedCharge.getGatewayTransactionId(),
                 updatedCharge.getGatewayAccount().getAnalyticsId(),
                 updatedCharge.getGatewayAccount().getId(),
-                operationResponse, 
                 oldChargeStatus,
                 updatedCharge.getStatus()
         );

--- a/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
@@ -21,7 +21,6 @@ import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeEx
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
@@ -95,7 +94,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
 
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         appleAuthoriseService = new AppleAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
@@ -5,15 +5,16 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import static java.lang.String.format;
+import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.ERROR;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REJECTED;
@@ -34,20 +35,19 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldAuthorise3dsResponseIfMatchesWithEpdqStatus() {
         mockPaymentProviderResponse(200, successAuthorisedQueryResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(buildTestAuthorisation3dsVerifyRequest("AUTHORISED"));
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(buildTestAuthorisation3dsVerifyRequest("AUTHORISED"));
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().authoriseStatus(), is(AUTHORISED));
     }
 
     @Test
     public void shouldRejectOnRejectedEpdqStatusResponse_evenIfFrontendStatusIsSuccess() {
         mockPaymentProviderResponse(200, declinedAuthorisedQueryResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("AUTHORISED");
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
-        assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().authoriseStatus(), is(REJECTED));
+        assertFalse(response.isSuccessful());
+        assertThat(response.isDeclined(), is(true));
         verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "AUTHORISED", REJECTED.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
@@ -56,10 +56,9 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldErrorOnErrorEpdqStatusResponse_evenIfFrontendStatusIsSuccess() {
         mockPaymentProviderResponse(200, errorAuthorisedQueryResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("AUTHORISED");
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
-        assertTrue(response.isFailed());
-        assertThat(response.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
+        assertTrue(response.isException());
         verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "AUTHORISED", "ERROR"));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
@@ -68,10 +67,9 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldErrorAuthorisationWhenFrontendStatusIsError_evenIfEpdqStatusIsSuccess() {
         mockPaymentProviderResponse(200, successAuthResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("ERROR");
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
-        assertTrue(response.isFailed());
-        assertThat(response.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
+        assertTrue(response.isException());
         verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "ERROR", AUTHORISED.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
@@ -80,10 +78,9 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldRejectAuthorisationWhenFrontendStatusIsDeclined_evenIfEpdqStatusIsSuccess() {
         mockPaymentProviderResponse(200, successAuthResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("DECLINED");
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
-        assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().authoriseStatus(), is(REJECTED));
+        assertFalse(response.isSuccessful());
         verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "DECLINED", AUTHORISED.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
@@ -92,10 +89,9 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     public void shouldRejectAuthorisationWhenFrontendStatusIsDeclined_evenIfEpdqStatusIsError() {
         mockPaymentProviderResponse(200, errorAuthResponse());
         Auth3dsResponseGatewayRequest request = buildTestAuthorisation3dsVerifyRequest("DECLINED");
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(request);
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
-        assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().authoriseStatus(), is(REJECTED));
+        assertFalse(response.isSuccessful());
         verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "DECLINED", ERROR.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -103,13 +104,9 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
         Auth3dsDetails auth3dsDetails = AuthUtils.buildAuth3dsDetails();
         auth3dsDetails.setMd("Some smart text here");
 
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise3dsResponse(new Auth3dsResponseGatewayRequest(chargeEntity, auth3dsDetails));
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(new Auth3dsResponseGatewayRequest(chargeEntity, auth3dsDetails));
 
         assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().isPresent(), is(true));
-        SmartpayAuthorisationResponse smartpayAuthorisationResponse = (SmartpayAuthorisationResponse) response.getBaseResponse().get();
-        assertThat(smartpayAuthorisationResponse.authoriseStatus(), is(AUTHORISED));
-        assertThat(smartpayAuthorisationResponse.getPspReference(), is(not(nullValue())));
     }
 
     private void mockSmartpaySuccessfulOrderSubmitResponse() {

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -166,7 +167,7 @@ public class EpdqPaymentProviderTest {
         assertThat(response.isSuccessful(), is(true));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
 
-        GatewayResponse<BaseAuthoriseResponse> queryResponse = paymentProvider.authorise3dsResponse(buildQueryRequest(chargeEntity, Auth3dsDetails.Auth3dsResult.AUTHORISED.name()));
+        Gateway3DSAuthorisationResponse queryResponse = paymentProvider.authorise3dsResponse(buildQueryRequest(chargeEntity, Auth3dsDetails.Auth3dsResult.AUTHORISED.name()));
         assertThat(queryResponse.isSuccessful(), is(true));
         assertThat(response.getBaseResponse().get().authoriseStatus(), is(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED));
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -69,9 +69,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, mockConfiguration, null);
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService, mockEnvironment);
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);
     }
 
     public void setupMockExecutorServiceMock() {
@@ -105,7 +105,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        GatewayResponse response = card3dsResponseAuthService.process3DSecure(charge.getExternalId(), auth3dsDetails);
+        GatewayResponse response = card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), auth3dsDetails);
 
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -125,7 +125,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         setupMockExecutorServiceMock();
 
         try {
-            card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+            card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
             fail("Won’t get this far");
         } catch (RuntimeException e) {
             assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
@@ -149,7 +149,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), auth3dsDetails);
+        card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), auth3dsDetails);
 
         assertTrue(argumentCaptor.getValue().getProviderSessionId().isPresent());
         assertThat(argumentCaptor.getValue().getProviderSessionId().get(), is(providerSessionId));
@@ -197,7 +197,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
-            card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+            card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
             fail("Exception not thrown.");
         } catch (OperationAlreadyInProgressRuntimeException e) {
             Map<String, String> expectedMessage = ImmutableMap.of("message", format("Authorisation for charge already in progress, %s", charge.getExternalId()));
@@ -214,7 +214,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockedChargeDao.findByExternalId(chargeId))
                 .thenReturn(Optional.empty());
 
-        card3dsResponseAuthService.process3DSecure(chargeId, AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecureAuthorisation(chargeId, AuthUtils.buildAuth3dsDetails());
     }
 
     @Test(expected = OperationAlreadyInProgressRuntimeException.class)
@@ -225,7 +225,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         setupMockExecutorServiceMock();
 
-        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
@@ -238,7 +238,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         setupMockExecutorServiceMock();
 
-        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
     
@@ -250,7 +250,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         setupMockExecutorServiceMock();
 
-        card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
@@ -276,7 +276,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        return card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        return card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
     }
 
     private GatewayResponse anAuthorisationErrorResponse(ChargeEntity charge,
@@ -288,6 +288,6 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        return card3dsResponseAuthService.process3DSecure(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
+        return card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -20,9 +20,7 @@ import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeEx
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.util.AuthUtils;
 
 import java.util.Map;
@@ -44,7 +42,6 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
-import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.IN_PROGRESS;
 
@@ -79,15 +76,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
                 .when(mockExecutorService).execute(any(Supplier.class));
     }
 
-    private void setupPaymentProviderMock(String transactionId, AuthoriseStatus authoriseStatus, String errorCode, ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
-        WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
-        when(worldpayResponse.getTransactionId()).thenReturn(transactionId);
-        when(worldpayResponse.authoriseStatus()).thenReturn(authoriseStatus);
-        when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
-        GatewayResponseBuilder<WorldpayOrderStatusResponse> gatewayResponseBuilder = responseBuilder();
-        GatewayResponse authorisationResponse = gatewayResponseBuilder
-                .withResponse(worldpayResponse)
-                .build();
+    private void setupPaymentProviderMock(String transactionId, AuthoriseStatus authoriseStatus, ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
+        Gateway3DSAuthorisationResponse authorisationResponse = Gateway3DSAuthorisationResponse.of(authoriseStatus, transactionId);
         when(mockedPaymentProvider.authorise3dsResponse(argumentCaptor.capture())).thenReturn(authorisationResponse);
     }
 
@@ -101,11 +91,11 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
                 .thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
-        GatewayResponse response = card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), auth3dsDetails);
+        Gateway3DSAuthorisationResponse response = card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), auth3dsDetails);
 
         assertThat(response.isSuccessful(), is(true));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -116,7 +106,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void doAuthorise_shouldRetainGeneratedTransactionId_evenIfAuthorisationAborted()  {
+    public void doAuthorise_shouldRetainGeneratedTransactionId_evenIfAuthorisationAborted() {
 
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
@@ -145,7 +135,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
                 .thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -156,13 +146,13 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void shouldRespondAuthorisationRejected()  {
+    public void shouldRespondAuthorisationRejected() {
         ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
 
-        GatewayResponse response = anAuthorisationRejectedResponse(charge, charge.getGatewayTransactionId(), argumentCaptor);
+        Gateway3DSAuthorisationResponse response = anAuthorisationRejectedResponse(charge, charge.getGatewayTransactionId(), argumentCaptor);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.isSuccessful(), is(false));
 
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
@@ -171,13 +161,13 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void shouldRespondAuthorisationCancelled()  {
+    public void shouldRespondAuthorisationCancelled() {
         ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
 
-        GatewayResponse response = anAuthorisationCancelledResponse(charge, charge.getGatewayTransactionId(), argumentCaptor);
+        Gateway3DSAuthorisationResponse response = anAuthorisationCancelledResponse(charge, charge.getGatewayTransactionId(), argumentCaptor);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertThat(response.isSuccessful(), is(false));
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
         assertTrue(argumentCaptor.getValue().getTransactionId().isPresent());
@@ -185,15 +175,15 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test
-    public void shouldRespondAuthorisationError()  {
+    public void shouldRespondAuthorisationError() {
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
-        GatewayResponse response = anAuthorisationErrorResponse(charge, argumentCaptor);
+        Gateway3DSAuthorisationResponse response = anAuthorisationErrorResponse(charge, argumentCaptor);
 
-        assertThat(response.isFailed(), is(true));
+        assertThat(response.isSuccessful(), is(false));
     }
 
     @Test
-    public void authoriseShouldThrowAnOperationAlreadyInProgressRuntimeExceptionWhenTimeout()  {
+    public void authoriseShouldThrowAnOperationAlreadyInProgressRuntimeExceptionWhenTimeout() {
         when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));
 
         try {
@@ -230,7 +220,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     @Test(expected = IllegalStateRuntimeException.class)
-    public void shouldThrowAnIllegalStateRuntimeExceptionWhenInvalidStatus()  {
+    public void shouldThrowAnIllegalStateRuntimeExceptionWhenInvalidStatus() {
 
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.AUTHORISATION_READY);
 
@@ -241,7 +231,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
-    
+
     @Test(expected = IllegalStateRuntimeException.class)
     public void shouldThrowChargeExpiredRuntimeExceptionWhenChargeExpired() {
         ChargeEntity charge = createNewChargeWith(1L, ChargeStatus.EXPIRED);
@@ -254,37 +244,37 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         verifyNoMoreInteractions(mockedChargeDao, mockedProviders);
     }
 
-    private GatewayResponse anAuthorisationRejectedResponse(ChargeEntity charge,
-                                                            String transactionId,
-                                                            ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
+    private Gateway3DSAuthorisationResponse anAuthorisationRejectedResponse(ChargeEntity charge,
+                                                                            String transactionId,
+                                                                            ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
         return anAuthorisedFailedResponse(charge, transactionId, AuthoriseStatus.REJECTED, argumentCaptor);
     }
 
-    private GatewayResponse anAuthorisationCancelledResponse(ChargeEntity charge,
-                                                             String transactionId,
-                                                             ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
+    private Gateway3DSAuthorisationResponse anAuthorisationCancelledResponse(ChargeEntity charge,
+                                                                             String transactionId,
+                                                                             ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
         return anAuthorisedFailedResponse(charge, transactionId, AuthoriseStatus.CANCELLED, argumentCaptor);
     }
 
-    private GatewayResponse anAuthorisedFailedResponse(ChargeEntity charge,
-                                                       String transactionId, AuthoriseStatus authoriseStatus,
-                                                       ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
+    private Gateway3DSAuthorisationResponse anAuthorisedFailedResponse(ChargeEntity charge,
+                                                                       String transactionId, AuthoriseStatus authoriseStatus,
+                                                                       ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(transactionId, authoriseStatus, null, argumentCaptor);
+        setupPaymentProviderMock(transactionId, authoriseStatus, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
         return card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
     }
 
-    private GatewayResponse anAuthorisationErrorResponse(ChargeEntity charge,
-                                                         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
+    private Gateway3DSAuthorisationResponse anAuthorisationErrorResponse(ChargeEntity charge,
+                                                                         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(null, AuthoriseStatus.REJECTED, "error-code", argumentCaptor);
+        setupPaymentProviderMock(null, AuthoriseStatus.REJECTED, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -98,7 +98,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao, 
                 mockedProviders,


### PR DESCRIPTION
This PR does two things:
- Pushes some functionality in `Auth3DSResponseService` into `CarAuthoriseBaseService` - basically logging and metrics, which we can also use from any other authorise service
- Simplifies the interface of the payment provider method `authorise3dsResponse` to respond with a simpler object, that only contains the necessary information for doing the things that the service and resource need to do. This is still not perfect, but is massively simpler and cleaner, and can be refined in further work. 