### PR TITLE
BAU: Add extra logging to Stripe HTTP Client

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -127,9 +127,8 @@ public class StripePaymentProvider implements PaymentProvider {
             }
 
             StripeErrorResponse stripeErrorResponse = response.readEntity(StripeErrorResponse.class);
-            String errorId = UUID.randomUUID().toString();
-            logger.error("Authorisation failed for charge {}. Failure code from Stripe: {}, failure message from Stripe: {}. ErrorId: {}. Response code from Stripe: {}",
-                    request.getChargeExternalId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), errorId, response.getStatus());
+            logger.error("Authorisation failed for charge {}. Failure code from Stripe: {}, failure message from Stripe: {}. Response code from Stripe: {}",
+                    request.getChargeExternalId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), response.getStatus());
             GatewayError gatewayError = genericGatewayError(stripeErrorResponse.getError().getMessage());
 
             return responseBuilder.withGatewayError(gatewayError).build();


### PR DESCRIPTION
# WHAT
We were experiencing problems with test where HTTP calls out to Stripe don't seem to reach them. We need to up the logging to see what is happening.

I also squeezed two lots of changes:
* Removed the error Id generation and logging that goes nowhere because there is a separate story to implement it properly. 
* Moved where we call `throwIfErrorResponse` because of potential NPE.