### PR TITLE
PP-4512 Relax conditions for discrepancy resolution

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqStatusMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqStatusMapper.java
@@ -15,14 +15,18 @@ public class EpdqStatusMapper {
     
     static {
         Map<String, ChargeStatus> aMap = new HashMap<>();
-        aMap.put("5", ChargeStatus.AUTHORISATION_SUCCESS);
-        aMap.put("51", ChargeStatus.AUTHORISATION_SUCCESS);
+        aMap.put("2", ChargeStatus.AUTHORISATION_REJECTED);
+
         aMap.put("46", ChargeStatus.AUTHORISATION_3DS_REQUIRED);
+        
+        aMap.put("5", ChargeStatus.AUTHORISATION_SUCCESS);
         aMap.put("50", ChargeStatus.AUTHORISATION_SUBMITTED);
         aMap.put("51", ChargeStatus.AUTHORISATION_SUBMITTED);
-        aMap.put("2", ChargeStatus.AUTHORISATION_REJECTED);
+        aMap.put("52", ChargeStatus.AUTHORISATION_SUBMITTED);
+        
         aMap.put("6", ChargeStatus.USER_CANCELLED);
-        aMap.put("61", ChargeStatus.AUTHORISATION_SUBMITTED);
+        aMap.put("61", ChargeStatus.USER_CANCEL_SUBMITTED);
+        
         aMap.put("9", ChargeStatus.CAPTURED);
         aMap.put("91", ChargeStatus.CAPTURED);
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeExpiryService;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.report.model.GatewayStatusComparison;
 
 import javax.inject.Inject;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,12 +44,24 @@ public class DiscrepancyService {
     }
     
     private GatewayStatusComparison resolve(GatewayStatusComparison gatewayStatusComparison) {
-        if (gatewayStatusComparison.getPayStatus().equals(ChargeStatus.EXPIRED) &&
-                gatewayStatusComparison.getGatewayStatus().equals(ChargeStatus.AUTHORISATION_SUCCESS)) {
+        if (canBeCancelled(gatewayStatusComparison)) {
             expiryService.forceCancelWithGateway(gatewayStatusComparison.getCharge());
             gatewayStatusComparison.setProcessed(true);
         }
         
         return gatewayStatusComparison;
+    }
+
+    private boolean canBeCancelled(GatewayStatusComparison gatewayStatusComparison) {
+        ExternalChargeState payExternalChargeStatus = gatewayStatusComparison.getPayStatus().toExternal();
+        return gatewayStatusComparison.hasExternalStatusMismatch() &&
+                !gatewayStatusComparison.getGatewayStatus().toExternal().isFinished() &&
+                payExternalChargeStatus.isFinished() &&
+                !payExternalChargeStatus.equals(ExternalChargeState.EXTERNAL_SUCCESS) &&
+                chargeAgeInDaysIsGreaterThan(gatewayStatusComparison.getCharge(), 7);
+    }
+
+    private boolean chargeAgeInDaysIsGreaterThan(ChargeEntity charge, long minimumAge) {
+        return charge.getCreatedDate().plusDays(minimumAge).isBefore(ZonedDateTime.now());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceITest.java
@@ -20,15 +20,15 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class ChargeGatewayStatusComparisonReportITest extends ChargingITestBase {
-    public ChargeGatewayStatusComparisonReportITest() {
+public class DiscrepancyResourceITest extends ChargingITestBase {
+    public DiscrepancyResourceITest() {
         super("epdq");
     }
 
     @Test
-    public void shouldReturnAllChargesInDiscrepantState_whenRequestDiscrepancyReport() {
+    public void shouldReturnAllCharges_whenRequestDiscrepancyReport() {
         String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId2 = addCharge(ChargeStatus.CREATED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
+        String chargeId2 = addCharge(ChargeStatus.AUTHORISATION_SUCCESS, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
         epdqMockClient.mockAuthorisationQuerySuccess();
 
         List<JsonNode> results = connectorRestApiClient
@@ -48,11 +48,11 @@ public class ChargeGatewayStatusComparisonReportITest extends ChargingITestBase 
         assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
 
         assertEquals( "AUTHORISATION SUCCESS", results.get(1).get("gatewayStatus").asText());
-        assertEquals( "CREATED", results.get(1).get("payStatus").asText());
+        assertEquals( "AUTHORISATION SUCCESS", results.get(1).get("payStatus").asText());
         assertEquals( chargeId2, results.get(1).get("chargeId").asText());
         assertEquals( "ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(1).get("rawGatewayResponse").asText());
         assertEquals( "EXTERNAL_SUBMITTED", results.get(1).get("gatewayExternalStatus").asText());
-        assertEquals( "EXTERNAL_CREATED", results.get(1).get("payExternalStatus").asText());
+        assertEquals( "EXTERNAL_SUBMITTED", results.get(1).get("payExternalStatus").asText());
     }
     
 
@@ -68,8 +68,8 @@ public class ChargeGatewayStatusComparisonReportITest extends ChargingITestBase 
 
     @Test
     public void shouldProcessDiscrepanciesWherePayStateIsExpiredAndGatewayStateIsAuthorised() {
-        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId2 = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusDays(8), "irrelevant");
+        String chargeId2 = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusDays(8), "irrelevant");
         epdqMockClient.mockAuthorisationQuerySuccess();
         epdqMockClient.mockCancelSuccess();
 
@@ -89,62 +89,5 @@ public class ChargeGatewayStatusComparisonReportITest extends ChargingITestBase 
         assertEquals( "EXTERNAL_SUBMITTED", results.get(0).get("gatewayExternalStatus").asText());
         assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
         assertEquals( true, results.get(0).get("processed").asBoolean());
-    }
-
-    @Test
-    public void shouldNotProcessDiscrepanciesWherePayStateIsAnythingOtherThanExpired() {
-        String chargeId = addCharge(ChargeStatus.CREATED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId2 = addCharge(ChargeStatus.ENTERING_CARD_DETAILS, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId3 = addCharge(ChargeStatus.USER_CANCELLED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId4 = addCharge(ChargeStatus.CAPTURE_APPROVED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId5 = addCharge(ChargeStatus.CAPTURE_SUBMITTED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId6 = addCharge(ChargeStatus.CAPTURED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId7 = addCharge(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId8 = addCharge(ChargeStatus.AUTHORISATION_READY, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        
-        epdqMockClient.mockAuthorisationQuerySuccess();
-
-        List<JsonNode> results = connectorRestApiClient
-                .resolveDiscrepancies(toJson(Arrays.asList(
-                        chargeId,
-                        chargeId2,
-                        chargeId3,
-                        chargeId4,
-                        chargeId5,
-                        chargeId6, 
-                        chargeId7,
-                        chargeId8
-                )))
-                .statusCode(200)
-                .contentType(JSON)
-                .extract().body().jsonPath().getList(".", JsonNode.class);
-
-        assertEquals(8, results.size());
-        
-        assertEquals( false, results.get(0).get("processed").asBoolean());
-        assertEquals( false, results.get(1).get("processed").asBoolean());
-        assertEquals( false, results.get(2).get("processed").asBoolean());
-        assertEquals( false, results.get(3).get("processed").asBoolean());
-        assertEquals( false, results.get(4).get("processed").asBoolean());
-        assertEquals( false, results.get(5).get("processed").asBoolean());
-        assertEquals( false, results.get(6).get("processed").asBoolean());
-        assertEquals( false, results.get(7).get("processed").asBoolean());
-    }
-
-    @Test
-    public void shouldNotProcessDiscrepanciesWhereGatewayStateIsAnythingOtherThanAuthorised() {
-        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-
-        epdqMockClient.mockCaptureQuerySuccess();
-
-        List<JsonNode> results = connectorRestApiClient
-                .resolveDiscrepancies(toJson(Arrays.asList(chargeId)))
-                .statusCode(200)
-                .contentType(JSON)
-                .extract().body().jsonPath().getList(".", JsonNode.class);
-
-        assertEquals(1, results.size());
-
-        assertEquals( false, results.get(0).get("processed").asBoolean());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
@@ -1,0 +1,120 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.service.ChargeExpiryService;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.epdq.ChargeQueryResponse;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DiscrepancyServiceTest {
+
+    private DiscrepancyService discrepancyService;
+    @Mock
+    private ChargeService chargeService;
+
+    @Mock
+    private QueryService queryService;
+
+    @Mock
+    private ChargeExpiryService expiryService;
+
+    @Before
+    public void beforeTest() {
+        discrepancyService = new DiscrepancyService(chargeService, queryService, expiryService);
+    }
+    
+    @Test
+    public void aChargeShouldBeCancellable_whenPayAndGatewayStatusesAllowItAndIsOlderThan7Days() {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.now().minusDays(8))
+                .withStatus(EXPIRED)
+                .build();
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, "Raw response");
+
+        when(chargeService.findChargeById(charge.getExternalId())).thenReturn(charge);
+        when(queryService.getChargeGatewayStatus(charge)).thenReturn(chargeQueryResponse);
+
+        discrepancyService.resolveDiscrepancies(Collections.singletonList(charge.getExternalId()));
+        verify(expiryService).forceCancelWithGateway(charge);
+    }
+
+    @Test
+    public void aChargeShouldNotBeCancellable_whenPayAndGatewayStatusesMatch() {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.now().minusDays(8))
+                .withStatus(AUTHORISATION_SUCCESS)
+                .build();
+        
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, "Raw response");
+        assertChargeIsNotCancelled(charge, chargeQueryResponse);
+    }
+
+    @Test
+    public void aChargeShouldNotBeCancellable_whenPayStatusIsSuccess() {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.now().minusDays(8))
+                .withStatus(CAPTURED)
+                .build();
+        
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, "Raw response");
+        assertChargeIsNotCancelled(charge, chargeQueryResponse);
+    }
+
+    @Test
+    public void aChargeShouldNotBeCancellable_whenPayStatusIsUnfinished() {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.now().minusDays(8))
+                .withStatus(AUTHORISATION_3DS_READY)
+                .build();
+
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, "Raw response");
+        assertChargeIsNotCancelled(charge, chargeQueryResponse);
+    }
+
+    @Test
+    public void aChargeShouldNotBeCancellable_whenGatewayStatusIsFinished() {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.now().minusDays(8))
+                .withStatus(EXPIRED)
+                .build();
+        
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(CAPTURED, "Raw response");
+        assertChargeIsNotCancelled(charge, chargeQueryResponse);
+    }
+
+    @Test
+    public void aChargeShouldNotBeCancellable_whenChargeIsLessThan7DaysOld() {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.now().minusDays(6))
+                .withStatus(EXPIRED)
+                .build();
+        
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, "Raw response");
+        assertChargeIsNotCancelled(charge, chargeQueryResponse);
+    }
+
+    private void assertChargeIsNotCancelled(ChargeEntity charge, ChargeQueryResponse chargeQueryResponse) {
+        when(chargeService.findChargeById(charge.getExternalId())).thenReturn(charge);
+        when(queryService.getChargeGatewayStatus(charge)).thenReturn(chargeQueryResponse);
+
+        discrepancyService.resolveDiscrepancies(Collections.singletonList(charge.getExternalId()));
+        verifyNoMoreInteractions(expiryService);
+    }
+}


### PR DESCRIPTION
Amends the criteria applied to decide whether a charge can be 'force cancelled'
with the gateway. The criteria are now:
- charge has a not finished state with gateway
- charge is finished and not successful with pay
- charge is older than 7 days (this is to avoid accidentally cancelling something
that is temporarily out of sync)

At the moment doing this kind of cancellation may still leave charges in a slightly
weird state. For example if a charge is in `AUTHORISATION_ERROR` with Pay, but
in `AUTHORISATION_SUCCESS` with the gateway (and is older than 7 days etc), then
this change will mean this charge will be allowed to be cancelled, but it
will not result in the states matching, since it makes no change on the Pay
side. Adding something to try and align the Pay state with the gateway state
in this kind of case would be a good next step, but involves a fair bit more work
as we would need to relax all the restrictions around status change etc.

This commit makes some small changes to EPDQ Status Mapper - see
https://support.epdq.co.uk/~/media/kdb/pdf/epdq/en/955815bf-4514-4d75-b683-21034ff5789b/statuses-and-errors.ashx