### PR TITLE
PP-4570 Add 'requires_3ds' to create gateway account API

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -48,6 +48,7 @@ Content-Type: application/json
 | `type`                   |          | Account type for this provider.                                  | test, live (defaults to test if missing) |
 | `description`            |          | Some useful non-ambiguiuos description about the gateway account | |
 | `analytics_id`           |          | Google Analytics (GA) unique ID for the GOV.UK Pay platform      | |
+| `requires_3ds`           |          | Set to 'true' to enable 3DS for this account                     | true, false (default) |
 
 ### Response example
 
@@ -61,6 +62,7 @@ Location: https://connector.example.com/v1/api/accounts/1
     "type": "live",
     "description": "This is an account for the GOV.UK Pay team",
     "analytics_id": "PAY-GA-123",
+    "requires_3ds": "false"
     "links": [{
         "href": "https://connector.example.com/v1/api/accounts/1",
         "rel" : "self",
@@ -76,6 +78,7 @@ Location: https://connector.example.com/v1/api/accounts/1
 | `gateway_account_id`     | X              | The account Id created by the connector       |
 | `type`                   | X              | Account type for this provider (test/live)    |
 | `description`            | X              | Some useful non-ambiguiuos description about the gateway account |
+| `requires_3ds`           | X              | Indicates if 3DS is enabled or disabled for the account |
 | `analytics_id`           | X              | Google Analytics (GA) unique ID for the GOV.UK Pay platform      |
 | `links`                  | X              | HTTP self link containing resource reference to the account.     |
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -35,14 +35,19 @@ public class GatewayAccountRequest {
 
     private String paymentProvider;
     
+    private boolean requires3ds;
+    
     public GatewayAccountRequest(@JsonProperty("type") String providerAccountType,
                                  @JsonProperty("payment_provider") String paymentProvider,
                                  @JsonProperty("service_name") String serviceName,
                                  @JsonProperty("description") String description,
-                                 @JsonProperty("analytics_id") String analyticsId) {
+                                 @JsonProperty("analytics_id") String analyticsId,
+                                 @JsonProperty("requires_3ds") boolean requires3ds
+    ) {
         this.serviceName = serviceName;
         this.description = description;
         this.analyticsId = analyticsId;
+        this.requires3ds = requires3ds;
 
         this.providerAccountType = (providerAccountType == null || providerAccountType.isEmpty()) ?
                 TEST.toString() : providerAccountType;
@@ -51,7 +56,7 @@ public class GatewayAccountRequest {
                 PaymentGatewayName.SANDBOX.getName() : paymentProvider;
 
     }
-    
+
     @ValidationMethod(message = "Unsupported payment provider account type, should be one of (test, live)")
     @JsonIgnore
     public boolean isValidProviderAccountType() {
@@ -91,5 +96,9 @@ public class GatewayAccountRequest {
 
     public Map<String, String> getCredentialsAsMap() {
         return newHashMap();
+    }
+
+    public boolean getRequires3ds() {
+        return requires3ds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResponse.java
@@ -25,10 +25,13 @@ public class GatewayAccountResponse {
 
     @JsonProperty("gateway_account_id")
     private final String gatewayAccountId;
-    
+
+    @JsonProperty("requires_3ds")
+    private final boolean requires3ds;
+
     @JsonProperty("links")
     private final List<Map<String, Object>> links;
-    
+
     @JsonIgnore
     private final URI location;
 
@@ -40,6 +43,7 @@ public class GatewayAccountResponse {
         this.analyticsId = gatewayAccountResponseBuilder.analyticsId;
         this.links = gatewayAccountResponseBuilder.links;
         this.location = gatewayAccountResponseBuilder.location;
+        this.requires3ds = gatewayAccountResponseBuilder.requires3ds;
     }
 
     public String getProviderAccountType() {
@@ -70,6 +74,10 @@ public class GatewayAccountResponse {
         return location;
     }
 
+    public boolean getRequires3ds() {
+        return requires3ds;
+    }
+
     public static class GatewayAccountResponseBuilder {
 
         private String providerAccountType;
@@ -78,6 +86,7 @@ public class GatewayAccountResponse {
         private String description;
         private String analyticsId;
         private String gatewayAccountId;
+        private boolean requires3ds;
         private URI location;
         private List<Map<String, Object>> links;
 
@@ -118,6 +127,11 @@ public class GatewayAccountResponse {
 
         public GatewayAccountResponseBuilder location(URI href) {
             this.location = href;
+            return this;
+        }
+
+        public GatewayAccountResponseBuilder requires3ds(boolean requires3ds) {
+            this.requires3ds = requires3ds;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
@@ -18,9 +18,11 @@ public class StripeGatewayAccountRequest extends GatewayAccountRequest {
                                        @JsonProperty("service_name") String serviceName,
                                        @JsonProperty("description") String description,
                                        @JsonProperty("analytics_id") String analyticsId,
-                                       @JsonProperty("credentials") StripeCredentials credentials) {
-        
-        super(providerAccountType, paymentProvider, serviceName, description, analyticsId);
+                                       @JsonProperty("credentials") StripeCredentials credentials,
+                                       @JsonProperty("requires_3ds") boolean requires3ds
+    ) {
+
+        super(providerAccountType, paymentProvider, serviceName, description, analyticsId, requires3ds);
         this.credentials = Optional.ofNullable(credentials);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -24,6 +24,7 @@ public class GatewayAccountObjectConverter {
         gatewayAccountEntity.setServiceName(gatewayAccountRequest.getServiceName());
         gatewayAccountEntity.setDescription(gatewayAccountRequest.getDescription());
         gatewayAccountEntity.setAnalyticsId(gatewayAccountRequest.getAnalyticsId());
+        gatewayAccountEntity.setRequires3ds(gatewayAccountRequest.getRequires3ds());
 
         gatewayAccountEntity.addNotification(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(gatewayAccountEntity));
         gatewayAccountEntity.addNotification(EmailNotificationType.REFUND_ISSUED, new EmailNotificationEntity(gatewayAccountEntity));
@@ -36,18 +37,16 @@ public class GatewayAccountObjectConverter {
         URI uri = uriInfo.
                 getBaseUriBuilder().
                 path("/v1/api/accounts/{accountId}").build(entity.getId());
-        
-        GatewayAccountResponse gatewayAccountResponse
-                = new GatewayAccountResponse.GatewayAccountResponseBuilder()
+
+        return new GatewayAccountResponse.GatewayAccountResponseBuilder()
                 .gatewayAccountId(entity.getId().toString())
                 .serviceName(entity.getServiceName())
                 .description(entity.getDescription())
                 .analyticsId(entity.getAnalyticsId())
                 .providerAccountType(entity.getType())
+                .requires3ds(entity.isRequires3ds())
                 .location(uri)
                 .generateLinks(uri)
                 .build();
-
-        return gatewayAccountResponse;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceTest.java
@@ -31,7 +31,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTestBase {
 
     GatewayAccountDao gatewayAccountDao;
-    
+
     @Before
     public void setUp() {
         super.setUp();
@@ -43,7 +43,7 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
     public void createAGatewayAccount(String provider) {
         createAGatewayAccountFor(provider, "my test service", "analytics");
     }
-    
+
     @Test
     public void createStripeGatewayAccountWithoutCredentials() throws Exception {
         Map<String, Object> payload = ImmutableMap.of(
@@ -64,7 +64,7 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
                 .body("links[0].rel", is("self"))
                 .body("links[0].method", is("GET"));
     }
-    
+
     @Test
     public void createStripeGatewayAccountWithCredentials() throws Exception {
         Map<String, Object> payload = ImmutableMap.of(
@@ -93,10 +93,10 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
         assertThat(gatewayAccount.isPresent(), is(true));
         assertThat(gatewayAccount.get().getCredentials().get("stripe_account_id"), is("abc"));
     }
-    
+
     @Test
     public void createGatewayAccountWithoutPaymentProviderDefaultsToSandbox() {
-        String payload = toJson(ImmutableMap.of("name", "test account","type","test"));
+        String payload = toJson(ImmutableMap.of("name", "test account", "type", "test"));
 
         ValidatableResponse response = givenSetup()
                 .body(payload)
@@ -134,6 +134,34 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
 
         assertCorrectCreateResponse(response, LIVE);
         assertGettingAccountReturnsProviderName(response, "worldpay", LIVE);
+    }
+
+    @Test
+    public void createGatewayAccountWithRequires3dsToTrue() {
+        String payload = toJson(ImmutableMap.of("payment_provider", "stripe", "type", LIVE.toString(), "requires_3ds", "true"));
+        ValidatableResponse response = givenSetup()
+                .body(payload)
+                .post(ACCOUNTS_API_URL)
+                .then()
+                .statusCode(201);
+
+        assertCorrectCreateResponse(response, LIVE);
+
+        response.body("requires_3ds", is(true));
+    }
+
+    @Test
+    public void createGatewayAccountWithRequires3dsDefaultsToFalse() {
+        String payload = toJson(ImmutableMap.of("payment_provider", "worldpay", "type", LIVE.toString()));
+        ValidatableResponse response = givenSetup()
+                .body(payload)
+                .post(ACCOUNTS_API_URL)
+                .then()
+                .statusCode(201);
+
+        assertCorrectCreateResponse(response, LIVE);
+
+        response.body("requires_3ds", is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -92,6 +92,16 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
     }
 
     @Test
+    public void getAccountShouldReturn3dsSetting() {
+        String gatewayAccountId = createAGatewayAccountFor("stripe", "desc", null, "true");
+        givenSetup()
+                .get(ACCOUNTS_API_URL + gatewayAccountId)
+                .then()
+                .statusCode(200)
+                .body("toggle_3ds", is("true"));
+    }
+
+    @Test
     public void getAccountShouldReturnCorporateCreditCardSurchargeAmountAndCorporateDebitCardSurchargeAmount() {
         int corporateCreditCardSurchargeAmount = 250;
         int corporateDebitCardSurchargeAmount = 50;
@@ -424,7 +434,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
     }
 
     @Test
-    public void shouldReturn200_whenEmailCollectionModeIsUpdated() throws Exception{
+    public void shouldReturn200_whenEmailCollectionModeIsUpdated() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
         String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
                 "path", "email_collection_mode",
@@ -437,7 +447,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
     }
 
     @Test
-    public void shouldReturn400_whenEmailCollectionModeIsUpdated_withWrongValue() throws Exception{
+    public void shouldReturn400_whenEmailCollectionModeIsUpdated_withWrongValue() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
         String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
                 "path", "email_collection_mode",
@@ -499,7 +509,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
     }
-    
+
     @Test
     public void allow_web_payments_shouldBeFalseByDefault() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
@@ -508,7 +518,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .then()
                 .body("allow_web_payments", is("false"));
     }
-    
+
     @Test
     public void patchGatewayAccountToAllowWebPayments() throws JsonProcessingException {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
@@ -520,13 +530,13 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .patch("/v1/api/accounts/" + gatewayAccountId)
                 .then()
                 .statusCode(OK.getStatusCode());
-        
+
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()
                 .body("allow_web_payments", is("true"));
     }
-    
+
     @Test
     public void patchGatewayAccount_forCorporateCreditCardSurcharge() throws JsonProcessingException {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -56,6 +56,10 @@ public class GatewayAccountResourceTestBase {
     }
 
     String createAGatewayAccountFor(String testProvider, String description, String analyticsId) {
+        return createAGatewayAccountFor(testProvider, description, analyticsId, null);
+    }
+
+    String createAGatewayAccountFor(String testProvider, String description, String analyticsId, String requires_3ds) {
         Map<String, String> payload = Maps.newHashMap();
         payload.put("payment_provider", testProvider);
         if (description != null) {
@@ -63,6 +67,9 @@ public class GatewayAccountResourceTestBase {
         }
         if (analyticsId != null) {
             payload.put("analytics_id", analyticsId);
+        }
+        if (requires_3ds != null) {
+            payload.put("requires_3ds", requires_3ds);
         }
         ValidatableResponse response = givenSetup()
                 .body(toJson(payload))


### PR DESCRIPTION
## WHAT

Added new field `requires_3ds` to create new Gateway Account endpoint (HTTP method POST, URL /v1/api/accounts). This will allow us to set 3DS to enabled/disabled at the time of creating gateway account and as per service requirement.



