### PR TITLE
PP-4637: Remove json-path-assert from pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,12 +327,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path-assert</artifactId>
-            <version>2.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>au.com.dius</groupId>
             <artifactId>pact-jvm-provider-junit_2.12</artifactId>
             <version>3.6.1</version>


### PR DESCRIPTION
The usage of this library was removed in commit
e4af978d0334eb4ab4ae89df57dd6403f3338ba0

