### PR TITLE
Pp 4553 integration test for refund email notifications

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -90,7 +90,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
     @Override
     public void run(ConnectorConfiguration configuration, Environment environment) {
-        final Injector injector = createInjector(environment, new ConnectorModule(configuration, environment));
+        final Injector injector = createInjector(environment, getModule(configuration, environment));
 
         injector.getInstance(PersistenceServiceInitialiser.class);
 
@@ -134,6 +134,10 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
         if (configuration.isXrayEnabled())
             Xray.init(environment, "pay-connector", Optional.empty(),"/v1/*");
+    }
+
+    protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
+        return new ConnectorModule(configuration, environment);
     }
 
     private Injector createInjector(Environment environment, Module module) {

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -116,6 +116,10 @@ public class ConnectorModule extends AbstractModule {
     @Provides
     @Singleton
     public NotifyClientFactory notifyClientFactory(ConnectorConfiguration connectorConfiguration) {
+        return getNotifyClientFactory(connectorConfiguration);
+    }
+
+    protected NotifyClientFactory getNotifyClientFactory(ConnectorConfiguration connectorConfiguration) {
         return new NotifyClientFactory(connectorConfiguration);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
@@ -1,0 +1,132 @@
+package uk.gov.pay.connector.it;
+
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.ConfigOverride;
+import org.apache.commons.lang.math.RandomUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.ConnectorModule;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.rules.AppRule;
+import uk.gov.pay.connector.rules.AppWithPostgresRule;
+import uk.gov.pay.connector.rules.DropwizardAppRule;
+import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
+import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.service.notify.NotificationClient;
+
+import java.util.Map;
+
+import static com.jayway.restassured.RestAssured.given;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
+import static uk.gov.pay.connector.it.util.EpdqNotificationUtils.notificationPayloadForTransaction;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
+import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.REFUND_ISSUED;
+
+public class SendRefundEmailTest {
+
+    @ClassRule
+    public static DropwizardApp app = new DropwizardApp(config("notifyConfig.emailNotifyEnabled", "true"));
+
+    private static NotifyClientFactory notifyClientFactory = mock(NotifyClientFactory.class);
+    private static NotificationClient notificationClient = mock(NotificationClient.class);
+    private static DatabaseTestHelper databaseTestHelper;
+    private Map<String, String> credentials = ImmutableMap.of(
+            CREDENTIALS_MERCHANT_ID, "merchant-id",
+            CREDENTIALS_USERNAME, "test-user",
+            CREDENTIALS_PASSWORD, "test-password",
+            CREDENTIALS_SHA_IN_PASSPHRASE, "test-sha-in-passphrase",
+            CREDENTIALS_SHA_OUT_PASSPHRASE, "test-sha-out-passphrase"
+    );
+    private String accountId;
+
+    @BeforeClass
+    public static void before() {
+        when(notifyClientFactory.getInstance()).thenReturn(notificationClient);
+        databaseTestHelper = app.getDatabaseTestHelper();
+    }
+    
+    @Before
+    public void setup() {
+        accountId = String.valueOf(RandomUtils.nextInt());
+    }
+
+    @Test
+    public void shouldSendEmailFollowingASuccessfulRefund() throws Exception {
+        addGatewayAccount();
+
+        String transactionId = String.valueOf(RandomUtils.nextInt());
+        String payIdSub = "2";
+        String refundExternalId = "999999";
+
+        long chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper).chargeId;
+        createNewRefund(REFUND_SUBMITTED, chargeId, refundExternalId, transactionId + "/" + payIdSub, 100, databaseTestHelper);
+
+        given().port(app.getLocalPort())
+                .body(notificationPayloadForTransaction(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE)))
+                .contentType(APPLICATION_FORM_URLENCODED)
+                .post("/v1/api/notifications/epdq");
+
+        verify(notificationClient).sendEmail(anyString(), anyString(), anyMap(), isNull());
+    }
+
+    private void addGatewayAccount() {
+        databaseTestHelper.addGatewayAccount(accountId, "epdq", credentials);
+        databaseTestHelper.addEmailNotification(Long.valueOf(accountId), "a template", true, REFUND_ISSUED);
+    }
+
+    public static class DropwizardApp extends AppWithPostgresRule {
+
+        public DropwizardApp(ConfigOverride... configOverrides) {
+            super(configOverrides);
+        }
+
+        @Override
+        protected AppRule<ConnectorConfiguration> newApplication(String configPath, ConfigOverride... configOverrides) {
+            return new DropwizardAppRule<>(ConnectorAppWithCustomInjector.class, configPath, configOverrides);
+        }
+    }
+    
+    public static class ConnectorAppWithCustomInjector extends ConnectorApp {
+
+        @Override
+        protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
+            return new ConnectorModuleWithOverrides(configuration, environment);
+        }
+    }
+
+    private static class ConnectorModuleWithOverrides extends ConnectorModule {
+
+        public ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
+            super(configuration, environment);
+        }
+
+        @Override
+        protected NotifyClientFactory getNotifyClientFactory(ConnectorConfiguration connectorConfiguration) {
+            return notifyClientFactory;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
@@ -2,31 +2,26 @@ package uk.gov.pay.connector.it;
 
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.testing.ConfigOverride;
 import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.ConnectorModule;
-import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.rules.AppRule;
-import uk.gov.pay.connector.rules.AppWithPostgresRule;
-import uk.gov.pay.connector.rules.DropwizardAppRule;
-import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
+import uk.gov.pay.connector.junit.ConfigOverride;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
-import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.service.notify.NotificationClient;
 
 import java.util.Map;
 
 import static com.jayway.restassured.RestAssured.given;
-import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,19 +37,22 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
-import static uk.gov.pay.connector.it.util.EpdqNotificationUtils.notificationPayloadForTransaction;
+import static uk.gov.pay.connector.it.util.NotificationUtils.epdqNotificationPayload;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.REFUND_ISSUED;
 
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = SendRefundEmailTest.ConnectorAppWithCustomInjector.class, config = "config/test-it-config.yaml", 
+        configOverrides = {@ConfigOverride(key = "notifyConfig.emailNotifyEnabled", value = "true")})
 public class SendRefundEmailTest {
 
-    @ClassRule
-    public static DropwizardApp app = new DropwizardApp(config("notifyConfig.emailNotifyEnabled", "true"));
-
+    @DropwizardTestContext
+    protected TestContext testContext;
+    
     private static NotifyClientFactory notifyClientFactory = mock(NotifyClientFactory.class);
     private static NotificationClient notificationClient = mock(NotificationClient.class);
     private static DatabaseTestHelper databaseTestHelper;
-    private Map<String, String> credentials = ImmutableMap.of(
+    private static Map<String, String> credentials = ImmutableMap.of(
             CREDENTIALS_MERCHANT_ID, "merchant-id",
             CREDENTIALS_USERNAME, "test-user",
             CREDENTIALS_PASSWORD, "test-password",
@@ -66,11 +64,11 @@ public class SendRefundEmailTest {
     @BeforeClass
     public static void before() {
         when(notifyClientFactory.getInstance()).thenReturn(notificationClient);
-        databaseTestHelper = app.getDatabaseTestHelper();
     }
     
     @Before
     public void setup() {
+        databaseTestHelper = testContext.getDatabaseTestHelper();
         accountId = String.valueOf(RandomUtils.nextInt());
     }
 
@@ -85,8 +83,8 @@ public class SendRefundEmailTest {
         long chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper).chargeId;
         createNewRefund(REFUND_SUBMITTED, chargeId, refundExternalId, transactionId + "/" + payIdSub, 100, databaseTestHelper);
 
-        given().port(app.getLocalPort())
-                .body(notificationPayloadForTransaction(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE)))
+        given().port(testContext.getPort())
+                .body(epdqNotificationPayload(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE)))
                 .contentType(APPLICATION_FORM_URLENCODED)
                 .post("/v1/api/notifications/epdq");
 
@@ -98,18 +96,6 @@ public class SendRefundEmailTest {
         databaseTestHelper.addEmailNotification(Long.valueOf(accountId), "a template", true, REFUND_ISSUED);
     }
 
-    public static class DropwizardApp extends AppWithPostgresRule {
-
-        public DropwizardApp(ConfigOverride... configOverrides) {
-            super(configOverrides);
-        }
-
-        @Override
-        protected AppRule<ConnectorConfiguration> newApplication(String configPath, ConfigOverride... configOverrides) {
-            return new DropwizardAppRule<>(ConnectorAppWithCustomInjector.class, configPath, configOverrides);
-        }
-    }
-    
     public static class ConnectorAppWithCustomInjector extends ConnectorApp {
 
         @Override

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -40,6 +40,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -47,7 +48,10 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
 import static uk.gov.pay.connector.junit.DropwizardJUnitRunner.WIREMOCK_PORT;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
@@ -204,19 +208,7 @@ public class ChargingITestBase {
     }
 
     protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId) {
-        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId);
-    }
-
-    protected String createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId) {
-        long chargeId = RandomUtils.nextInt();
-        String externalChargeId = "charge-" + chargeId;
-        databaseTestHelper.addCharge(chargeId, externalChargeId, accountId, 6234L, status, "RETURN_URL", gatewayTransactionId);
-        return externalChargeId;
-    }
-
-    protected void createNewRefund(RefundStatus status, long chargeId, String refundExternalId, String reference, long amount) {
-        long refundId = RandomUtils.nextInt();
-        databaseTestHelper.addRefund(refundId, refundExternalId, reference, amount, status.getValue(), chargeId, ZonedDateTime.now());
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper).toString();
     }
 
     protected RequestSpecification givenSetup() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
