### PR TITLE
PP-4695, PP-4696: Upgrade httpclient and logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.2</version>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.bitbucket.b_c</groupId>


### PR DESCRIPTION
## WHAT
Upgrade logback from 1.2.2 to 1.2.3

Release notes: https://logback.qos.ch/news.html

Nothing notable

Upgrade httpclient from 4.5.3 to 4.5.6

Release notes: https://archive.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.5.x.txt

Nothing stands out as super important