### PR TITLE
PP-4375 Stripe Notification - 3DS authorisation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
@@ -51,6 +52,7 @@ public class ChargeExpiryService {
     public static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = ImmutableList.of(
             CREATED,
             ENTERING_CARD_DETAILS,
+            AUTHORISATION_3DS_READY,
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_SUCCESS);
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -275,10 +275,16 @@ public class ChargeService {
                                                          OperationType operationType,
                                                          Optional<String> transactionId) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
-            charge.setStatus(status);
-            setTransactionId(charge, transactionId);
-            chargeEventDao.persistChargeEventOf(charge);
-
+            try {
+                charge.setStatus(status);
+                setTransactionId(charge, transactionId);
+                chargeEventDao.persistChargeEventOf(charge);
+            } catch (InvalidStateTransitionException e) {
+                if (chargeIsInLockedStatus(operationType, charge)) {
+                    throw new OperationAlreadyInProgressRuntimeException(operationType.getValue(), charge.getExternalId());
+                }
+                throw new IllegalStateRuntimeException(charge.getExternalId());
+            }
             return charge;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
     }
@@ -322,6 +328,11 @@ public class ChargeService {
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
 
+    public ChargeEntity findChargeById(String chargeId) {
+        return chargeDao.findByExternalId(chargeId)
+                .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
+    }
+
     private ChargeEntity updateChargeStatus(ChargeEntity chargeEntity, ChargeStatus chargeStatus) {
         chargeEntity.setStatus(chargeStatus);
         chargeEventDao.persistChargeEventOf(chargeEntity);
@@ -332,6 +343,10 @@ public class ChargeService {
         return chargeDao.findByExternalId(chargeId).map(chargeEntity ->
                 updateChargeStatus(chargeEntity, chargeStatus)
         ).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
+    }
+
+    public Optional<ChargeEntity> findByProviderAndTransactionId(String paymentGatewayName, String transactionId) {
+        return chargeDao.findByProviderAndTransactionId(paymentGatewayName, transactionId);
     }
 
     public ChargeEntity markChargeAsEligibleForCapture(String externalId) {
@@ -388,7 +403,7 @@ public class ChargeService {
     private boolean hasFullCardNumber(AuthCardDetails authCardDetails) {
         return authCardDetails.getCardNo().length() > 6;
     }
-    
+
     private TokenEntity createNewChargeEntityToken(ChargeEntity chargeEntity) {
         TokenEntity token = TokenEntity.generateNewTokenFor(chargeEntity);
         tokenDao.persist(token);

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -68,6 +68,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, EXPIRED, "ChargeExpiryService");
         graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRED, "ChargeExpiryService");
         graph.putEdgeValue(EXPIRE_CANCEL_SUBMITTED, EXPIRED, "ChargeExpiryService");
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRED, "ChargeExpiryService");
 
         graph.putEdgeValue(CREATED, ENTERING_CARD_DETAILS, "frontend: POST /frontend/charges/{chargeId}/status");
         graph.putEdgeValue(CREATED, SYSTEM_CANCELLED, "");

--- a/src/main/java/uk/gov/pay/connector/gateway/model/Auth3dsDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/Auth3dsDetails.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class Auth3dsDetails implements AuthorisationDetails {
 
     public enum Auth3dsResult {
-        AUTHORISED, DECLINED, ERROR
+        AUTHORISED, DECLINED, ERROR, CANCELED
     }
 
     private String paResponse;
@@ -39,5 +39,34 @@ public class Auth3dsDetails implements AuthorisationDetails {
 
     public String getMd() {
         return this.md;
+    }
+
+    @Override
+    public String toString() {
+        return "Auth3dsDetails{" +
+                "paResponse='" + paResponse + '\'' +
+                ", auth3DsResult=" + auth3DsResult +
+                ", md='" + md + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Auth3dsDetails that = (Auth3dsDetails) o;
+
+        if (paResponse != null ? !paResponse.equals(that.paResponse) : that.paResponse != null) return false;
+        if (auth3DsResult != that.auth3DsResult) return false;
+        return md != null ? md.equals(that.md) : that.md == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = paResponse != null ? paResponse.hashCode() : 0;
+        result = 31 * result + (auth3DsResult != null ? auth3DsResult.hashCode() : 0);
+        result = 31 * result + (md != null ? md.hashCode() : 0);
+        return result;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
@@ -1,9 +1,10 @@
 package uk.gov.pay.connector.gateway.model.request;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.Optional;
 
@@ -11,7 +12,6 @@ public class Auth3dsResponseGatewayRequest implements GatewayRequest {
 
     private final ChargeEntity charge;
     private final Auth3dsDetails auth3DsDetails;
-
 
     public Auth3dsResponseGatewayRequest(ChargeEntity charge, Auth3dsDetails auth3DsDetails) {
         this.charge = charge;
@@ -46,5 +46,13 @@ public class Auth3dsResponseGatewayRequest implements GatewayRequest {
 
     public static Auth3dsResponseGatewayRequest valueOf(ChargeEntity charge, Auth3dsDetails auth3DsDetails) {
         return new Auth3dsResponseGatewayRequest(charge, auth3DsDetails);
+    }
+
+    public String getAmount() {
+        return String.valueOf(CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
+    }
+
+    public String getDescription() {
+        return charge.getDescription();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
@@ -18,6 +18,7 @@ public interface BaseAuthoriseResponse extends BaseResponse {
         AUTHORISED(ChargeStatus.AUTHORISATION_SUCCESS),
         REJECTED(ChargeStatus.AUTHORISATION_REJECTED),
         REQUIRES_3DS(ChargeStatus.AUTHORISATION_3DS_REQUIRED),
+        AUTH_3DS_READY(ChargeStatus.AUTHORISATION_3DS_READY),
         CANCELLED(ChargeStatus.AUTHORISATION_CANCELLED),
         ERROR(ChargeStatus.AUTHORISATION_ERROR),
         EXCEPTION(ChargeStatus.AUTHORISATION_ERROR);

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -33,7 +33,8 @@ public class Gateway3DSAuthorisationResponse {
     }
 
     public boolean isSuccessful() {
-        return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
+        return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED
+                || authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTH_3DS_READY;
     }
 
     public boolean isException() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClient.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 
@@ -72,7 +71,10 @@ public class StripeGatewayClient {
         }
         if (SERVER_ERROR == response.getStatusInfo().getFamily()) {
             metricRegistry.counter(metricsPrefix + ".failures").inc();
-            throw new DownstreamException(response.getStatus(), response.readEntity(String.class));
+            String responseMessage = response.readEntity(String.class);
+            logger.error("Unexpected HTTP status code {} from gateway, error=[{}]",
+                    response.getStatus(), responseMessage);
+            throw new DownstreamException(response.getStatus(), responseMessage);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -129,6 +129,7 @@ public class StripeNotificationService {
         }
 
         return Optional.empty();
+        
     }
 
     private StripeNotification parseNotification(String payload) throws StripeParseException {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -3,19 +3,20 @@ package uk.gov.pay.connector.gateway.stripe;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.net.Webhook;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.stripe.json.StripeSourcesResponse;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
+import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
 
 import javax.ws.rs.WebApplicationException;
 import java.util.List;
@@ -24,21 +25,20 @@ import java.util.Optional;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_CANCELED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_CHARGEABLE;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_FAILED;
+import static uk.gov.pay.connector.paymentprocessor.model.OperationType.AUTHORISATION_3DS;
 
 public class StripeNotificationService {
-
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final List<StripeNotificationType> sourceTypes = ImmutableList.of(SOURCE_CANCELED, SOURCE_CHARGEABLE, SOURCE_FAILED);
+    private final List<ChargeStatus> threeDSAuthorisableStates = ImmutableList.of(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_3DS_READY);
 
-    private final ChargeDao chargeDao;
-    private final ChargeNotificationProcessor chargeNotificationProcessor;
+    private final ChargeService chargeService;
+    private final Card3dsResponseAuthService card3dsResponseAuthService;
     private final ObjectMapper objectMapper;
     private final StripeGatewayConfig stripeGatewayConfig;
 
@@ -46,16 +46,15 @@ public class StripeNotificationService {
     private static final long DEFAULT_TOLERANCE = 300L;
 
     @Inject
-    public StripeNotificationService(ChargeDao chargeDao,
-                                     ChargeNotificationProcessor chargeNotificationProcessor,
+    public StripeNotificationService(Card3dsResponseAuthService card3dsResponseAuthService,
+                                     ChargeService chargeService,
                                      StripeGatewayConfig stripeGatewayConfig) {
-        this.chargeDao = chargeDao;
-        this.chargeNotificationProcessor = chargeNotificationProcessor;
+        this.card3dsResponseAuthService = card3dsResponseAuthService;
+        this.chargeService = chargeService;
         objectMapper = new ObjectMapper();
         this.stripeGatewayConfig = stripeGatewayConfig;
     }
 
-    @Transactional
     public void handleNotificationFor(String payload, String signatureHeader) {
         logger.info("Parsing {} notification", PAYMENT_GATEWAY_NAME);
 
@@ -88,7 +87,7 @@ public class StripeNotificationService {
 
             logger.info("Evaluating {} for source notification [{}]", PAYMENT_GATEWAY_NAME, stripeSourcesResponse.getTransactionId());
 
-            Optional<ChargeEntity> maybeCharge = chargeDao.findByProviderAndTransactionId(PAYMENT_GATEWAY_NAME, stripeSourcesResponse.getTransactionId());
+            Optional<ChargeEntity> maybeCharge = chargeService.findByProviderAndTransactionId(PAYMENT_GATEWAY_NAME, stripeSourcesResponse.getTransactionId());
 
             if (!maybeCharge.isPresent()) {
                 logger.error("{} notification for source [{}] could not be verified (associated charge entity not found)",
@@ -98,13 +97,35 @@ public class StripeNotificationService {
 
             ChargeEntity charge = maybeCharge.get();
 
-            final Optional<ChargeStatus> newChargeStatus = newChargeStateForSourceNotification(notification.getType(), ChargeStatus.fromString(charge.getStatus()));
-
-            if (newChargeStatus.isPresent()) {
-                chargeNotificationProcessor.invoke(stripeSourcesResponse.getTransactionId(), charge, newChargeStatus.get(), null);
+            if (isChargeIn3DSRequiredOrReadyState(ChargeStatus.fromString(charge.getStatus()))) {
+                authorise3DSSource(charge, notification.getType());
             }
+
         } catch (StripeParseException e) {
             logger.error("{} notification parsing for source object failed: {}", PAYMENT_GATEWAY_NAME, e);
+        }
+    }
+
+    private void authorise3DSSource(ChargeEntity charge, String notificationEventType) {
+        try {
+            final StripeNotificationType type = StripeNotificationType.byType(notificationEventType);
+
+            if (AUTHORISATION_3DS_REQUIRED.equals(ChargeStatus.fromString(charge.getStatus()))) {
+                logger.info("Updating charge for notification - " +
+                                "charge_external_id={}, status={}, status_to={}, transaction_id={}, " +
+                                "account_id={}, provider={}, provider_type={}",
+                        charge.getExternalId(), charge.getStatus(), charge.getStatus(), charge.getGatewayTransactionId(),
+                        charge.getGatewayAccount().getId(), charge.getGatewayAccount().getGatewayName(), charge.getGatewayAccount().getType());
+                chargeService.lockChargeForProcessing(charge.getExternalId(), AUTHORISATION_3DS);
+            }
+
+            Auth3dsDetails auth3dsDetails = new Auth3dsDetails();
+            auth3dsDetails.setAuth3dsResult(getMappedAuth3dsResult(type));
+            card3dsResponseAuthService.process3DSecureAuthorisationWithoutLocking(charge.getExternalId(), auth3dsDetails);
+        } catch (OperationAlreadyInProgressRuntimeException e) {
+            // CardExecutorService is asynchronous and sends back 'OperationAlreadyInProgressRuntimeException' 
+            // exception while the charge is being authorised. Catch this exception to send a response with 
+            // http status 200 instead of depending on the status returned by Exception 
         }
     }
 
@@ -112,24 +133,21 @@ public class StripeNotificationService {
         return sourceTypes.contains(StripeNotificationType.byType(notification.getType()));
     }
 
-    private static Optional<ChargeStatus> newChargeStateForSourceNotification(String notificationEventType, ChargeStatus chargeStatus) {
-        final StripeNotificationType type = StripeNotificationType.byType(notificationEventType);
-
-        if (AUTHORISATION_3DS_REQUIRED.equals(chargeStatus)) {
-            switch (type) {
-                case SOURCE_CHARGEABLE:
-                    return Optional.of(AUTHORISATION_3DS_READY);
-                case SOURCE_CANCELED:
-                    return Optional.of(AUTHORISATION_CANCELLED);
-                case SOURCE_FAILED:
-                    return Optional.of(AUTHORISATION_REJECTED);
-                default:
-                    return Optional.empty();
-            }
+    private String getMappedAuth3dsResult(StripeNotificationType type) {
+        switch (type) {
+            case SOURCE_CHARGEABLE:
+                return Auth3dsDetails.Auth3dsResult.AUTHORISED.toString();
+            case SOURCE_CANCELED:
+                return Auth3dsDetails.Auth3dsResult.CANCELED.toString();
+            case SOURCE_FAILED:
+                return Auth3dsDetails.Auth3dsResult.DECLINED.toString();
+            default:
+                return Auth3dsDetails.Auth3dsResult.ERROR.toString();
         }
+    }
 
-        return Optional.empty();
-        
+    private boolean isChargeIn3DSRequiredOrReadyState(ChargeStatus chargeStatus) {
+        return threeDSAuthorisableStates.contains(chargeStatus);
     }
 
     private StripeNotification parseNotification(String payload) throws StripeParseException {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -121,9 +121,8 @@ public class StripePaymentProvider implements PaymentProvider {
         } catch (GatewayClientException e) {
 
             Response response = e.getResponse();
-            int status = response.getStatus();
 
-            if (status == HttpStatus.SC_UNAUTHORIZED) {
+            if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED) {
                 return unexpectedGatewayResponse(request.getChargeExternalId(), responseBuilder, e.getMessage(), HttpStatus.SC_UNAUTHORIZED);
             }
 
@@ -136,11 +135,57 @@ public class StripePaymentProvider implements PaymentProvider {
             return responseBuilder.withGatewayError(gatewayError).build();
 
         } catch (DownstreamException e) {
-
             return unexpectedGatewayResponse(request.getChargeExternalId(), responseBuilder, e.getMessage(), e.getStatusCode());
-
         } catch (GatewayException e) {
             return responseBuilder.withGatewayError(GatewayError.of(e)).build();
+        }
+    }
+
+    @Override
+    public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
+
+        if (request.getAuth3DsDetails() != null && request.getAuth3DsDetails().getAuth3DsResult() != null) {
+
+            switch (request.getAuth3DsDetails().getAuth3DsResult()) {
+                case CANCELED:
+                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.CANCELLED);
+                case ERROR:
+                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.ERROR);
+                case DECLINED:
+                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED);
+                case AUTHORISED:
+                    return authorise3DSSource(request);
+            }
+        }
+
+        // if Auth3DSResult is not available, return response as AUTH_3DS_READY
+        // (to keep the transaction in auth waiting until a notification is received from Stripe for 3DS authorisation)
+        return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.AUTH_3DS_READY);
+    }
+
+    private Gateway3DSAuthorisationResponse authorise3DSSource(Auth3dsResponseGatewayRequest request) {
+        try {
+            Response authorisationResponse = createChargeFor3DSSource(request, request.getTransactionId().get());
+            StripeAuthorisationResponse stripeAuthResponse = new StripeAuthorisationResponse(authorisationResponse.readEntity(StripeCreateChargeResponse.class));
+
+            return Gateway3DSAuthorisationResponse.of(stripeAuthResponse.authoriseStatus(), stripeAuthResponse.getTransactionId());
+        } catch (GatewayClientException e) {
+
+            Response response = e.getResponse();
+
+            if (response.getStatus() == HttpStatus.SC_UNAUTHORIZED) {
+                return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.ERROR);
+            }
+
+            StripeErrorResponse stripeErrorResponse = response.readEntity(StripeErrorResponse.class);
+            String errorId = UUID.randomUUID().toString();
+            logger.error("3DS Authorisation failed for charge {}. Failure code from Stripe: {}, failure message from Stripe: {}. ErrorId: {}. Response code from Stripe: {}",
+                    request.getChargeExternalId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), errorId, response.getStatus());
+
+            return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED);
+
+        } catch (DownstreamException | GatewayException e) {
+            return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION);
         }
     }
 
@@ -166,12 +211,24 @@ public class StripePaymentProvider implements PaymentProvider {
         );
     }
 
+    private Response createChargeFor3DSSource(Auth3dsResponseGatewayRequest request, String sourceId)
+            throws GatewayClientException, GatewayException, DownstreamException {
+        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
+        return postToStripe(
+                "/v1/charges",
+                authorise3DSChargePayload(request, sourceId),
+                format("gateway-operations.%s.%s.authorise.create_charge",
+                        gatewayAccount.getGatewayName(),
+                        gatewayAccount.getType())
+        );
+    }
+
     private Response createCharge(CardAuthorisationGatewayRequest request, String sourceId) throws GatewayClientException, GatewayException, DownstreamException {
         GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
         return postToStripe(
                 "/v1/charges",
                 authorisePayload(request, sourceId),
-                format("gateway-operations.%s.%s.authorise.create_source",
+                format("gateway-operations.%s.%s.authorise.create_charge",
                         gatewayAccount.getGatewayName(),
                         gatewayAccount.getType())
         );
@@ -210,11 +267,6 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        return null;
-    }
-
-    @Override
     public GatewayResponse<BaseAuthoriseResponse> authoriseApplePay(ApplePayAuthorisationGatewayRequest request) {
         throw new UnsupportedOperationException("Apple Pay is not supported for Stripe");
     }
@@ -248,8 +300,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     private String threeDSecurePayload(CardAuthorisationGatewayRequest request, String sourceId) {
-        //todo: revisit for frontendUrl format
-        String frontend3dsIncomingUrl = String.format("%s/card_details/%s/3ds_required_in/stripe", frontendUrl, request.getChargeExternalId());
+        String frontend3dsIncomingUrl = String.format("%s/card_details/%s/3ds_required_in", frontendUrl, request.getChargeExternalId());
         List<BasicNameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("type", "three_d_secure"));
         params.add(new BasicNameValuePair("amount", request.getAmount()));
@@ -260,19 +311,32 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     private String authorisePayload(CardAuthorisationGatewayRequest request, String sourceId) {
+        return buildAuthorisePayload(sourceId, request.getAmount(), request.getDescription(), request.getGatewayAccount());
+    }
+
+    private String authorise3DSChargePayload(Auth3dsResponseGatewayRequest request, String sourceId) {
+        return buildAuthorisePayload(sourceId, request.getAmount(), request.getDescription(), request.getGatewayAccount());
+    }
+
+    private String buildAuthorisePayload(String sourceId, String amount, String description, GatewayAccountEntity gatewayAccount) {
         List<BasicNameValuePair> params = new ArrayList<>();
-        params.add(new BasicNameValuePair("amount", request.getAmount()));
+        params.add(new BasicNameValuePair("amount", amount));
         params.add(new BasicNameValuePair("currency", "GBP"));
-        params.add(new BasicNameValuePair("description", request.getDescription()));
+        params.add(new BasicNameValuePair("description", description));
         params.add(new BasicNameValuePair("source", sourceId));
         params.add(new BasicNameValuePair("capture", "false"));
-        String stripeAccountId = request.getGatewayAccount().getCredentials().get("stripe_account_id");
-
-        if (StringUtils.isBlank(stripeAccountId))
-            throw new WebApplicationException(format("There is no stripe_account_id for gateway account with id %s", request.getGatewayAccount().getId()));
+        String stripeAccountId = getStripeAccountId(gatewayAccount);
 
         params.add(new BasicNameValuePair("destination[account]", stripeAccountId));
         return URLEncodedUtils.format(params, UTF_8);
+    }
+
+    private String getStripeAccountId(GatewayAccountEntity gatewayAccount) {
+        String stripeAccountId = gatewayAccount.getCredentials().get("stripe_account_id");
+
+        if (StringUtils.isBlank(stripeAccountId))
+            throw new WebApplicationException(format("There is no stripe_account_id for gateway account with id %s", gatewayAccount.getId()));
+        return stripeAccountId;
     }
 
     private String tokenPayload(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -178,9 +178,8 @@ public class StripePaymentProvider implements PaymentProvider {
             }
 
             StripeErrorResponse stripeErrorResponse = response.readEntity(StripeErrorResponse.class);
-            String errorId = UUID.randomUUID().toString();
-            logger.error("3DS Authorisation failed for charge {}. Failure code from Stripe: {}, failure message from Stripe: {}. ErrorId: {}. Response code from Stripe: {}",
-                    request.getChargeExternalId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), errorId, response.getStatus());
+            logger.error("3DS Authorisation failed for charge {}. Failure code from Stripe: {}, failure message from Stripe: {}. Response code from Stripe: {}",
+                    request.getChargeExternalId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), response.getStatus());
 
             return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED);
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -6,13 +6,9 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
-import javax.ws.rs.HEAD;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.paymentprocessor.model.OperationType.AUTHORISATION_3DS;
@@ -36,17 +32,29 @@ public class Card3dsResponseAuthService {
         return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
 
             final ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, AUTHORISATION_3DS);
-            Gateway3DSAuthorisationResponse gateway3DSAuthorisationResponse =  providers
-                    .byName(charge.getPaymentGatewayName())
-                    .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(charge, auth3DsDetails));
-            processGateway3DSecureResponse(
-                    charge.getExternalId(),
-                    ChargeStatus.fromString(charge.getStatus()),
-                    gateway3DSAuthorisationResponse
-            );
-
-            return gateway3DSAuthorisationResponse;
+            return authoriseAndProcess3DS(auth3DsDetails, charge);
         });
+    }
+
+    public Gateway3DSAuthorisationResponse process3DSecureAuthorisationWithoutLocking(String chargeId, Auth3dsDetails auth3DsDetails) {
+        return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
+            final ChargeEntity charge = chargeService.findChargeById(chargeId);
+            return authoriseAndProcess3DS(auth3DsDetails, charge);
+        });
+    }
+
+    private Gateway3DSAuthorisationResponse authoriseAndProcess3DS(Auth3dsDetails auth3DsDetails, ChargeEntity charge) {
+        Gateway3DSAuthorisationResponse gateway3DSAuthorisationResponse = providers
+                .byName(charge.getPaymentGatewayName())
+                .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(charge, auth3DsDetails));
+
+        processGateway3DSecureResponse(
+                charge.getExternalId(),
+                ChargeStatus.fromString(charge.getStatus()),
+                gateway3DSAuthorisationResponse
+        );
+
+        return gateway3DSAuthorisationResponse;
     }
 
     private void processGateway3DSecureResponse(

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
@@ -39,11 +39,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_3DS_SOURCES_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE_GENERAL;
 
 public abstract class BaseStripePaymentProviderTest {
 
@@ -98,6 +98,12 @@ public abstract class BaseStripePaymentProviderTest {
     String success3dsSourceResponse() {
         return TestTemplateResourceLoader.load(STRIPE_CREATE_3DS_SOURCES_RESPONSE);
     }
+    String successChargeResponse() {
+        return TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_SUCCESS_RESPONSE);
+    }
+    String errorResponse() {
+        return TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
+    }
 
     CardAuthorisationGatewayRequest buildTestAuthorisationRequest() {
         return buildTestAuthorisationRequest(buildTestGatewayAccountEntity());
@@ -145,6 +151,14 @@ public abstract class BaseStripePaymentProviderTest {
                 .withGatewayAccountEntity(accountEntity)
                 .build();
         return buildTestAuthorisationRequest(chargeEntity);
+    }
+
+    protected ChargeEntity buildTestCharge() {
+        return aValidChargeEntity()
+                .withExternalId("mq4ht90j2oir6am585afk58kml")
+                .withTransactionId("transaction-id")
+                .withGatewayAccountEntity(buildTestGatewayAccountEntity())
+                .build();
     }
 
     CardAuthorisationGatewayRequest buildTestAuthorisationRequest(ChargeEntity chargeEntity) {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -41,8 +41,6 @@ public class StripeNotificationServiceTest {
     @Mock
     private Card3dsResponseAuthService mockCard3dsResponseAuthService;
     @Mock
-    private ChargeDao mockChargeDao;
-    @Mock
     private ChargeService mockChargeService;
     @Mock
     private ChargeEntity mockCharge;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -8,7 +8,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -10,7 +10,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.gateway.processor.ChargeNotificationProcessor;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import javax.ws.rs.WebApplicationException;
@@ -18,13 +21,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_CANCELED;
@@ -38,25 +39,32 @@ public class StripeNotificationServiceTest {
     private StripeNotificationService notificationService;
 
     @Mock
+    private Card3dsResponseAuthService mockCard3dsResponseAuthService;
+    @Mock
     private ChargeDao mockChargeDao;
     @Mock
-    private ChargeNotificationProcessor mockChargeNotificationProcessor;
+    private ChargeService mockChargeService;
     @Mock
     private ChargeEntity mockCharge;
     @Mock
+    private GatewayAccountEntity mockGatewayAccountEntity;
+    @Mock
     private StripeGatewayConfig stripeGatewayConfig;
 
+    private final String externalId = "external-id";
     private final String sourceId = "source-id";
     private final String webhookSigningSecret = "whsec";
 
     @Before
     public void setup() {
-        notificationService = new StripeNotificationService(mockChargeDao,
-                mockChargeNotificationProcessor, stripeGatewayConfig);
+        notificationService = new StripeNotificationService(mockCard3dsResponseAuthService,
+                mockChargeService, stripeGatewayConfig);
 
         when(stripeGatewayConfig.getWebhookSigningSecret()).thenReturn(webhookSigningSecret);
+        when(mockCharge.getExternalId()).thenReturn(externalId);
         when(mockCharge.getStatus()).thenReturn(AUTHORISATION_3DS_REQUIRED.getValue());
-        when(mockChargeDao.findByProviderAndTransactionId(STRIPE.getName(), sourceId)).thenReturn(Optional.of(mockCharge));
+        when(mockCharge.getGatewayAccount()).thenReturn(mockGatewayAccountEntity);
+        when(mockChargeService.findByProviderAndTransactionId(STRIPE.getName(), sourceId)).thenReturn(Optional.of(mockCharge));
     }
 
     @Test
@@ -66,7 +74,7 @@ public class StripeNotificationServiceTest {
 
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
-        verify(mockChargeNotificationProcessor).invoke(sourceId, mockCharge, AUTHORISATION_3DS_READY, null);
+        verify(mockCard3dsResponseAuthService).process3DSecureAuthorisationWithoutLocking(externalId, getAuth3dsDetails(Auth3dsDetails.Auth3dsResult.AUTHORISED));
     }
 
     private String signPayload(String payload) {
@@ -79,7 +87,7 @@ public class StripeNotificationServiceTest {
                 sourceId, SOURCE_FAILED);
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
-        verify(mockChargeNotificationProcessor).invoke(sourceId, mockCharge, AUTHORISATION_REJECTED, null);
+        verify(mockCard3dsResponseAuthService).process3DSecureAuthorisationWithoutLocking(externalId, getAuth3dsDetails(Auth3dsDetails.Auth3dsResult.DECLINED));
     }
 
     @Test
@@ -88,7 +96,7 @@ public class StripeNotificationServiceTest {
                 sourceId, SOURCE_CANCELED);
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
-        verify(mockChargeNotificationProcessor).invoke(sourceId, mockCharge, AUTHORISATION_CANCELLED, null);
+        verify(mockCard3dsResponseAuthService).process3DSecureAuthorisationWithoutLocking(externalId, getAuth3dsDetails(Auth3dsDetails.Auth3dsResult.CANCELED));
     }
 
     @Test
@@ -103,7 +111,7 @@ public class StripeNotificationServiceTest {
             notificationService.handleNotificationFor(payload, signPayload(payload));
         }
 
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockCard3dsResponseAuthService, never()).process3DSecureAuthorisationWithoutLocking(anyString(), any());
     }
 
     @Test
@@ -113,7 +121,7 @@ public class StripeNotificationServiceTest {
 
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockCard3dsResponseAuthService, never()).process3DSecureAuthorisationWithoutLocking(anyString(), any());
     }
 
     @Test
@@ -123,7 +131,7 @@ public class StripeNotificationServiceTest {
 
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockCard3dsResponseAuthService, never()).process3DSecureAuthorisationWithoutLocking(anyString(), any());
     }
 
     @Test
@@ -133,7 +141,7 @@ public class StripeNotificationServiceTest {
 
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockCard3dsResponseAuthService, never()).process3DSecureAuthorisationWithoutLocking(anyString(), any());
     }
 
     @Test
@@ -141,7 +149,7 @@ public class StripeNotificationServiceTest {
         final String payload = "invalid-payload";
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verify(mockCard3dsResponseAuthService, never()).process3DSecureAuthorisationWithoutLocking(anyString(), any());
     }
 
     @Test(expected = WebApplicationException.class)
@@ -156,5 +164,11 @@ public class StripeNotificationServiceTest {
         return TestTemplateResourceLoader.load(location)
                 .replace("{{sourceId}}", sourceId)
                 .replace("{{type}}", stripeNotificationType.getType());
+    }
+
+    private Auth3dsDetails getAuth3dsDetails(Auth3dsDetails.Auth3dsResult auth3dsResult) {
+        Auth3dsDetails auth3dsDetails = new Auth3dsDetails();
+        auth3dsDetails.setAuth3dsResult(auth3dsResult.toString());
+        return auth3dsDetails;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -1,19 +1,27 @@
 package uk.gov.pay.connector.gateway.stripe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeCreateChargeResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeSourcesResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeTokenResponse;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsSourceResponse;
 import uk.gov.pay.connector.gateway.stripe.response.StripeParamsFor3ds;
 
 import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.Optional;
@@ -87,6 +95,104 @@ public class StripePaymentProviderTest extends BaseStripePaymentProviderTest {
 
     }
 
+    @Test
+    public void shouldAuthorise3DSSource_when3DSAuthDetailsStatusIsAuthorised() throws IOException {
+        mock3dsChargeSuccessResponse();
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.AUTHORISED);
+
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertTrue(response.isSuccessful());
+        assertThat(response.getTransactionId().get(), is("ch_1DRQ842eZvKYlo2CPbf7NNDv_test"));
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_SUCCESS));
+    }
+
+    @Test
+    public void shouldReject3DSCharge_when3DSAuthDetailsStatusIsRejected() {
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.DECLINED);
+
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertTrue(response.isDeclined());
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_REJECTED));
+    }
+
+    @Test
+    public void shouldCancel3DSCharge_when3DSAuthDetailsStatusIsCanceled() {
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.CANCELED);
+
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_CANCELLED));
+    }
+
+    @Test
+    public void shouldMark3DSChargeAsError_when3DSAuthDetailsStatusIsError() {
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.ERROR);
+
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_ERROR));
+    }
+
+    @Test
+    public void shouldMark3DSChargeAsError_whenGatewayOperationResultedInUnauthorisedException() {
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.AUTHORISED);
+
+        mockResponseWithPayload(401);
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_ERROR));
+    }
+
+    @Test
+    public void shouldMark3DSChargeAsRejected_whenGatewayOperationResultedIn4xxHttpStatus() throws IOException {
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.AUTHORISED);
+
+        mockPaymentProviderErrorResponse(403, errorResponse());
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_REJECTED));
+    }
+
+    @Test
+    public void shouldMark3DSChargeAsError_whenGatewayOperationResultedInException() {
+        mockProcessingException();
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.AUTHORISED);
+
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertTrue(response.isException());
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_ERROR));
+    }
+
+    @Test
+    public void shouldKeep3DSChargeInAuthReadyState_when3DSAuthDetailsAreNotAvailable() {
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(null);
+
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+
+        assertTrue(response.isSuccessful());
+        assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_3DS_READY));
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void shouldThrowExceptionFor3DSCharge_IfStripeAccountIsNotAvailable() {
+        Auth3dsResponseGatewayRequest request
+                = build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult.AUTHORISED);
+
+        request.getGatewayAccount().setCredentials(ImmutableMap.of());
+        Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
+    }
+
     private void mockProcessingException() {
         mockInvocationBuilder();
         when(mockClientInvocationBuilder.post(any())).thenThrow(ProcessingException.class);
@@ -105,4 +211,20 @@ public class StripePaymentProviderTest extends BaseStripePaymentProviderTest {
         when(response.readEntity(Stripe3dsSourceResponse.class)).thenReturn(stripe3dsSourceResponse);
     }
 
+    private Auth3dsResponseGatewayRequest build3dsResponseGatewayRequest(Auth3dsDetails.Auth3dsResult auth3dsResult) {
+        Auth3dsDetails auth3dsDetails = new Auth3dsDetails();
+        if (auth3dsResult != null) {
+            auth3dsDetails.setAuth3dsResult(auth3dsResult.toString());
+        }
+        ChargeEntity chargeEntity = buildTestCharge();
+        Auth3dsResponseGatewayRequest request = new Auth3dsResponseGatewayRequest(chargeEntity, auth3dsDetails);
+
+        return request;
+    }
+
+    private void mock3dsChargeSuccessResponse() throws IOException {
+        Response response = mockResponseWithPayload(200);
+        StripeCreateChargeResponse stripeCreateChargeResponse = new ObjectMapper().readValue(successChargeResponse(), StripeCreateChargeResponse.class);
+        when(response.readEntity(StripeCreateChargeResponse.class)).thenReturn(stripeCreateChargeResponse);
+    }
 }


### PR DESCRIPTION
## WHAT
When a user completes 3DS authorisation using Stripe, the status of the transaction is not available immediately. Stripe sends the status using webhooks(notifications) and charge will be in AUTHORISATION_3DS_REQUIRED / AUTHORISATION_3DS_READY state until such notification is available. Once a source notification is available, the status is used to update charge or authorise the same with Stripe.


