### PR TITLE
PP-4290 Add prepaid corporate card surcharge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
@@ -40,27 +40,23 @@ public class CorporateCardSurchargeCalculator {
     }
 
     public static Optional<Long> getCorporateCardSurchargeFor(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
-        if (!authCardDetails.isCorporateCard() ||
-                PayersPrepaidCardType.UNKNOWN.equals(authCardDetails.getPayersPrepaidCardType())) {
-            return Optional.empty();
-        }
+        if (authCardDetails.isCorporateCard()) {
+            if (isCreditSurcharge(authCardDetails, chargeEntity)) {
+                return Optional.of(chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount());
+            }
 
-        if (isCreditSurcharge(authCardDetails, chargeEntity)) {
-            return Optional.of(chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount());
-        }
+            if (isDebitSurcharge(authCardDetails, chargeEntity)) {
+                return Optional.of(chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount());
+            }
 
-        if (isDebitSurcharge(authCardDetails, chargeEntity)) {
-            return Optional.of(chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount());
-        }
+            if (isPrepaidCreditSurcharge(authCardDetails, chargeEntity)) {
+                return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidCreditCardSurchargeAmount());
+            }
 
-        if (isPrepaidCreditSurcharge(authCardDetails, chargeEntity)) {
-            return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidCreditCardSurchargeAmount());
+            if (isPrepaidDebitSurcharge(authCardDetails, chargeEntity)) {
+                return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidDebitCardSurchargeAmount());
+            }
         }
-
-        if (isPrepaidDebitSurcharge(authCardDetails, chargeEntity)) {
-            return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidDebitCardSurchargeAmount());
-        }
-
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.Transaction;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
 
 import java.util.Optional;
 
@@ -14,20 +15,6 @@ public class CorporateCardSurchargeCalculator {
     private CorporateCardSurchargeCalculator() {
         // prevent Java for adding a public constructor
     }
-
-    public static Optional<Long> getCorporateCardSurchargeFor(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
-        if (authCardDetails.isCorporateCard()) {
-            if (authCardDetails.getPayersCardType().equals(PayersCardType.CREDIT) &&
-                    chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount() > 0) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount());
-            } else if (authCardDetails.getPayersCardType().equals(PayersCardType.DEBIT) &&
-                    chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount() > 0) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount());
-            }
-        }
-        return Optional.empty();
-    }
-
 
     public static Long getTotalAmountFor(ChargeEntity charge) {
         return charge.getCorporateSurcharge()
@@ -51,4 +38,54 @@ public class CorporateCardSurchargeCalculator {
                 .map(surcharge -> surcharge + transaction.getAmount())
                 .orElseGet((transaction::getAmount));
     }
+
+    public static Optional<Long> getCorporateCardSurchargeFor(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
+        if (!authCardDetails.isCorporateCard() ||
+                PayersPrepaidCardType.UNKNOWN.equals(authCardDetails.getPayersPrepaidCardType())) {
+            return Optional.empty();
+        }
+
+        if (isCreditSurcharge(authCardDetails, chargeEntity)) {
+            return Optional.of(chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount());
+        }
+
+        if (isDebitSurcharge(authCardDetails, chargeEntity)) {
+            return Optional.of(chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount());
+        }
+
+        if (isPrepaidCreditSurcharge(authCardDetails, chargeEntity)) {
+            return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidCreditCardSurchargeAmount());
+        }
+
+        if (isPrepaidDebitSurcharge(authCardDetails, chargeEntity)) {
+            return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidDebitCardSurchargeAmount());
+        }
+
+        return Optional.empty();
+    }
+
+    private static boolean isCreditSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
+        return PayersCardType.CREDIT.equals(authCardDetails.getPayersCardType()) &&
+                PayersPrepaidCardType.NOT_PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
+                chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount() > 0;
+    }
+
+    private static boolean isDebitSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
+        return PayersCardType.DEBIT.equals(authCardDetails.getPayersCardType()) &&
+                PayersPrepaidCardType.NOT_PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
+                chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount() > 0;
+    }
+
+    private static boolean isPrepaidCreditSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
+        return PayersCardType.CREDIT.equals(authCardDetails.getPayersCardType()) &&
+                PayersPrepaidCardType.PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
+                chargeEntity.getGatewayAccount().getCorporatePrepaidCreditCardSurchargeAmount() > 0;
+    }
+
+    private static boolean isPrepaidDebitSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
+        return PayersCardType.DEBIT.equals(authCardDetails.getPayersCardType()) &&
+                PayersPrepaidCardType.PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
+                chargeEntity.getGatewayAccount().getCorporatePrepaidDebitCardSurchargeAmount() > 0;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
@@ -4,7 +4,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.Transaction;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
-import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 
 import java.util.Optional;
 
@@ -42,11 +42,11 @@ public class CorporateCardSurchargeCalculator {
     public static Optional<Long> getCorporateCardSurchargeFor(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
         if (authCardDetails.isCorporateCard()) {
             if (isCreditSurcharge(authCardDetails, chargeEntity)) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount());
+                return Optional.of(chargeEntity.getGatewayAccount().getCorporateNonPrepaidCreditCardSurchargeAmount());
             }
 
             if (isDebitSurcharge(authCardDetails, chargeEntity)) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount());
