### PR TITLE
PP-4784: Web payments flags

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -107,8 +107,15 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Column(name = "requires_3ds")
     private boolean requires3ds;
 
+    //Deprecate when frontend no longer uses this
     @Column(name = "allow_web_payments")
     private boolean allowWebPayments;
+
+    @Column(name = "allow_google_pay")
+    private boolean allowGooglePay;
+
+    @Column(name = "allow_apple_pay")
+    private boolean allowApplePay;
 
     @Column(name = "corporate_credit_card_surcharge_amount")
     private long corporateCreditCardSurchargeAmount;
@@ -170,12 +177,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return credentials;
     }
 
-    @JsonProperty("gateway_merchant_id")
-    @JsonView(Views.FrontendView.class)
-    public String getGatewayMerchantId() {
-        return credentials.get("gateway_merchant_id");
-    }
-
     @JsonView(Views.ApiView.class)
     public String getDescription() {
         return description;
@@ -230,6 +231,26 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setAllowWebPayments(boolean allowWebPayments) {
         this.allowWebPayments = allowWebPayments;
+    }
+
+    @JsonProperty("allow_google_pay")
+    @JsonView(Views.FrontendView.class)
+    public boolean isAllowGooglePay() {
+        return allowGooglePay && isNotBlank(credentials.get("gateway_merchant_id"));
+    }
+
+    @JsonProperty("allow_apple_pay")
+    @JsonView(Views.FrontendView.class)
+    public boolean isAllowApplePay() {
+        return allowApplePay;
+    }
+
+    public void setAllowGooglePay(boolean allowGooglePay) {
+        this.allowGooglePay = allowGooglePay;
+    }
+
+    public void setAllowApplePay(boolean allowApplePay) {
+        this.allowApplePay = allowApplePay;
     }
 
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -172,6 +172,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return gatewayName;
     }
 
