### PR TITLE
WIP PP 4439 refactor card authorise service response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import java.util.Optional;
 
@@ -23,7 +24,7 @@ public interface PaymentProvider {
 
     Optional<String> generateTransactionId();
 
-    GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request);
+    PaymentProviderAuthorisationResponse authorise(CardAuthorisationGatewayRequest request);
 
     Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Invocation;
@@ -110,9 +111,10 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) {
+    public PaymentProviderAuthorisationResponse authorise(CardAuthorisationGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(ROUTE_FOR_NEW_ORDER, request.getGatewayAccount(), buildAuthoriseOrder(request, frontendUrl));
-        return GatewayResponseGenerator.getEpdqGatewayResponse(authoriseClient, response, EpdqAuthorisationResponse.class);
+        final GatewayResponse<BaseAuthoriseResponse> epdqGatewayResponse = GatewayResponseGenerator.getEpdqGatewayResponse(authoriseClient, response, EpdqAuthorisationResponse.class);
+        return PaymentProviderAuthorisationResponse.from(request.getChargeExternalId(), epdqGatewayResponse);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -27,6 +27,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Invocation;
@@ -64,9 +65,10 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) {
+    public PaymentProviderAuthorisationResponse authorise(CardAuthorisationGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildAuthoriseOrderFor(request));
-        return GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayAuthorisationResponse.class);
+        final GatewayResponse gatewayResponse = GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayAuthorisationResponse.class);
+        return PaymentProviderAuthorisationResponse.from(request.getChargeExternalId(), gatewayResponse);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -27,6 +27,7 @@ import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalcul
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 import uk.gov.pay.connector.gateway.worldpay.applepay.WorldpayApplePayAuthorisationHandler;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Invocation.Builder;
@@ -82,9 +83,10 @@ public class WorldpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) {
+    public PaymentProviderAuthorisationResponse authorise(CardAuthorisationGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), buildAuthoriseOrder(request));
-        return GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
+        final GatewayResponse<BaseAuthoriseResponse> gatewayResponse = GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
+        return PaymentProviderAuthorisationResponse.from(request.getChargeExternalId(), gatewayResponse);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthorisationResponse.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.paymentprocessor.model;
 
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import java.util.Optional;
 
