### PR TITLE
PP-4779: Add/Replace gateway merchant id successfully

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/exception/ValidationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/ValidationExceptionMapper.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -17,7 +18,7 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
 
     @Override
     public Response toResponse(ValidationException exception) {
-        LOGGER.error(exception.getMessage());
+        LOGGER.error(exception.getErrors().stream().collect(Collectors.joining("\n")));
         Map<String, List<String>> entity = ImmutableMap.of("errors", exception.getErrors());
         return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -170,6 +170,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return credentials;
     }
 
+    @JsonProperty("gateway_merchant_id")
+    @JsonView(Views.FrontendView.class)
+    public String getGatewayMerchantId() {
+        return credentials.get("gateway_merchant_id");
+    }
+
     @JsonView(Views.ApiView.class)
     public String getDescription() {
         return description;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_NOTIFY_API_TOKEN;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_NOTIFY_REFUND_ISSUED_TEMPLATE_ID;
@@ -84,6 +85,12 @@ public class GatewayAccountRequestValidator {
     private void validateGatewayMerchantId(JsonNode payload) {
         throwIfInvalidFieldOperation(payload, ADD_OP, REPLACE_OP);
         throwIfNullFieldValue(payload.get(FIELD_VALUE));
+        throwIfBlankFieldValue(payload.get(FIELD_VALUE));
+    }
+
+    private void throwIfBlankFieldValue(JsonNode valueNode) {
+        if (isBlank(valueNode.asText())) 
+            throw new ValidationException(Collections.singletonList(format("Field [%s] cannot be empty", FIELD_VALUE)));
     }
 
     private void validateNotifySettingsRequest(JsonNode payload) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -23,7 +23,9 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_VAL
 public class GatewayAccountRequestValidator {
 
     private static final String REPLACE_OP = "replace";
+    private static final String ADD_OP = "add";
     private static final String REMOVE_OP = "remove";
+    public static final String CREDENTIALS_GATEWAY_MERCHANT_ID = "credentials/gateway_merchant_id";
     public static final String FIELD_ALLOW_WEB_PAYMENTS = "allow_web_payments";
     public static final String FIELD_NOTIFY_SETTINGS = "notify_settings";
     public static final String FIELD_EMAIL_COLLECTION_MODE = "email_collection_mode";
@@ -31,7 +33,9 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT = "corporate_debit_card_surcharge_amount";
     public static final String FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT = "corporate_prepaid_credit_card_surcharge_amount";
     public static final String FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT = "corporate_prepaid_debit_card_surcharge_amount";
-    private static final List<String> VALID_PATHS = asList(FIELD_NOTIFY_SETTINGS, 
+    private static final List<String> VALID_PATHS = asList(
+            CREDENTIALS_GATEWAY_MERCHANT_ID,
+            FIELD_NOTIFY_SETTINGS, 
             FIELD_EMAIL_COLLECTION_MODE, 
             FIELD_ALLOW_WEB_PAYMENTS,
             FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT,
@@ -56,6 +60,9 @@ public class GatewayAccountRequestValidator {
             throw new ValidationException(Collections.singletonList(format("Operation [%s] not supported for path [%s]", FIELD_OPERATION, path)));
         
         switch (path) {
+            case CREDENTIALS_GATEWAY_MERCHANT_ID:
+                validateGatewayMerchantId(payload);
+                break;
             case FIELD_NOTIFY_SETTINGS: 
                 validateNotifySettingsRequest(payload);
                 break;
@@ -72,6 +79,11 @@ public class GatewayAccountRequestValidator {
                 validateCorporateCardSurchargePayload(payload);
                 break;
         }
+    }
+
+    private void validateGatewayMerchantId(JsonNode payload) {
+        throwIfInvalidFieldOperation(payload, ADD_OP);
+        throwIfNullFieldValue(payload.get(FIELD_VALUE));
     }
 
     private void validateNotifySettingsRequest(JsonNode payload) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -82,7 +82,7 @@ public class GatewayAccountRequestValidator {
     }
 
     private void validateGatewayMerchantId(JsonNode payload) {
-        throwIfInvalidFieldOperation(payload, ADD_OP);
+        throwIfInvalidFieldOperation(payload, ADD_OP, REPLACE_OP);
         throwIfNullFieldValue(payload.get(FIELD_VALUE));
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -251,15 +251,17 @@ public class GatewayAccountResource {
             gatewayAccount.setCredentials(updatedCredentials);
             return Response.ok().build();
         }).orElseGet(() -> notFoundResponse(format("The gateway account id '%s' does not exist", gatewayAccountId)));
-    } 
-    
+    }
+
     @GET
     @Path("/v1/frontend/accounts/{accountId}/gateway-merchant-id")
     @Produces(APPLICATION_JSON)
     public Response getGatewayMerchantId(@PathParam("accountId") Long gatewayAccountId) {
         return gatewayDao.findById(gatewayAccountId).map(gatewayAccount -> {
-            String gatewayMerchantId = gatewayAccount.getCredentials().get("gateway_merchant_id");
-            return Response.ok(ImmutableMap.of("gateway_merchant_id", gatewayMerchantId)).build();
+            Optional<String> maybeGatewayMerchantId = Optional.ofNullable(gatewayAccount.getCredentials().get("gateway_merchant_id"));
+            return maybeGatewayMerchantId.map(gatewayMerchantId -> Response.ok(ImmutableMap.of("gateway_merchant_id", maybeGatewayMerchantId.get())).build())
+                    .orElse(notFoundResponse(format("The gateway account id '%s' does not have a merchant id set", gatewayAccountId)));
+
         }).orElseGet(() -> notFoundResponse(format("The gateway account id '%s' does not exist", gatewayAccountId)));
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -42,7 +42,6 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -236,21 +235,6 @@ public class GatewayAccountResource {
                 .doPatch(gatewayAccountId, PatchRequest.from(payload))
                 .map(gatewayAccount -> Response.ok().build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
-    }
-
-    //Deprecate when self service has functionality to update the gateway merchant id
-    @PATCH
-    @Path("/v1/frontend/accounts/{accountId}/gateway-merchant-id/{gatewayMerchantId}")
-    @Consumes(APPLICATION_JSON)
-    @Transactional
-    public Response updateGatewayAccountCredentialsWithGatewayMerchantId(@PathParam("accountId") Long gatewayAccountId, @PathParam("gatewayMerchantId") String gatewayMerchantId) {
-        return gatewayDao.findById(gatewayAccountId).map(gatewayAccount -> {
-            Map<String, String> credentials = gatewayAccount.getCredentials();
-            Map<String, String> updatedCredentials = new HashMap<>(credentials);
-            updatedCredentials.put("gateway_merchant_id", gatewayMerchantId);
-            gatewayAccount.setCredentials(updatedCredentials);
-            return Response.ok().build();
-        }).orElseGet(() -> notFoundResponse(format("The gateway account id '%s' does not exist", gatewayAccountId)));
     }
 
     @GET

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -237,18 +237,6 @@ public class GatewayAccountResource {
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }
 
-    @GET
-    @Path("/v1/frontend/accounts/{accountId}/gateway-merchant-id")
-    @Produces(APPLICATION_JSON)
-    public Response getGatewayMerchantId(@PathParam("accountId") Long gatewayAccountId) {
-        return gatewayDao.findById(gatewayAccountId).map(gatewayAccount -> {
-            Optional<String> maybeGatewayMerchantId = Optional.ofNullable(gatewayAccount.getCredentials().get("gateway_merchant_id"));
-            return maybeGatewayMerchantId.map(gatewayMerchantId -> Response.ok(ImmutableMap.of("gateway_merchant_id", maybeGatewayMerchantId.get())).build())
-                    .orElse(notFoundResponse(format("The gateway account id '%s' does not have a merchant id set", gatewayAccountId)));
-
-        }).orElseGet(() -> notFoundResponse(format("The gateway account id '%s' does not exist", gatewayAccountId)));
-    }
-
     @PATCH
     @Path("/v1/frontend/accounts/{accountId}/credentials")
     @Consumes(APPLICATION_JSON)

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -66,8 +66,7 @@ public class GatewayAccountService {
 
         return GatewayAccountObjectConverter.createResponseFrom(gatewayAccountEntity, uriInfo);
     }
-
-
+    
     private final Map<String, BiConsumer<PatchRequest, GatewayAccountEntity>> attributeUpdater =
             new HashMap<String, BiConsumer<PatchRequest, GatewayAccountEntity>>() {{
                 put(CREDENTIALS_GATEWAY_MERCHANT_ID,

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.CREDENTIALS_GATEWAY_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_WEB_PAYMENTS;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT;
@@ -62,13 +63,20 @@ public class GatewayAccountService {
         gatewayAccountEntity.setCardTypes(cardTypeDao.findAllNon3ds());
 
         gatewayAccountDao.persist(gatewayAccountEntity);
-        
+
         return GatewayAccountObjectConverter.createResponseFrom(gatewayAccountEntity, uriInfo);
     }
 
 
     private final Map<String, BiConsumer<PatchRequest, GatewayAccountEntity>> attributeUpdater =
             new HashMap<String, BiConsumer<PatchRequest, GatewayAccountEntity>>() {{
+                put(CREDENTIALS_GATEWAY_MERCHANT_ID,
+                        (gatewayAccountRequest, gatewayAccountEntity) -> {
+                            Map<String, String> credentials = gatewayAccountEntity.getCredentials();
+                            Map<String, String> updatedCredentials = new HashMap<>(credentials);
+                            updatedCredentials.put("gateway_merchant_id", gatewayAccountRequest.valueAsString());
+                            gatewayAccountEntity.setCredentials(updatedCredentials);
+                        });
                 put(FIELD_ALLOW_WEB_PAYMENTS,
                         (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setAllowWebPayments(Boolean.valueOf(gatewayAccountRequest.valueAsString())));
                 put(FIELD_NOTIFY_SETTINGS,

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -53,6 +53,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
 import static uk.gov.pay.connector.matcher.ResponseContainsLinkMatcher.containsLink;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -425,15 +426,7 @@ public class ChargesFrontendResourceITest {
 
     private String postToCreateACharge(long expectedAmount) {
         String reference = "Test reference";
-        String postBody = toJson(ImmutableMap.builder()
-                .put("reference", reference)
-                .put("description", description)
-                .put("amount", expectedAmount)
-                .put("gateway_account_id", accountId)
-                .put("return_url", returnUrl)
-                .put("email", email)
-                .put("delayed_capture", true).build());
-
+        String postBody = createChargePostBody(description, expectedAmount, accountId, returnUrl, email);
         ValidatableResponse response = connectorRestApi
                 .withAccountId(accountId)
                 .postCreateCharge(postBody)

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceTest.java
@@ -41,7 +41,12 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
     @Test
     @Parameters({"sandbox", "worldpay", "smartpay", "epdq"})
     public void createAGatewayAccount(String provider) {
-        createAGatewayAccountFor(provider, "my test service", "analytics");
+        String description = "my test service";
+        String analyticsId = "analytics";
+        ValidatableResponse validatableResponse = createAGatewayAccountFor(testContext.getPort(), provider, description, analyticsId);
+        assertCorrectCreateResponse(validatableResponse, GatewayAccountEntity.Type.TEST, description, analyticsId, null);
+        assertGettingAccountReturnsProviderName(testContext.getPort(), validatableResponse, provider, GatewayAccountEntity.Type.TEST);
+        assertGatewayAccountCredentialsAreEmptyInDB(validatableResponse, databaseTestHelper);
     }
 
     @Test
@@ -104,8 +109,8 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
                 .then()
                 .statusCode(201);
 
-        assertCorrectCreateResponse(response);
-        assertGettingAccountReturnsProviderName(response, "sandbox", TEST);
+        assertCorrectCreateResponse(response, TEST);
+        assertGettingAccountReturnsProviderName(testContext.getPort(), response, "sandbox", TEST);
     }
 
     @Test
@@ -133,7 +138,7 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
                 .statusCode(201);
 
         assertCorrectCreateResponse(response, LIVE);
-        assertGettingAccountReturnsProviderName(response, "worldpay", LIVE);
+        assertGettingAccountReturnsProviderName(testContext.getPort(), response, "worldpay", LIVE);
     }
 
     @Test
@@ -174,7 +179,7 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
                 .statusCode(201);
 
         assertCorrectCreateResponse(response, TEST, "desc", "analytics-id", "my service name");
-        assertGettingAccountReturnsProviderName(response, "sandbox", TEST);
+        assertGettingAccountReturnsProviderName(testContext.getPort(), response, "sandbox", TEST);
     }
 
     @Test
@@ -187,6 +192,10 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
                 .statusCode(201);
 
         assertCorrectCreateResponse(response, TEST);
-        assertGettingAccountReturnsProviderName(response, "worldpay", TEST);
+        assertGettingAccountReturnsProviderName(testContext.getPort(), response, "worldpay", TEST);
+    }
+
+    private void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountEntity.Type type) {
+        assertCorrectCreateResponse(response, type, null, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -1,12 +1,9 @@
 package uk.gov.pay.connector.it.resources;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import org.apache.http.HttpStatus;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.lang.String.join;
@@ -37,124 +35,15 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceTestBase {
 
     private static final String ACCOUNTS_CARD_TYPE_FRONTEND_URL = "v1/frontend/accounts/{accountId}/card-types";
-
-    static class GatewayAccountPayload {
-        String userName;
-        String password;
-        String merchantId;
-        String serviceName;
-
-        static GatewayAccountPayload createDefault() {
-            return new GatewayAccountPayload()
-                    .withUsername("a-username")
-                    .withPassword("a-password")
-                    .withMerchantId("a-merchant-id")
-                    .withServiceName("a-service-name");
-        }
-
-        public GatewayAccountPayload withServiceName(String serviceName) {
-            this.serviceName = serviceName;
-            return this;
-        }
-
-        public GatewayAccountPayload withUsername(String userName) {
-            this.userName = userName;
-            return this;
-        }
-
-        public GatewayAccountPayload withPassword(String password) {
-            this.password = password;
-            return this;
-        }
-
-        public GatewayAccountPayload withMerchantId(String merchantId) {
-            this.merchantId = merchantId;
-            return this;
-        }
-
-        public Map<String, String> getCredentials() {
-            HashMap<String, String> credentials = new HashMap<>();
-
-            if (this.userName != null) {
-                credentials.put("username", userName);
-            }
-
-            if (this.password != null) {
-                credentials.put("password", password);
-            }
-
-            if (this.merchantId != null) {
-                credentials.put("merchant_id", merchantId);
-            }
-
-            return credentials;
-        }
-
-        Map<String, Object> buildCredentialsPayload() {
-            return ImmutableMap.of("credentials", getCredentials());
-        }
-
-        Map buildServiceNamePayload() {
-            return ImmutableMap.of("service_name", serviceName);
-        }
-
-        String getServiceName() {
-            return serviceName;
-        }
-
-        String getPassword() {
-            return password;
-        }
-
-        String getUserName() {
-            return userName;
-        }
-
-        String getMerchantId() {
-            return merchantId;
-        }
-
-    }
-
+    
     private Gson gson = new Gson();
     
-    @Test
-    public void updateGatewayAccountWithGatewayMerchantId() throws Exception {
-        String accountId = createAGatewayAccountFor("worldpay");
-        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
-        updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload());
-
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
-                "path", "credentials/gateway_merchant_id",
-                "value", "1234abc"));
-        
-        givenSetup()
-                .body(payload)
-                .patch("/v1/api/accounts/" + accountId)
-                .then()
-                .statusCode(HttpStatus.SC_OK);
-
-        String chargeId = givenSetup()
-                .contentType(JSON)
-                .body(createChargePostBody(accountId))
-                .post(format("/v1/api/accounts/%s/charges", accountId))
-                .then()
-                .extract()
-                .path("charge_id");
-        
-        givenSetup().contentType(JSON)
-                .get("/v1/frontend/charges/" + chargeId)
-                .then().log().body()
-                .body("gateway_account.gateway_merchant_id", is("1234abc"));
-    }
-
     @Test
     public void shouldGetGatewayAccountForExistingAccount() {
         String accountId = createAGatewayAccountFor("worldpay");
@@ -300,7 +189,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault()
                 .withMerchantId("a-merchant-id");
 
-        updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload())
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload())
                 .then()
                 .statusCode(200);
 
@@ -314,7 +203,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
 
         GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault();
 
-        updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload())
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload())
                 .then()
                 .statusCode(200);
 
@@ -330,7 +219,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .withUsername("someone@some{[]where&^%>?\\/")
                 .withPassword("56g%%Bqv\\>/<wdUpi@#bh{[}]6JV+8w");
 
-        updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload())
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload())
                 .then()
                 .statusCode(200);
 
@@ -342,7 +231,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
     public void updateCredentials_shouldNotUpdateGatewayAccountCredentialsIfMissingCredentials() {
         String accountId = createAGatewayAccountFor("worldpay");
 
-        updateGatewayAccountCredentialsWith(accountId, new HashMap<>())
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, new HashMap<>())
                 .then()
                 .statusCode(400)
                 .body("message", is("Field(s) missing: [credentials]"));
@@ -357,7 +246,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .withServiceName("a-service-name")
                 .buildCredentialsPayload();
 
-        updateGatewayAccountCredentialsWith(accountId, credentials)
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, credentials)
                 .then()
                 .statusCode(400)
                 .body("message", is("Field(s) missing: [password]"));
@@ -375,7 +264,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .withPassword("a-password")
                 .buildCredentialsPayload();
 
-        updateGatewayAccountCredentialsWith(accountId, credentials)
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, credentials)
                 .then()
                 .statusCode(400)
                 .body("message", is("Field(s) missing: [merchant_id]"));
@@ -390,7 +279,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .withServiceName("a-service-name")
                 .buildCredentialsPayload();
 
-        updateGatewayAccountCredentialsWith(accountId, credentials)
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, credentials)
                 .then()
                 .statusCode(400)
                 .body("message", is("Field(s) missing: [password, merchant_id]"));
@@ -399,7 +288,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
     @Test
     public void updateCredentials_shouldNotUpdateGatewayAccountCredentialsIfAccountIdIsNotNumeric() {
         Map<String, Object> credentials = GatewayAccountPayload.createDefault().buildCredentialsPayload();
-        updateGatewayAccountCredentialsWith("NO_NUMERIC_ACCOUNT_ID", credentials)
+        updateGatewayAccountCredentialsWith(testContext.getPort(), "NO_NUMERIC_ACCOUNT_ID", credentials)
                 .then()
                 .contentType(JSON)
                 .statusCode(NOT_FOUND.getStatusCode())
@@ -413,7 +302,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         createAGatewayAccountFor("smartpay");
 
         Map<String, Object> credentials = GatewayAccountPayload.createDefault().buildCredentialsPayload();
-        updateGatewayAccountCredentialsWith(nonExistingAccountId, credentials)
+        updateGatewayAccountCredentialsWith(testContext.getPort(), nonExistingAccountId, credentials)
                 .then()
                 .statusCode(404)
                 .body("message", is("The gateway account id '111111111' does not exist"));
@@ -573,8 +462,9 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         assertEquals(0, acceptedCardTypes.size());
     }
 
-    private Response updateGatewayAccountCredentialsWith(String accountId, Map<String, Object> credentials) {
-        return givenSetup().accept(JSON)
+    public static Response updateGatewayAccountCredentialsWith(int port, String accountId, Map<String, Object> credentials) {
+        return given().port(port)
+                .contentType(JSON).accept(JSON)
                 .body(credentials)
                 .patch(ACCOUNTS_FRONTEND_URL + accountId + "/credentials");
     }
@@ -601,4 +491,18 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         return format("{\"card_types\": [%s]}", join(",", cardTypeIds));
     }
 
+    private String createAGatewayAccountFor(String provider) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider));
+    }
+
+    private String createAGatewayAccountFor(String provider, String desc, String id) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, desc, id));
+    }
+
+    private DatabaseFixtures.TestAccount createAccountRecordWithCards(CardTypeEntity... cardTypes) {
+        return databaseFixtures
+                .aTestAccount()
+                .withCardTypeEntities(Arrays.asList(cardTypes))
+                .insert();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.resources;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import io.restassured.http.ContentType;
@@ -124,13 +125,18 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
     private Gson gson = new Gson();
     
     @Test
-    public void updateAndGetGatewayAccountWithWorldpayMerchantId() {
+    public void updateAndGetGatewayAccountWithWorldpayMerchantId() throws Exception {
         String accountId = createAGatewayAccountFor("worldpay");
         GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
         updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload());
 
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+                "path", "credentials/gateway_merchant_id",
+                "value", "1234abc"));
+        
         givenSetup()
