### PR TITLE
PP-4650 Update GooglepayAuthRequest for non decryption.

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
@@ -3,139 +3,33 @@ package uk.gov.pay.connector.wallets.googlepay.api;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotEmpty;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 public class EncryptedPaymentData {
-    @NotNull @Valid private final SignedMessage signedMessage;
-    @NotNull @Valid private final IntermediateSigningKey intermediateSigningKey;
-    @NotNull @Valid private final Token token;
+    @NotEmpty(message= "Field [signed_message] must not be empty")
+    private final String signedMessage;
     
-    @NotEmpty(message= "Field [type] must not be empty")
-    private final String type;
-    
-    @NotEmpty(message= "Field [protocolVersion] must not be empty")
+    @NotEmpty(message= "Field [protocol_version] must not be empty")
     private final String protocolVersion;
 
-    public EncryptedPaymentData(@JsonProperty("signedMessage") SignedMessage signedMessage,
-                                @JsonProperty("intermediateSigningKey") IntermediateSigningKey intermediateSigningKey,
-                                @JsonProperty("token") Token token,
-                                @JsonProperty("type") String type,
-                                @JsonProperty("protocolVersion") String protocolVersion) {
+    @NotEmpty(message= "Field [signature] must not be empty")
+    private final String signature;
+
+    public EncryptedPaymentData(@JsonProperty("signed_message") String signedMessage,
+                                @JsonProperty("protocol_version") String protocolVersion,
+                                @JsonProperty("signature") String signature) {
         this.signedMessage = signedMessage;
-        this.intermediateSigningKey = intermediateSigningKey;
-        this.token = token;
-        this.type = type;
         this.protocolVersion = protocolVersion;
+        this.signature = signature;
     }
 
-    public SignedMessage getSignedMessage() {
+    public String getSignedMessage() {
         return signedMessage;
-    }
-
-    public IntermediateSigningKey getIntermediateSigningKey() {
-        return intermediateSigningKey;
-    }
-
-    public String getType() {
-        return type;
     }
 
     public String getProtocolVersion() {
         return protocolVersion;
     }
 
-    public Token getToken() {
-        return token;
-    }
-
-    public static class SignedMessage {
-        @NotEmpty(message= "Field [encryptedMessage] must not be empty")
-        private final String encryptedMessage;
-        
-        @NotEmpty(message= "Field [ephemeralPublicKey] must not be empty")
-        private final String ephemeralPublicKey;
-        
-        @NotEmpty(message= "Field [tag] must not be empty")
-        private final String tag;
-
-        public SignedMessage(@JsonProperty("encryptedMessage") String encryptedMessage,
-                             @JsonProperty("ephemeralPublicKey") String ephemeralPublicKey,
-                             @JsonProperty("tag") String tag) {
-            this.encryptedMessage = encryptedMessage;
-            this.ephemeralPublicKey = ephemeralPublicKey;
-            this.tag = tag;
-        }
-
-        public String getEncryptedMessage() {
-            return encryptedMessage;
-        }
-
-        public String getEphemeralPublicKey() {
-            return ephemeralPublicKey;
-        }
-
-        public String getTag() {
-            return tag;
-        }
-    }
-
-    public static class IntermediateSigningKey {
-        
-        @NotNull @Valid private final IntermediateSigningKey.SignedKey signedKey;
-        
-        @NotEmpty(message= "Field [signatures] must not be empty") 
-        private final String[] signatures;
-
-        public IntermediateSigningKey(@JsonProperty("signedKey") IntermediateSigningKey.SignedKey signedKey,
-                                      @JsonProperty("signatures") String[] signatures) {
-            this.signedKey = signedKey;
-            this.signatures = signatures;
-        }
-
-        public IntermediateSigningKey.SignedKey getSignedKey() {
-            return signedKey;
-        }
-
-        public String[] getSignatures() {
-            return signatures;
-        }
-
-        public static class SignedKey {
-            
-            @NotEmpty(message= "Field [keyValue] must not be empty")
-            private final String key;
-            
-            @NotEmpty(message= "Field [keyExpiration] must not be empty") 
-            private final String expirationDate;
-
-            public SignedKey(@JsonProperty("keyValue") String key,
-                             @JsonProperty("keyExpiration") String expirationDate) {
-                this.key = key;
-                this.expirationDate = expirationDate;
-            }
-
-            public String getKey() {
-                return key;
-            }
-
-            public String getExpirationDate() {
-                return expirationDate;
-            }
-        }
-    }
-
-    public static class Token {
-        
-        @NotEmpty(message= "Field [signature] must not be empty")
-        private final String signature;
-
-        public Token(@JsonProperty("signature") String signature) {
-            this.signature = signature;
-        }
-
-        public String getSignature() {
-            return signature;
-        }
+    public String getSignature() {
+        return signature;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -30,23 +30,9 @@ public class GooglePayAuthRequestTest {
         assertThat(actual.getPaymentInfo().getEmail(), is(paymentInfo.get("email").asText()));
 
         JsonNode encryptedPaymentData = expected.get("encrypted_payment_data");
-        assertThat(actual.getEncryptedPaymentData().getType(), is(encryptedPaymentData.get("type").asText()));
-        assertThat(actual.getEncryptedPaymentData().getProtocolVersion(), is(encryptedPaymentData.get("protocolVersion").asText()));
-
-        JsonNode signedMessage = encryptedPaymentData.get("signedMessage");
-        assertThat(actual.getEncryptedPaymentData().getSignedMessage().getEncryptedMessage(), is(signedMessage.get("encryptedMessage").asText()));
-        assertThat(actual.getEncryptedPaymentData().getSignedMessage().getEphemeralPublicKey(), is(signedMessage.get("ephemeralPublicKey").asText()));
-        assertThat(actual.getEncryptedPaymentData().getSignedMessage().getTag(), is(signedMessage.get("tag").asText()));
-
-        JsonNode intermediateSigningKey = encryptedPaymentData.get("intermediateSigningKey");
-        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignatures().length, is(intermediateSigningKey.get("signatures").size()));
-        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignatures()[0], is(intermediateSigningKey.get("signatures").get(0).asText()));
-
-        JsonNode signedKey = intermediateSigningKey.get("signedKey");
-        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignedKey().getExpirationDate(), is(signedKey.get("keyExpiration").asText()));
-        assertThat(actual.getEncryptedPaymentData().getIntermediateSigningKey().getSignedKey().getKey(), is(signedKey.get("keyValue").asText()));
-
-        JsonNode token = encryptedPaymentData.get("token");
-        assertThat(actual.getEncryptedPaymentData().getToken().getSignature(), is(token.get("signature").asText()));
+        assertThat(actual.getEncryptedPaymentData().getSignature(), is(encryptedPaymentData.get("signature").asText()));
+        assertThat(actual.getEncryptedPaymentData().getProtocolVersion(), is(encryptedPaymentData.get("protocol_version").asText()));
+        assertThat(actual.getEncryptedPaymentData().getSignedMessage(), is(encryptedPaymentData.get("signed_message").asText()));
+        
     }
 }

--- a/src/test/resources/googlepay/example-auth-request.json
+++ b/src/test/resources/googlepay/example-auth-request.json
@@ -7,24 +7,8 @@
     "email": "example@test.example"
   },
   "encrypted_payment_data": {
-    "type": "DIRECT",
-    "token": {
-      "signature": "aSignature"
-    },
-    "intermediateSigningKey": {
-      "signedKey": {
-        "keyValue": "aKey",
-        "keyExpiration": "anExpiration"
-      },
-      "signatures": [
-        "aSignature"
-      ]
-    },
-    "protocolVersion": "ECv2",
-    "signedMessage": {
-      "encryptedMessage": "aMessage",
-      "ephemeralPublicKey": "aPublicKey",
-      "tag": "aTag"
-    }
+    "signature": "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl",
+    "protocol_version": "ECv1",
+    "signed_message": "aSignedMessage"
   }
 }

