### PR TITLE
PP-4710: Remove unused jose4j 0.5.5 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,11 +204,6 @@
             <version>1.2.3</version>
         </dependency>
         <dependency>
-            <groupId>org.bitbucket.b_c</groupId>
-            <artifactId>jose4j</artifactId>
-            <version>0.5.5</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>


### PR DESCRIPTION
This was brought in explicitly as part of PP-1753 in commit
82368cebd88e33734f0a75646eb728638e1acf4f

It's hard to see exactly why, but it's a dependency of notifications-client, so
presumably at some point in the past notifications-client brought in an
outdated version.

With this removed from our pom.xml, the dependency tree now looks like this:

```[INFO] +- uk.gov.service.notify:notifications-java-client:jar:3.1.3-RELEASE:compile
[INFO] |  +- org.bitbucket.b_c:jose4j:jar:0.5.5:compile
[INFO] |  +- commons-cli:commons-cli:jar:1.1:compile
[INFO] |  +- org.json:json:jar:20160212:compile
[INFO] |  \- joda-time:joda-time:jar:2.7:compile
```

Since we don't use this library directly and notifications-java-client is
pulling in the same version we were, we should just drop the explicit
dependency.


