### PR TITLE
PP-4781 revert db lib upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.8</dropwizard.version>
         <wiremock.version>2.21.0</wiremock.version>
-        <eclipselink.version>2.7.4</eclipselink.version>
+        <eclipselink.version>2.7.3</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <jackson.version>2.9.8</jackson.version>
         <pay-java-commons.version>1.0.20190129170136</pay-java-commons.version>

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.11.9</version>
+            <version>3.9.5</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.2.1</version>
+            <version>2.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.5</version>
+            <version>9.4-1201-jdbc41</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.service.notify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <dropwizard.version>1.3.8</dropwizard.version>
         <wiremock.version>2.21.0</wiremock.version>
         <eclipselink.version>2.7.3</eclipselink.version>
-        <guice.version>4.2.2</guice.version>
+        <guice.version>4.1.0</guice.version>
         <jackson.version>2.9.8</jackson.version>
         <pay-java-commons.version>1.0.20190129170136</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>

--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -52,7 +52,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)
                 .setParameter("externalId", externalId)
-                .getResultStream().findFirst();
+                .getResultList().stream().findFirst();
     }
 
     public Optional<ChargeEntity> findByTokenId(String tokenId) {
@@ -61,7 +61,8 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)
                 .setParameter("tokenId", tokenId)
-                .getResultStream()
+                .getResultList()
+                .stream()
                 .findFirst();
     }
 
@@ -75,7 +76,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .createQuery(query, ChargeEntity.class)
                 .setParameter("externalId", externalId)
                 .setParameter("accountId", accountId)
-                .getResultStream().findFirst();
+                .getResultList().stream().findFirst();
     }
 
     public Optional<ChargeEntity> findByProviderAndTransactionId(String provider, String transactionId) {
@@ -87,7 +88,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)
                 .setParameter("gatewayTransactionId", transactionId)
-                .setParameter("provider", provider).getResultStream().findFirst();
+                .setParameter("provider", provider).getResultList().stream().findFirst();
     }
 
     public List<ChargeEntity> findBeforeDateWithStatusIn(ZonedDateTime date, List<ChargeStatus> statuses) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -31,7 +31,7 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
         return entityManager.get()
                 .createQuery(query, GatewayAccountEntity.class)
                 .setParameter("username", username)
