### PR TITLE
PP-4352 Transition Stripe charge to CAPTURED

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -6,13 +6,9 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
-import javax.ws.rs.HEAD;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.paymentprocessor.model.OperationType.AUTHORISATION_3DS;

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -10,10 +10,10 @@ import uk.gov.pay.connector.it.service.CardCaptureProcessBaseITest;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.StripeMockClient;
 
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -28,7 +28,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Stripe charges don't receive a notification to confirm capture and to
transition the charge to CAPTURED. This is done synchronously, when we receive
the response for the call to capture. We need to transition this charge immediately
if the response is successful.

