### PR TITLE
PP-4598: Upgrade jackson from 2.9.7 to 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
         <wiremock.version>2.20.0</wiremock.version>
         <eclipselink.version>2.7.3</eclipselink.version>
         <guice.version>4.1.0</guice.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <pay-java-commons.version>1.0.0-f6097986677849386f283bb84072198b57931b1b</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>
         <dependency-check.skip>true</dependency-check.skip>


### PR DESCRIPTION
This addresses the following CVEs:

CVE-2018-19360
CVE-2018-19361
CVE-2018-19362

We do not use Jackson in a way that would make us vulnerable