### PR TITLE
bau: upgrade pay-java-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <guice.version>4.1.0</guice.version>
         <docker-client.version>8.9.2</docker-client.version>
         <jackson.version>2.9.7</jackson.version>
-        <pay-java-commons.version>1.0.0-c1f7dc45bc457bd1209cde4513003f5bf4679c6a</pay-java-commons.version>
+        <pay-java-commons.version>1.0.0-f6097986677849386f283bb84072198b57931b1b</pay-java-commons.version>
     </properties>
     <repositories>
         <repository>
@@ -412,7 +412,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
-            <version>5.3.0</version>
+            <version>5.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/ClientFactoryTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockserver.integration.ClientAndProxy;
 import org.mockserver.integration.ClientAndServer;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
@@ -44,7 +43,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 public class ClientFactoryTest {
 
     DropwizardTestSupport<ConnectorConfiguration> app;
-    private ClientAndProxy proxy;
+    private ClientAndServer proxy;
     private ClientAndServer mockServer;
     private int serverPort = findFreePort();
     private int proxyPort = findFreePort();
@@ -53,7 +52,7 @@ public class ClientFactoryTest {
     MetricRegistry mockMetricRegistry;
     @Before
     public void setup() {
-        proxy = new ClientAndProxy(proxyPort, "localhost", serverPort);
+        proxy = startClientAndServer("localhost", serverPort, proxyPort);
         mockServer = startClientAndServer(serverPort);
     }
 


### PR DESCRIPTION
pay-java-commons uses mockserver 5.5.0, so it had to be upgraded here as well.

@oswaldquek



