### PR TITLE
PP-4790 Bump libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>1.3.8</dropwizard.version>
+        <liquibase.version>3.3.5</liquibase.version>
         <wiremock.version>2.21.0</wiremock.version>
-        <eclipselink.version>2.7.3</eclipselink.version>
-        <guice.version>4.1.0</guice.version>
+        <eclipselink.version>2.7.4</eclipselink.version>
+        <guice.version>4.2.2</guice.version>
         <jackson.version>2.9.8</jackson.version>
-        <pay-java-commons.version>1.0.20190129170136</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190212145152</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>
         <dependency-check.skip>true</dependency-check.skip>
+        <javax.persistence.version>2.2.1</javax.persistence.version>
+        <jooq.version>3.11.9</jooq.version>
+        <postgresql.version>42.2.5</postgresql.version>
     </properties>
     <repositories>
         <repository>
@@ -73,7 +77,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.3.5</version>
+            <version>${liquibase.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.servlet</groupId>
@@ -109,7 +113,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4-1201-jdbc41</version>
+            <version>${postgresql.version}</version>
         </dependency>
         <dependency>
             <groupId>uk.gov.service.notify</groupId>
@@ -160,7 +164,7 @@
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
-            <version>2.1.1</version>
+            <version>${javax.persistence.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
@@ -276,7 +280,7 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.9.5</version>
+            <version>${jooq.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
## WHAT
- Added pay-java-commons with fix for NPE in XRaySessionFilter
- Not all the libraries have been upgraded as Liquibase and JDBC driver are throwing exceptions locally for missing extensions that need to be installed via db migrations. These should be fixed in a future PR. 

Edit: I added `postgresql` to this commit, as the error is from Liquibase.
