### PR TITLE
Silence liquibase noise during tests

### DIFF
--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -8,13 +8,16 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-    level: WARN
-    appenders:
-      - type: console
-        threshold: ALL
-        timeZone: UTC
-        target: stdout
-        logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+  level: WARN
+  appenders:
+    - type: console
+      threshold: ALL
+      timeZone: UTC
+      target: stdout
+      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%thread] %highlight(%-5level) %cyan(%logger{15}) [requestID=%X{X-Request-Id}] - %msg %n"
+  loggers:
+    # Liquibase is very chatty and we only want to hear from it if things go wrong
+    "liquibase": WARN
 
 links:
   frontendUrl: http://Frontend/


### PR DESCRIPTION
Downgrade the logging level of liquibase during test runs. Liquibase logs all
its SQL which clutters the build log.

