### PR TITLE
PP-4431 Fix charge not persisted in charge pre-authorisation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/applepay/AppleAuthoriseService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.applepay;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,8 @@ public class AppleAuthoriseService {
         });
     }
 
-    private ChargeEntity prepareChargeForAuthorisation(String chargeId) {
+    @Transactional
+    public ChargeEntity prepareChargeForAuthorisation(String chargeId) {
         ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
         getPaymentProviderFor(charge)
                 .generateTransactionId()

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -63,7 +64,8 @@ public class CardAuthoriseService {
         });
     }
 
-    private ChargeEntity prepareChargeForAuthorisation(String chargeId, AuthCardDetails authCardDetails) {
+    @Transactional
+    public ChargeEntity prepareChargeForAuthorisation(String chargeId, AuthCardDetails authCardDetails) {
         ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
         ensureCardBrandGateway3DSCompatibility(charge, authCardDetails.getCardBrand());
         getCorporateCardSurchargeFor(authCardDetails, charge).ifPresent(charge::setCorporateSurcharge);

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -38,6 +38,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -147,6 +148,22 @@ public class ChargingITestBase {
                 .body("status", is(status));
     }
 
+    protected void assertFrontendChargeCorporateSurchargeAmount(String chargeId, String status, Long corporateSurcharge) {
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getFrontendCharge()
+                .body("status", is(status))
+                .body("corporate_card_surcharge", is(corporateSurcharge.intValue()));
+    }
+
+    protected void assertFrontendChargeStatusAndTransactionId(String chargeId, String status) {
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getFrontendCharge()
+                .body("status", is(status))
+                .body("gateway_transaction_id", is(notNullValue()));
+    }
+
     protected void assertRefundStatus(String chargeId, String refundId, String status, Integer amount) {
         connectorRestApiClient.withChargeId(chargeId)
                 .withRefundId(refundId)
@@ -187,6 +204,10 @@ public class ChargingITestBase {
     }
 
     protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId) {
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId);
+    }
+
+    protected String createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId) {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge-" + chargeId;
         databaseTestHelper.addCharge(chargeId, externalChargeId, accountId, 6234L, status, "RETURN_URL", gatewayTransactionId);

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureITest.java
@@ -24,9 +24,9 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class CardCaptureResourceITest extends ChargingITestBase {
+public class CardResourceCaptureITest extends ChargingITestBase {
 
-    public CardCaptureResourceITest() {
+    public CardResourceCaptureITest() {
         super("sandbox");
     }
 

--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -2,10 +2,22 @@ package uk.gov.pay.connector.rules;
 
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingXPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.*;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCEL_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCEL_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CAPTURE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_SUCCESS_RESPONSE;
 
 public class WorldpayMockClient {
 
@@ -64,6 +76,15 @@ public class WorldpayMockClient {
         paymentServiceResponse(refundResponse);
     }
 
+    public void mockAuthorisationGatewayError() {
+        stubFor(
+                post(urlPathEqualTo("/jsp/merchant/xml/paymentService.jsp"))
+                        .willReturn(
+                                aResponse().withStatus(404)
+                        )
+        );
+    }
+    
     private void paymentServiceResponse(String responseBody) {
         //FIXME - This mocking approach is very poor. Needs to be revisited. Story PP-900 created.
         stubFor(


### PR DESCRIPTION
## WHAT 
- adds test to ensure corporate surcharge amount exists after
 authorisation
- adds test to check transaction id exists after
  pre-authorisation

  with: @cobainc0 

## HOW 
Renamed CardAuthoriseResourceITest to CardResourceAuthoriseITest so it's more easily discoverable in intelliJ.
Same for CardCaptureResourceITest -> CardResourceCaptureITest


