### PR TITLE
PP-4597 Use millisecond precision timestamps in API responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 @JsonInclude(Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
@@ -124,7 +125,7 @@ public class ChargeResponse {
 
         @JsonProperty("capture_submit_time")
         public String getCaptureSubmitTime() {
-            return (captureSubmitTime != null) ? DateTimeUtils.toUTCDateTimeString(captureSubmitTime) : null;
+            return (captureSubmitTime != null) ? ISO_INSTANT_MILLISECOND_PRECISION.format(captureSubmitTime) : null;
         }
 
         public void setCapturedTime(ZonedDateTime capturedTime) {

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -15,10 +15,9 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
+import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -39,6 +38,7 @@ import java.util.Optional;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.charge.model.FrontendChargeResponse.aFrontendChargeResponse;
 import static uk.gov.pay.connector.charge.resource.ChargesApiResource.EMAIL_KEY;
 import static uk.gov.pay.connector.common.service.PatchRequestBuilder.aPatchRequestBuilder;
@@ -158,7 +158,7 @@ public class ChargesFrontendResource {
                 .withAmount(charge.getAmount())
                 .withDescription(charge.getDescription())
                 .withGatewayTransactionId(charge.getGatewayTransactionId())
-                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(charge.getCreatedDate()))
+                .withCreatedDate(ISO_INSTANT_MILLISECOND_PRECISION.format(charge.getCreatedDate()))
                 .withReturnUrl(charge.getReturnUrl())
                 .withEmail(charge.getEmail())
                 .withChargeCardDetails(persistedCard)

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -43,7 +43,6 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.UriBuilder;
@@ -61,6 +60,7 @@ import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ABORTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
@@ -199,7 +199,7 @@ public class ChargeService {
                 .withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()))
                 .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
                 .withProviderName(chargeEntity.getGatewayAccount().getGatewayName())
-                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(chargeEntity.getCreatedDate()))
+                .withCreatedDate(ISO_INSTANT_MILLISECOND_PRECISION.format(chargeEntity.getCreatedDate()))
                 .withReturnUrl(chargeEntity.getReturnUrl())
                 .withEmail(chargeEntity.getEmail())
                 .withLanguage(chargeEntity.getLanguage())

--- a/src/main/java/uk/gov/pay/connector/charge/service/TransactionSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/TransactionSearchStrategy.java
@@ -17,13 +17,13 @@ import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.common.service.search.AbstractSearchStrategy;
 import uk.gov.pay.connector.common.service.search.SearchStrategy;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.UriInfo;
 import java.util.List;
 
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.charge.model.TransactionResponse.aTransactionResponseBuilder;
 
 public class TransactionSearchStrategy extends AbstractSearchStrategy<Transaction, ChargeResponse> implements SearchStrategy {
@@ -71,7 +71,7 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
                 .withState(externalTransactionState)
                 .withCardDetails(cardDetails)
                 .withChargeId(transaction.getExternalId())
-                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(transaction.getCreatedDate()))
+                .withCreatedDate(ISO_INSTANT_MILLISECOND_PRECISION.format(transaction.getCreatedDate()))
                 .withDescription(transaction.getDescription())
                 .withReference(transaction.getReference())
                 .withEmail(transaction.getEmail())

--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
@@ -6,9 +6,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.jackson.JsonSnakeCase;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import java.time.ZonedDateTime;
+
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 @JsonSnakeCase
 public class TransactionEvent implements Comparable<TransactionEvent> {
@@ -144,7 +145,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
 
     @JsonProperty("updated")
     public String getUpdated() {
-        return DateTimeUtils.toUTCDateTimeString(updated);
+        return ISO_INSTANT_MILLISECOND_PRECISION.format(updated);
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/pay/connector/refund/model/RefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/RefundResponse.java
@@ -2,10 +2,11 @@ package uk.gov.pay.connector.refund.model;
 
 import black.door.hate.HalRepresentation;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
+
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class RefundResponse extends HalResourceResponse {
 
@@ -31,7 +32,7 @@ public class RefundResponse extends HalResourceResponse {
                 .addProperty("refund_id", refundEntity.getExternalId())
                 .addProperty("amount", refundEntity.getAmount())
                 .addProperty("status", refundEntity.getStatus().toExternal().getStatus())
-                .addProperty("created_date", DateTimeUtils.toUTCDateTimeString(refundEntity.getCreatedDate()))
+                .addProperty("created_date", ISO_INSTANT_MILLISECOND_PRECISION.format(refundEntity.getCreatedDate()))
                 .addProperty("user_external_id", refundEntity.getUserExternalId())
                 .addLink("self", selfLink)
                 .addLink("payment", paymentLink), selfLink);

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundSearchStrategy.java
@@ -1,15 +1,12 @@
 package uk.gov.pay.connector.refund.service;
 
 import uk.gov.pay.connector.charge.dao.SearchParams;
-import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
-import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.common.service.search.AbstractSearchStrategy;
 import uk.gov.pay.connector.common.service.search.BuildResponseStrategy;
 import uk.gov.pay.connector.common.service.search.SearchStrategy;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.SearchRefundsResponse;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
@@ -18,6 +15,7 @@ import java.util.List;
 
 import static java.lang.String.format;
 import static javax.ws.rs.HttpMethod.GET;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.refund.model.SearchRefundsResponse.anAllRefundsResponseBuilder;
 
 public class RefundSearchStrategy extends AbstractSearchStrategy<RefundEntity, SearchRefundsResponse> implements SearchStrategy, BuildResponseStrategy<RefundEntity, SearchRefundsResponse> {
@@ -52,7 +50,7 @@ public class RefundSearchStrategy extends AbstractSearchStrategy<RefundEntity, S
 
         return responseBuilder
                 .withRefundId(externalRefundId)
-                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(refundEntity.getCreatedDate()))
+                .withCreatedDate(ISO_INSTANT_MILLISECOND_PRECISION.format(refundEntity.getCreatedDate()))
                 .withStatus(refundEntity.getStatus().toExternal().getStatus())
                 .withChargeId(externalChargeId)
                 .withAmountSubmitted(refundEntity.getAmount())

--- a/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
@@ -40,21 +40,6 @@ public class DateTimeUtils {
     }
 
     /**
-     * Converts a ZonedDateTime to a UTC ISO_8601 string representation
-     * <p>
-     * e.g. <br/>
-     * 1. ZonedDateTime("2010-01-01T12:00:00+01:00[Europe/Paris]") ==> "2010-12-31T22:59:59.132Z" <br/>
-     * 2. ZonedDateTime("2010-12-31T22:59:59.132Z") ==> "2010-12-31T22:59:59.132Z" <br/>
-     * </p>
-     *
-     * @param dateTime
-     * @return UTC ISO_8601 date string
-     */
-    public static String toUTCDateTimeString(ZonedDateTime dateTime) {
-        return dateTime.format(dateTimeFormatterUTC);
-    }
-
-    /**
      * Converts a LocalDateTime to a UTC ISO_8601 string representation
      * <p>
      * e.g. <br/>

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -32,7 +32,6 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -57,6 +56,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.ChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
@@ -448,7 +448,7 @@ public class ChargeServiceTest {
                 .withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()))
                 .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
                 .withProviderName(chargeEntity.getGatewayAccount().getGatewayName())
-                .withCreatedDate(DateTimeUtils.toUTCDateTimeString(chargeEntity.getCreatedDate()))
+                .withCreatedDate(ISO_INSTANT_MILLISECOND_PRECISION.format(chargeEntity.getCreatedDate()))
                 .withEmail(chargeEntity.getEmail())
                 .withRefunds(refunds)
                 .withSettlement(settlement)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiFilterChargesITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiFilterChargesITest.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.util.List;
@@ -32,6 +31,7 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
@@ -59,8 +59,8 @@ public class ChargesApiFilterChargesITest extends ChargingITestBase {
 
         ValidatableResponse response = connectorRestApiClient
                 .withAccountId(accountId)
-                .withQueryParam("from_date", DateTimeUtils.toUTCDateTimeString(now().minusDays(1)))
-                .withQueryParam("to_date", DateTimeUtils.toUTCDateTimeString(now().plusDays(1)))
+                .withQueryParam("from_date", ISO_INSTANT_MILLISECOND_PRECISION.format(now().minusDays(1)))
+                .withQueryParam("to_date", ISO_INSTANT_MILLISECOND_PRECISION.format(now().plusDays(1)))
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getChargesV1()
                 .statusCode(OK.getStatusCode())

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -274,7 +274,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("results[0].reference", is("My reference"))
                 .body("results[0].return_url", is(RETURN_URL))
                 .body("results[0].description", is(description))
-                .body("results[0].created_date", is("2016-01-26T13:45:32Z"))
+                .body("results[0].created_date", is("2016-01-26T13:45:32.000Z"))
                 .body("results[0].payment_provider", is(PROVIDER_NAME));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
@@ -11,20 +11,18 @@ import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.ws.rs.core.HttpHeaders;
-
 import java.time.ZonedDateTime;
 
 import static com.jayway.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
-import static java.time.ZonedDateTime.now;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -53,8 +51,8 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
         
         String refundExternalId1 = randomAlphanumeric(10);
         String refundExternalId2 = randomAlphanumeric(10);
-        String refundDate1 = "2016-02-03T00:00:00Z";
-        String refundDate2 = "2016-02-02T00:00:00Z";
+        String refundDate1 = "2016-02-03T00:00:00.000Z";
+        String refundDate2 = "2016-02-02T00:00:00.000Z";
         
         databaseTestHelper.addRefund(RandomUtils.nextInt(), refundExternalId1, "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId, ZonedDateTime.parse(refundDate1));
         databaseTestHelper.addRefund(RandomUtils.nextInt(), refundExternalId2, "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId, ZonedDateTime.parse(refundDate2));

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
@@ -334,13 +334,13 @@ public class EpdqRefundITest extends ChargingITestBase {
                 .body("_embedded.refunds[0].refund_id", is(testRefund1.getExternalRefundId()))
                 .body("_embedded.refunds[0].amount", is(10))
                 .body("_embedded.refunds[0].status", is("submitted"))
-                .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00Z"))
+                .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00.000Z"))
                 .body("_embedded.refunds[0]._links.self.href", is(paymentUrl + "/refunds/" + testRefund1.getExternalRefundId()))
                 .body("_embedded.refunds[0]._links.payment.href", is(paymentUrl))
                 .body("_embedded.refunds[1].refund_id", is(testRefund2.getExternalRefundId()))
                 .body("_embedded.refunds[1].amount", is(20))
                 .body("_embedded.refunds[1].status", is("submitted"))
-                .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00Z"))
+                .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00.000Z"))
                 .body("_embedded.refunds[1]._links.self.href", is(paymentUrl + "/refunds/" + testRefund2.getExternalRefundId()))
                 .body("_embedded.refunds[1]._links.payment.href", is(paymentUrl));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
@@ -314,13 +314,13 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 .body("_embedded.refunds[0].refund_id", is(testRefund1.getExternalRefundId()))
                 .body("_embedded.refunds[0].amount", is(10))
                 .body("_embedded.refunds[0].status", is("submitted"))
-                .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00Z"))
+                .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00.000Z"))
                 .body("_embedded.refunds[0]._links.self.href", is(paymentUrl + "/refunds/" + testRefund1.getExternalRefundId()))
                 .body("_embedded.refunds[0]._links.payment.href", is(paymentUrl))
                 .body("_embedded.refunds[1].refund_id", is(testRefund2.getExternalRefundId()))
                 .body("_embedded.refunds[1].amount", is(20))
                 .body("_embedded.refunds[1].status", is("submitted"))
-                .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00Z"))
+                .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00.000Z"))
                 .body("_embedded.refunds[1]._links.self.href", is(paymentUrl + "/refunds/" + testRefund2.getExternalRefundId()))
                 .body("_embedded.refunds[1]._links.payment.href", is(paymentUrl));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
@@ -312,13 +312,13 @@ public class WorldpayRefundITest extends ChargingITestBase {
                 .body("_embedded.refunds[0].refund_id", is(testRefund1.getExternalRefundId()))
                 .body("_embedded.refunds[0].amount", is(10))
                 .body("_embedded.refunds[0].status", is("submitted"))
-                .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00Z"))
+                .body("_embedded.refunds[0].created_date", is("2016-08-01T00:00:00.000Z"))
                 .body("_embedded.refunds[0]._links.self.href", is(paymentUrl + "/refunds/" + testRefund1.getExternalRefundId()))
                 .body("_embedded.refunds[0]._links.payment.href", is(paymentUrl))
                 .body("_embedded.refunds[1].refund_id", is(testRefund2.getExternalRefundId()))
                 .body("_embedded.refunds[1].amount", is(20))
                 .body("_embedded.refunds[1].status", is("submitted"))
-                .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00Z"))
+                .body("_embedded.refunds[1].created_date", is("2016-08-02T00:00:00.000Z"))
                 .body("_embedded.refunds[1]._links.self.href", is(paymentUrl + "/refunds/" + testRefund2.getExternalRefundId()))
                 .body("_embedded.refunds[1]._links.payment.href", is(paymentUrl));
     }

--- a/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
+++ b/src/test/java/uk/gov/pay/connector/matcher/TransactionEventMatcher.java
@@ -3,10 +3,11 @@ package uk.gov.pay.connector.matcher;
 import org.apache.commons.lang.ObjectUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import uk.gov.pay.connector.util.DateTimeUtils;
 
 import java.time.ZonedDateTime;
 import java.util.Map;
+
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 
 public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>> {
 
@@ -52,7 +53,7 @@ public class TransactionEventMatcher extends TypeSafeMatcher<Map<String, Object>
         this.type = type;
         this.state = state;
         this.amount = amount;
-        this.updated = DateTimeUtils.toUTCDateTimeString(updated);
+        this.updated = ISO_INSTANT_MILLISECOND_PRECISION.format(updated);
         this.refundReference = refundReference;
         this.refundSubmittedBy = submittedBy;
     }

--- a/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
@@ -2,7 +2,11 @@ package uk.gov.pay.connector.util;
 
 import org.junit.Test;
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
@@ -11,22 +15,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DateTimeUtilsTest {
-
-    @Test
-    public void shouldConvertUTCZonedDateTimeToAISO_8601_UTCString() throws Exception {
-        ZonedDateTime localDateTime = ZonedDateTime.of(2010, 11, 13, 12, 0, 0, 0, ZoneId.of("Z"));
-
-        String dateString = DateTimeUtils.toUTCDateTimeString(localDateTime);
-        assertThat(dateString, is("2010-11-13T12:00:00Z"));
-    }
-
-    @Test
-    public void shouldConvertNonUTCZonedDateTimeToAISO_8601_UTCString() throws Exception {
-        ZonedDateTime localDateTime = ZonedDateTime.of(2010, 11, 13, 12, 0, 0, 0, ZoneId.of("Europe/Paris"));
-
-        String dateString = DateTimeUtils.toUTCDateTimeString(localDateTime);
-        assertThat(dateString, is("2010-11-13T11:00:00Z"));
-    }
 
     @Test
     public void shouldConvertUTCZonedISO_8601StringToADateTime() throws Exception {


### PR DESCRIPTION
We use `DateTimeFormatter.ISO_INSTANT.withZone(UTC)` to format a lot of the timestamps we put in API responses, which produces strings like `"2015-10-21T07:28:00.123Z"`. The fractional part, if present, will have either three, six or nine digits, depending on the precision available.

When one asks Java 8 for the current time, it always returns the time with millisecond precision, even if the underlying system clock can do better. Java 9 and above don’t have this limitation
and will return higher accuracy if the system clock offers it (see https://bugs.openjdk.java.net/browse/JDK-8068730 for details). On Linux and macOS, this usually means microsecond precision.

Therefore, when `DateTimeFormatter.ISO_INSTANT.withZone(UTC)` is used to format the current time on Java 8, the resulting string has three digits after the decimal point. When it’s used on Java 9 on Linux or macOS, it will have six digits. This means that the timestamps we put into API responses — many of which are the current time or a stored past current time — may vary depending on the Java version.

Eliminate this difference by introducing a `DateTimeFormatter` that always uses millisecond precision. If this `DateTimeFormatter` is used throughout the system, then there will be no change to the timestamps in our API responses when we upgrade to Java 11.

Note that this new `DateTimeFormatter` has one slight behaviour change: if `DateTimeFormatter.ISO_INSTANT.withZone(UTC)` is asked to format a time that’s exactly on the second, it will not include a fractional component (e.g. `"2015-10-21T07:28:00Z"`). The new `DateTimeFormatter` always includes a fractional component (e.g. `"2015-10-21T07:28:00.000Z"`). This actually makes things more consistent, so we’re happy with this change.