### PR TITLE
PP-4512 Payment discrepancy checker

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -45,6 +45,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CaptureProcessScheduler;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.refund.resource.ChargeRefundsResource;
 import uk.gov.pay.connector.refund.resource.SearchRefundsResource;
+import uk.gov.pay.connector.report.resource.GatewayStatusComparisonReportResource;
 import uk.gov.pay.connector.report.resource.PerformanceReportResource;
 import uk.gov.pay.connector.report.resource.TransactionsSummaryResource;
 import uk.gov.pay.connector.token.resource.SecurityTokensResource;
@@ -117,6 +118,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(SchemeRewriteFilter.class));
         environment.jersey().register(injector.getInstance(PerformanceReportResource.class));
         environment.jersey().register(injector.getInstance(SearchRefundsResource.class));
+        environment.jersey().register(injector.getInstance(GatewayStatusComparisonReportResource.class));
 
         setupSchedulers(configuration, environment, injector);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -23,6 +24,8 @@ public interface PaymentProvider {
     Optional<String> generateTransactionId();
 
     GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request);
+
+    ChargeQueryResponse queryPaymentStatus(ChargeEntity charge);
 
     Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/ChargeQueryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/ChargeQueryResponse.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+
+public class ChargeQueryResponse {
+    private final ChargeStatus mappedStatus;
+    private final String rawGatewayResponse;
+
+    public ChargeQueryResponse(ChargeStatus mappedStatus, String rawGatewayResponse) {
+        this.mappedStatus = mappedStatus;
+        this.rawGatewayResponse = rawGatewayResponse;
+    }
+
+    public ChargeStatus getMappedStatus() {
+        return mappedStatus;
+    }
+
+    public String getRawGatewayResponse() {
+        return rawGatewayResponse;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqStatusMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqStatusMapper.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EpdqStatusMapper {
+    private EpdqStatusMapper() {
+        
+    }
+    
+    private static  Map<String, ChargeStatus> epdqStatusMap;
+    
+    static {
+        Map<String, ChargeStatus> aMap = new HashMap<>();
+        aMap.put("5", ChargeStatus.AUTHORISATION_SUCCESS);
+        aMap.put("46", ChargeStatus.AUTHORISATION_3DS_REQUIRED);
+        aMap.put("50", ChargeStatus.AUTHORISATION_SUBMITTED);
+        aMap.put("51", ChargeStatus.AUTHORISATION_SUBMITTED);
+        aMap.put("2", ChargeStatus.AUTHORISATION_REJECTED);
+        aMap.put("6", ChargeStatus.USER_CANCELLED);
+        aMap.put("61", ChargeStatus.AUTHORISATION_SUBMITTED);
+        aMap.put("91", ChargeStatus.CAPTURED);
+
+        epdqStatusMap = Collections.unmodifiableMap(aMap);
+    }
+     
+    public static ChargeStatus map(String epdqStatus) {
+        return epdqStatusMap.get(epdqStatus);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/model/response/EpdqQueryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/model/response/EpdqQueryResponse.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.gateway.epdq.model.response;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
+import uk.gov.pay.connector.gateway.epdq.EpdqStatusMapper;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
+
+@XmlRootElement(name = "ncresponse")
+public class EpdqQueryResponse extends EpdqBaseResponse implements BaseResponse {
+
+    private String status;
+
+    @XmlAttribute(name = "PAYID")
+    private String transactionId;
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    @XmlAttribute(name = "STATUS")
+    public void setStatus(String status) {
+        this.status = status;
+    }
+    
+    public String getStatus() {
+        return status;
+    }
+
+    private boolean hasError() {
+        return !"0".equals(super.getErrorCode());
+    }
+    
+    @Override
+    public String getErrorMessage() {
+        if (hasError())
+            return super.getErrorMessage();
+        return null;
+    }
+
+    @Override
+    public String getErrorCode() {
+        if (hasError())
+            return super.getErrorMessage();
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "ePDQ query response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("PAYID: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(status)) {
+            joiner.add("STATUS: " + status);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("NCERROR: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("NCERRORPLUS: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+
+    public static ChargeQueryResponse toChargeQueryResponse(EpdqQueryResponse epdqQueryResponse) {
+        epdqQueryResponse.getErrorCode();
+        
+        return new ChargeQueryResponse(EpdqStatusMapper.map(epdqQueryResponse.getStatus()), epdqQueryResponse.toString());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
@@ -26,6 +27,7 @@ import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalcul
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.GatewayResponseGenerator;
 
+import javax.naming.OperationNotSupportedException;
 import java.util.Optional;
 
 import static java.util.UUID.randomUUID;
@@ -65,6 +67,11 @@ public class SandboxPaymentProvider implements PaymentProvider {
         return gatewayResponseBuilder
                 .withGatewayError(new GatewayError("Unsupported card details.", GENERIC_GATEWAY_ERROR))
                 .build();
+    }
+
+    @Override
+    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
+        throw new UnsupportedOperationException("Querying payment status not currently supported by Sandbox");
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.smartpay;
 import fj.data.Either;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
@@ -101,6 +102,11 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authoriseWallet(WalletAuthorisationGatewayRequest request) {
         throw new UnsupportedOperationException("Wallets are not supported for Smartpay");
+    }
+
+    @Override
+    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
+        throw new UnsupportedOperationException("Querying payment status not currently supported by Smartpay");
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
@@ -95,7 +96,12 @@ public class StripePaymentProvider implements PaymentProvider {
     public Optional<String> generateTransactionId() {
         return Optional.empty();
     }
-
+    
+    @Override
+    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
+        throw new UnsupportedOperationException("Querying payment status not currently supported by Stripe");
+    }
+    
     @Override
     public GatewayResponse authorise(CardAuthorisationGatewayRequest request) {
         logger.info("Calling Stripe for authorisation of charge [{}]", request.getChargeExternalId());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.worldpay;
 import fj.data.Either;
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
@@ -82,6 +83,11 @@ public class WorldpayPaymentProvider implements PaymentProvider {
         return Optional.of(randomUUID().toString());
     }
 
+    @Override
+    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
+        throw new UnsupportedOperationException("Querying payment status not currently supported by Worldpay");
+    }
+    
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) {
         Either<GatewayError, GatewayClient.Response> response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), buildAuthoriseOrder(request));

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -164,6 +164,7 @@ public class CardResource {
                 .orElseGet(() -> ResponseUtil.responseWithChargeNotFound(chargeId));
     }
 
+
     private Response handleError(String chargeId, GatewayError error) {
         switch (error.getErrorType()) {
             case UNEXPECTED_HTTP_STATUS_CODE_FROM_GATEWAY:

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
+
+import javax.inject.Inject;
+
+public class QueryService {
+    private final PaymentProviders providers;
+
+    @Inject
+    public QueryService(PaymentProviders providers) {
+        this.providers = providers;
+    }
+    
+    public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) {
+        return providers.byName(charge.getPaymentGatewayName())
+                .queryPaymentStatus(charge);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
+++ b/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.report.model;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ExternalChargeState;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
+
+public class GatewayStatusComparison {
+    private ChargeStatus payStatus;
+    private ChargeStatus gatewayStatus;
+    private String chargeId;
+    private String rawGatewayResponse;
+    
+    public static GatewayStatusComparison from(ChargeEntity charge, ChargeQueryResponse reportedStatus) {
+        return new GatewayStatusComparison(charge, reportedStatus);
+    }
+    
+    private GatewayStatusComparison(ChargeEntity charge, ChargeQueryResponse gatewayQueryResponse) {
+        chargeId = charge.getExternalId();
+        payStatus = ChargeStatus.fromString(charge.getStatus());
+        gatewayStatus = gatewayQueryResponse.getMappedStatus();
+        rawGatewayResponse = gatewayQueryResponse.getRawGatewayResponse();
+    }
+
+    public ChargeStatus getPayStatus() {
+        return payStatus;
+    }
+
+    public ChargeStatus getGatewayStatus() {
+        return gatewayStatus;
+    }
+    
+    public ExternalChargeState getGatewayExternalStatus() {
+        return gatewayStatus.toExternal();
+    }
+
+    public ExternalChargeState getPayExternalStatus() {
+        return payStatus.toExternal();
+    }
+
+    public String getChargeId() {
+        return chargeId;
+    }
+
+    public String getRawGatewayResponse() {
+        return rawGatewayResponse;
+    }
+
+    public boolean hasInternalStatusMismatch() {
+        return !payStatus.equals(gatewayStatus); 
+    }
+
+    public boolean hasExternalStatusMismatch() {
+        return !payStatus.toExternal().getStatus().equals(gatewayStatus.toExternal().getStatus()); 
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/report/resource/GatewayStatusComparisonReportResource.java
+++ b/src/main/java/uk/gov/pay/connector/report/resource/GatewayStatusComparisonReportResource.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.report.resource;
+
+import com.google.inject.Inject;
+import org.hibernate.validator.constraints.NotEmpty;
+import uk.gov.pay.connector.report.model.GatewayStatusComparison;
+import uk.gov.pay.connector.report.service.DiscrepancyService;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class GatewayStatusComparisonReportResource {
+
+    private final DiscrepancyService discrepancyService;
+    
+    @Inject
+    public GatewayStatusComparisonReportResource(DiscrepancyService discrepancyService) {
+        this.discrepancyService = discrepancyService;
+    }
+
+    @POST
+    @Path("/v1/api/reports/discrepancies")
+    @Produces(APPLICATION_JSON)
+    public List<GatewayStatusComparison> listDiscrepancies(@NotEmpty List<String> chargeIds) {
+        return discrepancyService.listGatewayStatusComparisons(chargeIds);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/report/service/DiscrepancyService.java
+++ b/src/main/java/uk/gov/pay/connector/report/service/DiscrepancyService.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.report.service;
+
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.paymentprocessor.service.QueryService;
+import uk.gov.pay.connector.report.model.GatewayStatusComparison;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class DiscrepancyService {
+    private final ChargeService chargeService;
+    private final QueryService queryService;
+
+    @Inject
+    public DiscrepancyService(ChargeService chargeService, QueryService queryService) {
+        this.chargeService = chargeService;
+        this.queryService = queryService;
+    }
+    
+    public List<GatewayStatusComparison> listGatewayStatusComparisons(List<String> chargeIds) {
+        return chargeIds.stream()
+                .map(chargeService::findChargeById)
+                .map(charge -> GatewayStatusComparison.from(charge, queryService.getChargeGatewayStatus(charge)))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeGatewayStatusComparisonReportITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeGatewayStatusComparisonReportITest.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.connector.it.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static io.restassured.http.ContentType.JSON;
+import static org.junit.Assert.assertEquals;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class ChargeGatewayStatusComparisonReportITest extends ChargingITestBase {
+    public ChargeGatewayStatusComparisonReportITest() {
+        super("epdq");
+    }
+
+    @Test
+    public void shouldReturnAllChargesInDiscrepantState_whenRequestDiscrepancyReport() {
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
+        String chargeId2 = addCharge(ChargeStatus.CREATED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
+        epdqMockClient.mockAuthorisationQuerySuccess();
+
+        List<JsonNode> results = connectorRestApiClient
+                .getDiscrepancyReport(toJson(Arrays.asList(chargeId, chargeId2)))
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().body().jsonPath().getList(".", JsonNode.class);
+
+        assertEquals(2, results.size());
+
+
+        assertEquals( "AUTHORISATION_SUCCESS", results.get(0).get("gatewayStatus").asText());
+        assertEquals( "EXPIRED", results.get(0).get("payStatus").asText());
+        assertEquals( chargeId, results.get(0).get("chargeId").asText());
+        assertEquals( "ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(0).get("rawGatewayResponse").asText());
+        assertEquals( "EXTERNAL_SUBMITTED", results.get(0).get("gatewayExternalStatus").asText());
+        assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
+
+        assertEquals( "AUTHORISATION_SUCCESS", results.get(1).get("gatewayStatus").asText());
+        assertEquals( "CREATED", results.get(1).get("payStatus").asText());
+        assertEquals( chargeId2, results.get(1).get("chargeId").asText());
+        assertEquals( "ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(1).get("rawGatewayResponse").asText());
+        assertEquals( "EXTERNAL_SUBMITTED", results.get(1).get("gatewayExternalStatus").asText());
+        assertEquals( "EXTERNAL_CREATED", results.get(1).get("payExternalStatus").asText());
+    }
+    
+
+    @Test
+    public void should404_whenAChargeIdDoesntExist() {
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
+        epdqMockClient.mockAuthorisationQuerySuccess();
+
+        connectorRestApiClient
+                .getDiscrepancyReport(toJson(Collections.singletonList("chargeIds")))
+                .statusCode(404);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
@@ -23,6 +23,10 @@ public class EpdqMockClient {
         paymentServiceResponse(ROUTE_FOR_QUERY_ORDER, TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_SUCCESS_RESPONSE));
     }
 
+    public void mockCancelQuerySuccess() {
+        paymentServiceResponse(ROUTE_FOR_QUERY_ORDER, TestTemplateResourceLoader.load(EPDQ_CANCEL_SUCCESS_RESPONSE));
+    }
+
     public void mockAuthorisation3dsSuccess() {
         paymentServiceResponse(ROUTE_FOR_NEW_ORDER, TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_SUCCESS_3D_RESPONSE));
     }

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -210,4 +210,11 @@ public class RestAssuredClient {
                 .post(path)
                 .then();
     }
+
+    public ValidatableResponse getDiscrepancyReport(String chargeIds) {
+        return addQueryParams(given().port(port))
+                .contentType(JSON).body(chargeIds)
+                .post("/v1/api/reports/discrepancies")
+                .then();
+    }
 }


### PR DESCRIPTION
Adds an endpoint that takes a list of charge IDs and for each one checks the status we have recorded in the DB vs the status as recorded by the payment gateway.

At the moment it only implements the checking functionality for ePDQ, as that is the immediate need, but can easily be extended in future.