### PR TITLE
bau: Reinstate logging for dashboard

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -135,6 +135,7 @@ public class ChargeCancelService {
         validateChargeStatus(statusFlow, chargeEntity, newStatus, chargeStatus);
         chargeEntity.setStatus(newStatus);
 
+        // Used by Sumo Logic saved search
         logger.info("Card cancel request sent - charge_external_id={}, charge_status={}, account_id={}, transaction_id={}, amount={}, operation_type={}, provider={}, provider_type={}, locking_status={}",
                 chargeEntity.getExternalId(),
                 chargeStatus,

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -229,6 +229,7 @@ public class ChargeExpiryService {
 
             GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
 
+            // Used by Sumo Logic saved search
             logger.info("Card cancel request sent - charge_external_id={}, charge_status={}, account_id={}, transaction_id={}, amount={}, operation_type={}, provider={}, provider_type={}, locking_status={}",
                     chargeEntity.getExternalId(),
                     chargeStatus,


### PR DESCRIPTION
We discovered recently that the "GOV.UK Pay LIVE services"
(https://service.eu.sumologic.com/ui/#/dashboard/7IZVW9dtDc3g1THQ4zIo5mzytUJ8273HQKac4lBigbuE3wFoQfb3WMEhTSj6)
was no longer returning any values. This is because it is searching connector
logs where operation_type is 'Capture':

```
_sourceCategory=prod service=docker container=connector
| parse "provider_type=*," as provider_type
| where provider_type="live"
| parse "operation_type=*," as operation_type
| where operation_type="Capture"
```
However this was accidentally deleted. This commit reinstates the logging code
in `ChargeService.lockChargeForProcessing`. It can be easily seen that in
`CardCaptureService.prepareChargeForCapture` it calls
`chargeService.lockChargeForProcessing(chargeId, OperationType.CAPTURE)`.

@oswaldquek
