### PR TITLE
PP 4439 - Refactor PaymentProvider.refund() response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -10,9 +10,8 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import java.util.Optional;
@@ -31,7 +30,7 @@ public interface PaymentProvider {
 
     CaptureResponse capture(CaptureGatewayRequest request);
 
-    GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request);
+    GatewayRefundResponse refund(RefundGatewayRequest request);
 
     GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/RefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/RefundHandler.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.connector.gateway;
+
+import fj.data.Either;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
+
+public interface RefundHandler {
+
+    GatewayRefundResponse refund(RefundGatewayRequest request);
+
+    default GatewayRefundResponse fromUnmarshalled(Either<GatewayError, ? extends BaseRefundResponse> unmarshalled, GatewayRefundResponse.RefundState refundState) {
+        if (unmarshalled.isLeft())
+            return GatewayRefundResponse.fromGatewayError(unmarshalled.left().value());
+
+        return GatewayRefundResponse.fromBaseRefundResponse(unmarshalled.right().value(), refundState);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -17,7 +17,6 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCancelResponse;
-import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -27,8 +26,8 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
@@ -50,7 +49,6 @@ import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdq3D
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqQueryOrderRequestBuilder;
-import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqRefundOrderRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
@@ -83,6 +81,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
 
     private final EpdqCaptureHandler epdqCaptureHandler;
+    private final EpdqRefundHandler epdqRefundHandler;
 
     @Inject
     public EpdqPaymentProvider(ConnectorConfiguration configuration,
@@ -97,6 +96,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
         this.externalRefundAvailabilityCalculator = new EpdqExternalRefundAvailabilityCalculator();
 
         epdqCaptureHandler = new EpdqCaptureHandler(captureClient);
+        epdqRefundHandler = new EpdqRefundHandler(refundClient);
     }
 
     @Override
@@ -116,9 +116,8 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request) {
-        Either<GatewayError, GatewayClient.Response> response = refundClient.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildRefundOrder(request));
-        return GatewayResponseGenerator.getEpdqGatewayResponse(refundClient, response, EpdqRefundResponse.class);
+    public GatewayRefundResponse refund(RefundGatewayRequest request) {
+        return epdqRefundHandler.refund(request);
     }
 
     @Override
@@ -233,18 +232,6 @@ public class EpdqPaymentProvider implements PaymentProvider {
                         CREDENTIALS_SHA_IN_PASSPHRASE))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withTransactionId(request.getTransactionId())
-                .build();
-    }
-
-    private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
-        return anEpdqRefundOrderRequestBuilder()
-                .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
-                .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
-                .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
-                        CREDENTIALS_SHA_IN_PASSPHRASE))
-                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withTransactionId(request.getTransactionId())
-                .withAmount(request.getAmount())
                 .build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import fj.data.Either;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.RefundHandler;
+import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
+
+import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqRefundOrderRequestBuilder;
+import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_MAINTENANCE_ORDER;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+
+public class EpdqRefundHandler implements RefundHandler {
+
+    private final GatewayClient client;
+
+    public EpdqRefundHandler(GatewayClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public GatewayRefundResponse refund(RefundGatewayRequest request) {
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildRefundOrder(request));
+
+        if (response.isLeft()) {
+            return GatewayRefundResponse.fromGatewayError(response.left().value());
+        } else {
+            Either<GatewayError, EpdqRefundResponse> unmarshalled = client.unmarshallResponse(response.right().value(), EpdqRefundResponse.class);
+            return fromUnmarshalled(unmarshalled, GatewayRefundResponse.RefundState.PENDING);
+        }
+    }
+
+    private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
+        return anEpdqRefundOrderRequestBuilder()
+                .withUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME))
+                .withPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD))
+                .withShaInPassphrase(request.getGatewayAccount().getCredentials().get(
+                        CREDENTIALS_SHA_IN_PASSPHRASE))
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withTransactionId(request.getTransactionId())
+                .withAmount(request.getAmount())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/model/response/EpdqRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/model/response/EpdqRefundResponse.java
@@ -49,7 +49,7 @@ public class EpdqRefundResponse extends EpdqBaseResponse implements BaseRefundRe
     }
 
     @Override
