### PR TITLE
BAU_clean_up_raw_generic_use

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -13,7 +13,6 @@ import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeEx
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
-import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 
@@ -39,7 +38,7 @@ public class CardAuthoriseBaseService {
 
  
     public <T> T executeAuthorise(String chargeId, Supplier<T> authorisationSupplier) {
-        Pair<ExecutionStatus, T> executeResult = (Pair<ExecutionStatus, T>) cardExecutorService.execute(authorisationSupplier);
+        Pair<ExecutionStatus, T> executeResult = cardExecutorService.execute(authorisationSupplier);
 
         switch (executeResult.getLeft()) {
             case COMPLETED:

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardExecutorService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardExecutorService.java
@@ -34,7 +34,7 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
  * catches the timeout exception and returns to frontend as 'in progress'. Frontend then polls connector until the 
  * charge is authorised (by the CES thread), and continues on its merry way.
  */
-public class CardExecutorService<T> {
+public class CardExecutorService {
 
     private static final Logger logger = LoggerFactory.getLogger(CardExecutorService.class);
     private static final int QUEUE_WAIT_WARN_THRESHOLD_MILLIS = 10000;
@@ -88,7 +88,7 @@ public class CardExecutorService<T> {
 
     // accepts a supplier function and executed that in a separate Thread of its own.
     // returns a Pair of the execution status and the return type
-    public Pair<ExecutionStatus, T> execute(Supplier<T> callable) {
+    public <T> Pair<ExecutionStatus, T> execute(Supplier<T> callable) {
         Callable<T> task = callable::get;
         final long startTime = System.currentTimeMillis();
 


### PR DESCRIPTION
- `CardExecutorService` needn't be a generic class since the parameter is only
used within `CardExecutorService.execute()`. At present this class is being used
as a raw generic in multiple places which presents compile and IDE
warnings. Also since the type isn't being specified the result of `.execute()`
is being cast which present a `unchecked cast warning`. To simplify the class
and its use, this makes `.execute()` a generic method and removes the generic
typing at the class level.

## WHAT
Little bit of tidy up.