+                return Optional.of(chargeEntity.getGatewayAccount().getCorporateNonPrepaidDebitCardSurchargeAmount());
             }
 
             if (isPrepaidCreditSurcharge(authCardDetails, chargeEntity)) {
@@ -62,25 +62,25 @@ public class CorporateCardSurchargeCalculator {
 
     private static boolean isCreditSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
         return PayersCardType.CREDIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersPrepaidCardType.NOT_PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
-                chargeEntity.getGatewayAccount().getCorporateCreditCardSurchargeAmount() > 0;
+                PayersCardPrepaidStatus.NOT_PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
+                chargeEntity.getGatewayAccount().getCorporateNonPrepaidCreditCardSurchargeAmount() > 0;
     }
 
     private static boolean isDebitSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
         return PayersCardType.DEBIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersPrepaidCardType.NOT_PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
-                chargeEntity.getGatewayAccount().getCorporateDebitCardSurchargeAmount() > 0;
+                PayersCardPrepaidStatus.NOT_PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
+                chargeEntity.getGatewayAccount().getCorporateNonPrepaidDebitCardSurchargeAmount() > 0;
     }
 
     private static boolean isPrepaidCreditSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
         return PayersCardType.CREDIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersPrepaidCardType.PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
+                PayersCardPrepaidStatus.PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
                 chargeEntity.getGatewayAccount().getCorporatePrepaidCreditCardSurchargeAmount() > 0;
     }
 
     private static boolean isPrepaidDebitSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
         return PayersCardType.DEBIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersPrepaidCardType.PREPAID.equals(authCardDetails.getPayersPrepaidCardType()) &&
+                PayersCardPrepaidStatus.PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
                 chargeEntity.getGatewayAccount().getCorporatePrepaidDebitCardSurchargeAmount() > 0;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
@@ -3,8 +3,6 @@ package uk.gov.pay.connector.charge.util;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.Transaction;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.PayersCardType;
-import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 
 import java.util.Optional;
 
