### PR TITLE
PP-4606 Support live and test webhooks for stripe

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -17,7 +17,7 @@ public class StripeGatewayConfig extends Configuration {
 
     @Valid
     @NotNull
-    private String webhookSigningSecret;
+    private StripeWebhookSigningSecrets webhookSigningSecrets;
 
     public String getUrl() {
         return url;
@@ -27,7 +27,7 @@ public class StripeGatewayConfig extends Configuration {
         return authTokens;
     }
 
-    public String getWebhookSigningSecret() {
-        return webhookSigningSecret;
+    public StripeWebhookSigningSecrets getWebhookSigningSecrets() {
+        return webhookSigningSecrets;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/StripeWebhookSigningSecrets.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeWebhookSigningSecrets.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.app;
+
+import io.dropwizard.Configuration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class StripeWebhookSigningSecrets extends Configuration {
+
+    @Valid
+    @NotNull
+    private String test;
+
+    @Valid
+    private String live;
+
+    public String getTest() {
+        return test;
+    }
+
+    public String getLive() {
+        return live;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -18,7 +18,7 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
 import java.util.HashMap;
-import java.util.Map;
+import java.util.Map;   
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -171,13 +171,22 @@ public class StripeNotificationService {
     }
 
     private boolean isValidNotificationSignature(String payload, String signatureHeader) {
+        if (isValidNotificationSignature(payload, signatureHeader, stripeGatewayConfig.getWebhookSigningSecrets().getTest()) || 
+                isValidNotificationSignature(payload, signatureHeader, stripeGatewayConfig.getWebhookSigningSecrets().getLive())) {
+            return true;
+        } else {
+            logger.warn("Could not verify Stripe authentication header");
+            return false;
+        }
+    }
+    
+    private boolean isValidNotificationSignature(String payload, String signatureHeader, String secret) {
         try {
             return Webhook.Signature.verifyHeader(payload,
                     signatureHeader,
-                    stripeGatewayConfig.getWebhookSigningSecret(),
+                    secret,
                     DEFAULT_TOLERANCE);
         } catch (SignatureVerificationException e) {
-            logger.error("Exception [{}] for signature header - {}", e.getMessage(), e.getSigHeader());
             return false;
         }
     }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -79,7 +79,9 @@ stripe:
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
-  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
+  webhookSigningSecrets:
+      test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+      live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceITest.java
@@ -164,7 +164,7 @@ public class StripeNotificationResourceITest {
 
     private Response notifyConnector(String payload) {
         return notifyConnectorWithHeader(payload, StripeNotificationUtilTest.generateSigHeader(
-                "whsec", payload));
+                "whtest", payload));
     }
 
     private static String sampleStripeNotification(String location,

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -63,8 +63,9 @@ stripe:
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
-  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
-
+  webhookSigningSecrets:
+      test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+      live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -62,8 +62,9 @@ stripe:
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
-  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
-
+  webhookSigningSecrets:
+      test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+      live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -52,7 +52,9 @@ stripe:
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
-  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
+  webhookSigningSecrets:
+      test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+      live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -58,7 +58,9 @@ stripe:
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
-  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
+  webhookSigningSecrets:
+      test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+      live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -55,7 +55,9 @@ stripe:
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN:-sk_live}
-  webhookSigningSecret: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whsec}
+  webhookSigningSecrets:
+    test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+    live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}


### PR DESCRIPTION
Stripe will use a different webhook secret depending on whether it is a test
or live account, so we need to support that. I have used the same approach
as with api keys.