### PR TITLE
Pp 4638 tidy up

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -12,15 +12,64 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 
 public class SandboxCardNumbers {
 
+    private static final String GOOD_CARD_PREPAID_NON_CORPORATE = "4000160000000004";
+    private static final String GOOD_WALLET_LAST_DIGITS_CARD_NUMBER = "4242";
+    private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD = "5101180000000007";
+    private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD = "5200828282828210";
+    private static final String GOOD_NON_CORPORATE_NON_PREPAID = "4000020000000000";
+    private static final String DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER = "0002";
+    private static final String DECLINED_CARD_NUMBER = "4000000000000002";
+    private static final String CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0127";
+    private static final String CVC_ERROR_CARD_NUMBER = "4000000000000127";
+    private static final String EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER = "0069";
+    private static final String EXPIRED_CARD_NUMBER = "4000000000000069";
+    private static final String PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0119";
+    private static final String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
+
+    private static final Set<String> GOOD_CARDS = ImmutableSet.of(
+            "4444333322221111",
+            "4242424242424242",
+            "4917610000000000003",
+            "4000056655665556",
+            "5105105105105100",
+            "371449635398431",
+            "3566002020360505",
+            "6011000990139424",
+            "36148900647913",
+            GOOD_WALLET_LAST_DIGITS_CARD_NUMBER,
+            GOOD_CARD_PREPAID_NON_CORPORATE,
+            GOOD_NON_CORPORATE_NON_PREPAID);
+
+    private static final Set<String> GOOD_CORPORATE_CARDS = ImmutableSet.of(
+            "4988080000000000",
+            "4000620000000007",
+            "4293189100000008",
+            GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD);
+
+    private static final Set<String> GOOD_CORPORATE_PREPAID_DEBIT_CARD = ImmutableSet.of(
+            "4131840000000003",
+            "4000180000000002",
+            GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD);
+
+    private static final Set<String> REJECTED_CARDS = ImmutableSet.of(
+            DECLINED_CARD_NUMBER,
+            DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER,
+            EXPIRED_CARD_NUMBER,
+            EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER,
+            CVC_ERROR_CARD_NUMBER,
+            CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER);
+
+    private static Map<String, CardError> ERROR_CARDS = Stream.of(
+            PROCESSING_ERROR_CARD_NUMBER,
+            PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER)
+            .collect(toMap(
+                    Function.identity(),
+                    cardNumber -> new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed.")));
+
     public static boolean isValidCard(String cardNumber) {
         return GOOD_CARDS.contains(cardNumber) ||
                 GOOD_CORPORATE_CARDS.contains(cardNumber) ||
-                GOOD_APPLE_PAY_LAST_DIGITS_CARD_NUMBER.equals(cardNumber) ||
-                GOOD_CORPORATE_PREPAID_DEBIT_CARD.contains(cardNumber) ||
-                GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD.equals(cardNumber) ||
-                GOOD_CARD_PREPAID_NON_CORPORATE.equals(cardNumber) ||
-                GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD.equals(cardNumber) ||
-                GOOD_NON_COPORATE_NON_PREPAID.equals(cardNumber);
+                GOOD_CORPORATE_PREPAID_DEBIT_CARD.contains(cardNumber);
     }
 
     public static boolean isRejectedCard(String cardNumber) {
@@ -34,45 +83,4 @@ public class SandboxCardNumbers {
     public static CardError cardErrorFor(String cardNumber) {
         return ERROR_CARDS.get(cardNumber);
     }
-
-    private static final List<String> GOOD_CARDS = ImmutableList.of(
-            "4444333322221111",
-            "4242424242424242",
-            "4917610000000000003",
-            "4000056655665556",
-            "5105105105105100",
-            "371449635398431",
-            "3566002020360505",
-            "6011000990139424",
-            "36148900647913");
-    private static final String GOOD_CARD_PREPAID_NON_CORPORATE = "4000160000000004";
-    private static final String GOOD_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "4242";
-    private static final List<String> GOOD_CORPORATE_CARDS = ImmutableList.of(
-            "4988080000000000",
-            "4000620000000007",
-            "4293189100000008");
-    private static final List<String> GOOD_CORPORATE_PREPAID_DEBIT_CARD = ImmutableList.of(
-            "4131840000000003",
-            "4000180000000002");
-    private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD = "5101180000000007";
-    private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD = "5200828282828210";
-    private static final String GOOD_NON_COPORATE_NON_PREPAID = "4000020000000000";
-    private static final String DECLINED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0002";
-    private static final String DECLINED_CARD_NUMBER = "4000000000000002";
-    private static final String CVC_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0127";
-    private static final String CVC_ERROR_CARD_NUMBER = "4000000000000127";
-    private static final String EXPIRED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0069";
-    private static final String EXPIRED_CARD_NUMBER = "4000000000000069";
-    private static final String PROCESSING_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER = "0119";
-    private static final String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
-
-    private static Map<String, CardError> ERROR_CARDS = Stream.of(
-            PROCESSING_ERROR_CARD_NUMBER,
-            PROCESSING_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER)
-            .collect(toMap(
-                    Function.identity(),
-                    cardNumber -> new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed.")));
-
-    private static final List<String>REJECTED_CARDS = ImmutableList.of(DECLINED_CARD_NUMBER, DECLINED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER, EXPIRED_CARD_NUMBER, EXPIRED_APPLE_PAY_LAST_DIGITS_CARD_NUMBER, CVC_ERROR_CARD_NUMBER,
-            CVC_ERROR_APPLE_PAY_LAST_DIGITS_CARD_NUMBER);
 }

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -113,7 +113,8 @@ public class WalletAuthoriseService {
         authCardDetails.setCardNo(walletAuthorisationData.getPaymentInfo().getLastDigitsCardNumber());
         authCardDetails.setPayersCardType(walletAuthorisationData.getPaymentInfo().getCardType());
         authCardDetails.setCardBrand(walletAuthorisationData.getPaymentInfo().getBrand());
-        authCardDetails.setEndDate(walletAuthorisationData.getCardExpiryDate().format(EXPIRY_DATE_FORMAT));
+        walletAuthorisationData.getCardExpiryDate().ifPresent(
+                cardExpiry -> authCardDetails.setEndDate(cardExpiry.format(EXPIRY_DATE_FORMAT)));
         authCardDetails.setCorporateCard(false);
         return authCardDetails;
     }

--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/AppleDecryptedPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/AppleDecryptedPaymentData.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 public class AppleDecryptedPaymentData implements AuthorisationDetails, WalletAuthorisationData {
     private WalletPaymentInfo paymentInfo;
@@ -43,8 +44,8 @@ public class AppleDecryptedPaymentData implements AuthorisationDetails, WalletAu
         return applicationPrimaryAccountNumber;
     }
 
-    public LocalDate getCardExpiryDate() {
-        return applicationExpirationDate;
+    public Optional<LocalDate> getCardExpiryDate() {
+        return Optional.ofNullable(applicationExpirationDate);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.Optional;
 
 public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletAuthorisationData {
 
@@ -26,9 +27,8 @@ public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletA
     }
 
     @Override
-    public LocalDate getCardExpiryDate() {
-        //TODO card expiry data is required when creating authCardDetails but not supplied by Google.
-        return LocalDate.now().plusYears(2);
+    public Optional<LocalDate> getCardExpiryDate() {
+        return Optional.empty();
     }
 
     public EncryptedPaymentData getEncryptedPaymentData() {

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletAuthorisationData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletAuthorisationData.java
@@ -3,11 +3,12 @@ package uk.gov.pay.connector.wallets.model;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 public interface WalletAuthorisationData {
     
     WalletPaymentInfo getPaymentInfo();
-    LocalDate getCardExpiryDate();
+    Optional<LocalDate> getCardExpiryDate();
     WalletType getWalletType();
     String getLastDigitsCardNumber();
     

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java
@@ -50,7 +50,7 @@ public class ApplePayDecrypterTest {
     @Test
     public void shouldDecryptData_whenPrivateKeyAndPublicCertificateAreValid() {
         AppleDecryptedPaymentData appleDecryptedPaymentData = applePayDecrypter.performDecryptOperation(applePayAuthRequest);
-        assertThat(appleDecryptedPaymentData.getCardExpiryDate(), is(LocalDate.of(2020, 7, 31)));
+        assertThat(appleDecryptedPaymentData.getCardExpiryDate().get(), is(LocalDate.of(2020, 7, 31)));
         assertThat(appleDecryptedPaymentData.getApplicationPrimaryAccountNumber(), is("4109370251004320"));
         assertThat(appleDecryptedPaymentData.getCurrencyCode(), is("840"));
         assertThat(appleDecryptedPaymentData.getDeviceManufacturerIdentifier(), is("040010030273"));

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -26,7 +26,6 @@ public class GooglePayAuthRequestTest {
         assertThat(actual.getPaymentInfo().getCardholderName(), is(paymentInfo.get("cardholder_name").asText()));
         assertThat(actual.getPaymentInfo().getLastDigitsCardNumber(), is(paymentInfo.get("last_digits_card_number").asText()));
         assertThat(actual.getPaymentInfo().getBrand(), is(paymentInfo.get("brand").asText()));
-        assertThat(actual.getPaymentInfo().getCardType().toString(), is(paymentInfo.get("card_type").asText()));
         assertThat(actual.getPaymentInfo().getEmail(), is(paymentInfo.get("email").asText()));
 
         JsonNode encryptedPaymentData = expected.get("encrypted_payment_data");

--- a/src/test/resources/googlepay/example-auth-request.json
+++ b/src/test/resources/googlepay/example-auth-request.json
@@ -2,7 +2,6 @@
   "payment_info": {
     "last_digits_card_number": "1234",
     "brand": "visa",
-    "card_type": "DEBIT",
     "cardholder_name": "Example Name",
     "email": "example@test.example"
   },

--- a/src/test/resources/googlepay/invalid-empty-signature-auth-request.json
+++ b/src/test/resources/googlepay/invalid-empty-signature-auth-request.json
@@ -2,7 +2,6 @@
   "payment_info": {
     "last_digits_card_number": "1234",
     "brand": "visa",
-    "card_type": "DEBIT",
     "cardholder_name": "Example Name",
     "email": "example@test.example"
   },


### PR DESCRIPTION
## WHAT
Remove card_type from google pay request.
    - Remove `card_type` from google auth request since google cannot provide.
    - Update test fixtures and tests.

Change getCardExpiryDate to return Optional.    
    - Google does not provide a card expiry date so change return type of
    `WalletAuthorisationData.getExpiryDate() to Optional<LocalDate>`.
    - Update creation of `AuthCardDetails` to accommodate Optional return type.

Tidy up SandboxCardNumbers
    - Replace `APPLE` with `WALLET` for re-use across all wallet types.
    - Use `Set` rather than `List` interface for efficiency.
    - Remove `.equals()` and add cards to appropriate set to be included in existing
    `.contains()` check.
    - Reorder for better clarity.