### PR TITLE
bau: Remove NotifyClientFactoryProvider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -18,7 +18,7 @@ import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
-import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactoryProvider;
+import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.pay.connector.usernotification.service.EntityBuilder;
 import uk.gov.pay.connector.util.HashUtil;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -50,7 +50,6 @@ public class ConnectorModule extends AbstractModule {
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
 
         install(jpaModule(configuration));
-        install(new FactoryModuleBuilder().build(NotifyClientFactoryProvider.class));
         install(new FactoryModuleBuilder().build(GatewayAccountServicesFactory.class));
     }
 
@@ -112,5 +111,11 @@ public class ConnectorModule extends AbstractModule {
     @Singleton
     public JsonObjectMapper jsonObjectMapper() {
         return new JsonObjectMapper(provideObjectMapper());
+    }
+    
+    @Provides
+    @Singleton
+    public NotifyClientFactory notifyClientFactory(ConnectorConfiguration connectorConfiguration) {
+        return new NotifyClientFactory(connectorConfiguration);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/usernotification/govuknotify/NotifyClientFactoryProvider.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/govuknotify/NotifyClientFactoryProvider.java
@@ -1,6 +1,0 @@
-package uk.gov.pay.connector.usernotification.govuknotify;
-
-public interface NotifyClientFactoryProvider {
-
-    NotifyClientFactory clientFactory();
-}

--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntit
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
-import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactoryProvider;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -42,15 +41,15 @@ public class UserNotificationService {
     private String refundIssuedEmailTemplateId;
     private boolean emailNotifyGloballyEnabled;
     protected final Logger logger = LoggerFactory.getLogger(getClass());
-    private NotifyClientFactoryProvider notifyClientFactoryProvider;
+    private NotifyClientFactory notifyClientFactory;
     private ExecutorService executorService;
     private final MetricRegistry metricRegistry;
 
     @Inject
-    public UserNotificationService(NotifyClientFactoryProvider notifyClientFactoryProvider, ConnectorConfiguration configuration, Environment environment) {
+    public UserNotificationService(NotifyClientFactory notifyClientFactory, ConnectorConfiguration configuration, Environment environment) {
         readEmailConfig(configuration);
         if (emailNotifyGloballyEnabled) {
-            this.notifyClientFactoryProvider = notifyClientFactoryProvider;
+            this.notifyClientFactory = notifyClientFactory;
             int numberOfThreads = configuration.getExecutorServiceConfig().getThreadsPerCpu() * getRuntime().availableProcessors();
             executorService = Executors.newFixedThreadPool(numberOfThreads);
         }
@@ -96,7 +95,6 @@ public class UserNotificationService {
     private NotifyClientSettings getNotifyClientSettings(EmailNotificationType emailNotificationType, ChargeEntity chargeEntity) {
         // todo introduce type for notify settings instead of Map
         Map<String, String> notifySettings = chargeEntity.getGatewayAccount().getNotifySettings();
-        NotifyClientFactory notifyClientFactory = notifyClientFactoryProvider.clientFactory();
         switch (emailNotificationType) {
             case REFUND_ISSUED:
                 return NotifyClientSettings.of(notifySettings, notifyClientFactory, "refund_issued_template_id", refundIssuedEmailTemplateId);


### PR DESCRIPTION
Passing in the NotifyClientFactoryProvider to UserNotificationService just to
get the NotifyClientFactory seems convoluted. Why not `@Provides` a
NotifyClientFactory instead?

By doing this I hope to be able to write a proper integration test for PP-4553
as this commit will make it easier to override the provision of
NotifyClientFactory in the ConnectorModule by extending the ConnectorModule.
Unfortunately we aren't able to write an integration test to test a call to
`/v1/api/notifications/epdq` actually sends a refund as the notify client
requires https and using wiremock with this is too complicated.

It would help greatly if we can mock out the NotifyClientFactory and that is
what this commit will help us to do.

@oswaldquek

