### PR TITLE
PP-4702: Upgrade jooq from 3.9.5 to 3.11.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.9.5</version>
+            <version>3.11.9</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Release notes: http://www.jooq.org/notes

3.10.0

* Java 9 support

3.11.0 added Java 10 support

* Java 10 support
* Support for Aurora PostgreSQL Edition