### PR TITLE
bau: Fix bug that caused pact verification results to not be published

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
         <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>3.5.24</version>
+            <version>3.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.pact;
 
+import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
@@ -12,7 +13,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import uk.gov.pay.commons.model.SupportedLanguage;
-import uk.gov.pay.commons.testing.pact.providers.PayPactRunner;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -26,13 +26,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
-@RunWith(PayPactRunner.class)
+@RunWith(PactRunner.class)
 @Provider("connector")
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))
 public class TransactionsApiContractTest {
-
-    private long chargeIdCounter;
 
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
@@ -45,6 +43,8 @@ public class TransactionsApiContractTest {
     public static void setUp() {
         target = new HttpTarget(app.getLocalPort());
         dbHelper = app.getDatabaseTestHelper();
+        System.clearProperty("https.proxyHost");
+        System.clearProperty("https.proxyPort");
     }
 
     @Before


### PR DESCRIPTION
When using pact's PactRunner to run the contract test, results ended up getting
published to `localhost:1234`. We found out that this address comes from the
jerseyClient's proxy configuration in the test-it-config.yaml. These proxy
values are set in ConnectorApp:

```
System.setProperty("https.proxyHost", configuration.getClientConfiguration().getProxyConfiguration().getHost());
System.setProperty("https.proxyPort", configuration.getClientConfiguration().getProxyConfiguration().getPort().toString());
```

This is the wrong way to set system properties but will be fixed at a later
date. These should be set via commandline and managed by Terraform.

Unsetting these property in the pact test now enables us to use PactRunner,
deprecate our custom PayPactRunner, and upgrade the pact library to version
3.6.1.

@oswaldquek