### PR TITLE
BAU: Rearrange Dockerfile to reduce the number of rebuilt layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ EXPOSE 8081
 
 WORKDIR /app
 
-ADD target/*.yaml .
-ADD target/pay-*-allinone.jar .
 ADD docker-startup.sh .
 ADD run-with-chamber.sh .
+ADD target/*.yaml .
+ADD target/pay-*-allinone.jar .
 
 CMD bash ./docker-startup.sh


### PR DESCRIPTION
The thing which changes most often is the .jar, so add that to the docker image
last. This means that in the common case, we only rebuild one layer rather than
several.