-                .getResultStream().findFirst();
+                .getResultList().stream().findFirst();
     }
 
     public List<GatewayAccountResourceDTO> list(List<Long> accountIds) {

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -54,7 +54,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
                 .createQuery(query, RefundEntity.class)
                 .setParameter("reference", reference)
                 .setParameter("provider", provider)
-                .getResultStream().findFirst();
+                .getResultList().stream().findFirst();
     }
 
     public List<RefundEntity> findByAccountBetweenDatesWithStatusIn(Long gatewayAccountId,
@@ -105,7 +105,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
         return entityManager.get()
                 .createQuery(query, RefundEntity.class)
                 .setParameter("externalId", externalId)
-                .getResultStream().findFirst();
+                .getResultList().stream().findFirst();
     }
 
     public Long getTotalFor(SearchParams params) {

--- a/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
@@ -11,7 +11,6 @@ import javax.persistence.EntityManager;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
@@ -43,7 +42,7 @@ public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {
       .getSingleResult();
   }
 
-  public Stream<GatewayAccountPerformanceReportEntity> aggregateNumberAndValueOfPaymentsByGatewayAccount() {
+  public List<GatewayAccountPerformanceReportEntity> aggregateNumberAndValueOfPaymentsByGatewayAccount() {
     return entityManager
       .get()
       .createQuery(
@@ -65,7 +64,7 @@ public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {
       )
       .setParameter("status", CAPTURED.toString())
       .setParameter("type", LIVE)
-      .getResultStream();
+      .getResultList();
   }
 
   public PerformanceReportEntity aggregateNumberAndValueOfPaymentsForAGivenDay(ZonedDateTime date) {

--- a/src/main/java/uk/gov/pay/connector/report/resource/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/connector/report/resource/PerformanceReportResource.java
@@ -11,8 +11,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
@@ -69,16 +67,22 @@ public class PerformanceReportResource {
     @Path("/v1/api/reports/gateway-account-performance-report")
     @Produces(APPLICATION_JSON)
     public Response getGatewayAccountPerformanceReport() {
-         Map<String, Map<String, Object>> response = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount()
-                 .collect(Collectors.toMap(
-                         performance -> performance.getGatewayAccountId().toString(), 
-                         performance -> ImmutableMap.of(
-                                 "total_volume", performance.getTotalVolume(),
-                                 "total_amount", performance.getTotalAmount(),
-                                 "average_amount", performance.getAverageAmount(),
-                                 "min_amount", performance.getMinAmount(),
-                                 "max_amount", performance.getMaxAmount()
-                 )));
+        HashMap<String, ImmutableMap<String, Object>> response = new HashMap<String, ImmutableMap<String, Object>>();
+
+         performanceReportDao
+           .aggregateNumberAndValueOfPaymentsByGatewayAccount()
+           .forEach(
+             performance -> response.put(
+               performance.getGatewayAccountId().toString(),
+               ImmutableMap.of(
+                 "total_volume", performance.getTotalVolume(),
+                 "total_amount", performance.getTotalAmount(),
+                 "average_amount", performance.getAverageAmount(),
+                 "min_amount", performance.getMinAmount(),
+                 "max_amount", performance.getMaxAmount()
+               )
+             )
+           );
 
          return ok().entity(response).build();
     }

--- a/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
+++ b/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
@@ -21,7 +21,7 @@ public class TokenDao extends JpaDao<TokenEntity> {
         return entityManager.get()
                 .createQuery("SELECT t FROM TokenEntity t WHERE t.token = :token", TokenEntity.class)
                 .setParameter("token", tokenId)
-                .getResultStream()
+                .getResultList().stream()
                 .findFirst();
     }
 
@@ -29,7 +29,7 @@ public class TokenDao extends JpaDao<TokenEntity> {
         return entityManager.get()
                 .createQuery("SELECT t FROM TokenEntity t WHERE t.chargeEntity.id = :chargeId", TokenEntity.class)
                 .setParameter("chargeId", chargeId)
-                .getResultStream()
+                .getResultList().stream()
                 .findFirst();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoITest.java
@@ -75,21 +75,14 @@ public class PerformanceReportDaoITest extends DaoITestBase {
         insertCharge(anotherGatewayAccount, 6L, ZonedDateTime.now());
         insertCharge(anotherGatewayAccount, 3L, ZonedDateTime.now());
         insertCharge(anotherGatewayAccount, 6L, ZonedDateTime.now());
-
-        Object[] gatewayAccountPerformanceReportEntities = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount().toArray();
-
-        assertThat(gatewayAccountPerformanceReportEntities.length, is(2));
-
-        GatewayAccountPerformanceReportEntity first = (GatewayAccountPerformanceReportEntity) gatewayAccountPerformanceReportEntities[0];
-        GatewayAccountPerformanceReportEntity second = (GatewayAccountPerformanceReportEntity) gatewayAccountPerformanceReportEntities[1];
-
-        assertThat(first.getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
-        assertThat(first.getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
-        assertThat(first.getTotalVolume(), is(2L));
-
-        assertThat(second.getAverageAmount(), is(closeTo(new BigDecimal("5"), ZERO)));
-        assertThat(second.getTotalAmount(), is(closeTo(new BigDecimal("15"), ZERO)));
-        assertThat(second.getTotalVolume(), is(3L));
+        List<GatewayAccountPerformanceReportEntity> gatewayAccountPerformanceReportEntities = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount();
+        assertThat(gatewayAccountPerformanceReportEntities.size(), is(2));
+        assertThat(gatewayAccountPerformanceReportEntities.get(0).getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(0).getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(0).getTotalVolume(), is(2L));
+        assertThat(gatewayAccountPerformanceReportEntities.get(1).getAverageAmount(), is(closeTo(new BigDecimal("5"), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(1).getTotalAmount(), is(closeTo(new BigDecimal("15"), ZERO)));
+        assertThat(gatewayAccountPerformanceReportEntities.get(1).getTotalVolume(), is(3L));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/resources/GatewayAccountPerformanceReportResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/GatewayAccountPerformanceReportResourceTest.java
@@ -62,7 +62,7 @@ public class GatewayAccountPerformanceReportResourceTest {
     @Test
     public void noTransactionsPerformanceReportEntitySerializesCorrectly() {
         given(mockPerformanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount())
-                .willReturn(noTransactionsPerformanceReportEntity.stream());
+                .willReturn(noTransactionsPerformanceReportEntity);
 
         Response result = resource.getGatewayAccountPerformanceReport();
 
@@ -76,7 +76,7 @@ public class GatewayAccountPerformanceReportResourceTest {
     @Test
     public void someTransactionsPerformanceReportEntitySerializesCorrectly() {
         given(mockPerformanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount())
-                .willReturn(someTransactionsPerformanceReportEntity.stream());
+                .willReturn(someTransactionsPerformanceReportEntity);
 
         Response result = resource.getGatewayAccountPerformanceReport();
 


### PR DESCRIPTION
## WHAT
Due to a suspicion that recent dependency updates have caused a change in behaviour in connector, we're going to revert them out of prudence for a while.

Revert:

JPA: https://github.com/alphagov/pay-connector/pull/1016
eclipselink: https://github.com/alphagov/pay-connector/pull/1010
postgresql JDBC driver: https://github.com/alphagov/pay-connector/pull/996
guice: https://github.com/alphagov/pay-connector/pull/985
jooq: https://github.com/alphagov/pay-connector/pull/1002