@@ -38,6 +38,7 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildDetailedJsonAuthori
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithFullAddress;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
 import static uk.gov.pay.connector.util.TransactionId.randomId;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -269,16 +270,16 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
         databaseTestHelper.addGatewayAccount(accountId, "sandbox", "description", "",
                 corporateCreditCardSurchargeAmount, 0, 0, 0);
         
-        String chargeId = createNewChargeWithAccountId(ENTERING_CARD_DETAILS, randomId(), accountId);
+        String externalChargeId = createNewChargeWithAccountId(ENTERING_CARD_DETAILS, randomId(), accountId, databaseTestHelper).toString();
         String cardDetails = buildCorporateJsonAuthorisationDetailsFor(PayersCardType.CREDIT);
 
         givenSetup()
                 .body(cardDetails)
-                .post(authoriseChargeUrlFor(chargeId))
+                .post(authoriseChargeUrlFor(externalChargeId))
                 .then()
                 .statusCode(200);
 
-        assertFrontendChargeCorporateSurchargeAmount(chargeId, AUTHORISATION_SUCCESS.getValue(), corporateCreditCardSurchargeAmount);
+        assertFrontendChargeCorporateSurchargeAmount(externalChargeId, AUTHORISATION_SUCCESS.getValue(), corporateCreditCardSurchargeAmount);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.util.ChargeUtils;
+import uk.gov.pay.connector.it.util.NotificationUtils;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
@@ -27,7 +28,7 @@ import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
-import static uk.gov.pay.connector.it.util.EpdqNotificationUtils.notificationPayloadForTransaction;
+import static uk.gov.pay.connector.it.util.NotificationUtils.epdqNotificationPayload;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -163,7 +164,7 @@ public class EpdqNotificationResourceITest extends ChargingITestBase {
     @Test
     public void shouldFailWhenUnexpectedContentType() {
         given().port(testContext.getPort())
-                .body(notificationPayloadForTransaction("any", "1", "WHATEVER", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE)))
+                .body(epdqNotificationPayload("any", "1", "WHATEVER", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE)))
                 .contentType(APPLICATION_JSON)
                 .post(NOTIFICATION_PATH)
                 .then()
