### PR TITLE
PP-4512 Revert auth 3ds required

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -63,7 +63,6 @@ public class ChargeExpiryService {
     private final ChargeEventDao chargeEventDao;
     private final PaymentProviders providers;
     static final List<ChargeStatus> GATEWAY_CANCELLABLE_STATUSES = Arrays.asList(
-            AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_SUCCESS,
             AWAITING_CAPTURE_REQUEST
     );

--- a/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
@@ -5,7 +5,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
 import java.util.List;
 
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -53,7 +52,6 @@ public class StatusFlow {
             ImmutableList.of(
                     CREATED,
                     ENTERING_CARD_DETAILS,
-                    AUTHORISATION_3DS_REQUIRED,
                     AUTHORISATION_SUCCESS,
                     AWAITING_CAPTURE_REQUEST
             ),

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -93,7 +93,6 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_REJECTED, "");
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_CANCELLED, "");
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, USER_CANCELLED, "");
-        graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED,  EXPIRE_CANCEL_READY, "");
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_SUCCESS, "");
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_REJECTED, "");
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_ERROR, "");

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -108,30 +108,6 @@ public class ChargeExpiryServiceTest {
     }
 
     @Test
-    public void shouldExpireChargesWithStatus_authorisation3DSRequired_byCallingProviderToCancel() {
-        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
-                .withStatus(ChargeStatus.AUTHORISATION_3DS_REQUIRED)
-                .withGatewayAccountEntity(gatewayAccount)
-                .build();
-
-        when(mockWorldpayCancelResponse.cancelStatus()).thenReturn(CancelStatus.CANCELLED);
-
-        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
-        when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
-        ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
-        ArgumentCaptor<CancelGatewayRequest> cancelCaptor = ArgumentCaptor.forClass(CancelGatewayRequest.class);
-        doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture());
-
-        chargeExpiryService.expire(singletonList(chargeEntity));
-
-        verify(mockPaymentProvider).cancel(cancelCaptor.capture());
-        assertThat(cancelCaptor.getValue().getTransactionId(), is(chargeEntity.getGatewayTransactionId()));
-        assertThat(chargeEntity.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
-    }
-
-    @Test
     public void shouldExpireChargesWithStatus_awaitingCaptureRequest_byCallingProviderToCancel() {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)


### PR DESCRIPTION
Revert "Merge pull request #1005 from alphagov/PP-4512-make-3ds-required-expirable-with-gateway"

This is likely to cause many payments to end up in an error state.

Think we need to think harder about this problem.

This reverts commit 5054c32f827fc1c1a68805d6c8bb787386cd63d1, reversing
changes made to 2e1ffbc48c2658c1f8f907e1adf8a4c83b688b32.