### PR TITLE
PP-4439 Stop BaseAuthoriseResponse from bubbling up

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/api/AuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/api/AuthorisationResponse.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.paymentprocessor.api;
+
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+
+import java.util.Optional;
+
+public class AuthorisationResponse {
+    private BaseAuthoriseResponse.AuthoriseStatus authoriseStatus;
+    private GatewayError gatewayError;
+
+    public AuthorisationResponse(GatewayResponse<BaseAuthoriseResponse> gatewayResponse) {
+        gatewayResponse.getBaseResponse().ifPresent(baseAuthoriseResponse -> authoriseStatus = baseAuthoriseResponse.authoriseStatus());
+        gatewayResponse.getGatewayError().ifPresent(error -> gatewayError = error);
+    }
+
+    public Optional<GatewayError> getGatewayError() {
+        return Optional.ofNullable(gatewayError);
+    }
+
+    public Optional<BaseAuthoriseResponse.AuthoriseStatus> getAuthoriseStatus() {
+        return Optional.ofNullable(authoriseStatus);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/api/AuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/api/AuthorisationResponse.java
@@ -7,19 +7,19 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import java.util.Optional;
 
 public class AuthorisationResponse {
-    private BaseAuthoriseResponse.AuthoriseStatus authoriseStatus;
-    private GatewayError gatewayError;
+    private final Optional<BaseAuthoriseResponse.AuthoriseStatus> authoriseStatus;
+    private final Optional<GatewayError> gatewayError;
 
     public AuthorisationResponse(GatewayResponse<BaseAuthoriseResponse> gatewayResponse) {
-        gatewayResponse.getBaseResponse().ifPresent(baseAuthoriseResponse -> authoriseStatus = baseAuthoriseResponse.authoriseStatus());
-        gatewayResponse.getGatewayError().ifPresent(error -> gatewayError = error);
+        authoriseStatus = gatewayResponse.getBaseResponse().map(BaseAuthoriseResponse::authoriseStatus);
+        gatewayError = gatewayResponse.getGatewayError();
     }
 
     public Optional<GatewayError> getGatewayError() {
-        return Optional.ofNullable(gatewayError);
+        return gatewayError;
     }
 
     public Optional<BaseAuthoriseResponse.AuthoriseStatus> getAuthoriseStatus() {
-        return Optional.ofNullable(authoriseStatus);
+        return authoriseStatus;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -7,10 +7,9 @@ import uk.gov.pay.connector.charge.service.ChargeCancelService;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureService;
@@ -58,13 +57,21 @@ public class CardResource {
         if (!isWellFormatted(authCardDetails)) {
             return badRequestResponse("Values do not match expected format/length.");
         }
-        GatewayResponse<BaseAuthoriseResponse> response = cardAuthoriseService.doAuthorise(chargeId, authCardDetails);
+        AuthorisationResponse response = cardAuthoriseService.doAuthorise(chargeId, authCardDetails);
 
-        if (isAuthorisationSubmitted(response)) {
-            return badRequestResponse("This transaction was deferred.");
-        }
+        return response.getGatewayError().map(this::handleError)
+                .orElseGet(() -> response.getAuthoriseStatus().map(authoriseStatus -> {
+                    if (authoriseStatus.equals(AuthoriseStatus.SUBMITTED)) {
+                        return badRequestResponse("This transaction was deferred.");
+                    }
 
-        return isAuthorisationDeclined(response) ? badRequestResponse("This transaction was declined.") : handleGatewayAuthoriseResponse(response);
+                    if (isAuthorisationDeclined(authoriseStatus)) {
+                        return badRequestResponse("This transaction was declined.");
+                    }
+
+                    return ResponseUtil.successResponseWithEntity(ImmutableMap.of("status", authoriseStatus.getMappedChargeStatus().toString()));
+
+                }).orElseGet(() -> ResponseUtil.serviceErrorResponse("InterpretedStatus not found for Gateway response")));
     }
 
     @POST
@@ -139,24 +146,8 @@ public class CardResource {
         }
     }
 
-    private Response handleGatewayAuthoriseResponse(GatewayResponse<? extends BaseAuthoriseResponse> response) {
-        return response.getGatewayError()
-                .map(this::handleError)
-                .orElseGet(() -> response.getBaseResponse()
-                        .map(r -> ResponseUtil.successResponseWithEntity(ImmutableMap.of("status", r.authoriseStatus().getMappedChargeStatus().toString())))
-                        .orElseGet(() -> ResponseUtil.serviceErrorResponse("InterpretedStatus not found for Gateway response")));
-    }
-
-    private static boolean isAuthorisationSubmitted(GatewayResponse<BaseAuthoriseResponse> response) {
-        return response.getBaseResponse()
-                .filter(baseResponse -> baseResponse.authoriseStatus() == AuthoriseStatus.SUBMITTED)
-                .isPresent();
-    }
-
-    private static boolean isAuthorisationDeclined(GatewayResponse<BaseAuthoriseResponse> response) {
-        return response.getBaseResponse()
-                .filter(baseResponse -> baseResponse.authoriseStatus() == AuthoriseStatus.REJECTED ||
-                        baseResponse.authoriseStatus() == AuthoriseStatus.ERROR)
-                .isPresent();
+    private static boolean isAuthorisationDeclined(AuthoriseStatus authoriseStatus) {
+        return authoriseStatus.equals(AuthoriseStatus.REJECTED) ||
+                authoriseStatus.equals(AuthoriseStatus.ERROR);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
 import javax.inject.Inject;
@@ -50,7 +51,7 @@ public class CardAuthoriseService {
         this.cardTypeDao = cardTypeDao;
     }
 
-    public GatewayResponse<BaseAuthoriseResponse> doAuthorise(String chargeId, AuthCardDetails authCardDetails) {
+    public AuthorisationResponse doAuthorise(String chargeId, AuthCardDetails authCardDetails) {
         return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
             final ChargeEntity charge = prepareChargeForAuthorisation(chargeId, authCardDetails);
             GatewayResponse<BaseAuthoriseResponse> operationResponse = authorise(charge, authCardDetails);
@@ -60,7 +61,7 @@ public class CardAuthoriseService {
                     authCardDetails,
                     operationResponse);
 
-            return operationResponse;
+            return new AuthorisationResponse(operationResponse);
         });
     }
 


### PR DESCRIPTION
## WHAT
- Stop BaseAuthoriseResponse from bubbling all the way up to the surface of a
resource. Added a custom object that is returned by the service and the
response is built at the resource level, based on error or success case