-                .patch(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id/" + "1234abc")
+                .body(payload)
+                .patch("/v1/api/accounts/" + accountId)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -139,6 +139,21 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("gateway_merchant_id", is("1234abc"));
+
+        givenSetup().accept(JSON)
+                .get(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("gateway_merchant_id", is("1234abc"));
+    }
+    
+    @Test
+    public void getGatewayAccountWithInvalidAccount(){
+        givenSetup().accept(JSON)
+                .get(ACCOUNTS_FRONTEND_URL + "99999999" + "/gateway-merchant-id")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body("message", is("The gateway account id '99999999' does not exist"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -5,6 +5,7 @@ import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
+import org.apache.http.HttpStatus;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -121,6 +122,24 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
     }
 
     private Gson gson = new Gson();
+    
+    @Test
+    public void updateAndGetGatewayAccountWithWorldpayMerchantId() {
+        String accountId = createAGatewayAccountFor("worldpay");
+        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
+        updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload());
+
+        givenSetup().accept(JSON)
+                .patch(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id/" + "1234abc")
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+
+        givenSetup().accept(JSON)
+                .get(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id")
+                .then()
+                .statusCode(HttpStatus.SC_OK)
+                .body("gateway_merchant_id", is("1234abc"));
+    }
 
     @Test
     public void shouldGetGatewayAccountForExistingAccount() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -129,31 +129,43 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
         updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload());
 
-        givenSetup().accept(JSON)
+        givenSetup()
                 .patch(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id/" + "1234abc")
                 .then()
                 .statusCode(HttpStatus.SC_OK);
 
-        givenSetup().accept(JSON)
+        givenSetup()
                 .get(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("gateway_merchant_id", is("1234abc"));
 
-        givenSetup().accept(JSON)
+        givenSetup()
                 .get(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id")
                 .then()
                 .statusCode(HttpStatus.SC_OK)
                 .body("gateway_merchant_id", is("1234abc"));
     }
-    
+
     @Test
     public void getGatewayAccountWithInvalidAccount(){
-        givenSetup().accept(JSON)
+        givenSetup()
                 .get(ACCOUNTS_FRONTEND_URL + "99999999" + "/gateway-merchant-id")
                 .then()
                 .statusCode(HttpStatus.SC_NOT_FOUND)
                 .body("message", is("The gateway account id '99999999' does not exist"));
+    }
+
+    @Test
+    public void getGatewayAccountWithoutMerchantId(){
+        String accountId = createAGatewayAccountFor("worldpay");
+        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
+        updateGatewayAccountCredentialsWith(accountId, gatewayAccountPayload.buildCredentialsPayload());
+        givenSetup()
+                .get(ACCOUNTS_FRONTEND_URL + accountId + "/gateway-merchant-id")
+                .then()
+                .statusCode(HttpStatus.SC_NOT_FOUND)
+                .body("message", is(format("The gateway account id '%s' does not have a merchant id set", accountId)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -28,7 +28,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;
-
+    
     @Test
     public void getAccountShouldReturn404IfAccountIdIsUnknown() {
         String unknownAccountId = "92348739";
@@ -93,7 +93,8 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
 
     @Test
     public void getAccountShouldReturn3dsSetting() {
-        String gatewayAccountId = createAGatewayAccountFor("stripe", "desc", null, "true");
+        String gatewayAccountId = extractGatewayAccountId(
+                createAGatewayAccountFor(testContext.getPort(), "stripe", "desc", null, "true"));
         givenSetup()
                 .get(ACCOUNTS_API_URL + gatewayAccountId)
                 .then()
@@ -656,5 +657,13 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .patch("/v1/api/accounts/" + gatewayAccountId)
                 .then()
                 .statusCode(NOT_FOUND.getStatusCode());
+    }
+
+    private String createAGatewayAccountFor(String provider) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider));
+    }
+
+    private String createAGatewayAccountFor(String provider, String desc, String id) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, desc, id));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
@@ -36,17 +36,7 @@ public class GatewayMerchantIdITest {
         replaceGatewayMerchantId(accountId, "abc1234");
         assertGatewayMerchantIdOnCharge(accountId, "abc1234");
     }
-
-    private void replaceGatewayMerchantId(String accountId, String gatewayMerchantId) throws JsonProcessingException {
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
-                "path", "credentials/gateway_merchant_id",
-                "value", gatewayMerchantId));
-        given().port(testContext.getPort())
-                .contentType(JSON)
-                .body(payload)
-                .patch("/v1/api/accounts/" + accountId);
-    }
-
+    
     @Test
     public void addGatewayMerchantIdToGatewayAccount() throws Exception {
         String accountId = setUpAccount();
@@ -72,17 +62,25 @@ public class GatewayMerchantIdITest {
                 .body("gateway_account.gateway_merchant_id", is(gatewayMerchantId));
     }
 
-    private void addGatewayMerchantIdToAccount(String accountId, String gatewayMerchantId) throws JsonProcessingException {
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+    private void replaceGatewayMerchantId(String accountId, String gatewayMerchantId) throws JsonProcessingException {
+        patch(accountId, gatewayMerchantId, "replace");
+    }
+
+    private void patch(String accountId, String gatewayMerchantId, String op) throws JsonProcessingException {
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", op,
                 "path", "credentials/gateway_merchant_id",
                 "value", gatewayMerchantId));
-
+        
         given().port(testContext.getPort())
                 .contentType(JSON)
                 .body(payload)
                 .patch("/v1/api/accounts/" + accountId)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
+    }
+
+    private void addGatewayMerchantIdToAccount(String accountId, String gatewayMerchantId) throws JsonProcessingException {
+        patch(accountId, gatewayMerchantId, "add");
     }
     
     private String setUpAccount() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
@@ -1,0 +1,113 @@
+package uk.gov.pay.connector.it.resources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.apache.http.HttpStatus;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.GatewayAccountPayload;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.it.resources.GatewayAccountFrontendResourceITest.updateGatewayAccountCredentialsWith;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.createAGatewayAccountFor;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.extractGatewayAccountId;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class GatewayMerchantIdITest {
+
+    @DropwizardTestContext
+    protected TestContext testContext;
+
+    @Test
+    public void shouldErrorIfAddingAGatewayMerchantIdWhenItAlreadyExists() {
+        
+    }
+    
+    @Ignore
+    @Test
+    public void updateGatewayAccountMerchantId() throws Exception {
+        String accountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
+        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload());
+
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+                "path", "credentials/gateway_merchant_id",
+                "value", "1234abc"));
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .body(payload)
+                .patch("/v1/api/accounts/" + accountId)
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+
+        payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+                "path", "credentials/gateway_merchant_id",
+                "value", "abc1234"));
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .body(payload)
+                .patch("/v1/api/accounts/" + accountId);
+
+        String chargeId = given().port(testContext.getPort())
+                .contentType(JSON)
+                .body(createChargePostBody(accountId))
+                .post(format("/v1/api/accounts/%s/charges", accountId))
+                .then()
+                .extract()
+                .path("charge_id");
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .contentType(JSON)
+                .get("/v1/frontend/charges/" + chargeId)
+                .then().log().body()
+                .body("gateway_account.gateway_merchant_id", is("abc1234"));
+    }
+
+    @Test
+    public void updateGatewayAccountWithGatewayMerchantId() throws Exception {
+        String accountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
+        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload());
+
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+                "path", "credentials/gateway_merchant_id",
+                "value", "1234abc"));
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .body(payload)
+                .patch("/v1/api/accounts/" + accountId)
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+
+        String chargeId = given().port(testContext.getPort())
+                .contentType(JSON)
+                .contentType(JSON)
+                .body(createChargePostBody(accountId))
+                .post(format("/v1/api/accounts/%s/charges", accountId))
+                .then()
+                .extract()
+                .path("charge_id");
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .contentType(JSON)
+                .get("/v1/frontend/charges/" + chargeId)
+                .then().log().body()
+                .body("gateway_account.gateway_merchant_id", is("1234abc"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.it.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.http.HttpStatus;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -30,38 +30,33 @@ public class GatewayMerchantIdITest {
     protected TestContext testContext;
 
     @Test
-    public void shouldErrorIfAddingAGatewayMerchantIdWhenItAlreadyExists() {
-        
+    public void replaceGatewayMerchantId() throws Exception {
+        String accountId = setUpAccount();
+        addGatewayMerchantIdToAccount(accountId, "1234abc");
+        replaceGatewayMerchantId(accountId, "abc1234");
+        assertGatewayMerchantIdOnCharge(accountId, "abc1234");
     }
-    
-    @Ignore
-    @Test
-    public void updateGatewayAccountMerchantId() throws Exception {
-        String accountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
-        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
-        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload());
 
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+    private void replaceGatewayMerchantId(String accountId, String gatewayMerchantId) throws JsonProcessingException {
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
                 "path", "credentials/gateway_merchant_id",
-                "value", "1234abc"));
-
-        given().port(testContext.getPort())
-                .contentType(JSON)
-                .body(payload)
-                .patch("/v1/api/accounts/" + accountId)
-                .then()
-                .statusCode(HttpStatus.SC_OK);
-
-        payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
-                "path", "credentials/gateway_merchant_id",
-                "value", "abc1234"));
-
+                "value", gatewayMerchantId));
         given().port(testContext.getPort())
                 .contentType(JSON)
                 .body(payload)
                 .patch("/v1/api/accounts/" + accountId);
