### PR TITLE
PP-4290 Add prepaid status to JsonRequestHelper

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.it;
 
 import com.google.gson.JsonObject;
+import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -18,6 +19,7 @@ public class JsonRequestHelper {
     private static final String CARD_BRAND = "cardBrand";
     private static final String ADDRESS_LINE_2 = "Moneybags Avenue";
     private static final String ADDRESS_COUNTY = "Greater London";
+    private static final PayersCardPrepaidStatus PREPAID_STATUS = PayersCardPrepaidStatus.NOT_PREPAID;
 
     public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cardBrand) {
         return buildJsonAuthorisationDetailsFor(cardNumber, CVC, EXPIRY_DATE, cardBrand);
@@ -59,7 +61,7 @@ public class JsonRequestHelper {
                                                           String postCode,
                                                           String countryCode) {
         return buildCorporateJsonAuthorisationDetailsFor(cardHolderName, cardNumber, cvc, expiryDate, cardBrand, line1,
-                line2, city, county, postCode, countryCode, null, null);
+                line2, city, county, postCode, countryCode, null, null, PREPAID_STATUS);
     }
 
     public static String buildCorporateJsonAuthorisationDetailsFor(PayersCardType payersCardType) {
@@ -76,7 +78,8 @@ public class JsonRequestHelper {
                 ADDRESS_POSTCODE,
                 ADDRESS_COUNTRY_GB,
                 Boolean.TRUE,
-                payersCardType);
+                payersCardType,
+                PREPAID_STATUS);
     }
 
     public static String buildJsonAuthorisationDetailsWithFullAddress() {
@@ -103,7 +106,8 @@ public class JsonRequestHelper {
                 EXPIRY_DATE,
                 CARD_BRAND,
                 Boolean.TRUE,
-                PayersCardType.CREDIT);
+                PayersCardType.CREDIT,
+                PREPAID_STATUS);
 
         return toJson(authorisationDetails);
     }
@@ -120,12 +124,13 @@ public class JsonRequestHelper {
                                                                     String postCode,
                                                                     String countryCode,
                                                                     Boolean isCorporateCard,
-                                                                    PayersCardType payersCardType) {
+                                                                    PayersCardType payersCardType,
+                                                                    PayersCardPrepaidStatus prepaidStatus) {
 
         JsonObject addressObject = buildAddressObject(line1, line2, city, county, postCode, countryCode);
 
         JsonObject authorisationDetails = buildJsonAuthorisationDetailsWithoutAddress(cardHolderName,
-                cardNumber, cvc, expiryDate, cardBrand, isCorporateCard, payersCardType);
+                cardNumber, cvc, expiryDate, cardBrand, isCorporateCard, payersCardType, prepaidStatus);
 
         authorisationDetails.add("address", addressObject);
 
@@ -138,7 +143,8 @@ public class JsonRequestHelper {
                                                                           String expiryDate,
                                                                           String cardBrand,
                                                                           Boolean isCorporateCard,
-                                                                          PayersCardType payersCardType) {
+                                                                          PayersCardType payersCardType,
+                                                                          PayersCardPrepaidStatus prepaidStatus) {
 
         JsonObject authorisationDetails = new JsonObject();
         authorisationDetails.addProperty("card_number", cardNumber);
@@ -148,6 +154,7 @@ public class JsonRequestHelper {
         authorisationDetails.addProperty("cardholder_name", cardHolderName);
         authorisationDetails.addProperty("accept_header", "text/html");
         authorisationDetails.addProperty("user_agent_header", "Mozilla/5.0");
+        authorisationDetails.addProperty("prepaid", prepaidStatus.toString());
 
         if (isCorporateCard != null) {
             authorisationDetails.addProperty("corporate_card", isCorporateCard);


### PR DESCRIPTION
- Add card prepaid status with default of `NOT_PREPAID` to the `JsonRequestHelper`.


