### PR TITLE
PP-4584: Manage HTTP proxies via env. vars

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -4,6 +4,10 @@ set -eu
 RUN_MIGRATION=${RUN_MIGRATION:-false}
 RUN_APP=${RUN_APP:-true}
 
+[ -z "${http_proxy:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttp.proxyHost=${http_proxy}"
+[ -z "${https_proxy:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttps.proxyHost=${https_proxy}"
+[ -z "${java_http_non_proxy_hosts:-}" ] || JAVA_OPTS="${JAVA_OPTS:-} -Dhttp.nonProxyHosts=${java_http_non_proxy_hosts}"
+
 java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -55,7 +55,6 @@ import uk.gov.pay.connector.util.XrayUtils;
 import uk.gov.pay.connector.webhook.resource.NotificationResource;
 
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLSocketFactory;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -130,7 +129,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.healthChecks().register("database", injector.getInstance(DatabaseHealthCheck.class));
         environment.healthChecks().register("cardExecutorService", injector.getInstance(CardExecutorServiceHealthCheck.class));
 
-        setGlobalProxies(configuration);
+        HttpsURLConnection.setDefaultSSLSocketFactory(new TrustingSSLSocketFactory());
 
         if (configuration.isXrayEnabled())
             Xray.init(environment, "pay-connector", Optional.empty(),"/v1/*");
@@ -168,14 +167,6 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
     public static void main(String[] args) throws Exception {
         new ConnectorApp().run(args);
-    }
-
-    private void setGlobalProxies(ConnectorConfiguration configuration) {
-        SSLSocketFactory socketFactory = new TrustingSSLSocketFactory();
-        HttpsURLConnection.setDefaultSSLSocketFactory(socketFactory);
-
-        System.setProperty("https.proxyHost", configuration.getClientConfiguration().getProxyConfiguration().getHost());
-        System.setProperty("https.proxyPort", configuration.getClientConfiguration().getProxyConfiguration().getPort().toString());
     }
 
     private void setupSchedulers(ConnectorConfiguration configuration, Environment environment, Injector injector) {

--- a/src/main/java/uk/gov/pay/connector/app/CustomJerseyClientConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/CustomJerseyClientConfiguration.java
@@ -4,21 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.util.Duration;
 
-import javax.validation.Valid;
-
 public class CustomJerseyClientConfiguration extends Configuration {
     private Duration readTimeout;
-
-    @Valid
-    @JsonProperty
-    private String enableProxy;
 
     @JsonProperty
     public Duration getReadTimeout() {
         return this.readTimeout;
-    }
-
-    public boolean isProxyEnabled() {
-        return "true".equals(enableProxy);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ClientFactory.java
@@ -4,7 +4,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.httpclient.InstrumentedHttpClientConnectionManager;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
-import io.dropwizard.client.proxy.ProxyConfiguration;
 import io.dropwizard.setup.Environment;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -14,9 +13,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.conn.ManagedHttpClientConnectionFactory;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.glassfish.jersey.SslConfigurator;
-import org.glassfish.jersey.apache.connector.ApacheClientProperties;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
-import org.glassfish.jersey.client.ClientProperties;
 import uk.gov.pay.commons.utils.xray.XRayHttpClientFilter;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.OperationOverrides;
@@ -65,11 +62,6 @@ public class ClientFactory {
             defaultClientBuilder
                     .withProperty(READ_TIMEOUT, getDefaultTimeout())
                     .withProperty(CONNECTION_MANAGER, createConnectionManager(gateway.getName(), "all", metricRegistry));
-        }
-
-        if (conf.getCustomJerseyClient().isProxyEnabled()) {
-            defaultClientBuilder
-                    .withProperty(ClientProperties.PROXY_URI, proxyUrl(clientConfiguration.getProxyConfiguration()));
         }
 
         Client client = defaultClientBuilder.build(gateway.getName());
@@ -125,29 +117,5 @@ public class ClientFactory {
                 format("%s.%s", gatewayName, operation)
         );
     }
-
-    /**
-     * Constructs the proxy URL required by JerseyClient property ClientProperties.PROXY_URI
-     * <p>
-     * <b>NOTE:</b> The reason for doing this is, Dropwizard jersey client doesn't seem to work as per
-     * http://www.dropwizard.io/0.9.2/docs/manual/configuration.html#proxy where just setting the proxy config in
-     * client configuration is only needed. But after several test, that doesn't seem to work, but by setting the
-     * native jersey proxy config as per this implementation seems to work
-     * <p>
-     * similar problem discussed in here -> https://groups.google.com/forum/#!topic/dropwizard-user/AbDSYfLB17M
-     * </p>
-     * </p>
-     *
-     * @param proxyConfig from config.yml
-     * @return proxy server URL
-     */
-    private String proxyUrl(ProxyConfiguration proxyConfig) {
-        return format("%s://%s:%s",
-                proxyConfig.getScheme(),
-                proxyConfig.getHost(),
-                proxyConfig.getPort()
-        );
-    }
-
 }
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -119,12 +119,6 @@ jerseyClient:
   retries: 0
   userAgent: connector
   gzipEnabledForRequests: false
-  proxy:
-    host: ${HTTP_PROXY_HOST:-0}
-    port: ${HTTP_PROXY_PORT:-0}
-    scheme : ${HTTP_PROXY_SCHEME:-https}
-    nonProxyHosts:
-      - localhost
 
 customJerseyClient:
   # Sets the read timeout to a specified timeout, in
@@ -134,7 +128,6 @@ customJerseyClient:
   # for read, a java.net.SocketTimeoutException is raised. A
   # timeout of zero is interpreted as an infinite timeout.
   readTimeout: 90000ms
-  enableProxy: ${HTTP_PROXY_ENABLED}
 
 database:
   driverClass: org.postgresql.Driver

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -45,8 +45,6 @@ public class TransactionsApiContractTest {
         target = new HttpTarget(app.getLocalPort());
         dbHelper = app.getDatabaseTestHelper();
 
-        System.clearProperty("https.proxyHost");
-        System.clearProperty("https.proxyPort");
     }
 
     @Before

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -76,16 +76,9 @@ jerseyClient:
   retries: 0
   userAgent: connector
   gzipEnabledForRequests: false
-  proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
 
 customJerseyClient:
   readTimeout: 50000ms
-  enableProxy: false
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -75,16 +75,9 @@ jerseyClient:
   retries: 0
   userAgent: connector
   gzipEnabledForRequests: false
-  proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
 
 customJerseyClient:
   readTimeout: 50000ms
-  enableProxy: false
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -65,16 +65,9 @@ jerseyClient:
   retries: 0
   userAgent: connector
   gzipEnabledForRequests: false
-  proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
 
 customJerseyClient:
   readTimeout: 500ms
-  enableProxy: false
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -86,16 +86,9 @@ jerseyClient:
   retries: 0
   userAgent: connector
   gzipEnabledForRequests: false
-  proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
 
 customJerseyClient:
   readTimeout: 90000ms
-  enableProxy: false
 
 database:
   driverClass: org.postgresql.Driver

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -83,16 +83,9 @@ jerseyClient:
   retries: 0
   userAgent: connector
   gzipEnabledForRequests: false
-  proxy:
-      host: localhost
-      port: 1234
-      scheme : http
-      nonProxyHosts:
-        - localhost
 
 customJerseyClient:
   readTimeout: 90000ms
-  enableProxy: false
 
 database:
   driverClass: org.postgresql.Driver


### PR DESCRIPTION
## WHAT
Remove all code for configuring HTTP proxies and instead use environment
variables to set JVM system properties.

This makes connector respond to the following 3 environment variables:

`http_proxy` - passed as `http.proxyHost`
`https_proxy` - passed as `https.proxyHost`
`java_http_non_proxy_hosts` - passed as `http.nonProxyHosts`

## HOW 
CI will save us here