### PR TITLE
PP-4597 format output using common formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <eclipselink.version>2.7.4</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <jackson.version>2.9.8</jackson.version>
-        <pay-java-commons.version>1.0.20190118181040</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190129170136</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>
         <dependency-check.skip>true</dependency-check.skip>
     </properties>

--- a/src/main/java/uk/gov/pay/connector/refund/model/SearchRefundsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/SearchRefundsResponse.java
@@ -8,38 +8,15 @@ import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.pay.connector.refund.model.builder.AbstractRefundsResponseBuilder;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @JsonInclude(Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class SearchRefundsResponse {
-
-    public static class SearchRefundsResponseBuilder extends AbstractRefundsResponseBuilder<SearchRefundsResponseBuilder, SearchRefundsResponse> {
-        @Override
-        protected SearchRefundsResponseBuilder thisObject() {
-            return this;
-        }
-
-        @Override
-        public SearchRefundsResponse build() {
-            return new SearchRefundsResponse(
-                    refundId,
-                    createdDate,
-                    status,
-                    extChargeId,
-                    amountSubmitted,
-                    dataLinks
-            );
-        }
-    }
-
-    public static SearchRefundsResponseBuilder anAllRefundsResponseBuilder() {
-        return new SearchRefundsResponseBuilder();
-    }
 
     @JsonProperty("refund_id")
     private String refundId;
@@ -57,7 +34,7 @@ public class SearchRefundsResponse {
     private Long amountSubmitted;
 
     @JsonProperty("links")
-    private List<Map<String, Object>> dataLinks = new ArrayList<>();
+    private List<Map<String, Object>> dataLinks;
 
     private SearchRefundsResponse(String refundId,
                                   ZonedDateTime createdDate,
@@ -106,19 +83,18 @@ public class SearchRefundsResponse {
 
         SearchRefundsResponse that = (SearchRefundsResponse) o;
 
-        if (refundId != null ? !refundId.equals(that.refundId) : that.refundId != null)
+        if (!Objects.equals(refundId, that.refundId))
             return false;
-        if (createdDate != null ? !createdDate.equals(that.createdDate) : that.createdDate != null)
+        if (!Objects.equals(createdDate, that.createdDate))
             return false;
         if (!status.equals(that.status)) {
             return false;
         }
-        if (extChargeId != null ? !extChargeId.equals(that.extChargeId) : that.extChargeId != null)
+        if (!Objects.equals(extChargeId, that.extChargeId))
             return false;
-        if (dataLinks != null ? !dataLinks.equals(that.dataLinks) : that.dataLinks != null)
+        if (!Objects.equals(dataLinks, that.dataLinks))
             return false;
-        return amountSubmitted != null ? amountSubmitted.equals(that.amountSubmitted)
-                : that.amountSubmitted == null;
+        return Objects.equals(amountSubmitted, that.amountSubmitted);
     }
 
     @Override
@@ -143,6 +119,29 @@ public class SearchRefundsResponse {
                 ", amountSubmitted=" + amountSubmitted +
                 ", dataLinks=" + dataLinks +
                 '}';
+    }
+
+    public static class SearchRefundsResponseBuilder extends AbstractRefundsResponseBuilder<SearchRefundsResponseBuilder, SearchRefundsResponse> {
+        @Override
+        protected SearchRefundsResponseBuilder thisObject() {
+            return this;
+        }
+
+        @Override
+        public SearchRefundsResponse build() {
+            return new SearchRefundsResponse(
+                    refundId,
+                    createdDate,
+                    status,
+                    extChargeId,
+                    amountSubmitted,
+                    dataLinks
+            );
+        }
+    }
+
+    public static SearchRefundsResponseBuilder anAllRefundsResponseBuilder() {
+        return new SearchRefundsResponseBuilder();
     }
 }
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/SearchRefundsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/SearchRefundsResponse.java
@@ -3,8 +3,11 @@ package uk.gov.pay.connector.refund.model;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.pay.connector.refund.model.builder.AbstractRefundsResponseBuilder;
 
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +45,8 @@ public class SearchRefundsResponse {
     private String refundId;
 
     @JsonProperty("created_date")
-    private String createdDate;
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime createdDate;
 
     @JsonProperty("status")
     private String status;
@@ -55,12 +59,12 @@ public class SearchRefundsResponse {
     @JsonProperty("links")
     private List<Map<String, Object>> dataLinks = new ArrayList<>();
 
-    protected SearchRefundsResponse(String refundId,
-                                    String createdDate,
-                                    String status,
-                                    String extChargeId,
-                                    Long amountSubmitted,
-                                    List<Map<String, Object>> dataLinks) {
+    private SearchRefundsResponse(String refundId,
+                                  ZonedDateTime createdDate,
+                                  String status,
+                                  String extChargeId,
+                                  Long amountSubmitted,
+                                  List<Map<String, Object>> dataLinks) {
         this.refundId = refundId;
         this.createdDate = createdDate;
         this.status = status;
@@ -74,7 +78,7 @@ public class SearchRefundsResponse {
     }
 
 
-    public String getCreatedDate() {
+    public ZonedDateTime getCreatedDate() {
         return createdDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/builder/AbstractRefundsResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/builder/AbstractRefundsResponseBuilder.java
@@ -4,12 +4,13 @@ import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.net.URI;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public abstract class AbstractRefundsResponseBuilder<T extends AbstractRefundsResponseBuilder<T, R>, R> {
-    protected String createdDate;
+    protected ZonedDateTime createdDate;
     protected List<Map<String, Object>> dataLinks = new ArrayList<>();
     protected String refundId;
     protected RefundEntity refundEntity;
@@ -24,7 +25,7 @@ public abstract class AbstractRefundsResponseBuilder<T extends AbstractRefundsRe
         return thisObject();
     }
 
-    public T withCreatedDate(String createdDate) {
+    public T withCreatedDate(ZonedDateTime createdDate) {
         this.createdDate = createdDate;
         return thisObject();
     }

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundSearchStrategy.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import static java.lang.String.format;
 import static javax.ws.rs.HttpMethod.GET;
-import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.refund.model.SearchRefundsResponse.anAllRefundsResponseBuilder;
 
 public class RefundSearchStrategy extends AbstractSearchStrategy<RefundEntity, SearchRefundsResponse> implements SearchStrategy, BuildResponseStrategy<RefundEntity, SearchRefundsResponse> {
@@ -50,7 +49,7 @@ public class RefundSearchStrategy extends AbstractSearchStrategy<RefundEntity, S
 
         return responseBuilder
                 .withRefundId(externalRefundId)
-                .withCreatedDate(ISO_INSTANT_MILLISECOND_PRECISION.format(refundEntity.getCreatedDate()))
+                .withCreatedDate(refundEntity.getCreatedDate())
                 .withStatus(refundEntity.getStatus().toExternal().getStatus())
                 .withChargeId(externalChargeId)
                 .withAmountSubmitted(refundEntity.getAmount())


### PR DESCRIPTION
## WHAT
- To be consistent in our responses to APIs we are using a common JSON
    serializer to limit our ZonedDateTime fields to millisecond precision.
    by removing the String type from the JSON response, we don't have to use
    the formatter every time when we create this field, we can send it as
    ZonedDateTime and we can let Jackson do he serialization with the custom