-    public String toString() {
+    public String stringify() {
         StringJoiner joiner = new StringJoiner(", ", "ePDQ refund response (", ")");
         if (StringUtils.isNotBlank(transactionId)) {
             joiner.add("PAYID: " + transactionId);
@@ -69,4 +69,8 @@ public class EpdqRefundResponse extends EpdqBaseResponse implements BaseRefundRe
         return joiner.toString();
     }
 
+    @Override
+    public String toString() {
+        return stringify();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseRefundResponse.java
@@ -1,9 +1,38 @@
 package uk.gov.pay.connector.gateway.model.response;
 
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+
 import java.util.Optional;
+
+import static java.lang.String.format;
 
 public interface BaseRefundResponse extends BaseResponse {
 
     Optional<String> getReference();
 
+    String stringify();
+
+    static BaseRefundResponse fromReference(String reference, PaymentGatewayName gatewayName) {
+        return new BaseRefundResponse() {
+            @Override
+            public Optional<String> getReference() {
+                return Optional.ofNullable(reference);
+            }
+
+            @Override
+            public String stringify() {
+                return format("%s refund response: (reference: %s)", gatewayName.getName(), reference);
+            }
+
+            @Override
+            public String getErrorCode() {
+                return null;
+            }
+
+            @Override
+            public String getErrorMessage() {
+                return null;
+            }
+        };
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayRefundResponse.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.connector.gateway.model.response;
+
+import uk.gov.pay.connector.gateway.model.GatewayError;
+
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
+
+public class GatewayRefundResponse {
+
+    private final Optional<String> reference;
+    private final GatewayRefundResponse.RefundState refundState;
+    private final GatewayError gatewayError;
+    private final String stringified;
+
+    private GatewayRefundResponse(Optional<String> reference, RefundState refundState,
+                                  GatewayError gatewayError, String stringified) {
+        this.reference = reference;
+        this.refundState = refundState;
+        this.gatewayError = gatewayError;
+        this.stringified = stringified;
+    }
+
+    public static GatewayRefundResponse fromGatewayError(GatewayError gatewayError) {
+        return new GatewayRefundResponse(Optional.empty(), RefundState.ERROR, gatewayError, gatewayError.toString());
+    }
+
+    public static GatewayRefundResponse fromBaseRefundResponse(BaseRefundResponse refundResponse, RefundState refundState) {
+        if (isNotBlank(refundResponse.getErrorCode()) || isNotBlank(refundResponse.getErrorMessage())) {
+            return new GatewayRefundResponse(refundResponse.getReference(), refundState, genericGatewayError(refundResponse.stringify()), refundResponse.stringify());
+        } else
+            return new GatewayRefundResponse(refundResponse.getReference(), refundState, null, refundResponse.stringify());
+    }
+
+    public Optional<GatewayError> getError() {
+        return Optional.ofNullable(gatewayError);
+    }
+
+    public GatewayRefundResponse.RefundState state() {
+        return refundState;
+    }
+
+    public Optional<String> getReference() {
+        return reference;
+    }
+
+    public boolean isSuccessful() {
+        return gatewayError == null;
+    }
+
+    public enum RefundState {
+        COMPLETE, PENDING, ERROR
+    }
+
+    @Override
+    public String toString() {
+        return stringified;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -18,6 +18,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxApplePayAuthorisationHandler;
@@ -97,8 +98,9 @@ public class SandboxPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request) {
-        return createGatewayBaseRefundResponse(request);
+    public GatewayRefundResponse refund(RefundGatewayRequest request) {
+        return GatewayRefundResponse.fromBaseRefundResponse(BaseRefundResponse.fromReference(randomUUID().toString(), SANDBOX),
+                GatewayRefundResponse.RefundState.COMPLETE);
     }
 
     @Override
@@ -135,33 +137,6 @@ public class SandboxPaymentProvider implements PaymentProvider {
             @Override
             public String toString() {
                 return "Sandbox cancel response (transactionId: " + getTransactionId() + ')';
-            }
-        }).build();
-    }
-
-    private GatewayResponse<BaseRefundResponse> createGatewayBaseRefundResponse(RefundGatewayRequest request) {
-        GatewayResponseBuilder<BaseRefundResponse> gatewayResponseBuilder = responseBuilder();
-        return gatewayResponseBuilder.withResponse(new BaseRefundResponse() {
-            @Override
-            public Optional<String> getReference() {
-                return Optional.of(request.getReference());
-            }
-
-            @Override
-            public String getErrorCode() {
-                return null;
-            }
-
-            @Override
-            public String getErrorMessage() {
-                return null;
-            }
-
-            @Override
-            public String toString() {
-                return getReference()
-                        .map(reference -> "Sandbox refund response (reference: " + reference + ')')
-                        .orElse("Sandbox refund response");
             }
         }).build();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import fj.data.Either;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.RefundHandler;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
+
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+
+public class SmartpayRefundHandler implements RefundHandler {
+
+    private final GatewayClient client;
+
+    public SmartpayRefundHandler(GatewayClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public GatewayRefundResponse refund(RefundGatewayRequest request) {
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildRefundOrderFor(request));
+
+        if (response.isLeft()) {
+            return GatewayRefundResponse.fromGatewayError(response.left().value());
+        } else {
+            Either<GatewayError, SmartpayRefundResponse> unmarshalled = client.unmarshallResponse(response.right().value(), SmartpayRefundResponse.class);
+            return fromUnmarshalled(unmarshalled, GatewayRefundResponse.RefundState.PENDING);
+        }
+    }
+
+    private GatewayOrder buildRefundOrderFor(RefundGatewayRequest request) {
+        return SmartpayOrderRequestBuilder.aSmartpayRefundOrderRequestBuilder()
+                .withReference(request.getReference())
+                .withTransactionId(request.getTransactionId())
+                .withMerchantCode(getMerchantCode(request))
+                .withAmount(request.getAmount())
+                .build();
+    }
+
+    private String getMerchantCode(GatewayRequest request) {
+        return request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundResponse.java
@@ -20,7 +20,7 @@ public class SmartpayRefundResponse extends SmartpayBaseResponse implements Base
     }
 
     @Override
-    public String toString() {
+    public String stringify() {
         StringJoiner joiner = new StringJoiner(", ", "SmartPay refund response (", ")");
         if (StringUtils.isNotBlank(pspReference)) {
             joiner.add("pspReference: " + pspReference);
@@ -34,4 +34,8 @@ public class SmartpayRefundResponse extends SmartpayBaseResponse implements Base
         return joiner.toString();
     }
 
+    @Override
+    public String toString() {
+        return stringify();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -23,9 +23,9 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCancelHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
@@ -275,7 +275,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseRefundResponse> refund(RefundGatewayRequest request) {
+    public GatewayRefundResponse refund(RefundGatewayRequest request) {
         return stripeRefundHandler.refund(request);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -67,7 +67,7 @@ public class StripeRefundHandler {
                     request.getTransactionId(), error.getCode(), error.getMessage(), response.getStatus());
 
             return fromBaseRefundResponse(
-                    StripeRefundResponse.of(request.getTransactionId(), error.getCode(), error.getMessage()),
+                    StripeRefundResponse.of(error.getCode(), error.getMessage()),
                     GatewayRefundResponse.RefundState.ERROR);
         } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(GatewayError.of(e));

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeRefundResponse.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.connector.gateway.stripe.response;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 
-import javax.ws.rs.core.Response;
-import java.util.Map;
 import java.util.Optional;
+import java.util.StringJoiner;
 
 public class StripeRefundResponse implements BaseRefundResponse {
     private String reference;
@@ -15,14 +15,43 @@ public class StripeRefundResponse implements BaseRefundResponse {
         this.reference = reference;
     }
 
-    public static StripeRefundResponse of(Response response) {
-        final String id = response.readEntity(Map.class).get("id").toString();
-        return new StripeRefundResponse(id);
+    private StripeRefundResponse(String reference, String errorCode, String errorMessage) {
+        this.reference = reference;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+    }
+
+    public static StripeRefundResponse of(String reference, String errorCode, String errorMessage) {
+        return new StripeRefundResponse(reference, errorCode, errorMessage);
+    }
+
+    public static StripeRefundResponse of(String reference) {
+        return new StripeRefundResponse(reference);
     }
 
     @Override
     public Optional<String> getReference() {
         return Optional.ofNullable(reference);
+    }
+
+    @Override
+    public String stringify() {
+        return toString();
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Stripe refund response (", ")");
+        if (StringUtils.isNotBlank(reference)) {
+            joiner.add("Refund gateway reference id: " + reference);
+        }
+        if (StringUtils.isNotBlank(errorCode)) {
+            joiner.add("error code: " + errorCode);
+        }
+        if (StringUtils.isNotBlank(errorMessage)) {
+            joiner.add("error: " + errorMessage);
+        }
+        return joiner.toString();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeRefundResponse.java
@@ -21,8 +21,8 @@ public class StripeRefundResponse implements BaseRefundResponse {
         this.errorMessage = errorMessage;
     }
 
-    public static StripeRefundResponse of(String reference, String errorCode, String errorMessage) {
-        return new StripeRefundResponse(reference, errorCode, errorMessage);
+    public static StripeRefundResponse of(String errorCode, String errorMessage) {
+        return new StripeRefundResponse(null, errorCode, errorMessage);
     }
 
     public static StripeRefundResponse of(String reference) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import fj.data.Either;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.RefundHandler;
+import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
+
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+
+public class WorldpayRefundHandler implements RefundHandler {
+
+    private final GatewayClient client;
+
+    public WorldpayRefundHandler(GatewayClient client) {
+        this.client = client;
+    }
+
+    @Override
+    public GatewayRefundResponse refund(RefundGatewayRequest request) {
+        Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), buildRefundOrder(request));
+
+        if (response.isLeft()) {
+            return GatewayRefundResponse.fromGatewayError(response.left().value());
+        } else {
+            Either<GatewayError, WorldpayRefundResponse> unmarshalled = client.unmarshallResponse(response.right().value(), WorldpayRefundResponse.class);
+            return fromUnmarshalled(unmarshalled, GatewayRefundResponse.RefundState.PENDING);
+        }
+    }
+
+    private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
+        return aWorldpayRefundOrderRequestBuilder()
+                .withReference(request.getReference())
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withAmount(request.getAmount())
+                .withTransactionId(request.getTransactionId())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundResponse.java
@@ -16,7 +16,7 @@ public class WorldpayRefundResponse extends WorldpayBaseResponse implements Base
     }
 
     @Override
-    public String toString() {
+    public String stringify() {
         if (!StringUtils.isNotBlank(getErrorCode()) && !StringUtils.isNotBlank(getErrorMessage())) {
             return "Worldpay refund response";
         }
@@ -31,4 +31,8 @@ public class WorldpayRefundResponse extends WorldpayBaseResponse implements Base
         return joiner.toString();
     }
 
+    @Override
+    public String toString() {
+        return stringify();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
@@ -6,6 +6,11 @@ import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 
+/**
+ * Entity which represents Refunds history (a record for each event for a particular refund)
+ * Each time a new status is set for RefundEntity a new record is created in RefundsHistory (Refunds_History table in database)
+ * which happens magically by @Customizer(HistoryCustomizer.class) annotation on RefundEntity
+ */
 public class RefundHistory extends RefundEntity {
 
     private ZonedDateTime historyStartDate;

--- a/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
@@ -3,8 +3,7 @@ package uk.gov.pay.connector.refund.resource;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.refund.exception.RefundException;
 import uk.gov.pay.connector.refund.model.RefundRequest;
 import uk.gov.pay.connector.refund.model.RefundResponse;
@@ -49,12 +48,12 @@ public class ChargeRefundsResource {
     public Response submitRefund(@PathParam("accountId") Long accountId, @PathParam("chargeId") String chargeId, RefundRequest refundRequest, @Context UriInfo uriInfo) {
         validateRefundRequest(refundRequest.getAmount());
         final ChargeRefundService.Response refundServiceResponse = refundService.doRefund(accountId, chargeId, refundRequest);
-        GatewayResponse<BaseRefundResponse> response = refundServiceResponse.getRefundGatewayResponse();
-        if (response.isSuccessful()) {
+        GatewayRefundResponse refundResponse = refundServiceResponse.getGatewayRefundResponse();
+        if (refundResponse.isSuccessful()) {
             return Response.accepted(RefundResponse.valueOf(refundServiceResponse.getRefundEntity(), uriInfo).serialize()).build();
         }
 
-        return serviceErrorResponse(response.getGatewayError().map(GatewayError::getMessage).orElse("unknown error"));
+        return serviceErrorResponse(refundResponse.getError().map(GatewayError::getMessage).orElse("unknown error"));
     }
 
     private void validateRefundRequest(long amount) {

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -118,11 +118,14 @@ public class ChargeRefundService {
                     gatewayRefundResponse, refundEntity.getStatus(), refundStatus);
 
             if (refundStatus == REFUNDED) {
+                // If the gateway confirms refunds immediately, insert history (REFUND_SUBMITTED) to record
+                // additional event for refund submitted date which also includes the user submitting the
+                // refund. This will also help services to view refund history in detail in self service
                 refundEntity.setStatus(REFUND_SUBMITTED);
                 userNotificationService.sendRefundIssuedEmail(refundEntity);
             }
-            
             refundEntity.setStatus(refundStatus);
+
             getRefundReference(refundEntity, gatewayRefundResponse).ifPresent(refundEntity::setReference);
         });
 

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -8,7 +8,6 @@ import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
-import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
@@ -120,9 +119,6 @@ public class ChargeRefundService {
 
             if (refundStatus == REFUNDED) {
                 refundEntity.setStatus(REFUND_SUBMITTED);
-            }
-            if (chargeEntity.getPaymentGatewayName() == PaymentGatewayName.SANDBOX
-                    && refundEntity.hasStatus(RefundStatus.REFUND_SUBMITTED)) {
                 userNotificationService.sendRefundIssuedEmail(refundEntity);
             }
             

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -7,7 +7,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import java.util.Optional;
@@ -92,36 +92,36 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldRefund() {
         mockPaymentProviderResponse(200, successRefundResponse());
-        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
+        GatewayRefundResponse response = provider.refund(buildTestRefundRequest());
         verifyPaymentProviderRequest(successRefundRequest());
         assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().getReference(), is(Optional.of("3014644340/1")));
+        assertThat(response.getReference(), is(Optional.of("3014644340/1")));
     }
 
     @Test
     public void shouldRefundWithPaymentDeletion() {
         mockPaymentProviderResponse(200, successDeletionResponse());
-        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
+        GatewayRefundResponse response = provider.refund(buildTestRefundRequest());
         verifyPaymentProviderRequest(successRefundRequest());
         assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().get().getReference(), is(Optional.of("3014644340/1")));
+        assertThat(response.getReference(), is(Optional.of("3014644340/1")));
     }
 
     @Test
     public void shouldNotRefundIfPaymentProviderReturnsErrorStatusCode() {
         mockPaymentProviderResponse(200, errorRefundResponse());
-        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
+        GatewayRefundResponse response = provider.refund(buildTestRefundRequest());
+        assertThat(response.isSuccessful(), is(false));
+        assertThat(response.getError().isPresent(), is(true));
     }
 
     @Test
     public void shouldNotRefundIfPaymentProviderReturnsNon200HttpStatusCode() {
         mockPaymentProviderResponse(400, errorRefundResponse());
-        GatewayResponse<BaseRefundResponse> response = provider.refund(buildTestRefundRequest());
-        assertThat(response.isFailed(), is(true));
-        assertThat(response.getGatewayError().isPresent(), is(true));
-        assertEquals(response.getGatewayError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
+        GatewayRefundResponse response = provider.refund(buildTestRefundRequest());
+        assertThat(response.isSuccessful(), is(false));
+        assertThat(response.getError().isPresent(), is(true));
+        assertEquals(response.getError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway",
                 UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -15,7 +15,7 @@ import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
@@ -131,17 +131,13 @@ public class SandboxPaymentProviderTest {
     @Test
     public void refund_shouldSucceedWhenRefundingAnyCharge() {
 
-        GatewayResponse<BaseRefundResponse> gatewayResponse = provider.refund(RefundGatewayRequest.valueOf(RefundEntityFixture.aValidRefundEntity().build()));
+        GatewayRefundResponse refundResponse = provider.refund(RefundGatewayRequest.valueOf(RefundEntityFixture.aValidRefundEntity().build()));
 
-        assertThat(gatewayResponse.isSuccessful(), is(true));
-        assertThat(gatewayResponse.isFailed(), is(false));
-        assertThat(gatewayResponse.getGatewayError().isPresent(), is(false));
-        assertThat(gatewayResponse.getBaseResponse().isPresent(), is(true));
-
-        BaseRefundResponse refundResponse = gatewayResponse.getBaseResponse().get();
+        assertThat(refundResponse.isSuccessful(), is(true));
+        assertThat(refundResponse.getReference().isPresent(), is(true));
         assertThat(refundResponse.getReference(), is(notNullValue()));
-        assertThat(refundResponse.getErrorCode(), is(nullValue()));
-        assertThat(refundResponse.getErrorMessage(), is(nullValue()));
+
+        assertThat(refundResponse.getError().isPresent(), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -68,6 +68,7 @@ public class StripeRefundHandlerTest {
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
         assertTrue(refund.isSuccessful());
+        assertThat(refund.state(), is(GatewayRefundResponse.RefundState.COMPLETE));
         assertThat(refund.getReference().get(), is("re_1DRiccHj08j21DRiccHj08j2_test"));
     }
 
@@ -82,6 +83,7 @@ public class StripeRefundHandlerTest {
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
         assertTrue(refund.getError().isPresent());
+        assertThat(refund.state(), is(GatewayRefundResponse.RefundState.ERROR));
         assertThat(refund.getError().get().getMessage(), is("Stripe refund response (error: Refund amount (£5.01) is greater than charge amount (£5.00))"));
         assertThat(refund.getError().get().getErrorType(), Is.is(GENERIC_GATEWAY_ERROR));
     }
@@ -98,6 +100,7 @@ public class StripeRefundHandlerTest {
         
         assertNotNull(refund);
         assertTrue(refund.getError().isPresent());
+        assertThat(refund.state(), is(GatewayRefundResponse.RefundState.ERROR));
         assertThat(refund.getError().get().getMessage(), is("Stripe refund response (error: The transfer tr_blah_blah_blah is already fully reversed.)"));
         assertThat(refund.getError().get().getErrorType(), Is.is(GENERIC_GATEWAY_ERROR));
     }
@@ -113,6 +116,7 @@ public class StripeRefundHandlerTest {
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
         assertTrue(refund.getError().isPresent());
+        assertThat(refund.state(), is(GatewayRefundResponse.RefundState.ERROR));
         assertThat(refund.getError().get().getMessage(), Is.is("Stripe refund response (error code: resource_missing, error: No such charge: ch_123456 or something similar)"));
         assertThat(refund.getError().get().getErrorType(), Is.is(GENERIC_GATEWAY_ERROR));
     }

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -31,8 +31,8 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -232,7 +232,7 @@ public class EpdqPaymentProviderTest {
         assertThat(captureResponse.isSuccessful(), is(true));
 
         RefundGatewayRequest refundGatewayRequest = buildRefundRequest(chargeEntity, (chargeEntity.getAmount() - 100));
-        GatewayResponse<BaseRefundResponse> refundResponse = paymentProvider.refund(refundGatewayRequest);
+        GatewayRefundResponse refundResponse = paymentProvider.refund(refundGatewayRequest);
         assertThat(refundResponse.isSuccessful(), is(true));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -28,6 +28,7 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayAuthorisationResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
@@ -235,7 +236,7 @@ public class SmartpayPaymentProviderTest {
 
         RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId);
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
-        GatewayResponse refundResponse = smartpay.refund(refundRequest);
+        GatewayRefundResponse refundResponse = smartpay.refund(refundRequest);
 
         assertThat(refundResponse.isSuccessful(), is(true));
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -20,7 +20,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
-import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
 import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
@@ -114,7 +114,7 @@ public class StripePaymentProviderTest {
         final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount, "some-user-external-id");
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
-        GatewayResponse<BaseRefundResponse> refundResponse = stripePaymentProvider.refund(refundRequest);
+        GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.isSuccessful());
     }
@@ -130,7 +130,7 @@ public class StripePaymentProviderTest {
         final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount / 2, "some-user-external-id");
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
-        GatewayResponse<BaseRefundResponse> refundResponse = stripePaymentProvider.refund(refundRequest);
+        GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.isSuccessful());
     }
@@ -146,12 +146,11 @@ public class StripePaymentProviderTest {
         final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount + 1L, "some-user-external-id");
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
-        GatewayResponse<BaseRefundResponse> refundResponse = stripePaymentProvider.refund(refundRequest);
+        GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
-        assertTrue(refundResponse.isFailed());
-        assertTrue(refundResponse.getGatewayError().isPresent());
-        assertThat(refundResponse.getGatewayError().get().getMessage(), is("Refund amount (£5.01) is greater than charge amount (£5.00)"));
-        assertThat(refundResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
+        assertTrue(refundResponse.getError().isPresent());
+        assertThat(refundResponse.getError().get().getMessage(), is("Refund amount (£5.01) is greater than charge amount (£5.00)"));
+        assertThat(refundResponse.getError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
     }
 
     @Test
@@ -165,7 +164,7 @@ public class StripePaymentProviderTest {
         final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount, "some-user-external-id");
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
-        GatewayResponse<BaseRefundResponse> refundResponse = stripePaymentProvider.refund(refundRequest);
+        GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.isSuccessful());
 
@@ -174,11 +173,10 @@ public class StripePaymentProviderTest {
         refundRequest = RefundGatewayRequest.valueOf(secondRefundEntity);
         refundResponse = stripePaymentProvider.refund(refundRequest);
 
-        assertTrue(refundResponse.isFailed());
-        assertTrue(refundResponse.getGatewayError().isPresent());
+        assertTrue(refundResponse.getError().isPresent());
         // full message looks like "The transfer tr_blah_blah_blah is already fully reversed."
-        assertThat(refundResponse.getGatewayError().get().getMessage(), containsString("is already fully reversed"));
-        assertThat(refundResponse.getGatewayError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
+        assertThat(refundResponse.getError().get().getMessage(), containsString("is already fully reversed"));
+        assertThat(refundResponse.getError().get().getErrorType(), is(GENERIC_GATEWAY_ERROR));
     }
 
     private GatewayResponse<BaseAuthoriseResponse> authorise() {

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
@@ -210,9 +211,9 @@ public class WorldpayPaymentProviderTest {
 
         RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId);
 
-        GatewayResponse refundGatewayResponse = paymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity));
+        GatewayRefundResponse refundResponse = paymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity));
 
-        assertTrue(refundGatewayResponse.isSuccessful());
+        assertTrue(refundResponse.isSuccessful());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -344,7 +344,7 @@ public class ChargeRefundServiceTest {
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(charge.getExternalId(), accountId);
         verify(mockRefundDao).persist(argThat(aRefundEntity(refundAmount, charge)));
         verify(mockProvider).refund(argThat(aRefundRequestWith(charge, refundAmount)));
-        verify(mockRefundDao, times(1)).findById(refundId);
+        verify(mockRefundDao, times(2)).findById(refundId);
         verify(mockUserNotificationService).sendRefundIssuedEmail(spiedRefundEntity);
 
         // should set refund status to both REFUND_SUBMITTED and REFUNDED in order - as gateway refund state is COMPLETE

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -16,8 +16,8 @@ import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.ErrorType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
-import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
+import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayRefundResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -52,7 +53,6 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailabi
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
@@ -123,15 +123,15 @@ public class ChargeRefundServiceTest {
 
         ChargeRefundService.Response gatewayResponse = chargeRefundService.doRefund(accountId, externalChargeId, new RefundRequest(refundAmount, charge.getAmount(), userExternalId));
 
-        assertThat(gatewayResponse.getRefundGatewayResponse().isSuccessful(), is(true));
-        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayRefundResponse().isSuccessful(), is(true));
+        assertThat(gatewayResponse.getGatewayRefundResponse().getError().isPresent(), is(false));
 
         assertThat(gatewayResponse.getRefundEntity(), is(spiedRefundEntity));
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, accountId);
         verify(mockRefundDao).persist(argThat(aRefundEntity(refundAmount, charge)));
         verify(mockProvider).refund(argThat(aRefundRequestWith(charge, refundAmount)));
-        verify(mockRefundDao, times(2)).findById(refundId);
+        verify(mockRefundDao, times(1)).findById(refundId);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_SUBMITTED);
         verify(spiedRefundEntity).setReference(refundEntity.getExternalId());
 
@@ -175,14 +175,14 @@ public class ChargeRefundServiceTest {
 
         ChargeRefundService.Response gatewayResponse = chargeRefundService.doRefund(accountId, externalChargeId, new RefundRequest(amount, charge.getAmount(), userExternalId));
 
-        assertThat(gatewayResponse.getRefundGatewayResponse().isSuccessful(), is(true));
-        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayRefundResponse().isSuccessful(), is(true));
+        assertThat(gatewayResponse.getGatewayRefundResponse().getError().isPresent(), is(false));
         assertThat(gatewayResponse.getRefundEntity(), is(spiedRefundEntity));
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, accountId);
         verify(mockRefundDao).persist(argThat(aRefundEntity(amount, charge)));
         verify(mockProvider).refund(argThat(aRefundRequestWith(charge, amount)));
-        verify(mockRefundDao, times(2)).findById(refundId);
+        verify(mockRefundDao, times(1)).findById(refundId);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_SUBMITTED);
         verify(spiedRefundEntity).setReference(reference);
 
@@ -225,7 +225,7 @@ public class ChargeRefundServiceTest {
 
         ChargeRefundService.Response gatewayResponse = chargeRefundService.doRefund(accountId, externalChargeId, new RefundRequest(amount, charge.getAmount(), userExternalId));
 
-        assertThat(gatewayResponse.getRefundGatewayResponse().isSuccessful(), is(true));
+        assertThat(gatewayResponse.getGatewayRefundResponse().isSuccessful(), is(true));
         assertThat(gatewayResponse.getRefundEntity(), is(spiedRefundEntity));
         verify(spiedRefundEntity).setReference(providerReference);
 
@@ -265,7 +265,7 @@ public class ChargeRefundServiceTest {
         when(mockRefundDao.findById(refundId)).thenReturn(Optional.of(spiedRefundEntity));
 
         ChargeRefundService.Response gatewayResponse = chargeRefundService.doRefund(accountId, externalChargeId, new RefundRequest(amount, charge.getAmount(), userExternalId));
-        assertThat(gatewayResponse.getRefundGatewayResponse().isSuccessful(), is(false));
+        assertThat(gatewayResponse.getGatewayRefundResponse().isSuccessful(), is(false));
         assertThat(gatewayResponse.getRefundEntity(), is(spiedRefundEntity));
         verify(spiedRefundEntity, never()).setReference(anyString());
 
@@ -325,7 +325,7 @@ public class ChargeRefundServiceTest {
 
         when(mockProviders.byName(SANDBOX)).thenReturn(mockProvider);
 
-        setupWorldpayMock(charge.getGatewayTransactionId(), null);
+        setupSandboxMock(charge.getGatewayTransactionId(), null);
 
         doAnswer(invocation -> {
             ((RefundEntity) invocation.getArgument(0)).setId(refundId);
@@ -337,14 +337,14 @@ public class ChargeRefundServiceTest {
 
         ChargeRefundService.Response gatewayResponse = chargeRefundService.doRefund(accountId, charge.getExternalId(), new RefundRequest(refundAmount, amountAvailableForRefund, userExternalId));
 
-        assertThat(gatewayResponse.getRefundGatewayResponse().isSuccessful(), is(true));
-        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().isPresent(), is(false));
+        assertThat(gatewayResponse.getGatewayRefundResponse().isSuccessful(), is(true));
+        assertThat(gatewayResponse.getGatewayRefundResponse().getError().isPresent(), is(false));
         assertThat(gatewayResponse.getRefundEntity(), is(spiedRefundEntity));
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(charge.getExternalId(), accountId);
         verify(mockRefundDao).persist(argThat(aRefundEntity(refundAmount, charge)));
         verify(mockProvider).refund(argThat(aRefundRequestWith(charge, refundAmount)));
-        verify(mockRefundDao, times(2)).findById(refundId);
+        verify(mockRefundDao, times(1)).findById(refundId);
         verify(mockUserNotificationService).sendRefundIssuedEmail(spiedRefundEntity);
 
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUNDED);
@@ -485,16 +485,15 @@ public class ChargeRefundServiceTest {
 
         ChargeRefundService.Response gatewayResponse = chargeRefundService.doRefund(accountId, externalChargeId, new RefundRequest(amount, capturedCharge.getAmount(), userExternalId));
 
-        assertThat(gatewayResponse.getRefundGatewayResponse().isFailed(), is(true));
-        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().isPresent(), is(true));
-        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().get().getMessage(),
+        assertThat(gatewayResponse.getGatewayRefundResponse().getError().isPresent(), is(true));
+        assertThat(gatewayResponse.getGatewayRefundResponse().toString(),
                 is("Randompay refund response (errorCode: error-code)"));
-        assertThat(gatewayResponse.getRefundGatewayResponse().getGatewayError().get().getErrorType(), is(ErrorType.GENERIC_GATEWAY_ERROR));
+        assertThat(gatewayResponse.getGatewayRefundResponse().getError().get().getErrorType(), is(ErrorType.GENERIC_GATEWAY_ERROR));
 
         verify(mockChargeDao).findByExternalIdAndGatewayAccount(externalChargeId, accountId);
         verify(mockRefundDao).persist(argThat(aRefundEntity(amount, capturedCharge)));
         verify(mockProvider).refund(argThat(aRefundRequestWith(capturedCharge, amount)));
-        verify(mockRefundDao, times(2)).findById(refundId);
+        verify(mockRefundDao, times(1)).findById(refundId);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_ERROR);
 
         verifyNoMoreInteractions(mockChargeDao, mockRefundDao);
@@ -517,27 +516,49 @@ public class ChargeRefundServiceTest {
         };
     }
 
-
     private void setupWorldpayMock(String reference, String errorCode) {
         WorldpayRefundResponse worldpayResponse = mock(WorldpayRefundResponse.class);
         when(worldpayResponse.getReference()).thenReturn(Optional.ofNullable(reference));
         when(worldpayResponse.getErrorCode()).thenReturn(errorCode);
-        when(worldpayResponse.toString()).thenReturn("Randompay refund response (errorCode: " + errorCode + ")");
-        GatewayResponseBuilder<WorldpayRefundResponse> gatewayResponseBuilder = responseBuilder();
-        GatewayResponse refundResponse = gatewayResponseBuilder
-                .withResponse(worldpayResponse)
-                .build();
-        when(mockProvider.refund(any())).thenReturn(refundResponse);
+        when(worldpayResponse.stringify()).thenReturn("Randompay refund response (errorCode: " + errorCode + ")");
+
+        GatewayRefundResponse.RefundState refundState;
+        if (isNotBlank(errorCode)) {
+            refundState = GatewayRefundResponse.RefundState.ERROR;
+        } else {
+            refundState = GatewayRefundResponse.RefundState.PENDING;
+        }
+
+        GatewayRefundResponse gatewayRefundResponse =
+                GatewayRefundResponse.fromBaseRefundResponse(worldpayResponse, refundState);
+
+        when(mockProvider.refund(any())).thenReturn(gatewayRefundResponse);
+    }
+
+    private void setupSandboxMock(String reference, String errorCode) {
+        BaseRefundResponse baseRefundResponse = BaseRefundResponse.fromReference(reference, SANDBOX);
+
+        GatewayRefundResponse gatewayRefundResponse = GatewayRefundResponse.fromBaseRefundResponse(baseRefundResponse,
+                GatewayRefundResponse.RefundState.COMPLETE);
+
+        when(mockProvider.refund(any())).thenReturn(gatewayRefundResponse);
     }
 
     private void setupSmartpayMock(String reference, String errorCode) {
         SmartpayRefundResponse smartpayRefundResponse = mock(SmartpayRefundResponse.class);
         when(smartpayRefundResponse.getReference()).thenReturn(Optional.ofNullable(reference));
         when(smartpayRefundResponse.getErrorCode()).thenReturn(errorCode);
-        GatewayResponseBuilder<SmartpayRefundResponse> gatewayResponseBuilder = responseBuilder();
-        GatewayResponse refundResponse = gatewayResponseBuilder
-                .withResponse(smartpayRefundResponse)
-                .build();
-        when(mockProvider.refund(any())).thenReturn(refundResponse);
+
+        GatewayRefundResponse.RefundState refundState;
+        if (isNotBlank(errorCode)) {
+            refundState = GatewayRefundResponse.RefundState.ERROR;
+        } else {
+            refundState = GatewayRefundResponse.RefundState.PENDING;
+        }
+
+        GatewayRefundResponse gatewayRefundResponse =
+                GatewayRefundResponse.fromBaseRefundResponse(smartpayRefundResponse, refundState);
+
+        when(mockProvider.refund(any())).thenReturn(gatewayRefundResponse);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -681,7 +681,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefundsHistoryByChargeId(Long chargeId) {
         return jdbi.withHandle(h ->
-                h.createQuery("SELECT status FROM refunds_history WHERE charge_id = :chargeId")
+                h.createQuery("SELECT status FROM refunds_history WHERE charge_id = :chargeId order by history_start_date desc")
                         .bind("chargeId", chargeId).list()
         );
     }


### PR DESCRIPTION
## WHAT
- This change simplifies the response object (GatewayResponse<BaseRefundResponse> --> GatewayRefundResponse) returned from PaymentProvider refund operation (inline with capture refactoring PR #898).
- ChargeRefundService has also been refactored to update refund based on state returned by PaymentProvider and not based on specific payment provider