--- a/src/test/resources/googlepay/invalid-empty-signature-auth-request.json
+++ b/src/test/resources/googlepay/invalid-empty-signature-auth-request.json
@@ -7,24 +7,8 @@
     "email": "example@test.example"
   },
   "encrypted_payment_data": {
-    "type": "DIRECT",
-    "token": {
-      "signature": ""
-    },
-    "intermediateSigningKey": {
-      "signedKey": {
-        "keyValue": "aKey",
-        "keyExpiration": "anExpiration"
-      },
-      "signatures": [
-        "aSignature"
-      ]
-    },
-    "protocolVersion": "ECv2",
-    "signedMessage": {
-      "encryptedMessage": "aMessage",
-      "ephemeralPublicKey": "aPublicKey",
-      "tag": "aTag"
-    }
+    "signature":"",
+    "protocol_version":"ECv1",
+    "signed_message": "aSignedMessage"
   }
 }


### PR DESCRIPTION
- Update `GooglePayAuthRequest` to remove fields which are not required when
not decrypting. Also update to make consistent use of snake_case.
- Update `example-auth-request.json` to match new expected payload from Frontend.
- Update tests.

## WHAT
Since we are not decrypting the encrypted parts of the google payload the `GooglePayAuthRequest` class has changed to match the new payload.

## HOW
Please review `example-auth-request.json` to ensure it includes everything we need from Frontend and in a sensible format.