+    }
 
+    @Test
+    public void addGatewayMerchantIdToGatewayAccount() throws Exception {
+        String accountId = setUpAccount();
+        addGatewayMerchantIdToAccount(accountId, "1234abc");
+        assertGatewayMerchantIdOnCharge(accountId, "1234abc");
+    }
+
+    private void assertGatewayMerchantIdOnCharge(String accountId, String gatewayMerchantId) {
         String chargeId = given().port(testContext.getPort())
+                .contentType(JSON)
                 .contentType(JSON)
                 .body(createChargePostBody(accountId))
                 .post(format("/v1/api/accounts/%s/charges", accountId))
@@ -73,19 +68,14 @@ public class GatewayMerchantIdITest {
                 .contentType(JSON)
                 .contentType(JSON)
                 .get("/v1/frontend/charges/" + chargeId)
-                .then().log().body()
-                .body("gateway_account.gateway_merchant_id", is("abc1234"));
+                .then()
+                .body("gateway_account.gateway_merchant_id", is(gatewayMerchantId));
     }
 
-    @Test
-    public void updateGatewayAccountWithGatewayMerchantId() throws Exception {
-        String accountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
-        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
-        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload());
-
+    private void addGatewayMerchantIdToAccount(String accountId, String gatewayMerchantId) throws JsonProcessingException {
         String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
                 "path", "credentials/gateway_merchant_id",
-                "value", "1234abc"));
+                "value", gatewayMerchantId));
 
         given().port(testContext.getPort())
                 .contentType(JSON)
