### PR TITLE
PP-4129 Add changes to payment receipt emails to reflect corporate card surcharge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -161,7 +161,14 @@ public class UserNotificationService {
         map.put("description", charge.getDescription());
         map.put("customParagraph", isBlank(customParagraph) ? "" : "^ " + customParagraph);
         map.put("serviceName", StringUtils.defaultString(gatewayAccount.getServiceName()));
-
+        
+        String corporateSurchargeMsg = charge.getCorporateSurcharge()
+                .map(corporateSurcharge -> 
+                        String.format("Your payment includes a fee of £%s for using a corporate credit or debit card.",
+                                formatToPounds(corporateSurcharge)))
+                .orElse("");
+        map.put("corporateCardSurcharge", corporateSurchargeMsg);
+        
         return map;
     }
 


### PR DESCRIPTION
## WHAT

- add corporateCardSurcharge field to relevant emails and fill it when there is a surcharge
- add relevant tests
