### PR TITLE
PP-4374 Remove Notifications from PaymentProvider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
@@ -2,11 +2,9 @@ package uk.gov.pay.connector.applepay;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
@@ -17,7 +15,6 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
-import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
@@ -29,7 +26,7 @@ public class AppleAuthoriseService {
     private final PaymentProviders paymentProviders;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private MetricRegistry metricRegistry;
-    
+
     @Inject
     AppleAuthoriseService(PaymentProviders paymentProviders,
                           ChargeService chargeService,
@@ -104,7 +101,7 @@ public class AppleAuthoriseService {
         return getPaymentProviderFor(chargeEntity)
                 .authoriseApplePay(authorisationGatewayRequest);
     }
-    
+
     private AuthCardDetails authCardDetailsFor(AppleDecryptedPaymentData applePaymentData) {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardHolder(applePaymentData.getPaymentInfo().getCardholderName());
@@ -116,7 +113,7 @@ public class AppleAuthoriseService {
         return authCardDetails;
     }
 
-    private PaymentProvider<BaseAuthoriseResponse> getPaymentProviderFor(ChargeEntity chargeEntity) {
+    private PaymentProvider getPaymentProviderFor(ChargeEntity chargeEntity) {
         return paymentProviders.byName(chargeEntity.getPaymentGatewayName());
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.connector.gateway;
 
-import fj.data.Either;
 import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
-import uk.gov.pay.connector.applepay.ApplePayAuthorisationHandler;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -15,17 +13,12 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.usernotification.model.Notification;
-import uk.gov.pay.connector.usernotification.model.Notifications;
 
 import java.util.Optional;
 
-public interface PaymentProvider<R> {
+public interface PaymentProvider {
 
     PaymentGatewayName getPaymentGatewayName();
-
-    StatusMapper getStatusMapper();
 
     Optional<String> generateTransactionId();
 
@@ -34,20 +27,12 @@ public interface PaymentProvider<R> {
     GatewayResponse<BaseAuthoriseResponse> authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 
     GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request);
-    
+
     GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request);
 
     GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request);
 
     GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request);
-
-    Either<String, Notifications<R>> parseNotification(String payload);
-
-    Boolean isNotificationEndpointSecured();
-
-    String getNotificationDomain();
-
-    boolean verifyNotification(Notification<R> notification, GatewayAccountEntity gatewayAccountEntity);
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity);
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -1,12 +1,10 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
-import fj.data.Either;
 import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
-import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -24,9 +22,6 @@ import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxApplePayAuthorisatio
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.usernotification.model.Notification;
-import uk.gov.pay.connector.usernotification.model.Notifications;
 
 import java.util.Optional;
 
@@ -34,7 +29,7 @@ import static java.util.UUID.randomUUID;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
-public class SandboxPaymentProvider implements PaymentProvider<String> {
+public class SandboxPaymentProvider implements PaymentProvider {
 
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 
@@ -80,7 +75,7 @@ public class SandboxPaymentProvider implements PaymentProvider<String> {
     public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
         return sandboxApplePayAuthorisationHandler.authorise(request);
     }
-    
+
     @Override
     public GatewayResponse<BaseCaptureResponse> capture(CaptureGatewayRequest request) {
         return sandboxCaptureHandler.capture(request);
@@ -100,35 +95,10 @@ public class SandboxPaymentProvider implements PaymentProvider<String> {
     public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) {
         return createGatewayBaseCancelResponse();
     }
-    
-    @Override
-    public Boolean isNotificationEndpointSecured() {
-        return false;
-    }
-
-    @Override
-    public String getNotificationDomain() {
-        return null;
-    }
-
-    @Override
-    public boolean verifyNotification(Notification notification, GatewayAccountEntity gatewayAccountEntity) {
-        return true;
-    }
 
     @Override
     public GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request) {
         return createGatewayBaseRefundResponse(request);
-    }
-
-    @Override
-    public Either<String, Notifications<String>> parseNotification(String payload) {
-        throw new UnsupportedOperationException("Sandbox account does not support notifications");
-    }
-
-    @Override
-    public StatusMapper<String> getStatusMapper() {
-        return null;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -1,9 +1,7 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import fj.data.Either;
 import io.dropwizard.setup.Environment;
-import org.apache.commons.lang3.tuple.Pair;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.applepay.ApplePayAuthorisationGatewayRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -13,7 +11,6 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
-import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -29,24 +26,17 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.usernotification.model.Notification;
-import uk.gov.pay.connector.usernotification.model.Notifications;
-import uk.gov.pay.connector.usernotification.model.Notifications.Builder;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Invocation;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
-import static fj.data.Either.left;
-import static fj.data.Either.right;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
-public class SmartpayPaymentProvider implements PaymentProvider<Pair<String, Boolean>> {
+public class SmartpayPaymentProvider implements PaymentProvider {
 
-    private final ObjectMapper objectMapper;
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
     private final GatewayClient client;
 
@@ -55,9 +45,7 @@ public class SmartpayPaymentProvider implements PaymentProvider<Pair<String, Boo
     @Inject
     public SmartpayPaymentProvider(ConnectorConfiguration configuration,
                                    GatewayClientFactory gatewayClientFactory,
-                                   Environment environment,
-                                   ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
+                                   Environment environment) {
         externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
         client = gatewayClientFactory.createGatewayClient(SMARTPAY, configuration.getGatewayConfigFor(SMARTPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
 
@@ -102,56 +90,10 @@ public class SmartpayPaymentProvider implements PaymentProvider<Pair<String, Boo
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildCancelOrderFor(request));
         return GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayCancelResponse.class);
     }
-    
+
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
         throw new UnsupportedOperationException("Apple Pay is not supported for Smartpay");
-    }
-    
-    @Override
-    public Boolean isNotificationEndpointSecured() {
-        return false;
-    }
-
-    @Override
-    public String getNotificationDomain() {
-        return null;
-    }
-
-    @Override
-    public boolean verifyNotification(Notification<Pair<String, Boolean>> notification, GatewayAccountEntity gatewayAccountEntity) {
-        return true;
-    }
-
-    @Override
-    public Either<String, Notifications<Pair<String, Boolean>>> parseNotification(String payload) {
-        try {
-            Builder<Pair<String, Boolean>> builder = Notifications.builder();
-
-            objectMapper.readValue(payload, SmartpayNotificationList.class)
-                    .getNotifications()
-                    // TODO for authorisation notifications, this does the wrong thing
-                    // Transaction ID is pspReference, not originalReference as the code below assumes
-                    // https://www.barclaycard.co.uk/business/files/SmartPay_Notifications_Guide.pdf
-                    // We will set the transaction ID to blank, which makes the notification effectively useless
-                    // This is OK at the moment because we ignore authorisation notifications for Smartpay
-                    .forEach(notification -> builder.addNotificationFor(
-                            notification.getOriginalReference(),
-                            notification.getPspReference(),
-                            notification.getStatus(),
-                            notification.getEventDate(),
-                            null
-                    ));
-
-            return right(builder.build());
-        } catch (Exception e) {
-            return left(e.getMessage());
-        }
-    }
-
-    @Override
-    public StatusMapper<Pair<String, Boolean>> getStatusMapper() {
-        return null;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe;
 
 import com.google.common.collect.ImmutableMap;
-import fj.data.Either;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -13,7 +12,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
-import uk.gov.pay.connector.gateway.StatusMapper;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -35,8 +33,6 @@ import uk.gov.pay.connector.gateway.stripe.util.StripeAuthUtil;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.usernotification.model.Notification;
-import uk.gov.pay.connector.usernotification.model.Notifications;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -60,7 +56,7 @@ import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayErro
 import static uk.gov.pay.connector.gateway.model.GatewayError.unexpectedStatusCodeFromGateway;
 
 @Singleton
-public class StripePaymentProvider implements PaymentProvider<String> {
+public class StripePaymentProvider implements PaymentProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(StripePaymentProvider.class);
 
@@ -83,11 +79,6 @@ public class StripePaymentProvider implements PaymentProvider<String> {
     @Override
     public PaymentGatewayName getPaymentGatewayName() {
         return STRIPE;
-    }
-
-    @Override
-    public StatusMapper getStatusMapper() {
-        return null;
     }
 
     @Override
@@ -147,9 +138,9 @@ public class StripePaymentProvider implements PaymentProvider<String> {
         }
     }
 
-    private GatewayResponse unexpectedGatewayResponse(String chargeExternalId, 
-                                                      GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder, 
-                                                      String errorMessage, 
+    private GatewayResponse unexpectedGatewayResponse(String chargeExternalId,
+                                                      GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder,
+                                                      String errorMessage,
                                                       int statusCode) {
         String errorId = UUID.randomUUID().toString();
         logger.error("Authorisation failed for charge {}. Reason: {}. Status code from Stripe: {}. ErrorId: {}",
@@ -235,26 +226,6 @@ public class StripePaymentProvider implements PaymentProvider<String> {
     @Override
     public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) {
         return null;
-    }
-
-    @Override
-    public Either<String, Notifications<String>> parseNotification(String payload) {
-        return null;
-    }
-
-    @Override
-    public Boolean isNotificationEndpointSecured() {
-        return null;
-    }
-
-    @Override
-    public String getNotificationDomain() {
-        return null;
-    }
-
-    @Override
-    public boolean verifyNotification(Notification<String> notification, GatewayAccountEntity gatewayAccountEntity) {
-        return false;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -25,7 +25,7 @@ public class Card3dsResponseAuthService {
     private final PaymentProviders providers;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final MetricRegistry metricRegistry;
-    
+
     @Inject
     public Card3dsResponseAuthService(PaymentProviders providers,
                                       ChargeService chargeService,
@@ -60,30 +60,30 @@ public class Card3dsResponseAuthService {
 
     private void processGateway3DSecureResponse(
             String chargeExternalId,
-            ChargeStatus oldChargeStatus, 
+            ChargeStatus oldChargeStatus,
             GatewayResponse<BaseAuthoriseResponse> operationResponse) {
-        
-            Optional<String> transactionId = operationResponse.getBaseResponse().map(BaseAuthoriseResponse::getTransactionId);
-            ChargeStatus status = cardAuthoriseBaseService.extractChargeStatus(operationResponse.getBaseResponse(), Optional.empty());
-            ChargeEntity updatedCharge = chargeService.updateChargePost3dsAuthorisation(chargeExternalId, status, transactionId);
 
-            logger.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
-                    updatedCharge.getExternalId(), 
-                    updatedCharge.getPaymentGatewayName().getName(), 
-                    updatedCharge.getGatewayTransactionId(),
-                    updatedCharge.getGatewayAccount().getAnalyticsId(), 
-                    updatedCharge.getGatewayAccount().getId(),
-                    operationResponse, oldChargeStatus, 
-                    status);
+        Optional<String> transactionId = operationResponse.getBaseResponse().map(BaseAuthoriseResponse::getTransactionId);
+        ChargeStatus status = cardAuthoriseBaseService.extractChargeStatus(operationResponse.getBaseResponse(), Optional.empty());
+        ChargeEntity updatedCharge = chargeService.updateChargePost3dsAuthorisation(chargeExternalId, status, transactionId);
 
-            metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.authorise-3ds.result.%s",
-                    updatedCharge.getGatewayAccount().getGatewayName(),
-                    updatedCharge.getGatewayAccount().getType(),
-                    updatedCharge.getGatewayAccount().getId(),
-                    status.toString())).inc();
+        logger.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
+                updatedCharge.getExternalId(),
+                updatedCharge.getPaymentGatewayName().getName(),
+                updatedCharge.getGatewayTransactionId(),
+                updatedCharge.getGatewayAccount().getAnalyticsId(),
+                updatedCharge.getGatewayAccount().getId(),
+                operationResponse, oldChargeStatus,
+                status);
+
+        metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.authorise-3ds.result.%s",
+                updatedCharge.getGatewayAccount().getGatewayName(),
+                updatedCharge.getGatewayAccount().getType(),
+                updatedCharge.getGatewayAccount().getId(),
+                status.toString())).inc();
     }
 
-    private PaymentProvider<BaseAuthoriseResponse> getPaymentProviderFor(ChargeEntity chargeEntity) {
+    private PaymentProvider getPaymentProviderFor(ChargeEntity chargeEntity) {
         return providers.byName(chargeEntity.getPaymentGatewayName());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -166,7 +166,7 @@ public class ChargeExpiryServiceTest {
 
         GatewayError mockGatewayError = mock(GatewayError.class);
         GatewayResponseBuilder<WorldpayBaseResponse> gatewayResponseBuilder = responseBuilder();
-        GatewayResponse<WorldpayBaseResponse> gatewayErrorResponse = gatewayResponseBuilder
+        GatewayResponse<BaseCancelResponse> gatewayErrorResponse = gatewayResponseBuilder
                 .withGatewayError(mockGatewayError)
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -21,7 +21,6 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -73,7 +72,7 @@ public abstract class BaseEpdqPaymentProviderTest {
     static final String NOTIFICATION_PAY_ID_SUB = "2";
     static final String NOTIFICATION_SHA_SIGN = "9537B9639F108CDF004459D8A690C598D97506CDF072C3926A60E39759A6402C5089161F6D7A8EA12BBC0FD6F899CE72D5A0C4ACC2913C56ACF6D01B034protected";
 
-    protected GatewayClientFactory gatewayClientFactory;    
+    protected GatewayClientFactory gatewayClientFactory;
     protected EpdqPaymentProvider provider;
 
 
@@ -122,7 +121,7 @@ public abstract class BaseEpdqPaymentProviderTest {
         when(configuration.getLinks()).thenReturn(linksConfig);
         when(linksConfig.getFrontendUrl()).thenReturn("http://frontendUrl");
 
-        provider = new EpdqPaymentProvider(configuration, gatewayClientFactory, environment, mockSignatureGenerator);
+        provider = new EpdqPaymentProvider(configuration, gatewayClientFactory, environment);
     }
 
     private Invocation.Builder mockClientInvocationBuilder() {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
@@ -1,24 +1,12 @@
 package uk.gov.pay.connector.gateway.epdq;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.message.BasicNameValuePair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.charge.dao.ChargeDao;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
-import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,15 +15,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_PAYMENT_REQUESTED;
 import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_REFUND;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 
 @RunWith(MockitoJUnitRunner.class)
-public class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest{
-   
+public class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest {
+
     @Before
     public void setup() {
         super.setup();

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -1,9 +1,5 @@
 package uk.gov.pay.connector.gateway.epdq;
 
-import com.google.common.collect.ImmutableList;
-import fj.data.Either;
-import org.apache.http.message.BasicNameValuePair;
-import org.hamcrest.core.IsNull;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,20 +9,13 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.usernotification.model.Notification;
-import uk.gov.pay.connector.usernotification.model.Notifications;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
@@ -54,7 +43,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     public void shouldThrow_IfTryingToAuthoriseAnApplePayPayment() {
         provider.authoriseApplePay(null);
     }
-    
+
     @Test
     public void shouldNotAuthoriseIfPaymentProviderReturnsUnexpectedStatusCode() {
         mockPaymentProviderResponse(200, errorAuthResponse());
@@ -134,76 +123,5 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
                 UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
-    }
-
-    @Test
-    public void shouldVerifyNotificationSignature() {
-        when(mockGatewayAccountEntity.getCredentials()).thenReturn(Collections.singletonMap(CREDENTIALS_SHA_OUT_PASSPHRASE, "passphrase"));
-
-        when(mockNotification.getPayload()).thenReturn(Optional.of(Arrays.asList(
-                new BasicNameValuePair("key1", "value1"),
-                new BasicNameValuePair("SHASIGN", "signature")
-        )));
-
-        when(mockSignatureGenerator.sign(Collections.singletonList(new BasicNameValuePair
-                ("key1", "value1")), "passphrase")).thenReturn("signature");
-
-        assertThat(provider.verifyNotification(mockNotification, mockGatewayAccountEntity), is(true));
-    }
-
-    @Test
-    public void shouldVerifyNotificationSignatureIgnoringCase() {
-        when(mockGatewayAccountEntity.getCredentials()).thenReturn(Collections.singletonMap(CREDENTIALS_SHA_OUT_PASSPHRASE, "passphrase"));
-
-        when(mockNotification.getPayload()).thenReturn(Optional.of(Arrays.asList(
-                new BasicNameValuePair("key1", "value1"),
-                new BasicNameValuePair("SHASIGN", "SIGNATURE")
-        )));
-
-        when(mockSignatureGenerator.sign(Collections.singletonList(new BasicNameValuePair
-                ("key1", "value1")), "passphrase")).thenReturn("signature");
-
-        assertThat(provider.verifyNotification(mockNotification, mockGatewayAccountEntity), is(true));
-    }
-
-    @Test
-    public void shouldNotVerifyNotificationIfWrongSignature() {
-        when(mockGatewayAccountEntity.getCredentials()).thenReturn(Collections.singletonMap(CREDENTIALS_SHA_OUT_PASSPHRASE, "passphrase"));
-
-        when(mockNotification.getPayload()).thenReturn(Optional.of(Arrays.asList(
-                new BasicNameValuePair("key1", "value1"),
-                new BasicNameValuePair("SHASIGN", "signature")
-        )));
-
-        when(mockSignatureGenerator.sign(Collections.singletonList(new BasicNameValuePair
-                ("key1", "value1")), "passphrase")).thenReturn("wrong signature");
-
-        assertThat(provider.verifyNotification(mockNotification, mockGatewayAccountEntity), is(false));
-    }
-
-    @Test
-    public void shouldNotVerifyNotificationIfEmptyPayload() {
-        when(mockNotification.getPayload()).thenReturn(Optional.empty());
-
-        assertThat(provider.verifyNotification(mockNotification, mockGatewayAccountEntity), is(false));
-    }
-
-    @Test
-    public void parseNotification_shouldReturnNotificationsIfValidFormUrlEncoded() throws IOException {
-        Either<String, Notifications<String>> response =
-                provider.parseNotification(notificationPayloadForTransaction(NOTIFICATION_STATUS, NOTIFICATION_PAY_ID, NOTIFICATION_PAY_ID_SUB, NOTIFICATION_SHA_SIGN));
-
-        assertThat(response.isRight(), is(true));
-
-        ImmutableList<Notification<String>> notifications = response.right().value().get();
-
-        assertThat(notifications.size(), is(1));
-
-        Notification<String> notification = notifications.get(0);
-
-        assertThat(notification.getTransactionId(), is(NOTIFICATION_PAY_ID));
-        assertThat(notification.getReference(), is(NOTIFICATION_PAY_ID + "/" + NOTIFICATION_PAY_ID_SUB));
-        assertThat(notification.getStatus(), is(NOTIFICATION_STATUS));
-        assertThat(notification.getGatewayEventDate(), IsNull.nullValue());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -17,7 +17,6 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 
@@ -26,8 +25,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsSame.sameInstance;
-import static org.mockito.Mockito.mock;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -38,7 +35,7 @@ public class SandboxPaymentProviderTest {
     private static final String AUTH_SUCCESS_CARD_NUMBER = "4242424242424242";
     private static final String AUTH_REJECTED_CARD_NUMBER = "4000000000000069";
     private static final String AUTH_ERROR_CARD_NUMBER = "4000000000000119";
-    
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -58,25 +55,6 @@ public class SandboxPaymentProviderTest {
         Assert.assertThat(provider.generateTransactionId().get(), is(instanceOf(String.class)));
     }
 
-    @Test
-    public void shouldAlwaysVerifyNotification() {
-        Assert.assertThat(provider.verifyNotification(null, mock(GatewayAccountEntity.class)), is(true));
-    }
-
-    @Test
-    public void parseNotification_shouldFailParsingNotification() {
-
-        String notification = "{\"transaction_id\":\"1\",\"status\":\"BOOM\", \"reference\":\"abc\"}";
-
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage(is("Sandbox account does not support notifications"));
-
-        provider.parseNotification(notification);
-    }
-    
-
- 
-    
     @Test
     public void authorise_shouldBeAuthorisedWhenCardNumIsExpectedToSucceedForAuthorisation() {
         AuthCardDetails authCardDetails = new AuthCardDetails();

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gateway.smartpay;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
@@ -56,7 +55,7 @@ public abstract class BaseSmartpayPaymentProviderTest {
         when(environment.metrics()).thenReturn(metricRegistry);
         when(metricRegistry.histogram(anyString())).thenReturn(mock(Histogram.class));
 
-        provider = new SmartpayPaymentProvider(configuration, gatewayClientFactory, environment, new ObjectMapper());
+        provider = new SmartpayPaymentProvider(configuration, gatewayClientFactory, environment);
     }
 
     protected GatewayAccountEntity aServiceAccount() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayBasePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayBasePaymentProviderTest.java
@@ -9,7 +9,6 @@ import org.junit.Before;
 import org.mockito.Mock;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.GatewayConfig;
-import uk.gov.pay.connector.app.WorldpayConfig;
 import uk.gov.pay.connector.gateway.ClientFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
@@ -80,7 +79,6 @@ public abstract class WorldpayBasePaymentProviderTest {
 
         when(configuration.getGatewayConfigFor(PaymentGatewayName.WORLDPAY)).thenReturn(gatewayConfig);
         when(gatewayConfig.getUrls()).thenReturn(urlMap);
-        when(configuration.getWorldpayConfig()).thenReturn(mock(WorldpayConfig.class));
         when(environment.metrics()).thenReturn(mockMetricRegistry);
 
         provider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -20,7 +20,6 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
-import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -93,9 +92,6 @@ public class EpdqPaymentProviderTest {
     @Mock
     private GatewayClientFactory mockGatewayClientFactory;
 
-    @Mock
-    private SignatureGenerator mockSignatureGenerator;
-
     @Before
     public void setUp() {
         when(mockConnectorConfiguration.getLinks()).thenReturn(mockLinksConfig);
@@ -115,7 +111,7 @@ public class EpdqPaymentProviderTest {
                 any(BiFunction.class),
                 any())).thenReturn(gatewayClient);
 
-        paymentProvider = new EpdqPaymentProvider(mockConnectorConfiguration, mockGatewayClientFactory, mockEnvironment, mockSignatureGenerator);
+        paymentProvider = new EpdqPaymentProvider(mockConnectorConfiguration, mockGatewayClientFactory, mockEnvironment);
     }
 
     @Test
@@ -192,7 +188,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldCaptureSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        
+
         CardAuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
@@ -221,7 +217,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldRefundSuccessfully() {
         setUpAndCheckThatEpdqIsUp();
-        
+
         CardAuthorisationGatewayRequest request = buildAuthorisationRequest(chargeEntity);
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));


### PR DESCRIPTION
## WHAT

Part of refactoring notification handling (see https://github.com/alphagov/pay-connector/pull/787 for the original full attempt...). 

- Notifications related code removed from PaymentProvider interface and sub classes as it is no longer required ( Each payment provider now has separate Notification service to handle notifications)
