### PR TITLE
PP-4595 Remove unused import not available in Java 11

### DIFF
--- a/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
+++ b/src/test/java/uk/gov/pay/connector/applepay/ApplePayDecrypterTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.applepay;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
The unused import doesn’t seem to trouble Maven much but it causes a build error in IntelliJ IDEA.