### PR TITLE
BAU: Do not run dependency-check maven plugin in verify phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <docker-client.version>8.9.2</docker-client.version>
         <jackson.version>2.9.7</jackson.version>
         <pay-java-commons.version>1.0.0-f6097986677849386f283bb84072198b57931b1b</pay-java-commons.version>
+        <dependency-check.skip>true</dependency-check.skip>
     </properties>
     <repositories>
         <repository>
@@ -571,6 +572,16 @@
                     </arguments>
                 </configuration>
             </plugin>
+            <!--
+                https://jeremylong.github.io/DependencyCheck/dependency-check-maven/
+                By default, the dependency-check plugin is tied to the verify phase
+                (when used as a build plugin). We don’t want this; we just want to
+                run it manually when required. So we define a property called
+                dependency-check.skip, set it to true, and use this property’s value
+                to set the dependency-check plugin’s own skip property. To execute
+                the plugin manually, override the dependency-check.skip property:
+                $ mvn dependency-check:check -Ddependency-check.skip=false
+            -->
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
@@ -579,6 +590,7 @@
                     <suppressionFiles>
                         <suppressionFile>project-suppression.xml</suppressionFile>
                     </suppressionFiles>
+                    <skip>${dependency-check.skip}</skip>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -585,7 +585,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>3.3.4</version>
+                <version>4.0.0</version>
                 <configuration>
                     <suppressionFiles>
                         <suppressionFile>project-suppression.xml</suppressionFile>


### PR DESCRIPTION
By default, the dependency-check plugin is tied to the `verify` phase (when used as a build plugin). We don’t want this; we just want to run it manually when required. So we define a property called `dependency-check.skip`, set it to `true`, and use this property’s value to set the dependency-check plugin’s own `skip` property. To execute the plugin manually, override the `dependency-check.skip` property:

```
$ mvn dependency-check:check -Ddependency-check.skip=false
```

Also upgrade from version 3.3.4 to 4.0.0.