### PR TITLE
PP-4627 upgrade dropwizard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>pay-connector</artifactId>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>1.3.5</dropwizard.version>
+        <dropwizard.version>1.3.8</dropwizard.version>
         <wiremock.version>2.20.0</wiremock.version>
         <eclipselink.version>2.7.3</eclipselink.version>
         <guice.version>4.1.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-graphite</artifactId>
-            <version>3.1.2</version>
+            <version>4.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## WHAT
Upgrade dropwizard from 1.3.5 -> 1.3.8

Release notes: https://www.dropwizard.io/1.3.8/docs/about/release-notes.html

1.3.6 fixes a DoS issue in Jackson:
      https://github.com/FasterXML/jackson-databind/issues/2141

1.3.7 fixes incorrect reading of somaxconn on Linux:
      https://github.com/dropwizard/dropwizard/pull/2430

1.3.8 upgrades Guava to fix a DoS (CVE-2018-10237)

Also, upgrade dropwizard-metrics 3.1.2 -> 4.0.5

