### PR TITLE
PP-4512 Make AUTHORISATION 3DS REQUIRED expirable with gateway

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -63,6 +63,7 @@ public class ChargeExpiryService {
     private final ChargeEventDao chargeEventDao;
     private final PaymentProviders providers;
     static final List<ChargeStatus> GATEWAY_CANCELLABLE_STATUSES = Arrays.asList(
+            AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_SUCCESS,
             AWAITING_CAPTURE_REQUEST
     );

--- a/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
 import java.util.List;
 
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -52,6 +53,7 @@ public class StatusFlow {
             ImmutableList.of(
                     CREATED,
                     ENTERING_CARD_DETAILS,
+                    AUTHORISATION_3DS_REQUIRED,
                     AUTHORISATION_SUCCESS,
                     AWAITING_CAPTURE_REQUEST
             ),

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -93,6 +93,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_REJECTED, "");
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_CANCELLED, "");
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, USER_CANCELLED, "");
+        graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED,  EXPIRE_CANCEL_READY, "");
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_SUCCESS, "");
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_REJECTED, "");
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_ERROR, "");

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -108,6 +108,30 @@ public class ChargeExpiryServiceTest {
     }
 
     @Test
+    public void shouldExpireChargesWithStatus_authorisation3DSRequired_byCallingProviderToCancel() {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+                .withAmount(200L)
+                .withCreatedDate(ZonedDateTime.now())
+                .withStatus(ChargeStatus.AUTHORISATION_3DS_REQUIRED)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        when(mockWorldpayCancelResponse.cancelStatus()).thenReturn(CancelStatus.CANCELLED);
+
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
+        ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
+        ArgumentCaptor<CancelGatewayRequest> cancelCaptor = ArgumentCaptor.forClass(CancelGatewayRequest.class);
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture());
+
+        chargeExpiryService.expire(singletonList(chargeEntity));
+
+        verify(mockPaymentProvider).cancel(cancelCaptor.capture());
+        assertThat(cancelCaptor.getValue().getTransactionId(), is(chargeEntity.getGatewayTransactionId()));
+        assertThat(chargeEntity.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
+    }
+
+    @Test
     public void shouldExpireChargesWithStatus_awaitingCaptureRequest_byCallingProviderToCancel() {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)


### PR DESCRIPTION
In certain circumstances a charge that is in status `AUTHORISATION 3DS REQUIRED`
can exist in an authorised state with the gateway (specifically ePDQ - see
https://payments-platform.atlassian.net/browse/PP-4512).

If the charge is stuck in this state then the expiry sweep expires the charge in our
DB, but not with the gateway. This causes user pain, as the authorisation hold
is not released for days/weeks.

This PR adds `AUTHORISATION 3DS REQUIRED` as a 'gateway expirable' status.
In many cases this is likely to fail as the charge won't exist with the gateway
but the job seems to be robust to such failures (the failure is reported
in the HTTP response, but has no other effect).