### PR TITLE
PP-4509: Remove errorId

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
@@ -29,4 +29,8 @@ public class CancelGatewayRequest implements GatewayRequest {
     public GatewayOperation getRequestType() {
         return GatewayOperation.CANCEL;
     }
+
+    public String getExternalChargeId() {
+        return charge.getExternalId();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -9,13 +9,13 @@ public class RefundGatewayRequest implements GatewayRequest {
     private final GatewayAccountEntity gatewayAccountEntity;
     private final String amount;
     private final String transactionId;
-    private final String reference;
+    private final String refundExternalId;
 
-    private RefundGatewayRequest(String transactionId, GatewayAccountEntity gatewayAccount, String amount, String reference) {
+    private RefundGatewayRequest(String transactionId, GatewayAccountEntity gatewayAccount, String amount, String refundExternalId) {
         this.transactionId = transactionId;
         this.gatewayAccountEntity = gatewayAccount;
         this.amount = amount;
-        this.reference = reference;
+        this.refundExternalId = refundExternalId;
     }
 
     public String getAmount() {
@@ -36,6 +36,10 @@ public class RefundGatewayRequest implements GatewayRequest {
         return GatewayOperation.REFUND;
     }
 
+    public String getRefundExternalId() {
+        return refundExternalId;
+    }
+    
     /**
      * <p>
      * For Worldpay ->
@@ -61,8 +65,16 @@ public class RefundGatewayRequest implements GatewayRequest {
                 String.valueOf(refundEntity.getAmount()),
                 refundEntity.getExternalId());
     }
-
-    public String getReference() {
-        return reference;
+    
+    @Override
+    public String toString() {
+        return new StringBuilder()
+                .append("RefundGatewayRequest[\n")
+                .append("transactionId: ")
+                .append(transactionId)
+                .append("\nrefundExternalId: ")
+                .append(refundExternalId)
+                .append("]")
+                .toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -33,7 +33,7 @@ public class SmartpayRefundHandler implements RefundHandler {
 
     private GatewayOrder buildRefundOrderFor(RefundGatewayRequest request) {
         return SmartpayOrderRequestBuilder.aSmartpayRefundOrderRequestBuilder()
-                .withReference(request.getReference())
+                .withReference(request.getRefundExternalId())
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(getMerchantCode(request))
                 .withAmount(request.getAmount())

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -47,7 +47,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -195,10 +194,9 @@ public class StripePaymentProvider implements PaymentProvider {
                                                       GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder,
                                                       String errorMessage,
                                                       int statusCode) {
-        String errorId = UUID.randomUUID().toString();
-        logger.error("Authorisation failed for charge {}. Reason: {}. Status code from Stripe: {}. ErrorId: {}",
-                chargeExternalId, errorMessage, statusCode, errorId);
-        GatewayError gatewayError = unexpectedStatusCodeFromGateway("There was an internal server error. ErrorId: " + errorId);
+        logger.error("Authorisation failed for charge {}. Reason: {}. Status code from Stripe: {}.",
+                chargeExternalId, errorMessage, statusCode);
+        GatewayError gatewayError = unexpectedStatusCodeFromGateway("There was an internal server error authorising charge_external_id: " + chargeExternalId);
         return responseBuilder.withGatewayError(gatewayError).build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCancelHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCancelHandler.java
@@ -88,9 +88,8 @@ public class StripeCancelHandler {
             
             Response response = e.getResponse();
             StripeErrorResponse stripeErrorResponse = response.readEntity(StripeErrorResponse.class);
-            String errorId = UUID.randomUUID().toString();
-            logger.error("Cancel failed for gateway transaction id {}. Failure code from Stripe: {}, failure message from Stripe: {}. ErrorId: {}. Response code from Stripe: {}",
-                    request.getTransactionId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), errorId, response.getStatus());
+            logger.error("Cancel failed for gateway transaction id {}. Failure code from Stripe: {}, failure message from Stripe: {}. Charge External Id: {}. Response code from Stripe: {}",
+                    request.getTransactionId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), request.getExternalChargeId(), response.getStatus());
             GatewayError gatewayError = genericGatewayError(stripeErrorResponse.getError().getMessage());
             return responseBuilder.withGatewayError(gatewayError).build();
 
@@ -100,10 +99,9 @@ public class StripeCancelHandler {
             
         } catch (DownstreamException e) {
             
-            String errorId = UUID.randomUUID().toString();
-            logger.error("Cancel failed for transaction id {}. Reason: {}. Status code from Stripe: {}. ErrorId: {}",
-                    request.getTransactionId(), e.getMessage(), e.getStatusCode(), errorId);
-            GatewayError gatewayError = unexpectedStatusCodeFromGateway("An internal server error occurred. ErrorId: " + errorId);
+            logger.error("Cancel failed for transaction id {}. Reason: {}. Status code from Stripe: {}. Charge External Id: {}",
+                    request.getTransactionId(), e.getMessage(), e.getStatusCode(), request.getExternalChargeId());
+            GatewayError gatewayError = unexpectedStatusCodeFromGateway("An internal server error occurred while cancelling external charge id: " + request.getExternalChargeId());
             return responseBuilder.withGatewayError(gatewayError).build();
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -80,10 +80,9 @@ public class StripeCaptureHandler implements CaptureHandler {
             return CaptureResponse.fromGatewayError(GatewayError.of(e));
         
         } catch (DownstreamException e) {
-            String errorId = UUID.randomUUID().toString();
-            logger.error("Capture failed for transaction id {}. Reason: {}. Status code from Stripe: {}. ErrorId: {}",
-                    transactionId, e.getMessage(), e.getStatusCode(), errorId);
-            GatewayError gatewayError = unexpectedStatusCodeFromGateway("An internal server error occurred. ErrorId: " + errorId);
+            logger.error("Capture failed for transaction id {}. Reason: {}. Status code from Stripe: {}. Charge External Id: {}",
+                    transactionId, e.getMessage(), e.getStatusCode(), request.getExternalId());
+            GatewayError gatewayError = unexpectedStatusCodeFromGateway("An internal server error occurred when capturing charge_external_id: " + request.getExternalId());
             return CaptureResponse.fromGatewayError(gatewayError);
         }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -33,7 +33,7 @@ public class WorldpayRefundHandler implements RefundHandler {
 
     private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
         return aWorldpayRefundOrderRequestBuilder()
-                .withReference(request.getReference())
+                .withReference(request.getRefundExternalId())
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withAmount(request.getAmount())
                 .withTransactionId(request.getTransactionId())

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -86,7 +86,7 @@ public class StripeCancelHandlerTest {
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
         assertThat(gatewayResponse.isFailed(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
-        assertThat(gatewayResponse.getGatewayError().get().getMessage(), containsString("An internal server error occurred. ErrorId:"));
+        assertThat(gatewayResponse.getGatewayError().get().getMessage(), containsString("An internal server error occurred while cancelling external charge id: " + request.getExternalChargeId()));
         assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
     

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -105,7 +105,7 @@ public class StripeCaptureHandlerTest {
         assertThat(response.isSuccessful(), is(false));
         assertThat(response.getError().isPresent(), is(true));
         assertThat(response.state(), is(nullValue()));
-        assertThat(response.getError().get().getMessage(), containsString("An internal server error occurred. ErrorId:"));
+        assertThat(response.getError().get().getMessage(), containsString("An internal server error occurred when capturing charge_external_id: " + captureGatewayRequest.getExternalId()));
         assertThat(response.getError().get().getErrorType(), is(UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -128,7 +128,7 @@ public class StripeRefundHandlerTest {
 
         GatewayRefundResponse response = refundHandler.refund(refundRequest);
         assertThat(response.getError().isPresent(), Is.is(true));
-        assertThat(response.getError().get().getMessage(), containsString("An internal server error occurred. ErrorId:"));
+        assertThat(response.getError().get().getMessage(), containsString("An internal server error occurred while refunding Transaction id:"));
         assertThat(response.getError().get().getErrorType(), Is.is(UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -222,7 +222,7 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlFor(externalChargeId))
                 .then()
                 .statusCode(INTERNAL_SERVER_ERROR_500)
-                .body("message", containsString("There was an internal server error. ErrorId:"));
+                .body("message", containsString("There was an internal server error authorising charge_external_id: " + externalChargeId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -74,7 +74,7 @@ public class RefundEntityFixture {
     }
 
     private ChargeEntity buildChargeEntity() {
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).build();
+        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withTransactionId("1234abc").build();
     }
 
     public RefundEntityFixture withCharge(ChargeEntity charge) {


### PR DESCRIPTION
errorId was originally put there to enable a support person to dig deeper into
a cause of failure without returning the cause back to the client. However
using the charge external id will do just fine.

@oswaldquek

