### PR TITLE
PP-4548 Failing test for bug and fix

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -24,7 +24,7 @@ public class Gateway3DSAuthorisationResponse {
     }
 
     public static Gateway3DSAuthorisationResponse ofException() {
-        return new Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED, null);
+        return new Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION, null);
     }
 
     public boolean isDeclined() {

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -68,7 +68,7 @@ public class SandboxPaymentProvider implements PaymentProvider {
 
     @Override
     public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
-        return Gateway3DSAuthorisationResponse.ofException();
+        return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -14,6 +14,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
@@ -208,4 +209,21 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_REJECTED.getValue());
     }
 
+    @Test
+    public void shouldReturnStatus500_WhenAuthorisationCallThrowsException() {
+        String chargeId = createNewCharge(AUTHORISATION_3DS_REQUIRED);
+
+        String expectedErrorMessage = "Failed";
+        worldpayMockClient.mockServerFault();
+
+        givenSetup()
+                .body(buildJsonWithPaResponse())
+                .post(authorise3dsChargeUrlFor(chargeId))
+                .then()
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .contentType(JSON)
+                .body("message", is(expectedErrorMessage));
+
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_ERROR.getValue());
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.rules;
 
+import com.github.tomakehurst.wiremock.http.Fault;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -49,6 +50,13 @@ public class SmartpayMockClient {
     public void mockCancel() {
         String cancelResponse = TestTemplateResourceLoader.load(SMARTPAY_CANCEL_SUCCESS_RESPONSE);
         paymentServiceResponse(cancelResponse);
+    }
+
+    public void mockServerFault() {
+        stubFor(
+                post(urlPathEqualTo("/pal/servlet/soap/Payment"))
+                        .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
+        );
     }
 
     public void mockRefundSuccess() {

--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.rules;
 
+import com.github.tomakehurst.wiremock.http.Fault;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -82,6 +83,13 @@ public class WorldpayMockClient {
                         .willReturn(
                                 aResponse().withStatus(404)
                         )
+        );
+    }
+    
+    public void mockServerFault() {
+        stubFor(
+                post(urlPathEqualTo("/jsp/merchant/xml/paymentService.jsp"))
+                        .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
         );
     }
     


### PR DESCRIPTION
Adds a test that reproduces the failure observed in the real world:
if an exception occurs when communicating with payment gateway, then the
charge is moved to status AUTHORISED. This is obviously incorrect.
I have fixed this - it was a simple typo :(