### PR TITLE
PP-4434 Card authorisation metrics/logging need to distinguish between payments have a billing address and payments that don’t

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -118,17 +118,21 @@ public class CardAuthoriseService {
                 operationResponse.getSessionIdentifier(),
                 authCardDetails);
 
-        logger.info("Authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
+        boolean billingAddressSubmitted = updatedCharge.getCardDetails().getBillingAddress().isPresent();
+
+        logger.info("Authorisation {} for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
+                billingAddressSubmitted ? "with billing address" : "without billing address",
                 updatedCharge.getExternalId(), updatedCharge.getPaymentGatewayName().getName(),
                 transactionId.orElse("missing transaction ID"),
                 updatedCharge.getGatewayAccount().getAnalyticsId(), updatedCharge.getGatewayAccount().getId(),
                 operationResponse, oldChargeStatus, status);
 
         metricRegistry.counter(String.format(
-                "gateway-operations.%s.%s.%s.authorise.result.%s",
+                "gateway-operations.%s.%s.%s.authorise.%s.result.%s",
                 updatedCharge.getGatewayAccount().getGatewayName(),
                 updatedCharge.getGatewayAccount().getType(),
                 updatedCharge.getGatewayAccount().getId(),
+                billingAddressSubmitted ? "with-billing-address" : "without-billing-address",
                 status.toString())).inc();
     }
 


### PR DESCRIPTION
Change the Graphite metric emitted when an authorisation result is processed from being like:

`gateway-operations.worldpay.live.123.authorise.result.AUTHORISATION-SUCCESS`

… to being like:

`gateway-operations.worldpay.live.123.authorise.with-billing-address.result.AUTHORISATION-SUCCESS`

… if a billing address was sent to the payment gateway, or:

`gateway-operations.worldpay.live.123.authorise.without-billing-address.result.AUTHORISATION-SUCCESS`

… if a billing address was not sent to the payment gateway.

Change the log line output when an authorisation result is
processed from being like:

`Authorisation for abcdefghijklmnopqrstuvwxyz (worldpay 806d3920-4698-4c06-9364-e2f824fad21a) for MOF-TLA (123) - Worldpay authorisation response (orderCode: 806d3920-4698-4c06-9364-e2f824fad21a, lastevent: AUTHORISED) .'. AUTHORISATION READY -> AUTHORISATION SUCCESS`

… to being like:

`Authorisation with billing address for abcdefghijklmnopqrstuvwxyz (worldpay 806d3920-4698-4c06-9364-e2f824fad21a) for MOF-TLA (123) - Worldpay authorisation response (orderCode: 806d3920-4698-4c06-9364-e2f824fad21a, lastevent: AUTHORISED) .'. AUTHORISATION READY -> AUTHORISATION SUCCESS`

… if a billing address was sent to the payment gateway, or:

`Authorisation without billing address for abcdefghijklmnopqrstuvwxyz (worldpay 806d3920-4698-4c06-9364-e2f824fad21a) for MOF-TLA (123) - Worldpay authorisation response (orderCode: 806d3920-4698-4c06-9364-e2f824fad21a, lastevent: AUTHORISED) .'.
AUTHORISATION READY -> AUTHORISATION SUCCESS`

… if a billing address was not sent to the payment gateway.