@@ -171,11 +172,11 @@ public class EpdqNotificationResourceITest extends ChargingITestBase {
     }
 
     private ValidatableResponse notifyConnector(String transactionId, String status, String shaOutPassphrase) {
-        return notifyConnector(notificationPayloadForTransaction(transactionId, status, shaOutPassphrase));
+        return notifyConnector(NotificationUtils.epdqNotificationPayload(transactionId, status, shaOutPassphrase));
     }
 
     private ValidatableResponse notifyConnector(String transactionId, String payIdSub, String status, String shaOutPassphrase) {
-        return notifyConnector(notificationPayloadForTransaction(transactionId, payIdSub, status, shaOutPassphrase));
+        return notifyConnector(epdqNotificationPayload(transactionId, payIdSub, status, shaOutPassphrase));
     }
 
     private ValidatableResponse notifyConnector(String payload) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceITest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 
@@ -191,7 +192,7 @@ public class WorldpayNotificationResourceITest extends ChargingITestBase {
     private String createNewChargeWithRefund(String transactionId, String refundExternalId, long refundAmount) {
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         String chargeId = externalChargeId.substring(externalChargeId.indexOf("-") + 1);
-        createNewRefund(REFUND_SUBMITTED, Long.valueOf(chargeId), refundExternalId, refundExternalId, refundAmount);
+        createNewRefund(REFUND_SUBMITTED, Long.valueOf(chargeId), refundExternalId, refundExternalId, refundAmount, databaseTestHelper);
         return externalChargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.it.util;
+
+import org.apache.commons.lang.math.RandomUtils;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+
+import java.time.ZonedDateTime;
+
+public class ChargeUtils {
+
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, DatabaseTestHelper databaseTestHelper) {
+        long chargeId = RandomUtils.nextInt();
+        ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
+        databaseTestHelper.addCharge(chargeId, externalChargeId.toString(), accountId, 6234L, status, "RETURN_URL", gatewayTransactionId);
+        return externalChargeId;
+    }
+
+    public static void createNewRefund(RefundStatus status, long chargeId, String refundExternalId, String reference, long amount, DatabaseTestHelper databaseTestHelper) {
+        long refundId = RandomUtils.nextInt();
+        databaseTestHelper.addRefund(refundId, refundExternalId, reference, amount, status.getValue(), chargeId, ZonedDateTime.now());
+    }
+
+    public static class ExternalChargeId {
+        public final long chargeId;
+
+        public ExternalChargeId(long chargeId) {
+            this.chargeId = chargeId;
+        }
+
+        @Override
+        public String toString() {
+            return "charge-" + chargeId;
+        }
+
+        public static ExternalChargeId fromChargeId(long chargeId) {
+            return new ExternalChargeId(chargeId);
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/util/EpdqNotificationUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/EpdqNotificationUtils.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.it.util;
+
+import com.google.common.collect.Lists;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class EpdqNotificationUtils {
+
+    public static String notificationPayloadForTransaction(String transactionId, String status, String shaOutPassphrase) {
+        List<NameValuePair> payloadParameters = buildPayload(transactionId, status);
+        return notificationPayloadForTransaction(payloadParameters, shaOutPassphrase);
+    }
+    
+    public static String notificationPayloadForTransaction(String transactionId, String payIdSub, String status, String shaOutPassphrase) {
+        List<NameValuePair> payloadParameters = buildPayload(transactionId, status);
+        payloadParameters.add(new BasicNameValuePair("PAYIDSUB", payIdSub));
+        return notificationPayloadForTransaction(payloadParameters, shaOutPassphrase);
+    }
+
+    private static List<NameValuePair> buildPayload(String transactionId, String status) {
+        return Lists.newArrayList(
+                new BasicNameValuePair("orderID", "order-id"),
+                new BasicNameValuePair("STATUS", status),
+                new BasicNameValuePair("PAYID", transactionId));
+    }
+
+    private static String notificationPayloadForTransaction(List<NameValuePair> payloadParameters, String shaOutPassphrase) {
+        String signature = new EpdqSha512SignatureGenerator().sign(payloadParameters, shaOutPassphrase);
+
+        payloadParameters.add(new BasicNameValuePair("SHASIGN", signature));
+        return URLEncodedUtils.format(payloadParameters, StandardCharsets.UTF_8.toString());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/util/NotificationUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/NotificationUtils.java
@@ -9,29 +9,28 @@ import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-public class EpdqNotificationUtils {
+public class NotificationUtils {
 
-    public static String notificationPayloadForTransaction(String transactionId, String status, String shaOutPassphrase) {
-        List<NameValuePair> payloadParameters = buildPayload(transactionId, status);
-        return notificationPayloadForTransaction(payloadParameters, shaOutPassphrase);
+    public static String epdqNotificationPayload(String transactionId, String status, String shaOutPassphrase) {
+        List<NameValuePair> payloadParameters = buildEpdqPayload(transactionId, status);
+        return epdqNotificationPayload(payloadParameters, shaOutPassphrase);
     }
     
-    public static String notificationPayloadForTransaction(String transactionId, String payIdSub, String status, String shaOutPassphrase) {
-        List<NameValuePair> payloadParameters = buildPayload(transactionId, status);
+    public static String epdqNotificationPayload(String transactionId, String payIdSub, String status, String shaOutPassphrase) {
+        List<NameValuePair> payloadParameters = buildEpdqPayload(transactionId, status);
         payloadParameters.add(new BasicNameValuePair("PAYIDSUB", payIdSub));
-        return notificationPayloadForTransaction(payloadParameters, shaOutPassphrase);
+        return epdqNotificationPayload(payloadParameters, shaOutPassphrase);
     }
 
-    private static List<NameValuePair> buildPayload(String transactionId, String status) {
+    private static List<NameValuePair> buildEpdqPayload(String transactionId, String status) {
         return Lists.newArrayList(
                 new BasicNameValuePair("orderID", "order-id"),
                 new BasicNameValuePair("STATUS", status),
                 new BasicNameValuePair("PAYID", transactionId));
     }
 
-    private static String notificationPayloadForTransaction(List<NameValuePair> payloadParameters, String shaOutPassphrase) {
+    private static String epdqNotificationPayload(List<NameValuePair> payloadParameters, String shaOutPassphrase) {
         String signature = new EpdqSha512SignatureGenerator().sign(payloadParameters, shaOutPassphrase);
-
         payloadParameters.add(new BasicNameValuePair("SHASIGN", signature));
         return URLEncodedUtils.format(payloadParameters, StandardCharsets.UTF_8.toString());
     }

--- a/src/test/java/uk/gov/pay/connector/junit/ConfigOverride.java
+++ b/src/test/java/uk/gov/pay/connector/junit/ConfigOverride.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ConfigOverride {
+    String key();
+    String value();
+}

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardConfig.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardConfig.java
@@ -6,6 +6,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Mandatory annotation when using {@link DropwizardJUnitRunner} to configure the
@@ -55,4 +57,6 @@ public @interface DropwizardConfig {
      * @return boolean
      */
     boolean withDockerPostgres() default true;
+    
+    ConfigOverride[] configOverrides() default {};
 }

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
@@ -9,6 +9,7 @@ import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
 import uk.gov.pay.connector.util.PortFactory;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,12 +58,18 @@ public final class DropwizardJUnitRunner extends JUnitParamsRunner {
     protected Statement classBlock(final RunNotifier notifier) {
         DropwizardConfig dropwizardConfigAnnotation = dropwizardConfigAnnotation();
         List<ConfigOverride> configOverride = newArrayList();
+        
         if (dropwizardConfigAnnotation.withDockerPostgres()) {
             getOrCreate();
             configOverride.add(config("database.url", getDbUri()));
             configOverride.add(config("database.user", getDbUsername()));
             configOverride.add(config("database.password", getDbPassword()));
         }
+        
+        if (dropwizardConfigAnnotation.configOverrides().length > 0) 
+            Arrays.stream(dropwizardConfigAnnotation.configOverrides()).forEach(c -> configOverride.add(config(c.key(), c.value())));
+        
+        
         configOverride.add(config("worldpay.urls.test", "http://localhost:" + WIREMOCK_PORT + "/jsp/merchant/xml/paymentService.jsp"));
         configOverride.add(config("smartpay.urls.test", "http://localhost:" + WIREMOCK_PORT + "/pal/servlet/soap/Payment"));
         configOverride.add(config("epdq.urls.test", "http://localhost:" + WIREMOCK_PORT + "/epdq"));


### PR DESCRIPTION
SendRefundEmailTest tests that email notifications are sent for refunds. One
bad thing about this PR is that ConnectorApp and ConnectorModule have new
protected methods (`getModule` and `getNotifyClientFactory`) respectively. This
is code that enables us to mock out the NotifyClientFactory in the
SendRefundEmailTest. Unfortunately there is no nice way round doing this (it's
not Spring :( ) but it has been deemed essential to have an integration for
this functionality (mocking at unit test level is not enough). The other option
is to spin up a WireMock email notification server but unfortunately the notify
client needs to use https and enabling https in a wiremock and integration test
scenario is hugely not trivial.

@oswaldquek