@@ -10,12 +10,9 @@ public class AuthorisationResponse {
     private BaseAuthoriseResponse.AuthoriseStatus authoriseStatus;
     private GatewayError gatewayError;
 
-    public AuthorisationResponse(GatewayResponse<BaseAuthoriseResponse> gatewayResponse) {
-        if (gatewayResponse.isSuccessful()) {
-            gatewayResponse.getBaseResponse().ifPresent(baseAuthoriseResponse -> authoriseStatus = baseAuthoriseResponse.authoriseStatus());
-        } else {
-            gatewayResponse.getGatewayError().ifPresent(error -> gatewayError = error);
-        }
+    public AuthorisationResponse(PaymentProviderAuthorisationResponse gatewayResponse) {
+        gatewayResponse.getAuthoriseStatus().ifPresent(status -> authoriseStatus = status);
+        gatewayResponse.getGatewayError().ifPresent(error -> gatewayError = error);
     }
 
     public Optional<GatewayError> getGatewayError() {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/model/AuthorisationResponse.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.paymentprocessor.model;
+
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import java.util.Optional;
+
+public class AuthorisationResponse {
+    private BaseAuthoriseResponse.AuthoriseStatus authoriseStatus;
+    private GatewayError gatewayError;
+
+    public AuthorisationResponse(GatewayResponse<BaseAuthoriseResponse> gatewayResponse) {
+        if (gatewayResponse.isSuccessful()) {
+            gatewayResponse.getBaseResponse().ifPresent(baseAuthoriseResponse -> authoriseStatus = baseAuthoriseResponse.authoriseStatus());
+        } else {
+            gatewayResponse.getGatewayError().ifPresent(error -> gatewayError = error);
+        }
+    }
+
+    public Optional<GatewayError> getGatewayError() {
+        return Optional.ofNullable(gatewayError);
+    }
+
+    public Optional<BaseAuthoriseResponse.AuthoriseStatus> getAuthoriseStatus() {
+        return Optional.ofNullable(authoriseStatus);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -60,12 +60,14 @@ public class Card3dsResponseAuthService {
     ) {
         Optional<String> transactionId = operationResponse.getTransactionId();
 
-        ChargeEntity updatedCharge = chargeService.updateChargePost3dsAuthorisation(
+        ChargeEntity updatedCharge = transactionId.map(transaction -> chargeService.updateChargePost3dsAuthorisationWithTransactionId(
                 chargeExternalId,
                 operationResponse.getMappedChargeStatus(),
-                AUTHORISATION_3DS,
-                transactionId
-        );
+                transaction))
+                .orElseGet(() -> chargeService.updateChargePost3dsAuthorisationNoTransactionId(
+                        chargeExternalId,
+                        operationResponse.getMappedChargeStatus()));
+
         logAuthorisation(updatedCharge, oldChargeStatus);
         emitAuthorisationMetric(updatedCharge);
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -1,25 +1,16 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
-import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
-import java.util.Optional;
 import java.util.function.Supplier;
 
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus;
 
 public class CardAuthoriseBaseService {
@@ -42,40 +33,6 @@ public class CardAuthoriseBaseService {
                 throw new OperationAlreadyInProgressRuntimeException(OperationType.AUTHORISATION.getValue(), chargeId);
             default:
                 throw new GenericGatewayRuntimeException("Exception occurred while doing authorisation");
-        }
-    }
-
-
-    public ChargeStatus extractChargeStatus(Optional<BaseAuthoriseResponse> baseResponse,
-                                            Optional<GatewayError> gatewayError) {
-        return baseResponse
-                .map(BaseAuthoriseResponse::authoriseStatus)
-                .map(BaseAuthoriseResponse.AuthoriseStatus::getMappedChargeStatus)
-                .orElseGet(() -> gatewayError
-                        .map(this::mapError)
-                        .orElse(ChargeStatus.AUTHORISATION_ERROR));
-    }
-    
-    public Optional<String> extractTransactionId(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> operationResponse) {
-        Optional<String> transactionId = operationResponse.getBaseResponse()
-                .map(BaseAuthoriseResponse::getTransactionId);
-
-        if (!transactionId.isPresent() || StringUtils.isBlank(transactionId.get())) {
-            logger.warn("AuthCardDetails authorisation response received with no transaction id. -  charge_external_id={}",
-                    chargeExternalId);
-        }
-
-        return transactionId;
-    }
-
-    private ChargeStatus mapError(GatewayError gatewayError) {
-        switch (gatewayError.getErrorType()) {
-            case GENERIC_GATEWAY_ERROR:
-                return AUTHORISATION_ERROR;
-            case GATEWAY_CONNECTION_TIMEOUT_ERROR:
-                return AUTHORISATION_TIMEOUT;
-            default:
-                return AUTHORISATION_UNEXPECTED_ERROR;
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.model.AuthorisationResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
@@ -50,7 +51,7 @@ public class CardAuthoriseService {
         this.cardTypeDao = cardTypeDao;
     }
 
-    public GatewayResponse<BaseAuthoriseResponse> doAuthorise(String chargeId, AuthCardDetails authCardDetails) {
+    public AuthorisationResponse doAuthorise(String chargeId, AuthCardDetails authCardDetails) {
         return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
             final ChargeEntity charge = prepareChargeForAuthorisation(chargeId, authCardDetails);
             GatewayResponse<BaseAuthoriseResponse> operationResponse = authorise(charge, authCardDetails);
@@ -60,7 +61,7 @@ public class CardAuthoriseService {
                     authCardDetails,
                     operationResponse);
 
-            return operationResponse;
+            return new AuthorisationResponse(operationResponse);
         });
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/PaymentProviderAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/PaymentProviderAuthorisationResponse.java
@@ -1,0 +1,123 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import java.util.Optional;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+
+public class PaymentProviderAuthorisationResponse {
+    private static final Logger logger = LoggerFactory.getLogger(PaymentProviderAuthorisationResponse.class);
+
+    private String transactionId;
+    private ChargeStatus chargeStatus;
+    private Auth3dsDetailsEntity auth3dsDetailsEntity;
+    private String sessionIdentifier;
+    private GatewayError gatewayError;
+    private BaseAuthoriseResponse.AuthoriseStatus authoriseStatus;
+
+    private PaymentProviderAuthorisationResponse(String transactionId, ChargeStatus chargeStatus, Auth3dsDetailsEntity auth3dsDetailsEntity, String sessionIdentifier, GatewayError gatewayError, BaseAuthoriseResponse.AuthoriseStatus authoriseStatus) {
+        this.transactionId = transactionId;
+        this.chargeStatus = chargeStatus;
+        this.auth3dsDetailsEntity = auth3dsDetailsEntity;
+        this.sessionIdentifier = sessionIdentifier;
+        this.gatewayError = gatewayError;
+        this.authoriseStatus = authoriseStatus;
+    }
+
+
+    public Optional<String> getTransactionId() {
+        return Optional.ofNullable(this.transactionId);
+    }
+
+    public ChargeStatus getChargeStatus() {
+        return this.chargeStatus;
+    }
+
+    public Optional<Auth3dsDetailsEntity> getAuth3dsDetailsEntity() {
+        return Optional.ofNullable(this.auth3dsDetailsEntity);
+    }
+
+    public Optional<String> getSessionIdentifier() {
+        return Optional.ofNullable(this.sessionIdentifier);
+    }
+
+    public Optional<BaseAuthoriseResponse.AuthoriseStatus> getAuthoriseStatus() {
+        return Optional.ofNullable(authoriseStatus);
+    }
+
+    public boolean isSuccessful() {
+        return gatewayError == null;
+    }
+
+    public static PaymentProviderAuthorisationResponse from(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> response) {
+        return new PaymentProviderAuthorisationResponse(
+                extractTransactionId(chargeExternalId, response),
+                extractChargeStatus(response),
+                extract3dsDetails(response).orElse(null),
+                response.getSessionIdentifier().orElse(null),
+                response.getGatewayError().orElse(null),
+                extractAuthoriseStatus(response));
+    }
+
+    public static PaymentProviderAuthorisationResponse from(GatewayResponse<BaseAuthoriseResponse> response) {
+        return from(null, response);
+    }
+
+    private static BaseAuthoriseResponse.AuthoriseStatus extractAuthoriseStatus(GatewayResponse<BaseAuthoriseResponse> response) {
+        return response.getBaseResponse().map(BaseAuthoriseResponse::authoriseStatus).orElse(null);
+    }
+
+    public Optional<GatewayError> getGatewayError() {
+        return Optional.ofNullable(this.gatewayError);
+    }
+
+    private static String extractTransactionId(String chargeExternalId, GatewayResponse<BaseAuthoriseResponse> response) {
+        String transactionId = response.getBaseResponse()
+                .map(BaseAuthoriseResponse::getTransactionId)
+                .orElse(null);
+
+        if (StringUtils.isBlank(transactionId)) {
+            logger.warn("AuthCardDetails authorisation response received with no transaction id. -  charge_external_id={}",
+                    chargeExternalId);
+        }
+
+        return transactionId;
+    }
+
+    private static ChargeStatus extractChargeStatus(GatewayResponse<BaseAuthoriseResponse> response) {
+        return response.getBaseResponse()
+                .map(BaseAuthoriseResponse::authoriseStatus)
+                .map(BaseAuthoriseResponse.AuthoriseStatus::getMappedChargeStatus)
+                .orElseGet(() -> response.getGatewayError()
+                        .map(PaymentProviderAuthorisationResponse::mapError)
+                        .orElse(ChargeStatus.AUTHORISATION_ERROR));
+    }
+
+    private static ChargeStatus mapError(GatewayError gatewayError) {
+        switch (gatewayError.getErrorType()) {
+            case GENERIC_GATEWAY_ERROR:
+                return AUTHORISATION_ERROR;
+            case GATEWAY_CONNECTION_TIMEOUT_ERROR:
+                return AUTHORISATION_TIMEOUT;
+            default:
+                return AUTHORISATION_UNEXPECTED_ERROR;
+        }
+    }
+
+    private static Optional<Auth3dsDetailsEntity> extract3dsDetails(GatewayResponse<BaseAuthoriseResponse> response) {
+        return response.getBaseResponse()
+                .flatMap(BaseAuthoriseResponse::getGatewayParamsFor3ds)
+                .map(GatewayParamsFor3ds::toAuth3dsDetailsEntity);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/AppleAuthoriseServiceTest.java
@@ -94,7 +94,7 @@ public class AppleAuthoriseServiceTest extends CardServiceTest {
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
 
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         appleAuthoriseService = new AppleAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
@@ -4,9 +4,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import static java.lang.String.format;
 import static junit.framework.TestCase.assertFalse;
@@ -26,10 +25,10 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldRequire3dsAuthoriseRequest() {
         mockPaymentProviderResponse(200, successAuth3dResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
+        PaymentProviderAuthorisationResponse response = provider.authorise(buildTestAuthorisationRequest());
         verifyPaymentProviderRequest(successAuthRequest());
-        assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().authoriseStatus(), is(REQUIRES_3DS));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(REQUIRES_3DS));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -5,10 +5,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import java.util.Optional;
 
@@ -33,10 +33,10 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldAuthorise() {
         mockPaymentProviderResponse(200, successAuthResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
+        PaymentProviderAuthorisationResponse response = provider.authorise(buildTestAuthorisationRequest());
         verifyPaymentProviderRequest(successAuthRequest());
-        assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().getTransactionId(), is("3014644340"));
+        assertTrue(response.getTransactionId().isPresent());
+        assertThat(response.getTransactionId().get(), is("3014644340"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -47,16 +47,14 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotAuthoriseIfPaymentProviderReturnsUnexpectedStatusCode() {
         mockPaymentProviderResponse(200, errorAuthResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
-        assertThat(response.isFailed(), is(true));
+        PaymentProviderAuthorisationResponse response = provider.authorise(buildTestAuthorisationRequest());
         assertThat(response.getGatewayError().isPresent(), is(true));
     }
 
     @Test
     public void shouldNotAuthoriseIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorAuthResponse());
-        GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(buildTestAuthorisationRequest());
-        assertThat(response.isFailed(), is(true));
+        PaymentProviderAuthorisationResponse response = provider.authorise(buildTestAuthorisationRequest());
         assertThat(response.getGatewayError().isPresent(), is(true));
         assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
                 UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -8,23 +8,24 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.paymentprocessor.service.PaymentProviderAuthorisationResponse;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -59,19 +60,13 @@ public class SandboxPaymentProviderTest {
     public void authorise_shouldBeAuthorisedWhenCardNumIsExpectedToSucceedForAuthorisation() {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_SUCCESS_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        PaymentProviderAuthorisationResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
         assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
-        assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
 
-        BaseAuthoriseResponse authoriseResponse = (BaseAuthoriseResponse) gatewayResponse.getBaseResponse().get();
-        assertThat(authoriseResponse.authoriseStatus(), is(AuthoriseStatus.AUTHORISED));
-        assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
-        assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
-        assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
+        assertTrue(gatewayResponse.getAuthoriseStatus().isPresent());
+        assertThat(gatewayResponse.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
+        assertThat(gatewayResponse.getTransactionId(), is(notNullValue()));
     }
 
     @Test
@@ -79,19 +74,12 @@ public class SandboxPaymentProviderTest {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_REJECTED_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        PaymentProviderAuthorisationResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
-        assertThat(gatewayResponse.getBaseResponse().get() instanceof BaseAuthoriseResponse, is(true));
-
-        BaseAuthoriseResponse authoriseResponse = (BaseAuthoriseResponse) gatewayResponse.getBaseResponse().get();
-        assertThat(authoriseResponse.authoriseStatus(), is(AuthoriseStatus.REJECTED));
-        assertThat(authoriseResponse.getTransactionId(), is(notNullValue()));
-        assertThat(authoriseResponse.getErrorCode(), is(nullValue()));
-        assertThat(authoriseResponse.getErrorMessage(), is(nullValue()));
+        assertFalse(gatewayResponse.getGatewayError().isPresent());
+        assertTrue(gatewayResponse.getTransactionId().isPresent());
+        assertTrue(gatewayResponse.getAuthoriseStatus().isPresent());
+        assertThat(gatewayResponse.getAuthoriseStatus().get(), is(AuthoriseStatus.REJECTED));
     }
 
     @Test
@@ -99,16 +87,13 @@ public class SandboxPaymentProviderTest {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_ERROR_CARD_NUMBER);
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        PaymentProviderAuthorisationResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertFalse(gatewayResponse.getAuthoriseStatus().isPresent());
 
-        GatewayError gatewayError = (GatewayError) gatewayResponse.getGatewayError().get();
-        assertThat(gatewayError.getErrorType(), is(GENERIC_GATEWAY_ERROR));
-        assertThat(gatewayError.getMessage(), is("This transaction could be not be processed."));
+        assertTrue(gatewayResponse.getGatewayError().isPresent());
+        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
+        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is("This transaction could be not be processed."));
     }
 
     @Test
@@ -116,16 +101,14 @@ public class SandboxPaymentProviderTest {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo("3456789987654567");
-        GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
+        PaymentProviderAuthorisationResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
 
-        assertThat(gatewayResponse.isSuccessful(), is(false));
-        assertThat(gatewayResponse.isFailed(), is(true));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(false));
+        assertFalse(gatewayResponse.getAuthoriseStatus().isPresent());
+        assertTrue(gatewayResponse.getGatewayError().isPresent());
 
-        GatewayError gatewayError = (GatewayError) gatewayResponse.getGatewayError().get();
-        assertThat(gatewayError.getErrorType(), is(GENERIC_GATEWAY_ERROR));
-        assertThat(gatewayError.getMessage(), is("Unsupported card details."));
+        assertTrue(gatewayResponse.getGatewayError().isPresent());
+        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
+        assertThat(gatewayResponse.getGatewayError().get().getMessage(), is("Unsupported card details."));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -66,9 +66,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, mockConfiguration, null);
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
 
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService, mockEnvironment);
     }
 
     public void setupMockExecutorServiceMock() {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -98,7 +98,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao, 
                 mockedProviders,

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.paymentprocessor.model.AuthorisationResponse;
 
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +41,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
+import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -61,6 +63,9 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.MALFORMED_RESPONSE_RECEIVED_FROM_GATEWAY;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionTimeoutException;
 import static uk.gov.pay.connector.gateway.model.GatewayError.malformedResponseReceivedFromGateway;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
@@ -97,10 +102,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
-        
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService);
+
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(
-                mockedCardTypeDao, 
+                mockedCardTypeDao,
                 mockedProviders,
                 cardAuthoriseBaseService,
                 chargeService,
@@ -143,11 +148,29 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         providerWillAuthorise();
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
-        assertThat(response.getSessionIdentifier().isPresent(), is(true));
-        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
+
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
+        assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
+        verify(mockedChargeEventDao).persistChargeEventOf(charge);
+        assertThat(charge.get3dsDetails(), is(nullValue()));
+        assertThat(charge.getCardDetails(), is(notNullValue()));
+        assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
+    }
+
+    @Test
+    public void doAuthoriseWithNonCorporateCard_shouldRespondAuthorisationSuccess_2() {
+
+        providerWillAuthorise();
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -166,11 +189,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 .withAddress(null)
                 .build();
 
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
-        assertThat(response.getSessionIdentifier().isPresent(), is(true));
-        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -193,11 +215,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         charge.getGatewayAccount().setCorporateCreditCardSurchargeAmount(0L);
 
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
-        assertThat(response.getSessionIdentifier().isPresent(), is(true));
-        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -219,11 +240,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 .build();
 
         charge.getGatewayAccount().setCorporateCreditCardSurchargeAmount(250L);
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
-        assertThat(response.getSessionIdentifier().isPresent(), is(true));
-        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -245,11 +265,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 .build();
 
         charge.getGatewayAccount().setCorporateDebitCardSurchargeAmount(50L);
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
-        assertThat(response.getSessionIdentifier().isPresent(), is(true));
-        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -272,11 +291,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         when(mockedPaymentProvider.generateTransactionId()).thenReturn(Optional.of(generatedTransactionId));
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
-        assertThat(response.getSessionIdentifier().isPresent(), is(true));
-        assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
         assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
@@ -292,9 +310,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         worldpayProviderWillRequire3ds(null);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.REQUIRES_3DS));
 
         assertThat(charge.getStatus(), is(AUTHORISATION_3DS_REQUIRED.getValue()));
         verify(mockedChargeEventDao).persistChargeEventOf(charge);
@@ -307,9 +326,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         epdqProviderWillRequire3ds();
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.REQUIRES_3DS));
+
         assertThat(charge.getStatus(), is(AUTHORISATION_3DS_REQUIRED.getValue()));
         verify(mockedChargeEventDao).persistChargeEventOf(charge);
         assertThat(charge.get3dsDetails().getHtmlOut(), is(notNullValue()));
@@ -322,9 +343,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         worldpayProviderWillRequire3ds(SESSION_IDENTIFIER);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.REQUIRES_3DS));
 
         assertThat(charge.getStatus(), is(AUTHORISATION_3DS_REQUIRED.getValue()));
         verify(mockedChargeEventDao).persistChargeEventOf(charge);
@@ -390,9 +412,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillReject();
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.REJECTED));
+
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
     }
@@ -405,9 +429,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillRespondToAuthoriseWith(authResponse);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isSuccessful(), is(true));
+        assertTrue(response.getAuthoriseStatus().isPresent());
+        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.CANCELLED));
+
         assertThat(charge.getStatus(), is(AUTHORISATION_CANCELLED.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
     }
@@ -418,9 +444,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillError();
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertTrue(response.getGatewayError().isPresent());
+        assertThat(response.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
+
         assertThat(charge.getStatus(), is(AUTHORISATION_ERROR.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(nullValue()));
     }
@@ -584,9 +612,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillRespondWithError(gatewayError);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertTrue(response.getGatewayError().isPresent());
+        assertThat(response.getGatewayError().get().getErrorType(), is(GATEWAY_CONNECTION_TIMEOUT_ERROR));
+
         assertThat(charge.getStatus(), is(AUTHORISATION_TIMEOUT.getValue()));
     }
 
@@ -597,9 +627,10 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillRespondWithError(gatewayError);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-        GatewayResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
+        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(response.isFailed(), is(true));
+        assertTrue(response.getGatewayError().isPresent());
+        assertThat(response.getGatewayError().get().getErrorType(), is(MALFORMED_RESPONSE_RECEIVED_FROM_GATEWAY));
         assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
     }
 


### PR DESCRIPTION
## WHAT
- At the moment we propagate `GatewayResponse<BaseAuthoriseResponse>` all
    the way up to the resource. This is not a desired behaviour as this object
    has a pretty convoluted structure, also issues compilation warnings and most
    importantly, a service or a resource don't need to know about the response
    from the payment provider (gateway). Also we were passing quite a few optional
    method arguments around, which brings a bit of code smell. Here I extracted
    into an object what a service needs to know from the payment gateway in order
    to update the charge. This object will be converted into an even lighter one
    that gets sent to the resource where the resource will deal with how to respond.
    - In this craziness I also moved some specific methods from CardAuthoriseBaseService
    into Card3dsResponseAuthService as it were specific to this class
    - I extracted logic onto how to generate a `PaymentProviderAuthorisationResponse` into
    this class as it will be into one place and anyone who needs one of this objects can
    easily pass a gateway response into the factory method and voila, you a new object
    - Simplified `AuthorisationResponse` to make use of the Java 8 Optional.ifPresent()
    - Changed Apple related services to use the new object
    - Inlined strings for logs and metrics
    - There is also more work to be done to get rid of the generic object that gets
    returned from the payment provider


