### PR TITLE
PP-4704: Upgrade guava from 21.0 to 27.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>21.0</version>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.functionaljava</groupId>

--- a/project-suppression.xml
+++ b/project-suppression.xml
@@ -9,13 +9,6 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: guava-21.0.jar
-   ]]></notes>
-        <gav regex="true">^com\.google\.guava:guava:.*$</gav>
-        <cve>CVE-2018-10237</cve>
-    </suppress>
-    <suppress>
-        <notes><![CDATA[
    file name: blackdoor-lib-v4r3t0.jar
    ]]></notes>
         <gav regex="true">^black\.door:blackdoor-lib:.*$</gav>

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -147,8 +147,7 @@ public class PaymentGatewayStateTransitions {
                 .map(edge -> Triple.of(
                         edge.nodeU(),
                         edge.nodeV(),
-                        graph.edgeValue(edge.nodeU(), edge.nodeV()
-                        )))
+                        graph.edgeValueOrDefault(edge.nodeU(), edge.nodeV(), "")))
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
* Remove the dependency-check-maven suppression rule
* Addresses CVE-2018-10237

Release notes:

https://github.com/google/guava/wiki/Release22
https://github.com/google/guava/wiki/Release23

* ValueGraph.edgeValue() now returns an optional instead of throwing an
  exception if the edge doesn't exist. Switch to using edgeValueOrDefault()
  with a default of "" (lots of edges have "" as their value)

https://github.com/google/guava/releases/tag/v23.1

* Java 9 compatibility (except for GWT)

https://github.com/google/guava/releases/tag/v23.2

* Fixes ValueGraph.edgeValueOrDefault() to not mistakenly return null sometimes

https://github.com/google/guava/releases/tag/v23.3

* Nothing very interesting

https://github.com/google/guava/releases/tag/v23.4

* Nothing very interesting

https://github.com/google/guava/releases/tag/v23.5

* Nothing very interesting

https://github.com/google/guava/releases/tag/v23.6

* Nothing very interesting

https://github.com/google/guava/releases/tag/v24.0

* Nothing very interesting

https://github.com/google/guava/releases/tag/v24.1

* Nothing very interesting

https://github.com/google/guava/releases/tag/v25.0

* Fixes CVE-2018-10237

https://github.com/google/guava/releases/tag/v25.1

* Nothing very interesting

https://github.com/google/guava/releases/tag/v26.0

* Nothing very interesting

https://github.com/google/guava/releases/tag/v27.0

* Nothing very interesting

https://github.com/google/guava/releases/tag/v27.0.1

* Nothing very interesting

