### PR TITLE
PP-4650 Add authorisation endpoint for googlepay.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.paymentprocessor.resource;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.wallets.applepay.ApplePayService;
 import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
 import uk.gov.pay.connector.charge.service.ChargeCancelService;
@@ -16,8 +17,11 @@ import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureService;
 import uk.gov.pay.connector.util.ResponseUtil;
+import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -59,6 +63,17 @@ public class CardResource {
     public Response authoriseCharge(@PathParam("chargeId") String chargeId, ApplePayAuthRequest applePayAuthRequest) {
         logger.info("Received encrypted payload for charge with id {} ", chargeId);
         return applePayService.authorise(chargeId, applePayAuthRequest);
+    }
+
+    @POST
+    @Path("/v1/frontend/charges/{chargeId}/wallets/google")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
+    public Response authoriseCharge(@PathParam("chargeId") String chargeId,
+                                    @NotNull @Valid GooglePayAuthRequest googlePayAuthRequest) {
+        logger.info("Received encrypted payload for charge with id {} ", chargeId);
+        //TODO implement service logic.
+        return Response.ok().entity(ImmutableMap.of("status", ChargeStatus.AUTHORISATION_SUCCESS.toString())).build();
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
@@ -10,8 +10,12 @@ public class EncryptedPaymentData {
     @NotNull @Valid private final SignedMessage signedMessage;
     @NotNull @Valid private final IntermediateSigningKey intermediateSigningKey;
     @NotNull @Valid private final Token token;
-    @NotEmpty private final String type;
-    @NotEmpty private final String protocolVersion;
+    
+    @NotEmpty(message= "Field [type] must not be empty")
+    private final String type;
+    
+    @NotEmpty(message= "Field [protocolVersion] must not be empty")
+    private final String protocolVersion;
 
     public EncryptedPaymentData(@JsonProperty("signedMessage") SignedMessage signedMessage,
                                 @JsonProperty("intermediateSigningKey") IntermediateSigningKey intermediateSigningKey,
@@ -46,9 +50,14 @@ public class EncryptedPaymentData {
     }
 
     public static class SignedMessage {
-        @NotEmpty private final String encryptedMessage;
-        @NotEmpty private final String ephemeralPublicKey;
-        @NotEmpty private final String tag;
+        @NotEmpty(message= "Field [encryptedMessage] must not be empty")
+        private final String encryptedMessage;
+        
+        @NotEmpty(message= "Field [ephemeralPublicKey] must not be empty")
+        private final String ephemeralPublicKey;
+        
+        @NotEmpty(message= "Field [tag] must not be empty")
+        private final String tag;
 
         public SignedMessage(@JsonProperty("encryptedMessage") String encryptedMessage,
                              @JsonProperty("ephemeralPublicKey") String ephemeralPublicKey,
@@ -72,8 +81,11 @@ public class EncryptedPaymentData {
     }
 
     public static class IntermediateSigningKey {
+        
         @NotNull @Valid private final IntermediateSigningKey.SignedKey signedKey;
-        @NotEmpty private final String[] signatures;
+        
+        @NotEmpty(message= "Field [signatures] must not be empty") 
+        private final String[] signatures;
 
         public IntermediateSigningKey(@JsonProperty("signedKey") IntermediateSigningKey.SignedKey signedKey,
                                       @JsonProperty("signatures") String[] signatures) {
@@ -90,8 +102,12 @@ public class EncryptedPaymentData {
         }
 
         public static class SignedKey {
-            @NotEmpty private final String key;
-            @NotEmpty private final String expirationDate;
+            
+            @NotEmpty(message= "Field [keyValue] must not be empty")
+            private final String key;
+            
+            @NotEmpty(message= "Field [keyExpiration] must not be empty") 
+            private final String expirationDate;
 
             public SignedKey(@JsonProperty("keyValue") String key,
                              @JsonProperty("keyExpiration") String expirationDate) {
@@ -110,7 +126,9 @@ public class EncryptedPaymentData {
     }
 
     public static class Token {
-        @NotEmpty private final String signature;
+        
+        @NotEmpty(message= "Field [signature] must not be empty")
+        private final String signature;
 
         public Token(@JsonProperty("signature") String signature) {
             this.signature = signature;

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -231,6 +231,10 @@ public class ChargingITestBase {
     public static String authoriseChargeUrlForApplePay(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/wallets/apple".replace("{chargeId}", chargeId);
     }
+
+    public static String authoriseChargeUrlForGooglePay(String chargeId) {
+        return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
+    }
     
     public static String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -5,11 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
 import java.io.IOException;
-import java.util.Set;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.CoreMatchers.is;
@@ -52,15 +48,5 @@ public class GooglePayAuthRequestTest {
 
         JsonNode token = encryptedPaymentData.get("token");
         assertThat(actual.getEncryptedPaymentData().getToken().getSignature(), is(token.get("signature").asText()));
-    }
-
-    @Test
-    public void shouldPassValidation() throws IOException {
-        GooglePayAuthRequest valid = Jackson.getObjectMapper()
-                .readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
-        
-        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-        Set<ConstraintViolation<GooglePayAuthRequest>> errors = validator.validate(valid);
-        assertThat(errors.size(), is(0));
     }
 }

--- a/src/test/resources/googlepay/invalid-empty-signature-auth-request.json
+++ b/src/test/resources/googlepay/invalid-empty-signature-auth-request.json
@@ -1,0 +1,30 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "1234",
+    "brand": "visa",
+    "card_type": "DEBIT",
+    "cardholder_name": "Example Name",
+    "email": "example@test.example"
+  },
+  "encrypted_payment_data": {
+    "type": "DIRECT",
+    "token": {
+      "signature": ""
+    },
+    "intermediateSigningKey": {
+      "signedKey": {
+        "keyValue": "aKey",
+        "keyExpiration": "anExpiration"
+      },
+      "signatures": [
+        "aSignature"
+      ]
+    },
+    "protocolVersion": "ECv2",
+    "signedMessage": {
+      "encryptedMessage": "aMessage",
+      "ephemeralPublicKey": "aPublicKey",
+      "tag": "aTag"
+    }
+  }
+}


### PR DESCRIPTION
- Add endpoint for authorising googlepay request at `/v1/frontend/charges/
{chargeId}/wallets/google`.
- Default response of new end-point to authorisation success whilst authorisation
flow remains a WIP.
- Add validation error messages to `EncryptedPaymentData`
- Add basic success and validation error message tests for new end-point.
- Remove validation test from `GooglePayAuthRequestTest` since it is duplicated
by the validation test at the Resource level.

## WHAT
Initial implementation of new end-point for googlepay authorisation. Since it defaults the response to Authorisation Success this PR includes basic test for Worldpay to permit some assurance that the validation of payload works as expected. As the authorisation service is developed then more detailed `CardResourceITests` should be added, including for other providers.

I looked at improving the default validation error messages to avoid having to annotate each validation with a message eg. `@NotEmpty(message= "Field [encryptedMessage] must not be empty")`. It appears possible but doing it in a manner which honours existing explicitly set messages, or refactors them away to use such a default felt more involved than warranted for inclusion in this PR. I'll look at it again separately and for now follow the pattern of setting the message on each annotation.


