### PR TITLE
🔥break - Lower authorisation already in progress to info

### DIFF
--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -75,7 +75,7 @@ public class ResponseUtil {
     }
 
     public static Response acceptedResponse(String message) {
-        logger.error(message);
+        logger.info(message);
         return responseWithMessageMap(ACCEPTED, message);
     }
 


### PR DESCRIPTION
## WHAT
 - The `OperationAlreadyInProgressRuntimeException` happens quite often - it's almost inevitable considering we have multiple connectors serving requests
 - It is not really an error: we throw an exception to make sure that the charge is not processed further, but we don't have to pollute the logs with that

