### PR TITLE
PP-4270 Multithreaded capture process

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
@@ -7,6 +7,7 @@ public class CaptureProcessConfig extends Configuration {
     private long schedulerInitialDelayInSeconds;
     private long schedulerRandomIntervalMinimumInSeconds;
     private long schedulerRandomIntervalMaximumInSeconds;
+    private int schedulerThreads;
 
     private int batchSize;
     private Duration retryFailuresEvery;
@@ -38,5 +39,9 @@ public class CaptureProcessConfig extends Configuration {
 
     public int getMaximumRetries() {
         return maximumRetries;
+    }
+
+    public int getSchedulerThreads() {
+        return schedulerThreads;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -9,6 +9,7 @@ import com.google.inject.persist.jpa.JpaPersistModule;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.applepay.ApplePayDecrypter;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -24,6 +25,8 @@ import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.util.XrayUtils;
 
 import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 
@@ -119,5 +122,11 @@ public class ConnectorModule extends AbstractModule {
 
     protected NotifyClientFactory getNotifyClientFactory(ConnectorConfiguration connectorConfiguration) {
         return new NotifyClientFactory(connectorConfiguration);
+    }
+
+    @Provides
+    @Singleton
+    public Queue<ChargeEntity> captureQueue(ConnectorConfiguration connectorConfiguration) {
+        return new ArrayBlockingQueue(connectorConfiguration.getCaptureProcessConfig().getBatchSize());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class CaptureProcessScheduler implements Managed {
-    final Logger logger = LoggerFactory.getLogger(CaptureProcessScheduler.class);
+    private final Logger logger = LoggerFactory.getLogger(CaptureProcessScheduler.class);
 
     static final String CAPTURE_PROCESS_SCHEDULER_NAME = "capture-process";
     static final int SCHEDULER_THREADS = 1;
@@ -25,13 +25,14 @@ public class CaptureProcessScheduler implements Managed {
     private long initialDelayInSeconds = INITIAL_DELAY_IN_SECONDS;
     private long randomIntervalMinimumInSeconds = RANDOM_INTERVAL_MINIMUM_IN_SECONDS;
     private long randomIntervalMaximumInSeconds = RANDOM_INTERVAL_MAXIMUM_IN_SECONDS;
+    private int schedulerThreads = SCHEDULER_THREADS;
 
     private final CardCaptureProcess cardCaptureProcess;
     private final ScheduledExecutorService scheduledExecutorService;
     private final XrayUtils xrayUtils;
 
-    public CaptureProcessScheduler(ConnectorConfiguration configuration, 
-                                   Environment environment, 
+    public CaptureProcessScheduler(ConnectorConfiguration configuration,
+                                   Environment environment,
                                    CardCaptureProcess cardCaptureProcess,
                                    XrayUtils xrayUtils) {
         this.cardCaptureProcess = cardCaptureProcess;
@@ -42,12 +43,13 @@ public class CaptureProcessScheduler implements Managed {
             initialDelayInSeconds = captureProcessConfig.getSchedulerInitialDelayInSeconds();
             randomIntervalMinimumInSeconds = captureProcessConfig.getSchedulerRandomIntervalMinimumInSeconds();
             randomIntervalMaximumInSeconds = captureProcessConfig.getSchedulerRandomIntervalMaximumInSeconds();
+            schedulerThreads = captureProcessConfig.getSchedulerThreads();
         }
 
         scheduledExecutorService = environment
                 .lifecycle()
                 .scheduledExecutorService(CAPTURE_PROCESS_SCHEDULER_NAME)
-                .threads(SCHEDULER_THREADS)
+                .threads(schedulerThreads + 1)
                 .build();
     }
 
@@ -56,15 +58,26 @@ public class CaptureProcessScheduler implements Managed {
         logger.info("Scheduling CardCaptureProcess to run every {} seconds (will start in {} seconds)", interval, initialDelayInSeconds);
 
         scheduledExecutorService.scheduleAtFixedRate(() -> {
+            for (int threadNumber = 1; threadNumber <= schedulerThreads; threadNumber++) {
+                final int finalThreadNumber = threadNumber;
+
+                cardCaptureProcess.loadCaptureQueue();
+                scheduleCaptureThreads(finalThreadNumber);
+            }
+        }, initialDelayInSeconds, interval, TimeUnit.SECONDS);
+    }
+
+    private void scheduleCaptureThreads(int finalThreadNumber) {
+        scheduledExecutorService.schedule(() -> {
             try {
                 xrayUtils.beginSegment();
-                cardCaptureProcess.runCapture();
+                cardCaptureProcess.runCapture(finalThreadNumber);
             } catch (Exception e) {
                 logger.error("Unexpected error running capture operations", e);
             } finally {
                 xrayUtils.endSegment();
             }
-        }, initialDelayInSeconds, interval, TimeUnit.SECONDS);
+        }, 0, TimeUnit.SECONDS);
     }
 
     private long randomTimeInterval() {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
@@ -46,10 +46,14 @@ public class CaptureProcessScheduler implements Managed {
             schedulerThreads = captureProcessConfig.getSchedulerThreads();
         }
 
+        // Total number of threads is schedulerThreads (dedicated threads that captures the charges)
+        //  + main thread that initiates loading and capturing the charges
+        int totalThreads = schedulerThreads + 1;
+        
         scheduledExecutorService = environment
                 .lifecycle()
                 .scheduledExecutorService(CAPTURE_PROCESS_SCHEDULER_NAME)
-                .threads(schedulerThreads + 1)
+                .threads(totalThreads)  
                 .build();
     }
 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -91,6 +91,7 @@ captureProcessConfig:
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-20}
 
   batchSize: ${CAPTURE_PROCESS_BATCH_SIZE:-10}
+  schedulerThreads: ${SCHEDULER_THREADS:-10}
 
   # The below effectively get multiplied together. In order to handle how
   # certain payment gateways do things, it is extremely desirable to keep these

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayCaptureFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayCaptureFailuresITest.java
@@ -31,7 +31,8 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenUnexpectedResponseCodeFromGateway() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithUnexpectedResponseCodeWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs(
                 String.format("Gateway returned unexpected status code: 999, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", port));
@@ -42,7 +43,8 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenMalformedResponseFromGateway() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithMalformedBody_WhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs("Could not unmarshall response >>>|<malformed xml/>|<<<.");
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
@@ -52,7 +54,8 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
     public void shouldSucceedCapture() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithSuccessWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
@@ -31,7 +31,8 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenInvalidConnectorUrl() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithUnexpectedResponseCodeWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs("DNS resolution error for gateway url=http://gobbledygook.invalid.url");
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -13,12 +12,10 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.dropwizard.testing.ConfigOverride.config;
-import static java.lang.String.format;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -39,9 +36,10 @@ public class GatewaySocketErrorITest extends BaseGatewayITest {
                 post(urlPathEqualTo("/pal/servlet/soap/Payment"))
                         .willReturn(aResponse().withStatus(404))
         );
-        
+
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs(
                 String.format("Gateway returned unexpected status code: 404, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", port));

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
@@ -31,7 +31,8 @@ public class GatewaySocketReadTimeoutITest extends BaseGatewayITest {
     public void shouldFailCaptureWhenConnectionTimeoutFromGateway() {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(app.getDatabaseTestHelper());
         setupGatewayStub().respondWithTimeoutWhenCapture();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertThatLastGatewayClientLoggingEventIs(
                 String.format("Connection timed out error for gateway url=http://localhost:%s/pal/servlet/soap/Payment", port));

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -75,7 +75,8 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .statusCode(204);
 
         // Trigger the capture process programmatically which normally would be invoked by the scheduler.
-        testContext.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        testContext.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        testContext.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         getCharge(chargeId)
                 .body("settlement_summary.capture_submit_time", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))

--- a/src/test/java/uk/gov/pay/connector/it/scheduler/CaptureProcessSchedulerITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/scheduler/CaptureProcessSchedulerITest.java
@@ -1,0 +1,120 @@
+package uk.gov.pay.connector.it.scheduler;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.google.common.collect.ImmutableMap;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.paymentprocessor.service.CaptureProcessScheduler;
+import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
+import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
+import uk.gov.pay.connector.rules.WorldpayMockClient;
+import uk.gov.pay.connector.util.PortFactory;
+import uk.gov.pay.connector.util.XrayUtils;
+
+import java.util.Map;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaptureProcessSchedulerITest {
+
+    private static final String PAYMENT_PROVIDER = "worldpay";
+
+    private int CAPTURE_MAX_RETRIES = 1;
+    private static final String TRANSACTION_ID = "7914440428682669";
+    private static final Map<String, String> CREDENTIALS =
+            ImmutableMap.of(
+                    CREDENTIALS_MERCHANT_ID, "merchant-id",
+                    CREDENTIALS_USERNAME, "test-user",
+                    CREDENTIALS_PASSWORD, "test-password",
+                    CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphraser"
+            );
+
+    protected int port = PortFactory.findFreePort();
+
+    private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(port);
+
+    @Rule
+    public GuiceAppWithPostgresRule app = new GuiceAppWithPostgresRule(
+            config("worldpay.urls.test", "http://localhost:" + port + "/jsp/merchant/xml/paymentService.jsp"),
+            config("captureProcessConfig.maximumRetries", Integer.toString(CAPTURE_MAX_RETRIES)),
+            config("captureProcessConfig.schedulerThreads", "2"),
+            config("captureProcessConfig.schedulerInitialDelayInSeconds", "0"),
+            config("captureProcessConfig.schedulerRandomIntervalMinimumInSeconds", "1"),
+            config("captureProcessConfig.schedulerRandomIntervalMaximumInSeconds", "1")
+    );
+
+    private DatabaseFixtures.TestCharge createTestCharge(String paymentProvider, ChargeStatus chargeStatus) {
+        DatabaseFixtures.TestAccount testAccount = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestAccount()
+                .withPaymentProvider(paymentProvider)
+                .withCredentials(CREDENTIALS);
+
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(app.getDatabaseTestHelper())
+                .aTestCharge()
+                .withTestAccount(testAccount)
+                .withChargeStatus(chargeStatus)
+                .withTransactionId(TRANSACTION_ID);
+
+        testAccount.insert();
+        return testCharge.insert();
+    }
+
+    @Before
+    public void setup() {
+        Logger root = (Logger) LoggerFactory.getLogger(CardCaptureProcess.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void schedulerShouldStartMultipleThreadsAsPerConfig_AndCaptureCharge() throws InterruptedException {
+
+        DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
+        new WorldpayMockClient().mockCaptureSuccess();
+
+        CaptureProcessScheduler captureProcessScheduler = new CaptureProcessScheduler(app.getConf(),
+                app.getEnvironment(), app.getInstanceFromGuiceContainer(CardCaptureProcess.class),
+                app.getInstanceFromGuiceContainer(XrayUtils.class));
+
+        captureProcessScheduler.start();
+
+        Thread.sleep(1000L); // Mininum configurable interval for capture scheduler
+
+        // Expected below : For 2 scheduler threads with a charge in CAPTURE_APPROVED state
+        // Thread 1: Capturing: 1 of 1 charges ,  Capturing [1 of 1] [chargeId=...] ,  Capture complete ...
+        // Thread 2: Capture complete ....
+        verify(mockAppender, times(4)).doAppend(loggingEventArgumentCaptor.capture());
+
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Rule;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.it.util.ChargeUtils;
 import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 import uk.gov.pay.connector.util.PortFactory;
 
@@ -43,20 +44,7 @@ abstract public class CardCaptureProcessBaseITest {
             config("captureProcessConfig.retryFailuresEvery", "0 minutes"));
 
     public DatabaseFixtures.TestCharge createTestCharge(String paymentProvider, ChargeStatus chargeStatus) {
-        DatabaseFixtures.TestAccount testAccount = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestAccount()
-                .withPaymentProvider(paymentProvider)
-                .withCredentials(CREDENTIALS);
-
-        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
-                .withDatabaseTestHelper(app.getDatabaseTestHelper())
-                .aTestCharge()
-                .withTestAccount(testAccount)
-                .withChargeStatus(chargeStatus)
-                .withTransactionId(TRANSACTION_ID);
-
-        testAccount.insert();
-        return testCharge.insert();
+        return ChargeUtils.createTestCharge(app.getDatabaseTestHelper(),
+                paymentProvider, chargeStatus, CREDENTIALS, TRANSACTION_ID);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new EpdqMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
@@ -36,7 +37,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new EpdqMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +48,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new EpdqMockClient().mockCaptureError();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +59,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new EpdqMockClient().mockCaptureError();
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
@@ -24,7 +24,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
     }
@@ -34,7 +35,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }

--- a/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new SmartpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
@@ -36,7 +37,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new SmartpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +47,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new SmartpayMockClient().mockCaptureError();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +58,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new SmartpayMockClient().mockCaptureError();
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
     }
@@ -36,7 +37,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +47,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureError(testCharge.getTransactionId());
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +58,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureError(testCharge.getTransactionId());
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
@@ -26,7 +26,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
     }
@@ -36,7 +37,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, ENTERING_CARD_DETAILS);
 
         new WorldpayMockClient().mockCaptureSuccess();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
     }
@@ -46,7 +47,8 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureError();
-        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
@@ -56,8 +58,9 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new WorldpayMockClient().mockCaptureError();
-        for (int i=0; i<CAPTURE_MAX_RETRIES+1; i++) {
-            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture();
+        for (int i = 0; i < CAPTURE_MAX_RETRIES + 1; i++) {
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+            app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -2,10 +2,12 @@ package uk.gov.pay.connector.it.util;
 
 import org.apache.commons.lang.math.RandomUtils;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 public class ChargeUtils {
 
@@ -19,6 +21,25 @@ public class ChargeUtils {
     public static void createNewRefund(RefundStatus status, long chargeId, String refundExternalId, String reference, long amount, DatabaseTestHelper databaseTestHelper) {
         long refundId = RandomUtils.nextInt();
         databaseTestHelper.addRefund(refundId, refundExternalId, reference, amount, status.getValue(), chargeId, ZonedDateTime.now());
+    }
+
+    public static DatabaseFixtures.TestCharge createTestCharge(DatabaseTestHelper databaseTestHelper, String paymentProvider, ChargeStatus chargeStatus,
+                                                               Map<String,String> credentials, String transactionId) {
+        DatabaseFixtures.TestAccount testAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withPaymentProvider(paymentProvider)
+                .withCredentials(credentials);
+
+        DatabaseFixtures.TestCharge testCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(testAccount)
+                .withChargeStatus(chargeStatus)
+                .withTransactionId(transactionId);
+
+        testAccount.insert();
+        return testCharge.insert();
     }
 
     public static class ExternalChargeId {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessSchedulerTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessSchedulerTest.java
@@ -11,8 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.paymentprocessor.service.CaptureProcessScheduler;
-import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.util.XrayUtils;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -59,7 +57,7 @@ public class CaptureProcessSchedulerTest {
     public void setup() {
         scheduledExecutorServiceBuilder = mock(ScheduledExecutorServiceBuilder.class, invocation -> {
             Object mock = invocation.getMock();
-            if(invocation.getMethod().getReturnType().isInstance(mock)) {
+            if (invocation.getMethod().getReturnType().isInstance(mock)) {
                 return mock;
             } else {
                 return RETURNS_DEFAULTS.answer(invocation);
@@ -75,7 +73,7 @@ public class CaptureProcessSchedulerTest {
         new CaptureProcessScheduler(null, environment, cardCaptureProcess, xrayUtils);
 
         verify(lifecycleEnvironment).scheduledExecutorService(CAPTURE_PROCESS_SCHEDULER_NAME);
-        verify(scheduledExecutorServiceBuilder).threads(SCHEDULER_THREADS);
+        verify(scheduledExecutorServiceBuilder).threads(SCHEDULER_THREADS + 1);
         verify(scheduledExecutorServiceBuilder).build();
     }
 
@@ -95,8 +93,9 @@ public class CaptureProcessSchedulerTest {
         long initialDelayInSeconds = 0L;
         long randomIntervalMinimumInSeconds = 10L;
         long randomIntervalMaximumInSeconds = 20L;
+        int schedulerThreads = 1;
 
-        ConnectorConfiguration mockConnectorConfiguration = mockConnectorConfigurationWith(initialDelayInSeconds, randomIntervalMinimumInSeconds, randomIntervalMaximumInSeconds);
+        ConnectorConfiguration mockConnectorConfiguration = mockConnectorConfigurationWith(initialDelayInSeconds, randomIntervalMinimumInSeconds, randomIntervalMaximumInSeconds, schedulerThreads);
 
         CaptureProcessScheduler captureProcessScheduler = new CaptureProcessScheduler(mockConnectorConfiguration, environment, cardCaptureProcess, xrayUtils);
         captureProcessScheduler.start();
@@ -112,8 +111,10 @@ public class CaptureProcessSchedulerTest {
         long initialDelayInSeconds = 0L;
         long randomIntervalMinimumInSeconds = 10L;
         long randomIntervalMaximumInSeconds = 10L;
+        int schedulerThreads = 1;
 
-        ConnectorConfiguration mockConnectorConfiguration = mockConnectorConfigurationWith(initialDelayInSeconds, randomIntervalMinimumInSeconds, randomIntervalMaximumInSeconds);
+        ConnectorConfiguration mockConnectorConfiguration = mockConnectorConfigurationWith(initialDelayInSeconds, randomIntervalMinimumInSeconds,
+                randomIntervalMaximumInSeconds, schedulerThreads);
 
         CaptureProcessScheduler captureProcessScheduler = new CaptureProcessScheduler(mockConnectorConfiguration, environment, cardCaptureProcess, xrayUtils);
         captureProcessScheduler.start();
@@ -132,13 +133,15 @@ public class CaptureProcessSchedulerTest {
         verify(scheduledExecutorService).shutdown();
     }
 
-    private ConnectorConfiguration mockConnectorConfigurationWith(long initialDelayInSeconds, long randomIntervalMinimumInSeconds, long randomIntervalMaximumInSeconds) {
+    private ConnectorConfiguration mockConnectorConfigurationWith(long initialDelayInSeconds, long randomIntervalMinimumInSeconds,
+                                                                  long randomIntervalMaximumInSeconds, int schedulerThreads) {
         ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
         CaptureProcessConfig mockCaptureProcessConfig = mock(CaptureProcessConfig.class);
 
         when(mockCaptureProcessConfig.getSchedulerInitialDelayInSeconds()).thenReturn(initialDelayInSeconds);
         when(mockCaptureProcessConfig.getSchedulerRandomIntervalMinimumInSeconds()).thenReturn(randomIntervalMinimumInSeconds);
         when(mockCaptureProcessConfig.getSchedulerRandomIntervalMaximumInSeconds()).thenReturn(randomIntervalMaximumInSeconds);
+        when(mockCaptureProcessConfig.getSchedulerThreads()).thenReturn(schedulerThreads);
         when(mockConnectorConfiguration.getCaptureProcessConfig()).thenReturn(mockCaptureProcessConfig);
 
         return mockConnectorConfiguration;

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -89,6 +89,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -88,6 +88,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -78,6 +78,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -69,6 +69,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -66,6 +66,7 @@ captureProcessConfig:
   schedulerRandomIntervalMinimumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MINIMUM_SECONDS:-150}
   schedulerRandomIntervalMaximumInSeconds: ${CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS:-200}
   batchSize: 10
+  schedulerThreads: 1
   retryFailuresEvery: 60 minutes
   maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
 


### PR DESCRIPTION
## WHAT
### `Background`

The capture process (captures charges asynchronously in the background) in connector is a single threaded job that takes a number of charges (based on batch size) and captures them one by one. Potential issues with this approach:

1. Multiple connector nodes could potentially end up with overlap of charges being captured.
2. The average response time (live) to capture charges is ~130ms. A batch size of 50 will take ~5 seconds to complete capture. So a single connector capture job scheduled every 10 seconds can only capture ~17k charges/day. Given a high volume of transactions (~1 million/day), capture processes can take weeks to capture charges from a single day and may end up with expiring authorisations.
3. Increasing number of connector nodes doesn't necessarily multiply the number of charges that can be captured as charges can overlap with other connector jobs

### `Solution`

Proposed solution is to introduce a queue (within connector node) and run multi-threaded capture process so that charges can be captured in parallel and quickly. For a batch size of 50 charges and with 10 capture threads we can clear the batch with in ~500ms. It can also likely to mitigate the issue of overlapping charges between connector nodes.

### `Changes`

- CaptureProcessScheduler now schedules multiple threads to capture charges
- Scheduler first loads shared queue (with charges awaiting capture)
- Each thread reads (removes charge from head of the queue - if queue is not empty) a charge from queue to process it further.
        - `ArrayBlockingQueue` is used as a queue which seemed most suitable to use as it is a fixed size queue that can hold charges equivalent to batch size, thread safe and size() method is constant-time operation. Although it is blocking queue, operations used (poll(), isEmpty()) are non blocking. So a thread can exit from operation without being blocked.

**Alternative considered:** 
Considered introducing blocking threads which wait (indefinitely) for charges to be available in queue. But due to the blocking nature all capture related unit tests will become invalid. We need complex test setup to terminate threads / add a mechanism to timeout tests to be able to use queue blocking methods (queue.take()).

