### PR TITLE
PP-4560 Add GET /v1/api/accounts/ACCOUNT_ID/stripe-setup

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.filters.SchemeRewriteFilter;
 import uk.gov.pay.connector.gateway.smartpay.auth.BasicAuthUser;
 import uk.gov.pay.connector.gateway.smartpay.auth.SmartpayAccountSpecificAuthenticator;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountResource;
+import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountStripeSetupResource;
 import uk.gov.pay.connector.healthcheck.CardExecutorServiceHealthCheck;
 import uk.gov.pay.connector.healthcheck.DatabaseHealthCheck;
 import uk.gov.pay.connector.healthcheck.Ping;
@@ -104,6 +105,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new EarlyEofExceptionMapper());
         
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
+        environment.jersey().register(injector.getInstance(GatewayAccountStripeSetupResource.class));
         environment.jersey().register(injector.getInstance(ChargeEventsResource.class));
         environment.jersey().register(injector.getInstance(SecurityTokensResource.class));
         environment.jersey().register(injector.getInstance(ChargesApiResource.class));

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetup.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetup.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+public class GatewayAccountStripeSetup {
+
+    private boolean bankDetailsCompleted = false;
+    private boolean responsiblePersonCompleted = false;
+    private boolean organisationDetailsCompleted = false;
+    
+    public boolean isBankDetailsCompleted() {
+        return bankDetailsCompleted;
+    }
+
+    public void setBankDetailsCompleted(boolean bankDetailsCompleted) {
+        this.bankDetailsCompleted = bankDetailsCompleted;
+    }
+
+    public boolean isResponsiblePersonCompleted() {
+        return responsiblePersonCompleted;
+    }
+
+    public void setResponsiblePersonCompleted(boolean responsiblePersonCompleted) {
+        this.responsiblePersonCompleted = responsiblePersonCompleted;
+    }
+
+    public boolean isOrganisationDetailsCompleted() {
+        return organisationDetailsCompleted;
+    }
+
+    public void setOrganisationDetailsCompleted(boolean organisationDetailsCompleted) {
+        this.organisationDetailsCompleted = organisationDetailsCompleted;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetup.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetup.java
@@ -9,21 +9,21 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 @JsonInclude(Include.NON_NULL)
 public class GatewayAccountStripeSetup {
 
-    @JsonProperty("bank_account_details")
-    private boolean bankDetailsCompleted = false;
+    @JsonProperty("bank_account")
+    private boolean bankAccountCompleted = false;
 
     @JsonProperty("responsible_person")
     private boolean responsiblePersonCompleted = false;
 
-    @JsonProperty("organisation_vat_number_company_number")
+    @JsonProperty("organisation_details")
     private boolean organisationDetailsCompleted = false;
     
-    public boolean isBankDetailsCompleted() {
-        return bankDetailsCompleted;
+    public boolean isBankAccountCompleted() {
+        return bankAccountCompleted;
     }
 
-    public void setBankDetailsCompleted(boolean bankDetailsCompleted) {
-        this.bankDetailsCompleted = bankDetailsCompleted;
+    public void setBankAccountCompleted(boolean bankAccountCompleted) {
+        this.bankAccountCompleted = bankAccountCompleted;
     }
 
     public boolean isResponsiblePersonCompleted() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetup.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetup.java
@@ -1,9 +1,21 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
 public class GatewayAccountStripeSetup {
 
+    @JsonProperty("bank_account_details")
     private boolean bankDetailsCompleted = false;
+
+    @JsonProperty("responsible_person")
     private boolean responsiblePersonCompleted = false;
+
+    @JsonProperty("organisation_vat_number_company_number")
     private boolean organisationDetailsCompleted = false;
     
     public boolean isBankDetailsCompleted() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetupTask.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountStripeSetupTask.java
@@ -2,8 +2,8 @@ package uk.gov.pay.connector.gatewayaccount.model;
 
 public enum GatewayAccountStripeSetupTask {
 
-    BANK_ACCOUNT_DETAILS,
+    BANK_ACCOUNT,
     RESPONSIBLE_PERSON,
-    ORGANISATION_VAT_NUMBER_COMPANY_NUMBER
+    ORGANISATION_DETAILS
 
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountStripeSetupResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountStripeSetupResource.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.gatewayaccount.resource;
+
+import com.google.inject.Inject;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetup;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountStripeSetupService;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class GatewayAccountStripeSetupResource {
+    private final GatewayAccountStripeSetupService gatewayAccountStripeSetupService;
+    private final GatewayAccountService gatewayAccountService;
+
+    @Inject
+    public GatewayAccountStripeSetupResource(GatewayAccountStripeSetupService gatewayAccountStripeSetupService,
+                                             GatewayAccountService gatewayAccountService) {
+        this.gatewayAccountStripeSetupService = gatewayAccountStripeSetupService;
+        this.gatewayAccountService = gatewayAccountService;
+    }
+
+    @GET
+    @Path("/v1/api/accounts/{accountId}/stripe-setup")
+    @Produces(APPLICATION_JSON)
+    public GatewayAccountStripeSetup getGatewayAccountStripeSetup(@PathParam("accountId") Long accountId) {
+        return gatewayAccountService.getGatewayAccount(accountId)
+                .filter(gatewayAccountEntity -> PaymentGatewayName.STRIPE.getName().equals(gatewayAccountEntity.getGatewayName()))
+                .map(gatewayAccountEntity -> gatewayAccountStripeSetupService.getCompletedTasks(gatewayAccountEntity.getId()))
+                .orElseThrow(NotFoundException::new);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupService.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.gatewayaccount.service;
+
+import com.google.inject.Inject;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountStripeSetupDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetup;
+
+public class GatewayAccountStripeSetupService {
+
+    private final GatewayAccountStripeSetupDao gatewayAccountStripeSetupDao;
+
+    @Inject
+    public GatewayAccountStripeSetupService(GatewayAccountStripeSetupDao gatewayAccountStripeSetupDao) {
+        this.gatewayAccountStripeSetupDao = gatewayAccountStripeSetupDao;
+    }
+    
+    public GatewayAccountStripeSetup getCompletedTasks(long gatewayAccountId) {
+        GatewayAccountStripeSetup gatewayAccountStripeSetup = new GatewayAccountStripeSetup();
+        gatewayAccountStripeSetupDao.findByGatewayAccountId(gatewayAccountId)
+                .stream()
+                .forEach(gatewayAccountStripeSetupTaskEntity -> {
+                    switch(gatewayAccountStripeSetupTaskEntity.getTask()) {
+                        case BANK_ACCOUNT_DETAILS:
+                            gatewayAccountStripeSetup.setBankDetailsCompleted(true);
+                            break;
+                        case RESPONSIBLE_PERSON:
+                            gatewayAccountStripeSetup.setResponsiblePersonCompleted(true);
+                            break;
+                        case ORGANISATION_VAT_NUMBER_COMPANY_NUMBER:
+                            gatewayAccountStripeSetup.setOrganisationDetailsCompleted(true);
+                            break;
+                        default:
+                            // Code doesn’t handle this task
+                    }
+                });
+        return gatewayAccountStripeSetup;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupService.java
@@ -19,13 +19,13 @@ public class GatewayAccountStripeSetupService {
                 .stream()
                 .forEach(gatewayAccountStripeSetupTaskEntity -> {
                     switch(gatewayAccountStripeSetupTaskEntity.getTask()) {
-                        case BANK_ACCOUNT_DETAILS:
-                            gatewayAccountStripeSetup.setBankDetailsCompleted(true);
+                        case BANK_ACCOUNT:
+                            gatewayAccountStripeSetup.setBankAccountCompleted(true);
                             break;
                         case RESPONSIBLE_PERSON:
                             gatewayAccountStripeSetup.setResponsiblePersonCompleted(true);
                             break;
-                        case ORGANISATION_VAT_NUMBER_COMPANY_NUMBER:
+                        case ORGANISATION_DETAILS:
                             gatewayAccountStripeSetup.setOrganisationDetailsCompleted(true);
                             break;
                         default:

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupServiceTest.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.connector.gatewayaccount.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountStripeSetupDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetup;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTaskEntity;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GatewayAccountStripeSetupServiceTest {
+
+    private static final long GATEWAY_ACCOUNT_ID = 42;
+    
+    @Mock private GatewayAccountStripeSetupDao mockGatewayAccountStripeSetupDao;
+    
+    @Mock private GatewayAccountStripeSetupTaskEntity mockBankDetailsCompletedTaskEntity;
+    @Mock private GatewayAccountStripeSetupTaskEntity mockResponsiblePersonCompletedTaskEntity;
+    @Mock private GatewayAccountStripeSetupTaskEntity mockOrganisationDetailsCompletedTaskEntity;
+
+    private GatewayAccountStripeSetupService gatewayAccountStripeSetupService;
+
+    @Before
+    public void setUp() {
+        given(mockBankDetailsCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.BANK_ACCOUNT_DETAILS);
+        given(mockResponsiblePersonCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.RESPONSIBLE_PERSON);
+        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.ORGANISATION_VAT_NUMBER_COMPANY_NUMBER);
+
+        this.gatewayAccountStripeSetupService = new GatewayAccountStripeSetupService(mockGatewayAccountStripeSetupDao);
+    }
+
+    @Test
+    public void shouldConfigureGatewayAccountStripeSetupWithNoTasksCompleted() {
+        given(mockGatewayAccountStripeSetupDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID))
+                .willReturn(Collections.emptyList());
+
+        GatewayAccountStripeSetup tasks = gatewayAccountStripeSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
+
+        assertThat(tasks.isBankDetailsCompleted(), is(false));
+        assertThat(tasks.isResponsiblePersonCompleted(), is(false));
+        assertThat(tasks.isOrganisationDetailsCompleted(), is(false));
+    }
+
+    @Test
+    public void shouldConfigureGatewayAccountStripeSetupWithAllTasksCompleted() {
+        given(mockGatewayAccountStripeSetupDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID))
+                .willReturn(Arrays.asList(mockOrganisationDetailsCompletedTaskEntity, mockResponsiblePersonCompletedTaskEntity,
+                        mockBankDetailsCompletedTaskEntity));
+
+        GatewayAccountStripeSetup tasks = gatewayAccountStripeSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
+
+        assertThat(tasks.isBankDetailsCompleted(), is(true));
+        assertThat(tasks.isResponsiblePersonCompleted(), is(true));
+        assertThat(tasks.isOrganisationDetailsCompleted(), is(true));
+    }
+
+    @Test
+    public void shouldConfigureGatewayAccountStripeSetupWithSomeTasksCompleted() {
+        given(mockGatewayAccountStripeSetupDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID))
+                .willReturn(Arrays.asList(mockOrganisationDetailsCompletedTaskEntity, mockResponsiblePersonCompletedTaskEntity));
+
+        GatewayAccountStripeSetup tasks = gatewayAccountStripeSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
+
+        assertThat(tasks.isBankDetailsCompleted(), is(false));
+        assertThat(tasks.isResponsiblePersonCompleted(), is(true));
+        assertThat(tasks.isOrganisationDetailsCompleted(), is(true));
+    }
+    
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountStripeSetupServiceTest.java
@@ -32,9 +32,9 @@ public class GatewayAccountStripeSetupServiceTest {
 
     @Before
     public void setUp() {
-        given(mockBankDetailsCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.BANK_ACCOUNT_DETAILS);
+        given(mockBankDetailsCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.BANK_ACCOUNT);
         given(mockResponsiblePersonCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.RESPONSIBLE_PERSON);
-        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.ORGANISATION_VAT_NUMBER_COMPANY_NUMBER);
+        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(GatewayAccountStripeSetupTask.ORGANISATION_DETAILS);
 
         this.gatewayAccountStripeSetupService = new GatewayAccountStripeSetupService(mockGatewayAccountStripeSetupDao);
     }
@@ -46,7 +46,7 @@ public class GatewayAccountStripeSetupServiceTest {
 
         GatewayAccountStripeSetup tasks = gatewayAccountStripeSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
 
-        assertThat(tasks.isBankDetailsCompleted(), is(false));
+        assertThat(tasks.isBankAccountCompleted(), is(false));
         assertThat(tasks.isResponsiblePersonCompleted(), is(false));
         assertThat(tasks.isOrganisationDetailsCompleted(), is(false));
     }
@@ -59,7 +59,7 @@ public class GatewayAccountStripeSetupServiceTest {
 
         GatewayAccountStripeSetup tasks = gatewayAccountStripeSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
 
-        assertThat(tasks.isBankDetailsCompleted(), is(true));
+        assertThat(tasks.isBankAccountCompleted(), is(true));
         assertThat(tasks.isResponsiblePersonCompleted(), is(true));
         assertThat(tasks.isOrganisationDetailsCompleted(), is(true));
     }
@@ -71,7 +71,7 @@ public class GatewayAccountStripeSetupServiceTest {
 
         GatewayAccountStripeSetup tasks = gatewayAccountStripeSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
 
-        assertThat(tasks.isBankDetailsCompleted(), is(false));
+        assertThat(tasks.isBankAccountCompleted(), is(false));
         assertThat(tasks.isResponsiblePersonCompleted(), is(true));
         assertThat(tasks.isOrganisationDetailsCompleted(), is(true));
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountStripeSetupDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountStripeSetupDaoITest.java
@@ -14,8 +14,8 @@ import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask.BANK_ACCOUNT_DETAILS;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask.ORGANISATION_VAT_NUMBER_COMPANY_NUMBER;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask.BANK_ACCOUNT;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask.ORGANISATION_DETAILS;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask.RESPONSIBLE_PERSON;
 
 public class GatewayAccountStripeSetupDaoITest extends DaoITestBase {
@@ -39,17 +39,17 @@ public class GatewayAccountStripeSetupDaoITest extends DaoITestBase {
         long anotherGatewayAccountId = 1;
         databaseTestHelper.addGatewayAccount(anotherGatewayAccountId, "stripe");
 
-        databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, BANK_ACCOUNT_DETAILS);
+        databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, BANK_ACCOUNT);
         databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, RESPONSIBLE_PERSON);
-        databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, BANK_ACCOUNT_DETAILS);
-        databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, ORGANISATION_VAT_NUMBER_COMPANY_NUMBER);
+        databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, BANK_ACCOUNT);
+        databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, ORGANISATION_DETAILS);
 
         List<GatewayAccountStripeSetupTaskEntity> tasks = gatewayAccountStripeSetupDao.findByGatewayAccountId(gatewayAccountId);
         assertThat(tasks, hasSize(2));
         assertThat(tasks, contains(
                 allOf(
                         hasProperty("gatewayAccount", hasProperty("id", is(gatewayAccountId))),
-                        hasProperty("task", is(BANK_ACCOUNT_DETAILS))),
+                        hasProperty("task", is(BANK_ACCOUNT))),
                 allOf(
                         hasProperty("gatewayAccount", hasProperty("id", is(gatewayAccountId))),
                         hasProperty("task", is(RESPONSIBLE_PERSON)))

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -489,10 +489,6 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         return format("{\"card_types\": [%s]}", join(",", cardTypeIds));
     }
 
-    private String createAGatewayAccountFor(String provider) {
-        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider));
-    }
-
     private String createAGatewayAccountFor(String provider, String desc, String id) {
         return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, desc, id));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -658,10 +658,6 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .statusCode(NOT_FOUND.getStatusCode());
     }
 
-    private String createAGatewayAccountFor(String provider) {
-        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider));
-    }
-
     private String createAGatewayAccountFor(String provider, String desc, String id) {
         return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, desc, id));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -50,10 +50,14 @@ public class GatewayAccountResourceTestBase {
                 .contentType(JSON);
     }
 
+    protected String createAGatewayAccountFor(String provider) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider));
+    }
+
     public static String extractGatewayAccountId(ValidatableResponse validatableResponse) {
         return validatableResponse.extract().path("gateway_account_id");
     }
