### PR TITLE
PP-4522: Add test and live token configuration

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/StripeAuthTokens.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeAuthTokens.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.app;
+
+import io.dropwizard.Configuration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class StripeAuthTokens extends Configuration {
+
+    @Valid
+    @NotNull
+    private String test;
+
+    @Valid
+    private String live;
+
+    public String getTest() {
+        return test;
+    }
+
+    public String getLive() {
+        return live;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -13,7 +13,7 @@ public class StripeGatewayConfig extends Configuration {
 
     @Valid
     @NotNull
-    private String authToken;
+    private StripeAuthTokens authTokens;
 
     @Valid
     @NotNull
@@ -23,8 +23,8 @@ public class StripeGatewayConfig extends Configuration {
         return url;
     }
 
-    public String getAuthToken() {
-        return authToken;
+    public StripeAuthTokens getAuthTokens() {
+        return authTokens;
     }
 
     public String getWebhookSigningSecret() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/util/StripeAuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/util/StripeAuthUtil.java
@@ -8,7 +8,7 @@ public class StripeAuthUtil {
     }
 
     public static String getAuthHeaderValue(StripeGatewayConfig stripeGatewayConfig) {
-        return "Bearer " + stripeGatewayConfig.getAuthToken();
+        return "Bearer " + stripeGatewayConfig.getAuthTokens().getTest();
     }
 
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -76,7 +76,9 @@ epdq:
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
-  authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  authTokens:
+    test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+    live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 executorServiceConfig:

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/BaseStripePaymentProviderTest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.mockito.Mock;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.LinksConfig;
+import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
@@ -78,6 +79,7 @@ public abstract class BaseStripePaymentProviderTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         when(stripeGatewayConfig.getUrl()).thenReturn("http://stripe.url");
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
         when(configuration.getStripeConfig()).thenReturn(stripeGatewayConfig);
 
         when(configuration.getLinks()).thenReturn(linksConfig);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -47,6 +48,7 @@ public class StripeCancelHandlerTest {
     @Before
     public void setup() {
         stripeCancelHandler = new StripeCancelHandler(client, stripeGatewayConfig);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.CaptureResponse;
@@ -29,6 +30,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
@@ -54,6 +56,7 @@ public class StripeCaptureHandlerTest {
     @Before
     public void setup() {
         when(stripeGatewayConfig.getUrl()).thenReturn("http://stripe.url");
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
         stripeCaptureHandler = new StripeCaptureHandler(stripeGatewayClient, stripeGatewayConfig);
 
         GatewayAccountEntity gatewayAccount = buildGatewayAccountEntity();

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseRefundResponse;
@@ -31,6 +32,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY;
@@ -57,6 +59,7 @@ public class StripeRefundHandlerTest {
         refundHandler = new StripeRefundHandler(gatewayClient, gatewayConfig);
         RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity().withAmount(100L).build();
         refundRequest = RefundGatewayRequest.valueOf(refundEntity);
+        when(gatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
     }
 
     @Test

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -60,7 +60,9 @@ epdq:
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
-  authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  authTokens:
+    test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+    live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 jerseyClient:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -59,7 +59,9 @@ epdq:
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
-  authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  authTokens:
+    test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+    live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 jerseyClient:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -49,7 +49,9 @@ epdq:
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
-  authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  authTokens:
+    test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+    live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 jerseyClient:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -55,7 +55,9 @@ epdq:
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
-  authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  authTokens:
+    test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+    live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 executorServiceConfig:

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -52,7 +52,9 @@ epdq:
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
-  authToken: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+  authTokens:
+    test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
+    live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
 
 executorServiceConfig:


### PR DESCRIPTION
This commit allows the configuration of a test and live token. We want to be able to support test and live accounts in production. The idea is that we can do smoke test payments in production using a test token. At the time of this commit, we aren't taking stripe payments in production yet. This commit only concerns itself with adding the live token configuration without breaking  existing functionality. As such, all tokens used will be the test token.

@oswaldquek

