### PR TITLE
PP-4548 Add test for handling Worldpay paRes parse error response

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -21,8 +21,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
-import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildCorporateJsonAuthorisationDetailsFor;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
 
@@ -215,6 +215,24 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
 
         String expectedErrorMessage = "Failed";
         worldpayMockClient.mockServerFault();
+
+        givenSetup()
+                .body(buildJsonWithPaResponse())
+                .post(authorise3dsChargeUrlFor(chargeId))
+                .then()
+                .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
+                .contentType(JSON)
+                .body("message", is(expectedErrorMessage));
+
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_ERROR.getValue());
+    }
+
+    @Test
+    public void shouldReturnStatus500_AWorldpayPaResParseError() {
+        String chargeId = createNewCharge(AUTHORISATION_3DS_REQUIRED);
+
+        String expectedErrorMessage = "Failed";
+        worldpayMockClient.mockAuthorisationPaResParseError();
 
         givenSetup()
                 .body(buildJsonWithPaResponse())

--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -12,6 +12,7 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCEL_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCEL_SUCCESS_RESPONSE;
@@ -37,6 +38,11 @@ public class WorldpayMockClient {
 
     public void mockAuthorisationFailure() {
         String authoriseResponse = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISATION_FAILED_RESPONSE);
+        paymentServiceResponse(authoriseResponse);
+    }
+
+    public void mockAuthorisationPaResParseError() {
+        String authoriseResponse = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE);
         paymentServiceResponse(authoriseResponse);
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -13,6 +13,7 @@ public class TestTemplateResourceLoader {
     static final String WORLDPAY_AUTHORISATION_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String WORLDPAY_AUTHORISATION_FAILED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-failed-response.xml";
     static final String WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-cancelled-response.xml";
+    public static final String WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-pares-parse-error-response.xml";
     public static final String WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS = WORLDPAY_BASE_NAME + "/special-char-valid-authorise-worldpay-request-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-min-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-excluding-3ds.xml";

--- a/src/test/resources/templates/worldpay/authorisation-pares-parse-error-response.xml
+++ b/src/test/resources/templates/worldpay/authorisation-pares-parse-error-response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <reply>
+        <orderStatus orderCode="MyUniqueTransactionId!12">
+            <error code="7"><![CDATA[Parse error with PaRes: XML not recognized]]></error>
+        </orderStatus>
+    </reply>
+</paymentService>
+


### PR DESCRIPTION
Add a test to ensure we treat a Worldpay error code 7 `"Parse error with PaRes: XML not recognized"` response (this can be received when trying to authorise the result of a 3D Secure authentication) as an actual error (because before #914 was merged we got this wrong).