### PR TITLE
Add comment to capture logging noting its use by Sumo Logic

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -95,6 +95,7 @@ public class CardCaptureService {
 
         ChargeEntity charge = chargeService.updateChargePostCapture(chargeId, nextStatus);
 
+        // Used by Sumo Logic saved search
         LOG.info("Capture for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                 charge.getExternalId(), charge.getPaymentGatewayName().getName(), charge.getGatewayTransactionId(),
                 charge.getGatewayAccount().getAnalyticsId(), charge.getGatewayAccount().getId(),


### PR DESCRIPTION
We now have a Sumo Logic saved search that depends on the logging performed when we attempt to capture a payment. Add a comment noting this so people think before tinkering with the logging and
breaking the saved search.

The comment is `// Used by Sumo Logic saved search`, which we’re also using elsewhere in the code.


