### PR TITLE
bau: Refactor refund testing

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.service.notify.NotificationClient;
 
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
@@ -36,7 +37,6 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
-import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
 import static uk.gov.pay.connector.it.util.NotificationUtils.epdqNotificationPayload;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.REFUND_ISSUED;
@@ -81,7 +81,7 @@ public class SendRefundEmailTest {
         String refundExternalId = "999999";
 
         long chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper).chargeId;
-        createNewRefund(REFUND_SUBMITTED, chargeId, refundExternalId, transactionId + "/" + payIdSub, 100, databaseTestHelper);
+        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 100,  REFUND_SUBMITTED, chargeId, ZonedDateTime.now());
 
         given().port(testContext.getPort())
                 .body(epdqNotificationPayload(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE)))

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -17,7 +17,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.rules.EpdqMockClient;
 import uk.gov.pay.connector.rules.SmartpayMockClient;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
@@ -36,8 +35,8 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -187,13 +186,6 @@ public class ChargingITestBase {
 
     protected String createNewCharge() {
         return createNewChargeWith(CREATED, "");
-    }
-
-    protected String createNewRefundWith(RefundStatus refundStatus, Long amount, Long chargeId, String reference) {
-        long refundId = RandomUtils.nextInt();
-        String externalRefundId = "refund-" + refundId;
-        databaseTestHelper.addRefund(refundId, externalRefundId, reference, amount, refundStatus.getValue(), chargeId, ZonedDateTime.now());
-        return externalRefundId;
     }
 
     protected String createNewChargeWithNoTransactionId(ChargeStatus status) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -638,7 +638,7 @@ public class  DatabaseFixtures {
     }
 
     public class TestRefund {
-        Long id = RandomUtils.nextLong(1, 99999);
+        int id;
         String externalRefundId = RandomIdGenerator.newId();
         String reference;
         long amount = 101L;
@@ -691,7 +691,7 @@ public class  DatabaseFixtures {
         public TestRefund insert() {
             if (testCharge == null)
                 throw new IllegalStateException("Test charge must be provided.");
-            databaseTestHelper.addRefund(id, externalRefundId, reference, amount, status.toString(), testCharge.getChargeId(), createdDate, submittedByUserExternalId);
+            id = databaseTestHelper.addRefund(externalRefundId, reference, amount, status, testCharge.getChargeId(), createdDate, submittedByUserExternalId);
             return this;
         }
 
@@ -758,10 +758,6 @@ public class  DatabaseFixtures {
                 throw new IllegalStateException("Test Account must be provided.");
             databaseTestHelper.addToken(testAccount.getAccountId(), template);
             return this;
-        }
-
-        public TestAccount getTestAccount() {
-            return testAccount;
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -12,7 +11,6 @@ import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
@@ -46,6 +44,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUBMITTED;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -231,7 +230,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String externalChargeId = RandomIdGenerator.newId();
 
         createCharge(externalChargeId, chargeId);
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", AMOUNT + 150L, RefundStatus.REFUNDED.getValue(), chargeId, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", AMOUNT + 150L, REFUNDED, chargeId, now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -9,7 +8,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.time.ZonedDateTime;
@@ -31,6 +29,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 
 /**
  * This is effectively a copy of TransactionsApiResourceITest pointing to V2 resource
@@ -89,8 +89,8 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -167,8 +167,8 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa",
                 returnUrl, email);
 
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -256,8 +256,8 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -8,7 +7,6 @@ import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.time.ZonedDateTime;
@@ -24,6 +22,8 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -54,9 +54,9 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
         String refundDate1 = "2016-02-03T00:00:00.000Z";
         String refundDate2 = "2016-02-02T00:00:00.000Z";
         
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), refundExternalId1, "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId, ZonedDateTime.parse(refundDate1));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), refundExternalId2, "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId, ZonedDateTime.parse(refundDate2));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), "shouldnotberetrieved", "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, ZonedDateTime.parse(refundDate1));
+        databaseTestHelper.addRefund(refundExternalId1, "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId, ZonedDateTime.parse(refundDate1));
+        databaseTestHelper.addRefund(refundExternalId2, "refund-2-provider-reference", 2L, REFUNDED, chargeId, ZonedDateTime.parse(refundDate2));
+        databaseTestHelper.addRefund("shouldnotberetrieved", "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, ZonedDateTime.parse(refundDate1));
         databaseTestHelper.addToken(chargeId, "tokenId");
 
         connectorRestApiClient.withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.resources;
 
-import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -9,7 +8,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.time.ZonedDateTime;
@@ -30,6 +28,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -84,8 +84,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -165,8 +165,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa",
                 returnUrl, email);
 
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -208,8 +208,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-1-provider-reference", 1L, RefundStatus.REFUND_SUBMITTED.getValue(), chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(RandomUtils.nextInt(), randomAlphanumeric(10), "refund-2-provider-reference", 2L, RefundStatus.REFUNDED.getValue(), chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
@@ -12,6 +12,8 @@ import uk.gov.pay.connector.it.util.NotificationUtils;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
+import java.time.ZonedDateTime;
+
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -27,7 +29,6 @@ import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ
 import static uk.gov.pay.connector.gateway.epdq.EpdqNotification.StatusCode.EPDQ_AUTHORISED_CANCELLED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createNewChargeWithAccountId;
-import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
 import static uk.gov.pay.connector.it.util.NotificationUtils.epdqNotificationPayload;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 
@@ -106,7 +107,7 @@ public class EpdqNotificationResourceITest extends ChargingITestBase {
         int refundAmount = 1000;
 
         ChargeUtils.ExternalChargeId externalChargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
-        createNewRefund(REFUND_SUBMITTED, externalChargeId.chargeId, refundExternalId, transactionId + "/" + payIdSub, 1000, databaseTestHelper);
+        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 1000,  REFUND_SUBMITTED, externalChargeId.chargeId, ZonedDateTime.now());
         
         String response = notifyConnector(transactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
                 .statusCode(200)

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceITest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import java.io.IOException;
+import java.time.ZonedDateTime;
 
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
@@ -23,7 +24,6 @@ import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
-import static uk.gov.pay.connector.it.util.ChargeUtils.createNewRefund;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_NOTIFICATION;
 
@@ -192,7 +192,7 @@ public class WorldpayNotificationResourceITest extends ChargingITestBase {
     private String createNewChargeWithRefund(String transactionId, String refundExternalId, long refundAmount) {
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         String chargeId = externalChargeId.substring(externalChargeId.indexOf("-") + 1);
-        createNewRefund(REFUND_SUBMITTED, Long.valueOf(chargeId), refundExternalId, refundExternalId, refundAmount, databaseTestHelper);
+        databaseTestHelper.addRefund(refundExternalId, refundExternalId, refundAmount, REFUND_SUBMITTED, Long.valueOf(chargeId), ZonedDateTime.now());
         return externalChargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -3,10 +3,8 @@ package uk.gov.pay.connector.it.util;
 import org.apache.commons.lang.math.RandomUtils;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
-import java.time.ZonedDateTime;
 import java.util.Map;
 
 public class ChargeUtils {
@@ -16,11 +14,6 @@ public class ChargeUtils {
         ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(chargeId, externalChargeId.toString(), accountId, 6234L, status, "RETURN_URL", gatewayTransactionId);
         return externalChargeId;
-    }
-
-    public static void createNewRefund(RefundStatus status, long chargeId, String refundExternalId, String reference, long amount, DatabaseTestHelper databaseTestHelper) {
-        long refundId = RandomUtils.nextInt();
-        databaseTestHelper.addRefund(refundId, refundExternalId, reference, amount, status.getValue(), chargeId, ZonedDateTime.now());
     }
 
     public static DatabaseFixtures.TestCharge createTestCharge(DatabaseTestHelper databaseTestHelper, String paymentProvider, ChargeStatus chargeStatus,

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -8,6 +8,7 @@ import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
+import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -16,7 +17,6 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
@@ -28,6 +28,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 
 @RunWith(PactRunner.class)
 @Provider("connector")
@@ -94,9 +95,7 @@ public class TransactionsApiContractTest {
                 "aTransactionId", ServicePaymentReference.of("aReference"), ZonedDateTime.now().minusHours(12), "test@test.com@");
 
         for (int i = 0; i < numberOfRefunds; i++) {
-            long refundId = ThreadLocalRandom.current().nextLong(100, 100000);
-
-            dbHelper.addRefund(refundId, String.valueOf(refundId), "reference", 1L, RefundStatus.REFUNDED.getValue(),
+            dbHelper.addRefund("external" + RandomUtils.nextInt(), "reference", 1L, REFUNDED,
                     chargeId, createdDate);
         }
     }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.util;
 
 import com.google.gson.Gson;
-import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang.math.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.postgresql.util.PGobject;
 import org.skife.jdbi.v2.DBI;
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
 import java.sql.SQLException;
@@ -123,7 +124,7 @@ public class DatabaseTestHelper {
     }
 
     public void addCharge(String externalChargeId, String gatewayAccountId, long amount, ChargeStatus status, String returnUrl, String transactionId) {
-        addCharge((long) RandomUtils.nextInt(1, 9999999), externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId,
+        addCharge((long) RandomUtils.nextInt(), externalChargeId, gatewayAccountId, amount, status, returnUrl, transactionId,
                 "Test description", ServicePaymentReference.of("Test reference"), now(), 1, null, SupportedLanguage.ENGLISH, false);
     }
 
@@ -258,37 +259,27 @@ public class DatabaseTestHelper {
                         .bind("accountId", accountId).execute());
     }
 
-    public void addRefund(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate) {
-        jdbi.withHandle(handle ->
-                handle
-                        .createStatement("INSERT INTO refunds(id, external_id, reference, amount, status, charge_id, created_date) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date)")
-                        .bind("id", id)
-                        .bind("external_id", externalId)
-                        .bind("reference", reference)
-                        .bind("amount", amount)
-                        .bind("status", status)
-                        .bind("charge_id", chargeId)
-                        .bind("created_date", Timestamp.from(createdDate.toInstant()))
-                        .bind("version", 1)
-                        .execute()
-        );
+    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, ZonedDateTime createdDate) {
+        return addRefund(externalId, reference, amount, status, chargeId, createdDate, null);
     }
 
-    public void addRefund(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate, String submittedByUserExternalId) {
+    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, ZonedDateTime createdDate, String submittedByUserExternalId) {
+        int refundId = RandomUtils.nextInt();
         jdbi.withHandle(handle ->
                 handle
                         .createStatement("INSERT INTO refunds(id, external_id, reference, amount, status, charge_id, created_date, user_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date, :user_external_id)")
-                        .bind("id", id)
+                        .bind("id", refundId)
                         .bind("external_id", externalId)
                         .bind("reference", reference)
                         .bind("amount", amount)
-                        .bind("status", status)
+                        .bind("status", status.getValue())
                         .bind("charge_id", chargeId)
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
                         .bind("user_external_id", submittedByUserExternalId)
                         .bind("version", 1)
                         .execute()
         );
+        return refundId;
     }
 
     public void addRefundHistory(long id, String externalId, String reference, long amount, String status, Long chargeId, ZonedDateTime createdDate, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByUserExternalId) {


### PR DESCRIPTION
Code can be made simpler if the refund Id were generated within the
DatabaseTestHelper's addRefund method.

@oswaldquek
