### PR TITLE
PP-4548 Restore 3D Secure authorisation response logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -151,11 +151,12 @@ public class EpdqPaymentProvider implements PaymentProvider {
                     authoriseStatus.name()))
                     .inc();
             gatewayResponse = reconstructErrorBiasedGatewayResponse(gatewayResponse, authoriseStatus, auth3DResult);
-
         }
-
-        return gatewayResponse.getBaseResponse().map(baseResponse -> Gateway3DSAuthorisationResponse.of(baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
-                .orElseGet(() -> Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION));
+        
+        String gatewayResponseString = gatewayResponse.toString();
+        return gatewayResponse.getBaseResponse()
+                .map(baseResponse -> Gateway3DSAuthorisationResponse.of(gatewayResponseString, baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
+                .orElseGet(() -> Gateway3DSAuthorisationResponse.of(gatewayResponseString, BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -9,22 +9,28 @@ import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.
 public class Gateway3DSAuthorisationResponse {
     private final BaseAuthoriseResponse.AuthoriseStatus authorisationStatus;
     private final String transactionId;
+    private final String stringified;
 
-    private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
+    private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, String stringified) {
         this.transactionId = transactionId;
         this.authorisationStatus = authorisationStatus;
+        this.stringified = stringified;
+    }
+
+    public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "");
+    }
+
+    public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringified);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null);
-    }
-
-    public static Gateway3DSAuthorisationResponse ofException() {
-        return new Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "");
     }
 
     public boolean isDeclined() {
@@ -48,4 +54,9 @@ public class Gateway3DSAuthorisationResponse {
     public Optional<String> getTransactionId() {
         return Optional.ofNullable(transactionId);
     }
+    
+    public String toString() {
+        return stringified;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -74,9 +74,10 @@ public class SmartpayPaymentProvider implements PaymentProvider {
         Either<GatewayError, GatewayClient.Response> response = client.postRequestFor(null, request.getGatewayAccount(), build3dsResponseAuthOrderFor(request));
         GatewayResponse<BaseAuthoriseResponse> gatewayResponse = GatewayResponseGenerator.getSmartpayGatewayResponse(client, response, SmartpayAuthorisationResponse.class);
 
+        
         return gatewayResponse.getBaseResponse().map(
-                baseResponse -> Gateway3DSAuthorisationResponse.of(baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
-                .orElseGet(Gateway3DSAuthorisationResponse::ofException);
+                baseResponse -> Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
+                .orElseGet(() -> Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -93,8 +93,8 @@ public class WorldpayPaymentProvider implements PaymentProvider {
         GatewayResponse<BaseAuthoriseResponse> gatewayResponse = GatewayResponseGenerator.getWorldpayGatewayResponse(authoriseClient, response, WorldpayOrderStatusResponse.class);
 
         return gatewayResponse.getBaseResponse().map(
-                baseResponse -> Gateway3DSAuthorisationResponse.of(baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
-                .orElseGet(Gateway3DSAuthorisationResponse::ofException);
+                baseResponse -> Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), baseResponse.authoriseStatus(), baseResponse.getTransactionId()))
+                .orElseGet(() -> Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
@@ -14,6 +16,9 @@ import java.util.Optional;
 import static uk.gov.pay.connector.paymentprocessor.model.OperationType.AUTHORISATION_3DS;
 
 public class Card3dsResponseAuthService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Card3dsResponseAuthService.class);
+
     private final ChargeService chargeService;
     private final CardAuthoriseBaseService cardAuthoriseBaseService;
     private final PaymentProviders providers;
@@ -70,7 +75,18 @@ public class Card3dsResponseAuthService {
                 AUTHORISATION_3DS,
                 transactionId
         );
-        cardAuthoriseBaseService.logAuthorisation("3DS response authorisation", updatedCharge, oldChargeStatus);
+
+        LOGGER.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
+                updatedCharge.getExternalId(),
+                updatedCharge.getPaymentGatewayName().getName(),
+                updatedCharge.getGatewayTransactionId(),
+                updatedCharge.getGatewayAccount().getAnalyticsId(),
+                updatedCharge.getGatewayAccount().getId(),
+                operationResponse,
+                oldChargeStatus,
+                updatedCharge.getStatus()
+        );
+
         cardAuthoriseBaseService.emitAuthorisationMetric(updatedCharge, "authorise-3ds");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeEx
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
@@ -84,24 +85,7 @@ public class CardAuthoriseBaseService {
         }
     }
     
-    public void logAuthorisation(
-            String operationDescription,
-            ChargeEntity updatedCharge,
-            ChargeStatus oldChargeStatus
-    ) {
-        logger.info("{} for {} ({} {}) for {} ({}) .'. {} -> {}",
-                operationDescription,
-                updatedCharge.getExternalId(),
-                updatedCharge.getPaymentGatewayName().getName(),
-                updatedCharge.getGatewayTransactionId(),
-                updatedCharge.getGatewayAccount().getAnalyticsId(),
-                updatedCharge.getGatewayAccount().getId(),
-                oldChargeStatus,
-                updatedCharge.getStatus()
-        );
-    }
-    
-    public void emitAuthorisationMetric(ChargeEntity charge, String operation) {
+    void emitAuthorisationMetric(ChargeEntity charge, String operation) {
         metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.%s.result.%s",
                 charge.getGatewayAccount().getGatewayName(),
                 charge.getGatewayAccount().getType(),


### PR DESCRIPTION
When logging the result of an attempt to authorise the result of a 3D Secure authentication with Worldpay, Smartpay or ePDQ, log more information from the response itself or the error that meant we could not get a response.

This restores the logging to a similar level of detail to what we used to record (though for implementation reasons the logging is not identical to previously).

Stripe never had this level of logging and this commit does not attempt to change that (though we should examine this before we go live with Stripe).

The logging relies on new stringification code in `Gateway3DSAuthorisationResponse`. It would be nice if the new code were similar to the code in the new `CaptureResponse` class that helps with logging the results of attempts to capture, but the two classes seem to have different ideas about how much they want to know about the `BaseResponse`. We should attempt to bridge this divide in the future.

Ideally there would be some tests for the logging (to stop it being accidentally degraded again) but this commit does not add any in the interests of restoring our logging detail quickly.