### PR TITLE
PP-4375 Validate Stripe notifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,11 @@
             <version>1.1.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.stripe</groupId>
+            <artifactId>stripe-java</artifactId>
+            <version>7.9.0</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -15,11 +15,19 @@ public class StripeGatewayConfig extends Configuration {
     @NotNull
     private String authToken;
 
+    @Valid
+    @NotNull
+    private String webhookSigningSecret;
+
     public String getUrl() {
         return url;
     }
 
     public String getAuthToken() {
         return authToken;
+    }
+
+    public String getWebhookSigningSecret() {
+        return webhookSigningSecret;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
@@ -89,8 +89,8 @@ public class NotificationResource {
     @Consumes(APPLICATION_JSON)
     @Path("/v1/api/notifications/stripe")
     @Produces({TEXT_XML, APPLICATION_JSON})
-    public Response authoriseStripeNotifications(String notification) {
-        stripeNotificationService.handleNotificationFor(notification);
+    public Response authoriseStripeNotifications(String notification, @HeaderParam("Stripe-Signature") String signatureHeader) {
+        stripeNotificationService.handleNotificationFor(notification, signatureHeader);
         String response = "[OK]";
         logger.info("Responding to notification from provider=Stripe with 200 {}", response);
         return Response.ok(response).build();

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-    level: INFO
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id}] - %msg%n"
+  level: INFO
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id}] - %msg%n"
 
 links:
   frontendUrl: ${FRONTEND_URL}
@@ -27,8 +27,8 @@ worldpay:
   notificationDomain: ${SECURE_WORLDPAY_NOTIFICATION_DOMAIN:-worldpay.com}
   credentials: ['username','password','merchant_id']
   applePay:
-   privateKey: ${WORLDPAY_APPLE_PAY_PRIVATE_KEY:-}
-   publicCertificate: ${WORLDPAY_APPLE_PAY_PUBLIC_CERTIFICATE:-}
+    privateKey: ${WORLDPAY_APPLE_PAY_PRIVATE_KEY:-}
+    publicCertificate: ${WORLDPAY_APPLE_PAY_PUBLIC_CERTIFICATE:-}
   jerseyClientOverrides:
     auth:
       # Auth is run in a background thread which will release the HTTP request from frontend after 1 second
@@ -77,6 +77,7 @@ epdq:
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}
@@ -117,11 +118,11 @@ jerseyClient:
   userAgent: connector
   gzipEnabledForRequests: false
   proxy:
-      host: ${HTTP_PROXY_HOST:-0}
-      port: ${HTTP_PROXY_PORT:-0}
-      scheme : ${HTTP_PROXY_SCHEME:-https}
-      nonProxyHosts:
-        - localhost
+    host: ${HTTP_PROXY_HOST:-0}
+    port: ${HTTP_PROXY_PORT:-0}
+    scheme : ${HTTP_PROXY_SCHEME:-https}
+    nonProxyHosts:
+      - localhost
 
 customJerseyClient:
   # Sets the read timeout to a specified timeout, in

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationUtilTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationUtilTest.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import com.stripe.net.Webhook;
+
+public abstract class StripeNotificationUtilTest {
+    public static String generateSigHeader(String webhookSigningSecret, String message) {
+
+        long currentTimestamp = System.currentTimeMillis() / 1000L;
+        final String payloadToSign = String.format("%d.%s", currentTimestamp, message);
+        String signature = null;
+
+        try {
+            signature = Webhook.Util.computeHmacSha256(webhookSigningSecret, payloadToSign);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        final String header = String.format("t=%d,v1=%s", currentTimestamp, signature);
+        return header;
+    }
+}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -61,6 +61,7 @@ epdq:
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -60,6 +60,7 @@ epdq:
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -50,6 +50,7 @@ epdq:
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -56,6 +56,7 @@ epdq:
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -53,6 +53,7 @@ epdq:
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}


### PR DESCRIPTION
## WHAT
Validate notification payload received from Stripe using stripe-java library. Signature is available in notification request header ('Stripe-Signature') from Stripe.

For info :

Format of the signature header is:
`t=1492774577, v1=5257a869e7ec,v0=aba816edb039989a39`

**where**
t - timestamp. Tolerance (suggested by Stripe) for timestamp is 5 minutes. Any payload with time difference above tolerance is invalid
v1 - scheme which has valid signature. Multiple values are possible when secret keys are rotated. So payload is valid if at least one signature is valid.
v0 - is ignored and sent only for test mode events

See Stripe docs for more details :
https://stripe.com/docs/webhooks/signatures