@@ -40,48 +38,8 @@ public class CorporateCardSurchargeCalculator {
     }
 
     public static Optional<Long> getCorporateCardSurchargeFor(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
-        if (authCardDetails.isCorporateCard()) {
-            if (isCreditSurcharge(authCardDetails, chargeEntity)) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporateNonPrepaidCreditCardSurchargeAmount());
-            }
-
-            if (isDebitSurcharge(authCardDetails, chargeEntity)) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporateNonPrepaidDebitCardSurchargeAmount());
-            }
-
-            if (isPrepaidCreditSurcharge(authCardDetails, chargeEntity)) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidCreditCardSurchargeAmount());
-            }
-
-            if (isPrepaidDebitSurcharge(authCardDetails, chargeEntity)) {
-                return Optional.of(chargeEntity.getGatewayAccount().getCorporatePrepaidDebitCardSurchargeAmount());
-            }
-        }
-        return Optional.empty();
-    }
-
-    private static boolean isCreditSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
-        return PayersCardType.CREDIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersCardPrepaidStatus.NOT_PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
-                chargeEntity.getGatewayAccount().getCorporateNonPrepaidCreditCardSurchargeAmount() > 0;
-    }
-
-    private static boolean isDebitSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
-        return PayersCardType.DEBIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersCardPrepaidStatus.NOT_PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
-                chargeEntity.getGatewayAccount().getCorporateNonPrepaidDebitCardSurchargeAmount() > 0;
-    }
-
-    private static boolean isPrepaidCreditSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
-        return PayersCardType.CREDIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersCardPrepaidStatus.PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
-                chargeEntity.getGatewayAccount().getCorporatePrepaidCreditCardSurchargeAmount() > 0;
-    }
-
-    private static boolean isPrepaidDebitSurcharge(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
-        return PayersCardType.DEBIT.equals(authCardDetails.getPayersCardType()) &&
-                PayersCardPrepaidStatus.PREPAID.equals(authCardDetails.getPayersCardPrepaidStatus()) &&
-                chargeEntity.getGatewayAccount().getCorporatePrepaidDebitCardSurchargeAmount() > 0;
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        return surcharge > 0 ? Optional.of(surcharge) : Optional.empty();
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/charge/util/FixedCorporateCardSurchargeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/FixedCorporateCardSurchargeCalculator.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.charge.util;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+class FixedCorporateCardSurchargeCalculator {
+
+    static long calculate(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {
+        if (authCardDetails.isCorporateCard()) {
+            GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
+            switch (authCardDetails.getPayersCardPrepaidStatus()) {
+                case NOT_PREPAID:
+                    switch (authCardDetails.getPayersCardType()) {
+                        case CREDIT:
+                            return gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount();
+                        case DEBIT:
+                            return gatewayAccount.getCorporateNonPrepaidDebitCardSurchargeAmount();
+                        case CREDIT_OR_DEBIT:
+                            return 0;
+                    }
+                case PREPAID:
+                    switch (authCardDetails.getPayersCardType()) {
+                        case CREDIT:
+                            return gatewayAccount.getCorporatePrepaidCreditCardSurchargeAmount();
+                        case DEBIT:
+                            return gatewayAccount.getCorporatePrepaidDebitCardSurchargeAmount();
+                        case CREDIT_OR_DEBIT:
+                            return 0;
+                    }
+                case UNKNOWN:
+                    return 0;
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -20,7 +20,7 @@ public class AuthCardDetails implements AuthorisationDetails {
     private String userAgentHeader;
     private String acceptHeader;
     private PayersCardType payersCardType;
-    private PayersPrepaidCardType payersPrepaidCardType;
+    private PayersCardPrepaidStatus payersCardPrepaidStatus;
     private Boolean corporateCard;
 
     public static AuthCardDetails anAuthCardDetails() {
@@ -78,8 +78,8 @@ public class AuthCardDetails implements AuthorisationDetails {
     }
 
     @JsonProperty("prepaid")
-    public void setPayersPrepaidCardType(PayersPrepaidCardType payersPrepaidCardType) {
-        this.payersPrepaidCardType = payersPrepaidCardType;
+    public void setPayersCardPrepaidStatus(PayersCardPrepaidStatus payersCardPrepaidStatus) {
+        this.payersCardPrepaidStatus = payersCardPrepaidStatus;
     }
 
     public String getCardNo() {
@@ -132,7 +132,7 @@ public class AuthCardDetails implements AuthorisationDetails {
         return payersCardType == null ? CREDIT_OR_DEBIT : payersCardType;
     }
 
-    public PayersPrepaidCardType getPayersPrepaidCardType() {
-        return payersPrepaidCardType == null ? PayersPrepaidCardType.UNKNOWN : payersPrepaidCardType;
+    public PayersCardPrepaidStatus getPayersCardPrepaidStatus() {
+        return payersCardPrepaidStatus == null ? PayersCardPrepaidStatus.UNKNOWN : payersCardPrepaidStatus;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -20,6 +20,7 @@ public class AuthCardDetails implements AuthorisationDetails {
     private String userAgentHeader;
     private String acceptHeader;
     private PayersCardType payersCardType;
+    private PayersPrepaidCardType payersPrepaidCardType;
     private Boolean corporateCard;
 
     public static AuthCardDetails anAuthCardDetails() {
@@ -76,6 +77,11 @@ public class AuthCardDetails implements AuthorisationDetails {
         this.payersCardType = payersCardType;
     }
 
+    @JsonProperty("prepaid")
+    public void setPayersPrepaidCardType(PayersPrepaidCardType payersPrepaidCardType) {
+        this.payersPrepaidCardType = payersPrepaidCardType;
+    }
+
     public String getCardNo() {
         return cardNo;
     }
@@ -124,5 +130,9 @@ public class AuthCardDetails implements AuthorisationDetails {
 
     public PayersCardType getPayersCardType() {
         return payersCardType == null ? CREDIT_OR_DEBIT : payersCardType;
+    }
+
+    public PayersPrepaidCardType getPayersPrepaidCardType() {
+        return payersPrepaidCardType == null ? PayersPrepaidCardType.UNKNOWN : payersPrepaidCardType;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/PayersCardPrepaidStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/PayersCardPrepaidStatus.java
@@ -6,7 +6,7 @@ package uk.gov.pay.connector.gateway.model;
  * used to make a payment. This is also used to calculate corporate
  * surcharges, based on other rules.
  */
-public enum PayersPrepaidCardType {
+public enum PayersCardPrepaidStatus {
     PREPAID,
     NOT_PREPAID,
     UNKNOWN

--- a/src/main/java/uk/gov/pay/connector/gateway/model/PayersPrepaidCardType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/PayersPrepaidCardType.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.gateway.model;
+
+/**
+ * The enum type that should be used to map from and to JSON when
+ * dealing with prepaid nature of the card (PREPAID, NOT_PREPAID, UNKNOWN)
+ * used to make a payment. This is also used to calculate corporate
+ * surcharges, based on other rules.
+ */
+public enum PayersPrepaidCardType {
+    PREPAID,
+    NOT_PREPAID,
+    UNKNOWN
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -228,13 +228,13 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_credit_card_surcharge_amount")
-    public long getCorporateCreditCardSurchargeAmount() {
+    public long getCorporateNonPrepaidCreditCardSurchargeAmount() {
         return corporateCreditCardSurchargeAmount;
     }
 
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_debit_card_surcharge_amount")
-    public long getCorporateDebitCardSurchargeAmount() {
+    public long getCorporateNonPrepaidDebitCardSurchargeAmount() {
         return corporateDebitCardSurchargeAmount;
     }
 
@@ -319,8 +319,8 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
             account.put("service_name", getServiceName());
         }
         account.put("toggle_3ds", String.valueOf(isRequires3ds()));
-        account.put("corporate_credit_card_surcharge_amount", getCorporateCreditCardSurchargeAmount());
-        account.put("corporate_debit_card_surcharge_amount", getCorporateDebitCardSurchargeAmount());
+        account.put("corporate_credit_card_surcharge_amount", getCorporateNonPrepaidCreditCardSurchargeAmount());
+        account.put("corporate_debit_card_surcharge_amount", getCorporateNonPrepaidDebitCardSurchargeAmount());
         account.put("corporate_prepaid_credit_card_surcharge_amount", getCorporatePrepaidCreditCardSurchargeAmount());
         account.put("corporate_prepaid_debit_card_surcharge_amount", getCorporatePrepaidDebitCardSurchargeAmount());
         account.put("allow_web_payments", String.valueOf(allowWebPayments));

--- a/src/test/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculatorTest.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.connector.charge.util;
 
-
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 
@@ -16,11 +16,259 @@ import static uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator.
 import static uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator.getTotalAmountFor;
 
 public class CorporateCardSurchargeCalculatorTest {
+
+    private static long CREDIT_CARD_SURCHARGE_AMOUNT = 250L;
+    private static long DEBIT_CARD_SURCHARGE_AMOUNT = 50L;
+
     @Test
-    public void shouldGetCorporateSurchargeForCreditCard() {
+    public void shouldNotGetSurchargeWhenNotEnabledOnGatewayAccount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(0L);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(corporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenNotCorporateCard() {
+        AuthCardDetails nonCorporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.FALSE)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(nonCorporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenCorporateCardWithUnknownPrepaid() {
+        AuthCardDetails nonCorporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.UNKNOWN)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(nonCorporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenCorporateCardWithNullPrepaid() {
+        AuthCardDetails nonCorporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(null)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(nonCorporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldGetCorporateSurchargeForPrepaidCorporateCreditCard() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+
+        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(corporateCard, chargeEntity);
+        assertThat(optionalSurcharge.isPresent(), is(true));
+        assertThat(optionalSurcharge.get(), is(CREDIT_CARD_SURCHARGE_AMOUNT));
+
+        chargeEntity.setCorporateSurcharge(optionalSurcharge.get());
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount() + CREDIT_CARD_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldGetCorporateSurchargeForPrepaidCorporateDebitCard() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.DEBIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+
+        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(corporateCard, chargeEntity);
+        assertThat(optionalSurcharge.isPresent(), is(true));
+        assertThat(optionalSurcharge.get(), is(DEBIT_CARD_SURCHARGE_AMOUNT));
+
+        chargeEntity.setCorporateSurcharge(optionalSurcharge.get());
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount() + DEBIT_CARD_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenPrepaidCreditCorporateCardAndCreditCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(0L);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(corporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenPrepaidDebitCorporateCardAndDebitCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.DEBIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(0L);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(corporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenNotPrepaidCreditCorporateCardAndNoCreditCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(0L);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(corporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldGetSurchargeWhenNotPrepaidCreditCorporateCardAndCreditCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(0L);
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+
+        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(corporateCard, chargeEntity);
+        assertThat(optionalSurcharge.isPresent(), is(true));
+        assertThat(optionalSurcharge.get(), is(CREDIT_CARD_SURCHARGE_AMOUNT));
+
+        chargeEntity.setCorporateSurcharge(optionalSurcharge.get());
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount() + CREDIT_CARD_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenNotPrepaidDebitCorporateCardAndNoDebitCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(0L);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(corporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldGetSurchargeWhenNotPrepaidDebitCorporateCardAndDebitCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.DEBIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(0L);
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+
+        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(corporateCard, chargeEntity);
+        assertThat(optionalSurcharge.isPresent(), is(true));
+        assertThat(optionalSurcharge.get(), is(DEBIT_CARD_SURCHARGE_AMOUNT));
+
+        chargeEntity.setCorporateSurcharge(optionalSurcharge.get());
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount() + DEBIT_CARD_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenUnknownPrepaidCreditCorporateCardAndNoCreditCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.UNKNOWN)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(0L);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(corporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetSurchargeWhenUnknownPrepaidCreditCorporateCardAndCreditCardSurchargeAmount() {
+        AuthCardDetails corporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.UNKNOWN)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+        assertThat(getCorporateCardSurchargeFor(corporateCard, chargeEntity).isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldGetCorporateSurchargeForCorporateNotPrepaidCreditCard() {
         AuthCardDetails corporateCreditCard = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCardType(PayersCardType.CREDIT)
                 .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
                 .build();
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
@@ -36,10 +284,11 @@ public class CorporateCardSurchargeCalculatorTest {
     }
 
     @Test
-    public void shouldGetCorporateSurchargeForDebitCard() {
+    public void shouldGetCorporateSurchargeForCorporateNotPrepaidDebitCard() {
         AuthCardDetails corporateDebitCard = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCardType(PayersCardType.DEBIT)
                 .withCorporateCard(Boolean.TRUE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
                 .build();
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
@@ -123,6 +372,63 @@ public class CorporateCardSurchargeCalculatorTest {
 
         Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(creditOrDebit, chargeEntity);
 
+        assertThat(optionalSurcharge.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerCreditCardAndPrepaidCardType() {
+        AuthCardDetails nonCorporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.FALSE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(chargeEntity.getCorporateSurcharge().isPresent(), is(false));
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+
+        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(nonCorporateCard, chargeEntity);
+        assertThat(optionalSurcharge.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerCreditCardAndNotPrepaidCardType() {
+        AuthCardDetails nonCorporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.FALSE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(chargeEntity.getCorporateSurcharge().isPresent(), is(false));
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+
+        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(nonCorporateCard, chargeEntity);
+        assertThat(optionalSurcharge.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerCreditCardAndUnknownCardType() {
+        AuthCardDetails nonCorporateCard = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.FALSE)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.UNKNOWN)
+                .build();
+
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_SURCHARGE_AMOUNT);
+
+        assertThat(chargeEntity.getCorporateSurcharge().isPresent(), is(false));
+        assertThat(getTotalAmountFor(chargeEntity), is(chargeEntity.getAmount()));
+
+        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(nonCorporateCard, chargeEntity);
         assertThat(optionalSurcharge.isPresent(), is(false));
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculatorTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
-import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
@@ -43,29 +43,29 @@ public class CorporateCardSurchargeCalculatorTest {
 
     @Test
     public void shouldGetCorporateSurchargeForPrepaidCorporateCreditCard() {
-        shouldApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersPrepaidCardType.PREPAID, CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT);
+        shouldApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID, CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT);
     }
 
     @Test
     public void shouldGetCorporateSurchargeForPrepaidCorporateDebitCard() {
-        shouldApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersPrepaidCardType.PREPAID, DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT);
+        shouldApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID, DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForPrepaidCorporateCreditCardWhenNoCorporatePrepaidCreditSurcharge() {
         chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersPrepaidCardType.PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForPrepaidCorporateDebitCardWhenNoCorporatePrepaidDebitSurcharge() {
         chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersPrepaidCardType.PREPAID);
+        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForPrepaidCorporateCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersPrepaidCardType.PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
     }
 
     //endregion
@@ -74,29 +74,29 @@ public class CorporateCardSurchargeCalculatorTest {
 
     @Test
     public void shouldGetCorporateSurchargeForNotPrepaidCorporateCreditCard() {
-        shouldApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersPrepaidCardType.NOT_PREPAID, CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
+        shouldApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID, CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
     }
 
     @Test
     public void shouldGetCorporateSurchargeForNotPrepaidCorporateDebitCard() {
-        shouldApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersPrepaidCardType.NOT_PREPAID, DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
+        shouldApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID, DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateCreditCardWhenNoCorporateCreditSurcharge() {
         chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersPrepaidCardType.NOT_PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateDebitCardWhenNoCorporateDebitSurcharge() {
         chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersPrepaidCardType.NOT_PREPAID);
+        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersPrepaidCardType.NOT_PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
     }
 
     //endregion
@@ -105,17 +105,17 @@ public class CorporateCardSurchargeCalculatorTest {
 
     @Test
     public void shouldNotGetCorporateSurchargeForCorporateCreditCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersPrepaidCardType.UNKNOWN);
+        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForCorporateDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersPrepaidCardType.UNKNOWN);
+        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForCorporateCreditOrDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersPrepaidCardType.UNKNOWN);
+        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
     }
 
     @Test
@@ -134,17 +134,17 @@ public class CorporateCardSurchargeCalculatorTest {
 
     @Test
     public void shouldNotGetCorporateSurchargeForPrepaidConsumerCreditCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersPrepaidCardType.PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForPrepaidConsumerDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersPrepaidCardType.PREPAID);
+        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForPrepaidConsumerCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersPrepaidCardType.PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
     }
 
     //endregion
@@ -153,17 +153,17 @@ public class CorporateCardSurchargeCalculatorTest {
 
     @Test
     public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerCreditCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersPrepaidCardType.NOT_PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersPrepaidCardType.NOT_PREPAID);
+        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersPrepaidCardType.NOT_PREPAID);
+        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
     }
 
     //endregion
@@ -172,17 +172,17 @@ public class CorporateCardSurchargeCalculatorTest {
 
     @Test
     public void shouldNotGetCorporateSurchargeForConsumerCreditCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersPrepaidCardType.UNKNOWN);
+        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForConsumerDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersPrepaidCardType.UNKNOWN);
+        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
     }
 
     @Test
     public void shouldNotGetCorporateSurchargeForConsumerCreditOrDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersPrepaidCardType.UNKNOWN);
+        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
     }
 
     @Test
@@ -228,26 +228,26 @@ public class CorporateCardSurchargeCalculatorTest {
 
     //endregion
 
-    private void shouldApplySurcharge(PayersCardType payersCardType, Boolean corporateCard, PayersPrepaidCardType payersPrepaidCardType, long expectedSurchargeAmount) {
-        AuthCardDetails authCardDetails = getAuthCardDetails(payersCardType, corporateCard, payersPrepaidCardType);
+    private void shouldApplySurcharge(PayersCardType payersCardType, Boolean corporateCard, PayersCardPrepaidStatus payersCardPrepaidStatus, long expectedSurchargeAmount) {
+        AuthCardDetails authCardDetails = getAuthCardDetails(payersCardType, corporateCard, payersCardPrepaidStatus);
         Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(authCardDetails, chargeEntity);
 
         assertThat(optionalSurcharge.isPresent(), is(true));
         assertThat(optionalSurcharge.get(), is(expectedSurchargeAmount));
     }
 
-    private void shouldNotApplySurcharge(PayersCardType payersCardType, Boolean corporateCard, PayersPrepaidCardType payersPrepaidCardType) {
-        AuthCardDetails authCardDetails = getAuthCardDetails(payersCardType, corporateCard, payersPrepaidCardType);
+    private void shouldNotApplySurcharge(PayersCardType payersCardType, Boolean corporateCard, PayersCardPrepaidStatus payersCardPrepaidStatus) {
+        AuthCardDetails authCardDetails = getAuthCardDetails(payersCardType, corporateCard, payersCardPrepaidStatus);
 
         assertThat(getCorporateCardSurchargeFor(authCardDetails, chargeEntity).isPresent(), is(false));
     }
 
-    private AuthCardDetails getAuthCardDetails(PayersCardType payersCardType, Boolean corporateCard, PayersPrepaidCardType payersPrepaidCardType) {
+    private AuthCardDetails getAuthCardDetails(PayersCardType payersCardType, Boolean corporateCard, PayersCardPrepaidStatus payersCardPrepaidStatus) {
         return AuthCardDetailsFixture
                 .anAuthCardDetails()
                 .withCardType(payersCardType)
                 .withCorporateCard(corporateCard)
-                .withPayersPrepaidCardType(payersPrepaidCardType)
+                .withPayersCardPrepaidStatus(payersCardPrepaidStatus)
                 .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculatorTest.java
@@ -1,11 +1,10 @@
 package uk.gov.pay.connector.charge.util;
 
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
@@ -14,190 +13,46 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator.getCorporateCardSurchargeFor;
 
 public class CorporateCardSurchargeCalculatorTest {
 
-    private static final long CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT = 50L;
-    private static final long CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT = 150L;
-    private static final long DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT = 75L;
-    private static final long DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT = 175L;
+    @Test
+    public void getCorporateCardSurchargeFor_shouldReturnEmptyOptionalWhenSurchargeIsZero() {
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture
+                .anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT_OR_DEBIT)
+                .withCorporateCard(Boolean.FALSE)
+                .withPayersCardPrepaidStatus(PayersCardPrepaidStatus.UNKNOWN)
+                .build();
+        ChargeEntity chargeEntity = ChargeEntityFixture
+                .aValidChargeEntity()
+                .build();
 
-    private static ChargeEntity chargeEntity;
+        Optional<Long> result = CorporateCardSurchargeCalculator.getCorporateCardSurchargeFor(authCardDetails, chargeEntity);
 
-    @Before
-    public void setUp() {
+        assertThat(result, is(Optional.empty()));
+    }
+
+    @Test
+    public void getCorporateCardSurchargeFor_shouldReturnLongOptionalWhenSurchargeIsNonZero() {
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture
+                .anAuthCardDetails()
+                .withCardType(PayersCardType.CREDIT)
+                .withCorporateCard(Boolean.TRUE)
+                .withPayersCardPrepaidStatus(PayersCardPrepaidStatus.NOT_PREPAID)
+                .build();
         GatewayAccountEntity gatewayAccountEntity = ChargeEntityFixture.defaultGatewayAccountEntity();
-        gatewayAccountEntity.setCorporateCreditCardSurchargeAmount(CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
-        gatewayAccountEntity.setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT);
-        gatewayAccountEntity.setCorporateDebitCardSurchargeAmount(DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
-        gatewayAccountEntity.setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT);
-
-        chargeEntity = ChargeEntityFixture
+        gatewayAccountEntity.setCorporateCreditCardSurchargeAmount(100L);
+        ChargeEntity chargeEntity = ChargeEntityFixture
                 .aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build();
+
+        Optional<Long> result = CorporateCardSurchargeCalculator.getCorporateCardSurchargeFor(authCardDetails, chargeEntity);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get(), is(100L));
     }
-
-    //region Corporate Prepaid
-
-    @Test
-    public void shouldGetCorporateSurchargeForPrepaidCorporateCreditCard() {
-        shouldApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID, CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT);
-    }
-
-    @Test
-    public void shouldGetCorporateSurchargeForPrepaidCorporateDebitCard() {
-        shouldApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID, DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForPrepaidCorporateCreditCardWhenNoCorporatePrepaidCreditSurcharge() {
-        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForPrepaidCorporateDebitCardWhenNoCorporatePrepaidDebitSurcharge() {
-        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForPrepaidCorporateCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
-    }
-
-    //endregion
-
-    //region Corporate Not Prepaid
-
-    @Test
-    public void shouldGetCorporateSurchargeForNotPrepaidCorporateCreditCard() {
-        shouldApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID, CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
-    }
-
-    @Test
-    public void shouldGetCorporateSurchargeForNotPrepaidCorporateDebitCard() {
-        shouldApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID, DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateCreditCardWhenNoCorporateCreditSurcharge() {
-        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateDebitCardWhenNoCorporateDebitSurcharge() {
-        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(0L);
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
-    }
-
-    //endregion
-
-    //region Corporate Unknown Prepaid
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForCorporateCreditCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForCorporateDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForCorporateCreditOrDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForCorporateCreditCardWithNullPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.TRUE, null);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForCorporateDebitCardWithNullPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.TRUE, null);
-    }
-
-    //endregion
-
-    //region Consumer Prepaid
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForPrepaidConsumerCreditCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForPrepaidConsumerDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForPrepaidConsumerCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
-    }
-
-    //endregion
-
-    //region Consumer Not Prepaid
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerCreditCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerCreditOrDebitCard() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
-    }
-
-    //endregion
-
-    //region Consumer Unknown Prepaid
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForConsumerCreditCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForConsumerDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForConsumerCreditOrDebitCardWithUnknownPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForConsumerCreditCardWithNullPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.CREDIT, Boolean.FALSE, null);
-    }
-
-    @Test
-    public void shouldNotGetCorporateSurchargeForConsumerDebitCardWithNullPrepaid() {
-        shouldNotApplySurcharge(PayersCardType.DEBIT, Boolean.FALSE, null);
-    }
-
-    //endregion
-
-    //region getAmount tests
 
     @Test
     public void shouldCalculateTotalAmountForCorporateSurchargeGreaterThanZero() {
@@ -226,28 +81,4 @@ public class CorporateCardSurchargeCalculatorTest {
         assertThat(actualAmount, is(expectedAmount));
     }
 
-    //endregion
-
-    private void shouldApplySurcharge(PayersCardType payersCardType, Boolean corporateCard, PayersCardPrepaidStatus payersCardPrepaidStatus, long expectedSurchargeAmount) {
-        AuthCardDetails authCardDetails = getAuthCardDetails(payersCardType, corporateCard, payersCardPrepaidStatus);
-        Optional<Long> optionalSurcharge = getCorporateCardSurchargeFor(authCardDetails, chargeEntity);
-
-        assertThat(optionalSurcharge.isPresent(), is(true));
-        assertThat(optionalSurcharge.get(), is(expectedSurchargeAmount));
-    }
-
-    private void shouldNotApplySurcharge(PayersCardType payersCardType, Boolean corporateCard, PayersCardPrepaidStatus payersCardPrepaidStatus) {
-        AuthCardDetails authCardDetails = getAuthCardDetails(payersCardType, corporateCard, payersCardPrepaidStatus);
-
-        assertThat(getCorporateCardSurchargeFor(authCardDetails, chargeEntity).isPresent(), is(false));
-    }
-
-    private AuthCardDetails getAuthCardDetails(PayersCardType payersCardType, Boolean corporateCard, PayersCardPrepaidStatus payersCardPrepaidStatus) {
-        return AuthCardDetailsFixture
-                .anAuthCardDetails()
-                .withCardType(payersCardType)
-                .withCorporateCard(corporateCard)
-                .withPayersCardPrepaidStatus(payersCardPrepaidStatus)
-                .build();
-    }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/util/FixedCorporateCardSurchargeCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/FixedCorporateCardSurchargeCalculatorTest.java
@@ -1,0 +1,258 @@
+package uk.gov.pay.connector.charge.util;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class FixedCorporateCardSurchargeCalculatorTest {
+
+    private static final long CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT = 50L;
+    private static final long CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT = 150L;
+    private static final long DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT = 75L;
+    private static final long DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT = 175L;
+
+    private static ChargeEntity chargeEntity;
+
+    @Before
+    public void setUp() {
+        GatewayAccountEntity gatewayAccountEntity = ChargeEntityFixture.defaultGatewayAccountEntity();
+        gatewayAccountEntity.setCorporateCreditCardSurchargeAmount(CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
+        gatewayAccountEntity.setCorporatePrepaidCreditCardSurchargeAmount(CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT);
+        gatewayAccountEntity.setCorporateDebitCardSurchargeAmount(DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT);
+        gatewayAccountEntity.setCorporatePrepaidDebitCardSurchargeAmount(DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT);
+
+        chargeEntity = ChargeEntityFixture
+                .aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .build();
+    }
+
+    //region Corporate Prepaid
+
+    @Test
+    public void shouldGetCorporateSurchargeForPrepaidCorporateCreditCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(CREDIT_CARD_PREPAID_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldGetCorporateSurchargeForPrepaidCorporateDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(DEBIT_CARD_PREPAID_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForPrepaidCorporateCreditCardWhenNoCorporatePrepaidCreditSurcharge() {
+        chargeEntity.getGatewayAccount().setCorporatePrepaidCreditCardSurchargeAmount(0L);
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForPrepaidCorporateDebitCardWhenNoCorporatePrepaidDebitSurcharge() {
+        chargeEntity.getGatewayAccount().setCorporatePrepaidDebitCardSurchargeAmount(0L);
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForPrepaidCorporateCreditOrDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    //endregion
+
+    //region Corporate Not Prepaid
+
+    @Test
+    public void shouldGetCorporateSurchargeForNotPrepaidCorporateCreditCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(CREDIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldGetCorporateSurchargeForNotPrepaidCorporateDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(DEBIT_CARD_NON_PREPAID_SURCHARGE_AMOUNT));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateCreditCardWhenNoCorporateCreditSurcharge() {
+        chargeEntity.getGatewayAccount().setCorporateCreditCardSurchargeAmount(0L);
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateDebitCardWhenNoCorporateDebitSurcharge() {
+        chargeEntity.getGatewayAccount().setCorporateDebitCardSurchargeAmount(0L);
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForNotPrepaidCorporateCreditOrDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    //endregion
+
+    //region Corporate Unknown Prepaid
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForCorporateCreditCardWithUnknownPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForCorporateDebitCardWithUnknownPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForCorporateCreditOrDebitCardWithUnknownPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT_OR_DEBIT, Boolean.TRUE, PayersCardPrepaidStatus.UNKNOWN);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForCorporateCreditCardWithNullPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.TRUE, null);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForCorporateDebitCardWithNullPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.TRUE, null);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    //endregion
+
+    //region Consumer Prepaid
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForPrepaidConsumerCreditCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForPrepaidConsumerDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForPrepaidConsumerCreditOrDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    //endregion
+
+    //region Consumer Not Prepaid
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerCreditCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForNotPrepaidConsumerCreditOrDebitCard() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.NOT_PREPAID);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    //endregion
+
+    //region Consumer Unknown Prepaid
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerCreditCardWithUnknownPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerDebitCardWithUnknownPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerCreditOrDebitCardWithUnknownPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT_OR_DEBIT, Boolean.FALSE, PayersCardPrepaidStatus.UNKNOWN);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerCreditCardWithNullPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.CREDIT, Boolean.FALSE, null);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    @Test
+    public void shouldNotGetCorporateSurchargeForConsumerDebitCardWithNullPrepaid() {
+        AuthCardDetails authCardDetails = getAuthCardDetails(PayersCardType.DEBIT, Boolean.FALSE, null);
+        long surcharge = FixedCorporateCardSurchargeCalculator.calculate(authCardDetails, chargeEntity);
+        assertThat(surcharge, is(0L));
+    }
+
+    //endregion
+
+    private AuthCardDetails getAuthCardDetails(PayersCardType payersCardType, Boolean corporateCard, PayersCardPrepaidStatus payersCardPrepaidStatus) {
+        return AuthCardDetailsFixture
+                .anAuthCardDetails()
+                .withCardType(payersCardType)
+                .withCorporateCard(corporateCard)
+                .withPayersCardPrepaidStatus(payersCardPrepaidStatus)
+                .build();
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoITest.java
@@ -73,8 +73,8 @@ public class GatewayAccountDaoITest extends DaoITestBase {
         assertThat(account.getDescription(), is(nullValue()));
         assertThat(account.getAnalyticsId(), is(nullValue()));
         assertThat(account.getNotificationCredentials(), is(nullValue()));
-        assertThat(account.getCorporateCreditCardSurchargeAmount(), is(0L));
-        assertThat(account.getCorporateDebitCardSurchargeAmount(), is(0L));
+        assertThat(account.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(0L));
+        assertThat(account.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(0L));
         assertThat(account.getCorporatePrepaidCreditCardSurchargeAmount(), is(0L));
         assertThat(account.getCorporatePrepaidDebitCardSurchargeAmount(), is(0L));
 
@@ -116,8 +116,8 @@ public class GatewayAccountDaoITest extends DaoITestBase {
         assertThat(gatewayAccount.getServiceName(), is(accountRecord.getServiceName()));
         assertThat(gatewayAccount.getDescription(), is(accountRecord.getDescription()));
         assertThat(gatewayAccount.getAnalyticsId(), is(accountRecord.getAnalyticsId()));
-        assertThat(gatewayAccount.getCorporateCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
-        assertThat(gatewayAccount.getCorporateDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
+        assertThat(gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
+        assertThat(gatewayAccount.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
         assertThat(gatewayAccount.getCorporatePrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidCreditCardSurchargeAmount()));
         assertThat(gatewayAccount.getCorporatePrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidDebitCardSurchargeAmount()));
         assertThat(gatewayAccount.getCardTypes(), contains(
@@ -149,8 +149,8 @@ public class GatewayAccountDaoITest extends DaoITestBase {
         assertThat(gatewayAccount.getServiceName(), is(accountRecord.getServiceName()));
         assertThat(gatewayAccount.getDescription(), is(accountRecord.getDescription()));
         assertThat(gatewayAccount.getAnalyticsId(), is(accountRecord.getAnalyticsId()));
-        assertThat(gatewayAccount.getCorporateCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
-        assertThat(gatewayAccount.getCorporateDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
+        assertThat(gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));
+        assertThat(gatewayAccount.getCorporateNonPrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporateDebitCardSurchargeAmount()));
         assertThat(gatewayAccount.getCorporatePrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidCreditCardSurchargeAmount()));
         assertThat(gatewayAccount.getCorporatePrepaidDebitCardSurchargeAmount(), is(accountRecord.getCorporatePrepaidDebitCardSurchargeAmount()));
         

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.model.domain;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
-import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 
 public final class AuthCardDetailsFixture {
     private String cardNo = "4242424242424242";
@@ -15,7 +15,7 @@ public final class AuthCardDetailsFixture {
     private String userAgentHeader = "Mozilla/5.0";
     private String acceptHeader = "text/html";
     private PayersCardType payersCardType = PayersCardType.DEBIT;
-    private PayersPrepaidCardType payersPrepaidCardType = PayersPrepaidCardType.UNKNOWN;
+    private PayersCardPrepaidStatus payersCardPrepaidStatus = PayersCardPrepaidStatus.UNKNOWN;
     private Boolean corporateCard = Boolean.FALSE;
 
     private AuthCardDetailsFixture() {
@@ -75,8 +75,8 @@ public final class AuthCardDetailsFixture {
         return this;
     }
 
-    public AuthCardDetailsFixture withPayersPrepaidCardType(PayersPrepaidCardType payersPrepaidCardType) {
-        this.payersPrepaidCardType = payersPrepaidCardType;
+    public AuthCardDetailsFixture withPayersCardPrepaidStatus(PayersCardPrepaidStatus payersCardPrepaidStatus) {
+        this.payersCardPrepaidStatus = payersCardPrepaidStatus;
         return this;
     }
 
@@ -91,7 +91,7 @@ public final class AuthCardDetailsFixture {
         authCardDetails.setUserAgentHeader(userAgentHeader);
         authCardDetails.setAcceptHeader(acceptHeader);
         authCardDetails.setPayersCardType(payersCardType);
-        authCardDetails.setPayersPrepaidCardType(payersPrepaidCardType);
+        authCardDetails.setPayersCardPrepaidStatus(payersCardPrepaidStatus);
         authCardDetails.setCorporateCard(corporateCard);
         return authCardDetails;
     }

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.model.domain;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
 
 public final class AuthCardDetailsFixture {
     private String cardNo = "4242424242424242";
@@ -14,6 +15,7 @@ public final class AuthCardDetailsFixture {
     private String userAgentHeader = "Mozilla/5.0";
     private String acceptHeader = "text/html";
     private PayersCardType payersCardType = PayersCardType.DEBIT;
+    private PayersPrepaidCardType payersPrepaidCardType = PayersPrepaidCardType.UNKNOWN;
     private Boolean corporateCard = Boolean.FALSE;
 
     private AuthCardDetailsFixture() {
@@ -73,6 +75,11 @@ public final class AuthCardDetailsFixture {
         return this;
     }
 
+    public AuthCardDetailsFixture withPayersPrepaidCardType(PayersPrepaidCardType payersPrepaidCardType) {
+        this.payersPrepaidCardType = payersPrepaidCardType;
+        return this;
+    }
+
     public AuthCardDetails build() {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(cardNo);
@@ -84,6 +91,7 @@ public final class AuthCardDetailsFixture {
         authCardDetails.setUserAgentHeader(userAgentHeader);
         authCardDetails.setAcceptHeader(acceptHeader);
         authCardDetails.setPayersCardType(payersCardType);
+        authCardDetails.setPayersPrepaidCardType(payersPrepaidCardType);
         authCardDetails.setCorporateCard(corporateCard);
         return authCardDetails;
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationRespons
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
@@ -214,6 +215,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCorporateCard(Boolean.TRUE)
                 .withCardType(PayersCardType.CREDIT)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
                 .build();
 
         charge.getGatewayAccount().setCorporateCreditCardSurchargeAmount(250L);
@@ -239,6 +241,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCorporateCard(Boolean.TRUE)
                 .withCardType(PayersCardType.DEBIT)
+                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
                 .build();
 
         charge.getGatewayAccount().setCorporateDebitCardSurchargeAmount(50L);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -24,7 +24,7 @@ import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationRespons
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
-import uk.gov.pay.connector.gateway.model.PayersPrepaidCardType;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
@@ -215,7 +215,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCorporateCard(Boolean.TRUE)
                 .withCardType(PayersCardType.CREDIT)
-                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
+                .withPayersCardPrepaidStatus(PayersCardPrepaidStatus.NOT_PREPAID)
                 .build();
 
         charge.getGatewayAccount().setCorporateCreditCardSurchargeAmount(250L);
@@ -241,7 +241,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCorporateCard(Boolean.TRUE)
                 .withCardType(PayersCardType.DEBIT)
-                .withPayersPrepaidCardType(PayersPrepaidCardType.NOT_PREPAID)
+                .withPayersCardPrepaidStatus(PayersCardPrepaidStatus.NOT_PREPAID)
                 .build();
 
         charge.getGatewayAccount().setCorporateDebitCardSurchargeAmount(50L);


### PR DESCRIPTION
## WHAT

This PR updates  surcharge calculator to consider prepaid cards and has some refactoring of CorporateCardSurchargeCalculator tests

## HOW 

- Added `PayersPrepaidCardType` that should be used to map from and to JSON when
  dealing with prepaid nature of the card (`PREPAID`, `NOT_PREPAID`, `UNKNOWN`)
  used to make a payment. This is also used to calculate corporate
  surcharges, based on other rules.
- Modified `CorporateCardSurchargeCalculator` to consider prepaid card surcharge
  when calculating the value in `CorporateCardSurchargeCalculator#getCorporateCardSurchargeFor`
- Split `CorporateCardSurchargeCalculatorTest` test into code regions to
  help navigation within the file
- Added tests to cover all scenarios
- Refactored duplicated setup and assertions within `CorporateCardSurchargeCalculatorTest` to improve clarity

with @danworth 


