### PR TITLE
PP-4597 Upgrade to latest Pay Java commons version 20190109152842

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <eclipselink.version>2.7.3</eclipselink.version>
         <guice.version>4.1.0</guice.version>
         <jackson.version>2.9.8</jackson.version>
-        <pay-java-commons.version>1.0.0-f6097986677849386f283bb84072198b57931b1b</pay-java-commons.version>
+        <pay-java-commons.version>20190109152842</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>
         <dependency-check.skip>true</dependency-check.skip>
     </properties>
@@ -417,12 +417,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>5.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -13,7 +13,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import uk.gov.pay.commons.model.SupportedLanguage;
-import uk.gov.pay.commons.testing.pact.providers.PayPactRunner;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;


### PR DESCRIPTION
- Upgrade from 1.0.0-f6097986677849386f283bb84072198b57931b1b to 20190109152842
- Remove unused import on class from Pay Java commons that isn’t there any more
- Remove test dependency on mockserver-netty because the latest Pay Java commons testing module now includes it


