### PR TITLE
PP-4437 Stripe - 3DS options

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
@@ -2,9 +2,14 @@ package uk.gov.pay.connector.gateway.stripe.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripeSourcesResponse {
+
+    private List<String> threeDSecureRequiredOptions = ImmutableList.of("required", "recommended", "optional");
 
     @JsonProperty("id")
     private String id;
@@ -21,7 +26,7 @@ public class StripeSourcesResponse {
     }
 
     public boolean require3ds() {
-        return card != null && "required".equals(card.getThreeDSecure());
+        return card != null && threeDSecureRequiredOptions.contains(card.getThreeDSecure());
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -75,7 +75,8 @@ public class StripeMockClient {
     }
 
     public void mockCreateSourceWithThreeDSecureRequired() {
-        String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE);
+        String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE)
+                .replace("{{three_d_secure_option}}","required");
         setupResponse(payload, "/v1/sources", 200);
     }
 

--- a/src/test/resources/templates/stripe/create_sources_3ds_required_response.json
+++ b/src/test/resources/templates/stripe/create_sources_3ds_required_response.json
@@ -3,7 +3,7 @@
   "object": "source",
   "amount": null,
   "card": {
-    "three_d_secure": "required"
+    "three_d_secure": "{{three_d_secure_option}}"
   },
   "client_secret": "src_client_secret_Dz9E1oktM2D04med4z8Il4Df",
   "currency": null,


### PR DESCRIPTION
## WHAT

Enable 3DS journey for payments (using Stripe as payment provider) whenever it is possible to do so. Currently, 3DS authentication is only performed if Stripe says it is `required` (based on 3DS Source response from Stripe). This change enables 3DS authentication when it is also `recommended` / `optional`.