-    
+
     public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider) {
         return createAGatewayAccountFor(port, testProvider, null, null);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountStripeSetupResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountStripeSetupResourceITest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask;
-import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
@@ -29,24 +28,24 @@ public class GatewayAccountStripeSetupResourceITest extends GatewayAccountResour
                 .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
                 .then()
                 .statusCode(200)
-                .body("bank_account_details", is(false))
+                .body("bank_account", is(false))
                 .body("responsible_person", is(false))
-                .body("organisation_vat_number_company_number", is(false));
+                .body("organisation_details", is(false));
     }
 
     @Test
     public void getStripeSetupWithSomeTasksCompletedReturnsAppopriateFlags() {
         long gatewayAccountId = Long.valueOf(createAGatewayAccountFor("stripe"));
-        addCompletedTask(gatewayAccountId, GatewayAccountStripeSetupTask.BANK_ACCOUNT_DETAILS);
-        addCompletedTask(gatewayAccountId, GatewayAccountStripeSetupTask.ORGANISATION_VAT_NUMBER_COMPANY_NUMBER);
+        addCompletedTask(gatewayAccountId, GatewayAccountStripeSetupTask.BANK_ACCOUNT);
+        addCompletedTask(gatewayAccountId, GatewayAccountStripeSetupTask.ORGANISATION_DETAILS);
 
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
                 .then()
                 .statusCode(200)
-                .body("bank_account_details", is(true))
+                .body("bank_account", is(true))
                 .body("responsible_person", is(false))
-                .body("organisation_vat_number_company_number", is(true));
+                .body("organisation_details", is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountStripeSetupResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountStripeSetupResourceITest.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.it.resources;
+
+import io.restassured.specification.RequestSpecification;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountStripeSetupTask;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class GatewayAccountStripeSetupResourceITest extends GatewayAccountResourceTestBase {
+ 
+    protected RequestSpecification givenSetup() {
+        return given().port(testContext.getPort()).contentType(JSON);
+    }
+
+    @Test
+    public void getStripeSetupWithNoTasksCompletedReturnsFalseFlags() {
+        String gatewayAccountId = createAGatewayAccountFor("stripe");
+
+        givenSetup()
+                .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
+                .then()
+                .statusCode(200)
+                .body("bank_account_details", is(false))
+                .body("responsible_person", is(false))
+                .body("organisation_vat_number_company_number", is(false));
+    }
+
+    @Test
+    public void getStripeSetupWithSomeTasksCompletedReturnsAppopriateFlags() {
+        long gatewayAccountId = Long.valueOf(createAGatewayAccountFor("stripe"));
+        addCompletedTask(gatewayAccountId, GatewayAccountStripeSetupTask.BANK_ACCOUNT_DETAILS);
+        addCompletedTask(gatewayAccountId, GatewayAccountStripeSetupTask.ORGANISATION_VAT_NUMBER_COMPANY_NUMBER);
+
+        givenSetup()
+                .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
+                .then()
+                .statusCode(200)
+                .body("bank_account_details", is(true))
+                .body("responsible_person", is(false))
+                .body("organisation_vat_number_company_number", is(true));
+    }
+
+    @Test
+    public void getStripeSetupGatewayAccountDoesNotExist() {
+        long notFoundGatewayAccountId = 13;
+        
+        givenSetup()
+                .get("/v1/api/accounts/" + notFoundGatewayAccountId + "/stripe-setup")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void getStripeSetupGatewayAccountIsNotAStripeAccount() {
+        long gatewayAccountId = Long.valueOf(createAGatewayAccountFor("worldpay"));
+        givenSetup()
+                .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
+                .then()
+                .statusCode(404);
+    }
+
+    private void addCompletedTask(long gatewayAccountId, GatewayAccountStripeSetupTask task) {
+        databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, task);
+    }
+}


### PR DESCRIPTION
Add GET endpoint to retrieve the bank account, responsible person and organisation details completed flags for Stripe gateway accounts in JSON format:

```json
{
  "bank_account": true,
  "responsible_person": false,
  "organisation_details": true
}
```

If the account does not exist or is not a Stripe account, return a 404.

with @stephencdaly