### PR TITLE
bau: add missing config

### DIFF
--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -134,6 +134,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
+  refundIssuedEmailTemplateId: ${NOTIFY_REFUND_ISSUED_EMAIL_TEMPLATE_ID}
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -133,6 +133,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
+  refundIssuedEmailTemplateId: ${NOTIFY_REFUND_ISSUED_EMAIL_TEMPLATE_ID}
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -123,6 +123,7 @@ jpa:
 
 notifyConfig:
   emailTemplateId: test-template-id
+  refundIssuedEmailTemplateId: ${NOTIFY_REFUND_ISSUED_EMAIL_TEMPLATE_ID}
   apiKey: ${NOTIFY_API_KEY:-pay-notify-api-key}
   notificationBaseURL: https://stubs.pymnt.localdomain
   emailNotifyEnabled: false


### PR DESCRIPTION
These missing configs were causing ClientFactoryTest to fail when running all tests in Intellij.

@oswaldquek