@@ -93,21 +83,12 @@ public class GatewayMerchantIdITest {
                 .patch("/v1/api/accounts/" + accountId)
                 .then()
                 .statusCode(HttpStatus.SC_OK);
-
-        String chargeId = given().port(testContext.getPort())
-                .contentType(JSON)
-                .contentType(JSON)
-                .body(createChargePostBody(accountId))
-                .post(format("/v1/api/accounts/%s/charges", accountId))
-                .then()
-                .extract()
-                .path("charge_id");
-
-        given().port(testContext.getPort())
-                .contentType(JSON)
-                .contentType(JSON)
-                .get("/v1/frontend/charges/" + chargeId)
-                .then().log().body()
-                .body("gateway_account.gateway_merchant_id", is("1234abc"));
+    }
+    
+    private String setUpAccount() {
+        String accountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
+        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload());
+        return accountId;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.util;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang.math.RandomUtils;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -7,8 +8,25 @@ import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import java.util.Map;
 
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+
 public class ChargeUtils {
 
+    public static String createChargePostBody(String accountId) {
+        return createChargePostBody("description", 100, accountId, "http://nothing", "default@email.com");
+    }
+    
+    public static String createChargePostBody(String description, long expectedAmount, String accountId, String returnUrl, String email) {
+        return toJson(ImmutableMap.builder()
+                .put("reference", "Test reference")
+                .put("description", description)
+                .put("amount", expectedAmount)
+                .put("gateway_account_id", accountId)
+                .put("return_url", returnUrl)
+                .put("email", email)
+                .put("delayed_capture", true).build());
+    }
+    
     public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, DatabaseTestHelper databaseTestHelper) {
         long chargeId = RandomUtils.nextInt();
         ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);


### PR DESCRIPTION
We could have used the `PATCH /v1/frontend/accounts/{accountId}` method to
update the credentials but operationally curling `PATCH
/v1/frontend/accounts/{accountId}/gateway-merchant-id/{gatewayMerchantId}` manually is
simpler and will be deprecated once the functionality in self service to update
a gateway account with the gateway merchant id is in place.

@oswaldquek @gidsg
