### PR TITLE
PP-4560 Make GatewayAccountResource not depend directly on DAO

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -9,12 +9,14 @@ import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.PatchRequest;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.UriInfo;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -41,6 +43,18 @@ public class GatewayAccountService {
     public GatewayAccountService(GatewayAccountDao gatewayAccountDao, CardTypeDao cardTypeDao) {
         this.gatewayAccountDao = gatewayAccountDao;
         this.cardTypeDao = cardTypeDao;
+    }
+
+    public Optional<GatewayAccountEntity> getGatewayAccount(long gatewayAccountId) {
+        return gatewayAccountDao.findById(gatewayAccountId);
+    }
+
+    public List<GatewayAccountResourceDTO> getAllGatewayAccounts() {
+        return gatewayAccountDao.listAll();
+    }
+
+    public List<GatewayAccountResourceDTO> getGatewayAccounts(List<Long> gatewayAccountIds) {
+        return gatewayAccountDao.list(gatewayAccountIds);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -4,34 +4,80 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InOrder;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
 import uk.gov.pay.connector.gatewayaccount.model.PatchRequest;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class GatewayAccountServiceTest {
 
-    private GatewayAccountDao gatewayAccountDao = mock(GatewayAccountDao.class);
-    private CardTypeDao cardTypeDao = mock(CardTypeDao.class);
-    private GatewayAccountService updater;
+    @Mock
+    private GatewayAccountDao mockGatewayAccountDao;
+    @Mock
+    private CardTypeDao mockCardTypeDao;
+    @Mock
+    private GatewayAccountEntity mockGatewayAccountEntity;
+    @Mock
+    private GatewayAccountResourceDTO mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2;
+
+    private GatewayAccountService gatewayAccountService;
 
     @Before
     public void setUp() {
-        updater = new GatewayAccountService(gatewayAccountDao, cardTypeDao);
+        gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao);
+    }
+
+    @Test
+    public void shouldGetGatewayAccount() {
+        long gatewayAccountId = 42;
+
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(mockGatewayAccountEntity));
+
+        Optional<GatewayAccountEntity> gatewayAccountEntity = gatewayAccountService.getGatewayAccount(gatewayAccountId);
+
+        assertThat(gatewayAccountEntity.get(), is(this.mockGatewayAccountEntity));
+    }
+
+    @Test
+    public void shouldGetAllGatewayAccounts() {
+        when(mockGatewayAccountDao.listAll()).thenReturn(Arrays.asList(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
+
+        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.getAllGatewayAccounts();
+
+        assertThat(gatewayAccounts, contains(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
+    }
+
+    @Test
+    public void shouldGetGatewayAccountsByIds() {
+        List<Long> accountIds = Arrays.asList(1L, 2L);
+
+        when(mockGatewayAccountDao.list(accountIds)).thenReturn(Arrays.asList(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
+
+        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.getGatewayAccounts(accountIds);
+
+        assertThat(gatewayAccounts, contains(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
     }
 
     @Test
@@ -44,13 +90,13 @@ public class GatewayAccountServiceTest {
                 "value", settings)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
-        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
 
-        Optional<GatewayAccount> optionalGatewayAcc = updater.doPatch(gatewayAccountId, request);
+        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
 
         assertThat(optionalGatewayAcc.isPresent(), is(true));
         verify(entity).setNotifySettings(settings);
-        verify(gatewayAccountDao).merge(entity);
+        verify(mockGatewayAccountDao).merge(entity);
     }
 
     @Test
@@ -60,13 +106,13 @@ public class GatewayAccountServiceTest {
                 "path", "notify_settings")));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
-        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
 
-        Optional<GatewayAccount> optionalGatewayAcc = updater.doPatch(gatewayAccountId, request);
+        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
 
         assertThat(optionalGatewayAcc.isPresent(), is(true));
         verify(entity).setNotifySettings(null);
-        verify(gatewayAccountDao).merge(entity);
+        verify(mockGatewayAccountDao).merge(entity);
     }
 
     @Test
@@ -77,14 +123,14 @@ public class GatewayAccountServiceTest {
                 "value", "off")));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
-        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
 
-        Optional<GatewayAccount> optionalGatewayAcc = updater.doPatch(gatewayAccountId, request);
+        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
 
         assertThat(optionalGatewayAcc.isPresent(), is(true));
-        InOrder inOrder = Mockito.inOrder(entity, gatewayAccountDao);
+        InOrder inOrder = Mockito.inOrder(entity, mockGatewayAccountDao);
         inOrder.verify(entity).setEmailCollectionMode(EmailCollectionMode.OFF);
-        inOrder.verify(gatewayAccountDao).merge(entity);
+        inOrder.verify(mockGatewayAccountDao).merge(entity);
     }
     
     @Test
@@ -95,11 +141,11 @@ public class GatewayAccountServiceTest {
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
-        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = updater.doPatch(gatewayAccountId, request);
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
         assertThat(optionalGatewayAcc.isPresent(), is(true));
         verify(entity).setCorporateCreditCardSurchargeAmount(100L);
-        verify(gatewayAccountDao).merge(entity);
+        verify(mockGatewayAccountDao).merge(entity);
     }
 
     @Test
@@ -110,11 +156,11 @@ public class GatewayAccountServiceTest {
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
-        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = updater.doPatch(gatewayAccountId, request);
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
         assertThat(optionalGatewayAcc.isPresent(), is(true));
         verify(entity).setCorporateDebitCardSurchargeAmount(100L);
-        verify(gatewayAccountDao).merge(entity);
+        verify(mockGatewayAccountDao).merge(entity);
     }
 
     @Test
@@ -125,11 +171,11 @@ public class GatewayAccountServiceTest {
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
-        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = updater.doPatch(gatewayAccountId, request);
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
         assertThat(optionalGatewayAcc.isPresent(), is(true));
         verify(entity).setCorporatePrepaidDebitCardSurchargeAmount(100L);
-        verify(gatewayAccountDao).merge(entity);
+        verify(mockGatewayAccountDao).merge(entity);
     }
 
     @Test
@@ -140,10 +186,10 @@ public class GatewayAccountServiceTest {
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
-        when(gatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = updater.doPatch(gatewayAccountId, request);
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
         assertThat(optionalGatewayAcc.isPresent(), is(true));
         verify(entity).setCorporatePrepaidCreditCardSurchargeAmount(100L);
-        verify(gatewayAccountDao).merge(entity);
+        verify(mockGatewayAccountDao).merge(entity);
     }
 }


### PR DESCRIPTION
Make the GatewayAccountResource not depend on the GatewyAccountDao directly and instead use the GatewayAccountService (which delegates to the GatewayAccountDao).

GatewayAccountResource no longer has GatewayAccountDao injected.

with @stephencdaly