+    @JsonProperty("gateway_merchant_id")
+    @JsonView(Views.FrontendView.class)
+    public String getGatewayMerchantId() {
+        return credentials.get("gateway_merchant_id");
+    }
+
     @JsonView(Views.ApiView.class)
     public Map<String, String> getCredentials() {
         return credentials;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -75,9 +75,13 @@ public class GatewayAccountRequestValidator {
                 validateEmailCollectionMode(payload);
                 break;
             case FIELD_ALLOW_GOOGLE_PAY:
+                validateAllowWebPayment(payload, FIELD_ALLOW_GOOGLE_PAY);
+                break;
             case FIELD_ALLOW_APPLE_PAY:
+                validateAllowWebPayment(payload, FIELD_ALLOW_APPLE_PAY);
+                break;
             case FIELD_ALLOW_WEB_PAYMENTS: //TODO deprecate
-                validateAllowWebPayment(payload);
+                validateAllowWebPayment(payload, FIELD_ALLOW_WEB_PAYMENTS);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT: 
             case FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT:
@@ -123,12 +127,12 @@ public class GatewayAccountRequestValidator {
         }
     }
 
-    private void validateAllowWebPayment(JsonNode payload) {
+    private void validateAllowWebPayment(JsonNode payload, String field) {
         throwIfInvalidFieldOperation(payload, REPLACE_OP);
         throwIfNullFieldValue(payload.get(FIELD_VALUE));
         String booleanString = payload.get(FIELD_VALUE).asText().toLowerCase();
         if (!booleanString.equals("false") && !booleanString.equals("true")) {
-            throw new ValidationException(Collections.singletonList(format("Value [%s] is not valid for [%s]", booleanString, FIELD_ALLOW_WEB_PAYMENTS)));
+            throw new ValidationException(Collections.singletonList(format("Value [%s] is not valid for [%s]", booleanString, field)));
         }
     }
     

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -28,6 +28,8 @@ public class GatewayAccountRequestValidator {
     private static final String REMOVE_OP = "remove";
     public static final String CREDENTIALS_GATEWAY_MERCHANT_ID = "credentials/gateway_merchant_id";
     public static final String FIELD_ALLOW_WEB_PAYMENTS = "allow_web_payments";
+    public static final String FIELD_ALLOW_APPLE_PAY = "allow_apple_pay";
+    public static final String FIELD_ALLOW_GOOGLE_PAY = "allow_google_pay";
     public static final String FIELD_NOTIFY_SETTINGS = "notify_settings";
     public static final String FIELD_EMAIL_COLLECTION_MODE = "email_collection_mode";
     public static final String FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT = "corporate_credit_card_surcharge_amount";
@@ -39,6 +41,8 @@ public class GatewayAccountRequestValidator {
             FIELD_NOTIFY_SETTINGS, 
             FIELD_EMAIL_COLLECTION_MODE, 
             FIELD_ALLOW_WEB_PAYMENTS,
+            FIELD_ALLOW_APPLE_PAY,
+            FIELD_ALLOW_GOOGLE_PAY,
             FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT,
             FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT,
             FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT,
@@ -70,7 +74,9 @@ public class GatewayAccountRequestValidator {
             case FIELD_EMAIL_COLLECTION_MODE:
                 validateEmailCollectionMode(payload);
                 break;
-            case FIELD_ALLOW_WEB_PAYMENTS:
+            case FIELD_ALLOW_GOOGLE_PAY:
+            case FIELD_ALLOW_APPLE_PAY:
+            case FIELD_ALLOW_WEB_PAYMENTS: //TODO deprecate
                 validateAllowWebPayment(payload);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT: 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.CREDENTIALS_GATEWAY_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_GOOGLE_PAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_WEB_PAYMENTS;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT;
@@ -76,6 +78,10 @@ public class GatewayAccountService {
                             updatedCredentials.put("gateway_merchant_id", gatewayAccountRequest.valueAsString());
                             gatewayAccountEntity.setCredentials(updatedCredentials);
                         });
+                put(FIELD_ALLOW_GOOGLE_PAY,
+                        (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setAllowGooglePay(Boolean.valueOf(gatewayAccountRequest.valueAsString())));
+                put(FIELD_ALLOW_APPLE_PAY,
+                        (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setAllowApplePay(Boolean.valueOf(gatewayAccountRequest.valueAsString())));
                 put(FIELD_ALLOW_WEB_PAYMENTS,
                         (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setAllowWebPayments(Boolean.valueOf(gatewayAccountRequest.valueAsString())));
                 put(FIELD_NOTIFY_SETTINGS,

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
@@ -1,0 +1,122 @@
+package uk.gov.pay.connector.it.resources;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import io.restassured.response.Response;
+import junitparams.Parameters;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.GatewayAccountPayload;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.ACCOUNTS_FRONTEND_URL;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.createAGatewayAccountFor;
+import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.extractGatewayAccountId;
+import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class ChargesApiResourceAllowWebPaymentsITest {
+    
+    private String accountId;
+    private String chargeId;
+
+    @DropwizardTestContext
+    protected TestContext testContext;
+    
+    @Before
+    public void setup() {
+        accountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
+        GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
+        updateGatewayAccountCredentialsWith(testContext.getPort(), accountId, gatewayAccountPayload.buildCredentialsPayload());
+        chargeId = createCharge(testContext.getPort(), accountId);
+        assertAppleAndGooglePayAreDisabledByDefault();
+    }
+
+    private void assertAppleAndGooglePayAreDisabledByDefault() {
+        given().port(testContext.getPort()).contentType(JSON)
+                .get("/v1/frontend/charges/" + chargeId)
+                .then()
+                .body("gateway_account.allow_apple_pay", is(false))
+                .body("gateway_account.allow_google_pay", is(false));
+    }
+
+    @Test
+    public void assertApplePayPermission() throws JsonProcessingException {
+        allowWebPaymentsOnGatewayAccount("allow_apple_pay");
+
+        given().port(testContext.getPort()).contentType(JSON)
+                .get("/v1/frontend/charges/" + chargeId)
+                .then()
+                .body("gateway_account.allow_apple_pay", is(true));
+    }
+    
+    @Test
+    @Parameters({
+            "true, false, false", 
+            "true, true, true", 
+            "false, true, false"})
+    public void assertGooglePayPermission(boolean setAllowGooglePayFlag, boolean setGatewayMerchantId, boolean isGooglePayAllowed) throws JsonProcessingException {
+        if (setAllowGooglePayFlag) allowWebPaymentsOnGatewayAccount("allow_google_pay");
+        
+        if (setGatewayMerchantId) addGatewayMerchantIdToGatewayAccount(accountId);
+
+        given().port(testContext.getPort()).contentType(JSON)
+                .get("/v1/frontend/charges/" + chargeId)
+                .then()
+                .body("gateway_account.allow_google_pay", is(isGooglePayAllowed));
+    }
+
+    private void allowWebPaymentsOnGatewayAccount(String path) throws JsonProcessingException {
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+                "path", path,
+                "value", "true"));
+
+        given().port(testContext.getPort()).contentType(JSON)
+                .body(payload)
+                .patch("/v1/api/accounts/" + accountId)
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+    
+    private void addGatewayMerchantIdToGatewayAccount(String accountId) throws JsonProcessingException {
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+                "path", "credentials/gateway_merchant_id",
+                "value", "1234abc"));
+
+        given().port(testContext.getPort()).contentType(JSON)
+                .body(payload)
+                .patch("/v1/api/accounts/" + accountId)
+                .then()
+                .statusCode(HttpStatus.SC_OK);
+    }
+    
+    public static Response updateGatewayAccountCredentialsWith(int port, String accountId, Map<String, Object> credentials) {
+        return given().port(port).contentType(JSON).accept(JSON)
+                .body(credentials)
+                .patch(ACCOUNTS_FRONTEND_URL + accountId + "/credentials");
+    }
+    
+    public static String createCharge(int port, String accountId) {
+        return given().port(port).contentType(JSON)
+                .contentType(JSON)
+                .body(createChargePostBody(accountId))
+                .post(format("/v1/api/accounts/%s/charges", accountId))
+                .then()
+                .extract()
+                .path("charge_id");
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceTest.java
@@ -41,12 +41,7 @@ public class CreateGatewayAccountResourceTest extends GatewayAccountResourceTest
     @Test
     @Parameters({"sandbox", "worldpay", "smartpay", "epdq"})
     public void createAGatewayAccount(String provider) {
-        String description = "my test service";
-        String analyticsId = "analytics";
-        ValidatableResponse validatableResponse = createAGatewayAccountFor(testContext.getPort(), provider, description, analyticsId);
-        assertCorrectCreateResponse(validatableResponse, GatewayAccountEntity.Type.TEST, description, analyticsId, null);
-        assertGettingAccountReturnsProviderName(testContext.getPort(), validatableResponse, provider, GatewayAccountEntity.Type.TEST);
-        assertGatewayAccountCredentialsAreEmptyInDB(validatableResponse, databaseTestHelper);
+        createAGatewayAccountFor(testContext.getPort(), provider, "my test service", "analytics");
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/EmailNotificationResourceITest.java
@@ -5,10 +5,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
-import uk.gov.pay.connector.usernotification.resource.EmailNotificationResource;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+import uk.gov.pay.connector.usernotification.resource.EmailNotificationResource;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -93,8 +93,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
 
     @Test
     public void getAccountShouldReturn3dsSetting() {
-        String gatewayAccountId = extractGatewayAccountId(
-                createAGatewayAccountFor(testContext.getPort(), "stripe", "desc", null, "true"));
+        String gatewayAccountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "stripe",  "desc", null,"true"));
         givenSetup()
                 .get(ACCOUNTS_API_URL + gatewayAccountId)
                 .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdITest.java
@@ -17,7 +17,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.pay.connector.it.resources.GatewayAccountFrontendResourceITest.updateGatewayAccountCredentialsWith;
+import static uk.gov.pay.connector.it.resources.ChargesApiResourceAllowWebPaymentsITest.updateGatewayAccountCredentialsWith;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.createAGatewayAccountFor;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.extractGatewayAccountId;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;


### PR DESCRIPTION
Return `allow_apple_pay` and `allow_google_pay` in the call to
`/v1/frontend/charges/{chargeId}`. Example return json:

```
{
    "amount": 100,
    "state": {
        "finished": false,
        "status": "created"
    },
    "description": "description",
    "language": "en",
    "status": "CREATED",
    "gateway_account": {
        "version": 2,
        "requires3ds": false,
        "allowWebPayments": false,
        "notifySettings": null,
        "live": false,
        "gateway_account_id": 1,
        "payment_provider": "worldpay",
        "type": "test",
        ...
        "allow_apple_pay": false,
        "allow_google_pay": false,
```

## WHAT
_A brief description of the pull request:_

## HOW 
_Steps to test or reproduce:_


