### PR TITLE
PP-4681: Upgrade guice from 4.1.0 to 4.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <dropwizard.version>1.3.8</dropwizard.version>
         <wiremock.version>2.20.0</wiremock.version>
         <eclipselink.version>2.7.3</eclipselink.version>
-        <guice.version>4.1.0</guice.version>
+        <guice.version>4.2.2</guice.version>
         <jackson.version>2.9.8</jackson.version>
         <pay-java-commons.version>1.0.20190118181040</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>


### PR DESCRIPTION
Release notes:

https://github.com/google/guice/wiki/Guice42
https://github.com/google/guice/wiki/Guice421
https://github.com/google/guice/wiki/Guice422

4.2.0 added Java 9 support and performance improvements
4.2.1 added Java 10 support
4.2.2 added Java 11 support