### PR TITLE
bau: Fix publishing issue

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -32,6 +32,10 @@ import java.util.concurrent.ThreadLocalRandom;
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"))
 public class TransactionsApiContractTest {
 
+    static {
+        System.setProperty("pact.verifier.publishResults", "true");
+    }
+    
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
 
@@ -43,6 +47,7 @@ public class TransactionsApiContractTest {
     public static void setUp() {
         target = new HttpTarget(app.getLocalPort());
         dbHelper = app.getDatabaseTestHelper();
+        
         System.clearProperty("https.proxyHost");
         System.clearProperty("https.proxyPort");
     }


### PR DESCRIPTION
Suspect the `-Dpact.verifier.publishResults=true` currently set via
https://github.com/alphagov/pay-jenkins-library/blob/be6a83adbb80f7957bf990699dc74c3f14c67928/vars/runProviderContractTests.groovy#L11
doesn't work.

Currently the build fails as no results are being published.

Trying this out.

@oswaldquek

