### PR TITLE
PP-4595 Remove assertion that charges stored to millisec precision

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -910,8 +910,6 @@ public class ChargeDaoITest extends DaoITestBase {
         chargeDao.persist(chargeEntity);
 
         assertThat(chargeEntity.getId(), is(notNullValue()));
-        // Ensure always max precision is being millis
-        assertThat(chargeEntity.getCreatedDate().getNano() % 1000000, is(0));
     }
 
     @Test


### PR DESCRIPTION
Remove an assertion from a test that the created time of a new charge is stored with only millisecond precision. The created time for a charge is the current time. In Java 8, this time is provided with millisecond precision, even if the underlying system clock can do better. Java 9 and above does not have this limitation (see https://bugs.openjdk.java.net/browse/JDK-8068730 for details), which means that the created time for charges will be stored with greater precision.

This means that the assertion fails under Java 11.

However, this doesn’t indicate a real problem. There’s no reason to turn down greater precision if it’s available. Previously, the concern was that it would alter the timestamps in our API responses but we now always output these with millisecond precision (see commit afc224935ee7d00c6aab7b8b49e33bb1bb69398b from PP-4597), so no-one outside of connector (and its database) will observe a difference when we move to a newer Java version.