### PR TITLE
PP-4650 Add GooglePayAuthRequest Type

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
@@ -1,0 +1,145 @@
+package uk.gov.pay.connector.wallets.googlepay.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public class GooglePayAuthRequest {
+
+    @NotNull @Valid private final WalletPaymentInfo paymentInfo;
+    @NotNull @Valid private final EncryptedPaymentData encryptedPaymentData;
+
+    GooglePayAuthRequest(@JsonProperty("payment_info") WalletPaymentInfo paymentInfo,
+                         @JsonProperty("encrypted_payment_data") EncryptedPaymentData encryptedPaymentData) {
+        this.paymentInfo = paymentInfo;
+        this.encryptedPaymentData = encryptedPaymentData;
+    }
+
+    public WalletPaymentInfo getPaymentInfo() {
+        return paymentInfo;
+    }
+
+    public EncryptedPaymentData getEncryptedPaymentData() {
+        return encryptedPaymentData;
+    }
+
+
+    public static class EncryptedPaymentData {
+        @NotNull @Valid private final SignedMessage signedMessage;
+        @NotNull @Valid private final IntermediateSigningKey intermediateSigningKey;
+        @NotNull @Valid private final Token token;
+        @NotEmpty private final String type;
+        @NotEmpty private final String protocolVersion;
+
+        public EncryptedPaymentData(@JsonProperty("signedMessage") SignedMessage signedMessage,
+                                    @JsonProperty("intermediateSigningKey") IntermediateSigningKey intermediateSigningKey,
+                                    @JsonProperty("token") Token token,
+                                    @JsonProperty("type") String type,
+                                    @JsonProperty("protocolVersion") String protocolVersion) {
+            this.signedMessage = signedMessage;
+            this.intermediateSigningKey = intermediateSigningKey;
+            this.token = token;
+            this.type = type;
+            this.protocolVersion = protocolVersion;
+        }
+
+        public SignedMessage getSignedMessage() {
+            return signedMessage;
+        }
+
+        public IntermediateSigningKey getIntermediateSigningKey() {
+            return intermediateSigningKey;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getProtocolVersion() {
+            return protocolVersion;
+        }
+
+        public Token getToken() {
+            return token;
+        }
+
+        public static class SignedMessage {
+            @NotEmpty private final String encryptedMessage;
+            @NotEmpty private final String ephemeralPublicKey;
+            @NotEmpty private final String tag;
+
+            public SignedMessage(@JsonProperty("encryptedMessage") String encryptedMessage,
+                                 @JsonProperty("ephemeralPublicKey") String ephemeralPublicKey,
+                                 @JsonProperty("tag") String tag) {
+                this.encryptedMessage = encryptedMessage;
+                this.ephemeralPublicKey = ephemeralPublicKey;
+                this.tag = tag;
+            }
+
+            public String getEncryptedMessage() {
+                return encryptedMessage;
+            }
+
+            public String getEphemeralPublicKey() {
+                return ephemeralPublicKey;
+            }
+
+            public String getTag() {
+                return tag;
+            }
+        }
+
+        public static class IntermediateSigningKey {
+            @NotNull @Valid private final SignedKey signedKey;
+            @NotEmpty private final String[] signatures;
+
+            public IntermediateSigningKey(@JsonProperty("signedKey") SignedKey signedKey,
+                                          @JsonProperty("signatures") String[] signatures) {
+                this.signedKey = signedKey;
+                this.signatures = signatures;
+            }
+
+            public SignedKey getSignedKey() {
+                return signedKey;
+            }
+
+            public String[] getSignatures() {
+                return signatures;
+            }
+
+            public static class SignedKey {
+                @NotEmpty private final String key;
+                @NotEmpty private final String expirationDate;
+
+                public SignedKey(@JsonProperty("keyValue") String key,
+                                 @JsonProperty("keyExpiration") String expirationDate) {
+                    this.key = key;
+                    this.expirationDate = expirationDate;
+                }
+
+                public String getKey() {
+                    return key;
+                }
+
+                public String getExpirationDate() {
+                    return expirationDate;
+                }
+            }
+        }
+
+        public static class Token {
+            @NotEmpty private final String signature;
+
+            public Token(@JsonProperty("signature") String signature) {
+                this.signature = signature;
+            }
+
+            public String getSignature() {
+                return signature;
+            }
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.connector.wallets.googlepay.api;
+
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.io.IOException;
+import java.util.Set;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class GooglePayAuthRequestTest {
+
+
+    @Test
+    public void shouldDeserializeFromJsonCorrectly() throws IOException {
+        ObjectMapper objectMapper = Jackson.getObjectMapper();
+        
+        JsonNode expected = objectMapper.readTree(fixture("googlepay/exampleAuthRequest.json"));
+        GooglePayAuthRequest actual = objectMapper.readValue(
+                fixture("googlepay/exampleAuthRequest.json"), GooglePayAuthRequest.class);
+
+        JsonNode paymentInfo = expected.get("payment_info");
+        assertThat(actual.getPaymentInfo().getCardholderName(), is(paymentInfo.get("cardholder_name").asText()));
+        assertThat(actual.getPaymentInfo().getLastDigitsCardNumber(), is(paymentInfo.get("last_digits_card_number").asText()));
+        assertThat(actual.getPaymentInfo().getBrand(), is(paymentInfo.get("brand").asText()));
+        assertThat(actual.getPaymentInfo().getCardType().toString(), is(paymentInfo.get("card_type").asText()));
+        assertThat(actual.getPaymentInfo().getEmail(), is(paymentInfo.get("email").asText()));
+
+        JsonNode encryptedPaymentData = expected.get("encrypted_payment_data");
+        assertThat(actual.getEncryptedPaymentData().getType(), is(encryptedPaymentData.get("type").asText()));
+        assertThat(actual.getEncryptedPaymentData().getProtocolVersion(), is(encryptedPaymentData.get("protocolVersion").asText()));
+
+        JsonNode signedMessage = encryptedPaymentData.get("signedMessage");
+        assertThat(actual.getEncryptedPaymentData().getSignedMessage().getEncryptedMessage(), is(signedMessage.get("encryptedMessage").asText()));
+        assertThat(actual.getEncryptedPaymentData().getSignedMessage().getEphemeralPublicKey(), is(signedMessage.get("ephemeralPublicKey").asText()));
+        assertThat(actual.getEncryptedPaymentData().getSignedMessage().getTag(), is(signedMessage.get("tag").asText()));
+
+        JsonNode intermediateSigningKey = encryptedPaymentData.get("intermediateSigningKey");
+        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignatures().length, is(intermediateSigningKey.get("signatures").size()));
+        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignatures()[0], is(intermediateSigningKey.get("signatures").get(0).asText()));
+
+        JsonNode signedKey = intermediateSigningKey.get("signedKey");
+        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignedKey().getExpirationDate(), is(signedKey.get("keyExpiration").asText()));
+        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignedKey().getKey(), is(signedKey.get("keyValue").asText()));
+
+        JsonNode token = encryptedPaymentData.get("token");
+        assertThat(actual.getEncryptedPaymentData().getToken().getSignature(), is(token.get("signature").asText()));
+    }
+
+    @Test
+    public void shouldPassValidation() throws IOException {
+        GooglePayAuthRequest valid = Jackson.getObjectMapper()
+                .readValue(fixture("googlepay/exampleAuthRequest.json"), GooglePayAuthRequest.class);
+        
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        Set<ConstraintViolation<GooglePayAuthRequest>> errors = validator.validate(valid);
+        assertThat(errors.size(), is(0));
+    }
+}

--- a/src/test/resources/googlepay/exampleAuthRequest.json
+++ b/src/test/resources/googlepay/exampleAuthRequest.json
@@ -1,0 +1,30 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "1234",
+    "brand": "visa",
+    "card_type": "DEBIT",
+    "cardholder_name": "Example Name",
+    "email": "example@test.example"
+  },
+  "encrypted_payment_data": {
+    "type": "DIRECT",
+    "token": {
+      "signature": "aSignature"
+    },
+    "intermediateSigningKey": {
+      "signedKey": {
+        "keyValue": "aKey",
+        "keyExpiration": "anExpiration"
+      },
+      "signatures": [
+        "aSignature"
+      ]
+    },
+    "protocolVersion": "ECv2",
+    "signedMessage": {
+      "encryptedMessage": "aMessage",
+      "ephemeralPublicKey": "aPublicKey",
+      "tag": "aTag"
+    }
+  }
+}


### PR DESCRIPTION
- Add GooglepayAuthRequest class, test and sample json payload.

## WHAT ##
New GoolepayAuthRequest class to permit deserialisation and validation of Googlepay authorisation payload from Frontend. As suggested by Oz the unit test of the deserialisation may become obsolete when the end-point and it's integration tests are added (should that happen then the tests included here can be removed).


