### PR TITLE
BAU: Mark Java source as being encoded in UTF-8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
     <version>0.1-SNAPSHOT</version>
     <artifactId>pay-connector</artifactId>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.5</dropwizard.version>
         <wiremock.version>2.19.0</wiremock.version>
         <eclipselink.version>2.7.3</eclipselink.version>


### PR DESCRIPTION
This removes the following warning from the build:

`[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!`

