### PR TITLE
PP-4791 Add length validation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
@@ -2,15 +2,17 @@ package uk.gov.pay.connector.common.validator;
 
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.ValidAuthCardDetails;
 
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
 import java.util.regex.Pattern;
 
 import static java.util.regex.Pattern.compile;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-public class AuthCardDetailsValidator {
-
+public class AuthCardDetailsValidator implements ConstraintValidator<ValidAuthCardDetails, AuthCardDetails> {
     private static final Pattern TWELVE_TO_NINETEEN_DIGITS = compile("[0-9]{12,19}");
     private static final Pattern THREE_TO_FOUR_DIGITS = compile("[0-9]{3,4}");
     private static final Pattern THREE_TO_FOUR_DIGITS_POSSIBLY_SURROUNDED_BY_WHITESPACE = compile("\\s*[0-9]{3,4}\\s*");
@@ -18,7 +20,19 @@ public class AuthCardDetailsValidator {
     private static final Pattern CONTAINS_MORE_THAN_11_NOT_NECESSARILY_CONTIGUOUS_DIGITS = compile(".*([0-9].*){12,}");
     private static final short MAX_LENGTH = 255;
 
-    public static boolean isWellFormatted(AuthCardDetails authCardDetails) {
+    @Override
+    public void initialize(ValidAuthCardDetails constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(AuthCardDetails value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return isWellFormatted(value);
+    }
+
+    private static boolean isWellFormatted(AuthCardDetails authCardDetails) {
         return isValidCardNumberLength(authCardDetails.getCardNo()) &&
                 isBetween3To4Digits(authCardDetails.getCvc()) &&
                 hasExpiryDateFormat(authCardDetails.getEndDate()) &&

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.model.PayersCardType.CREDIT_OR_DEBIT;
 
+@ValidAuthCardDetails
 public class AuthCardDetails implements AuthorisationDetails {
 
     private String cardNo;

--- a/src/main/java/uk/gov/pay/connector/gateway/model/ValidAuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/ValidAuthCardDetails.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.gateway.model;
+
+import uk.gov.pay.connector.common.validator.AuthCardDetailsValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ TYPE, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Constraint(validatedBy = { AuthCardDetailsValidator.class })
+@Documented
+public @interface ValidAuthCardDetails {
+    String message() default "Values do not match expected format/length.";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static uk.gov.pay.connector.common.validator.AuthCardDetailsValidator.isWellFormatted;
 import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
 import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
@@ -82,11 +81,8 @@ public class CardResource {
     @Path("/v1/frontend/charges/{chargeId}/cards")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public Response authoriseCharge(@PathParam("chargeId") String chargeId, AuthCardDetails authCardDetails) {
-        if (!isWellFormatted(authCardDetails)) {
-            logger.error("Charge {}: Card details are not well formatted. Values do not match expected format/length.", chargeId);
-            return badRequestResponse("Values do not match expected format/length.");
-        }
+    public Response authoriseCharge(@PathParam("chargeId") String chargeId,
+                                    @Valid AuthCardDetails authCardDetails) {
         AuthorisationResponse response = cardAuthoriseService.doAuthorise(chargeId, authCardDetails);
 
         return response.getGatewayError().map(error -> handleError(chargeId, error))

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -46,7 +46,7 @@ public class CardResource {
     private final ChargeCancelService chargeCancelService;
     private final ApplePayService applePayService;
     private final GooglePayService googlePayService;
-    
+
     @Inject
     public CardResource(CardAuthoriseService cardAuthoriseService, Card3dsResponseAuthService card3dsResponseAuthService,
                         CardCaptureService cardCaptureService, ChargeCancelService chargeCancelService, ApplePayService applePayService,
@@ -106,7 +106,7 @@ public class CardResource {
 
         return ResponseUtil.successResponseWithEntity(ImmutableMap.of("status", authoriseStatus.getMappedChargeStatus().toString()));
     }
-    
+
     @POST
     @Path("/v1/frontend/charges/{chargeId}/3ds")
     @Consumes(APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
@@ -27,6 +27,7 @@ import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
@@ -100,7 +101,7 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
         Map<String, Object> charge = databaseTestHelper.getChargeByExternalId(chargeId);
         assertThat(charge.get("email"), is(googlePayload.get("payment_info").get("email").asText()));
     }
-    
+
     @Test
     public void shouldAuthoriseCharge_ForAValidAmericanExpress() {
         shouldAuthoriseChargeFor(buildJsonAuthorisationDetailsFor("371449635398431", "1234", "11/99", "american-express"));
@@ -121,16 +122,13 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
     public void sanitizeCardDetails_shouldStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingMoreThan10Numbers() {
         String sanitizedValue = "r-**-**-*  Ju&^****-**";
         String valueWithMoreThan10CharactersAsNumbers = "r-12-34-5  Ju&^6501-76";
-        String cardHolderName = valueWithMoreThan10CharactersAsNumbers;
-        String addressLine1 = valueWithMoreThan10CharactersAsNumbers;
-        String addressLine2 = valueWithMoreThan10CharactersAsNumbers;
-        String city = valueWithMoreThan10CharactersAsNumbers;
-        String county = valueWithMoreThan10CharactersAsNumbers;
-        String postcode = valueWithMoreThan10CharactersAsNumbers;
-        String country = valueWithMoreThan10CharactersAsNumbers;
-        String cardBrand = valueWithMoreThan10CharactersAsNumbers;
 
-        String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor("4444333322221111", "123", "11/30", cardBrand, cardHolderName, addressLine1, addressLine2, city, county, postcode, country));
+        String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor(
+                "4444333322221111", "123", "11/30",
+                valueWithMoreThan10CharactersAsNumbers, valueWithMoreThan10CharactersAsNumbers,
+                valueWithMoreThan10CharactersAsNumbers, valueWithMoreThan10CharactersAsNumbers,
+                valueWithMoreThan10CharactersAsNumbers, valueWithMoreThan10CharactersAsNumbers,
+                valueWithMoreThan10CharactersAsNumbers, valueWithMoreThan10CharactersAsNumbers));
 
         Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge-"));
         Map<String, Object> chargeCardDetails = databaseTestHelper.getChargeCardDetailsByChargeId(chargeId);
@@ -147,19 +145,15 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
     }
 
     @Test
-    public void sanitizeCardDetails_shouldNotStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingRight10Numbers() throws Exception {
+    public void sanitizeCardDetails_shouldNotStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingRight10Numbers() {
 
         String valueWith10CharactersAsNumbers = "r-12-34-5  Ju&^6501-7m";
-        String cardHolderName = valueWith10CharactersAsNumbers;
-        String addressLine1 = valueWith10CharactersAsNumbers;
-        String addressLine2 = valueWith10CharactersAsNumbers;
-        String city = valueWith10CharactersAsNumbers;
-        String county = valueWith10CharactersAsNumbers;
-        String postcode = valueWith10CharactersAsNumbers;
-        String country = valueWith10CharactersAsNumbers;
-        String cardBrand = valueWith10CharactersAsNumbers;
 
-        String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor("4444333322221111", "123", "11/30", cardBrand, cardHolderName, addressLine1, addressLine2, city, county, postcode, country));
+        String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor(
+                "4444333322221111", "123", "11/30",
+                valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers,
+                valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers,
+                valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers));
 
         Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge-"));
         Map<String, Object> chargeCardDetails = databaseTestHelper.getChargeCardDetailsByChargeId(chargeId);
@@ -176,7 +170,7 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldNotAuthoriseCard_ForSpecificCardNumber1() throws Exception {
+    public void shouldNotAuthoriseCard_ForSpecificCardNumber1() {
         String cardDetailsToReject = buildJsonAuthorisationDetailsFor("4000000000000002", "visa");
 
         String expectedErrorMessage = "This transaction was declined.";
@@ -185,7 +179,7 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldNotAuthoriseCard_ForSpecificCardNumber2() throws Exception {
+    public void shouldNotAuthoriseCard_ForSpecificCardNumber2() {
         String cardDetailsToReject = buildJsonAuthorisationDetailsFor("4000000000000119", "visa");
 
         String expectedErrorMessage = "This transaction could be not be processed.";
@@ -194,68 +188,68 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldAuthoriseCharge_WithMinimalAddress() throws Exception {
+    public void shouldAuthoriseCharge_WithMinimalAddress() {
         String cardDetails = authorisationDetailsWithMinimalAddress(VALID_SANDBOX_CARD_LIST[0], "visa");
         shouldAuthoriseChargeFor(cardDetails);
     }
 
     @Test
-    public void shouldAuthoriseCharge_ForValidCardWithFullAddress() throws Exception {
+    public void shouldAuthoriseCharge_ForValidCardWithFullAddress() {
         String validCardDetails = buildJsonAuthorisationDetailsWithFullAddress();
         shouldAuthoriseChargeFor(validCardDetails);
     }
 
     @Test
-    public void shouldRejectRandomCardNumber() throws Exception {
+    public void shouldRejectRandomCardNumber() {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("1111111111111119234", "visa");
 
-        shouldReturnErrorFor(chargeId, randomCardNumberDetails, "Unsupported card details.");
+        shouldReturn_unsupportedCardDetails_errorFor(chargeId, randomCardNumberDetails);
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_ERROR.getValue());
     }
 
     @Test
-    public void shouldReturnError_WhenCardNumberLongerThanMaximumExpected() throws Exception {
+    public void shouldReturnError_WhenCardNumberLongerThanMaximumExpected() {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("11111111111111192345", "visa");
 
-        shouldReturnErrorFor(chargeId, randomCardNumberDetails, "Values do not match expected format/length.");
+        shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(chargeId, randomCardNumberDetails);
         assertFrontendChargeStatusIs(chargeId, ENTERING_CARD_DETAILS.getValue());
     }
 
     @Test
-    public void shouldReturnError_WhenCvcIsMoreThan4Digits() throws Exception {
+    public void shouldReturnError_WhenCvcIsMoreThan4Digits() {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "12345", "11/99", "visa");
 
-        shouldReturnErrorFor(chargeId, randomCardNumberDetails, "Values do not match expected format/length.");
+        shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(chargeId, randomCardNumberDetails);
         assertFrontendChargeStatusIs(chargeId, ENTERING_CARD_DETAILS.getValue());
     }
 
     @Test
-    public void shouldReturnError_WhenCvcIsLessThan3Digits() throws Exception {
+    public void shouldReturnError_WhenCvcIsLessThan3Digits() {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "12", "11/99", "visa");
 
-        shouldReturnErrorFor(chargeId, randomCardNumberDetails, "Values do not match expected format/length.");
+        shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(chargeId, randomCardNumberDetails);
         assertFrontendChargeStatusIs(chargeId, ENTERING_CARD_DETAILS.getValue());
     }
 
     @Test
-    public void shouldReturnError_WhenCardNumberShorterThanMinimumExpected() throws Exception {
+    public void shouldReturnError_WhenCardNumberShorterThanMinimumExpected() {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
         String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("11111111111", "visa");
 
-        shouldReturnErrorFor(chargeId, randomCardNumberDetails, "Values do not match expected format/length.");
+        shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(chargeId, randomCardNumberDetails);
         assertFrontendChargeStatusIs(chargeId, ENTERING_CARD_DETAILS.getValue());
     }
 
     @Test
-    public void shouldReturnErrorAndDoNotUpdateChargeStatus_IfCardDetailsAreInvalid() throws Exception {
+    public void shouldReturnErrorAndDoNotUpdateChargeStatus_IfCardDetailsAreInvalid() {
         String chargeId = createNewCharge();
         String detailsWithInvalidExpiryDate = buildJsonAuthorisationDetailsFor("4242424242424242", "123", "1299");
 
-        shouldReturnErrorFor(chargeId, detailsWithInvalidExpiryDate, "Values do not match expected format/length.");
+        shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(chargeId, detailsWithInvalidExpiryDate);
 
         assertFrontendChargeStatusIs(chargeId, CREATED.getValue());
     }
@@ -272,6 +266,7 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
         return chargeId;
     }
+
     private String shouldAuthoriseChargeForApplePay(String cardHolderName, String email) {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
 
@@ -286,13 +281,14 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
         assertThat(charge.get("email"), is(email));
         return chargeId;
     }
+
     @Test
     public void shouldPersistCorporateSurcharge() {
         String accountId = String.valueOf(RandomUtils.nextInt());
         long corporateCreditCardSurchargeAmount = 2222L;
         databaseTestHelper.addGatewayAccount(accountId, "sandbox", "description", "",
                 corporateCreditCardSurchargeAmount, 0, 0, 0);
-        
+
         String externalChargeId = createNewChargeWithAccountId(ENTERING_CARD_DETAILS, randomId(), accountId, databaseTestHelper).toString();
         String cardDetails = buildCorporateJsonAuthorisationDetailsFor(PayersCardType.CREDIT);
 
@@ -308,7 +304,13 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
     @Test
     public void shouldReturnAuthError_IfChargeExpired() {
         String chargeId = createNewChargeWithNoTransactionId(EXPIRED);
-        authoriseAndVerifyFor(chargeId, validCardDetails, format("Charge not in correct state to be processed, %s", chargeId), 400);
+        givenSetup()
+                .body(validCardDetails)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is(format("Charge not in correct state to be processed, %s", chargeId)));
         assertFrontendChargeStatusIs(chargeId, EXPIRED.getValue());
     }
 
@@ -331,7 +333,13 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
 
         String msg = format("Charge not in correct state to be processed, %s", chargeId);
-        authoriseAndVerifyFor(chargeId, validCardDetails, msg, 400);
+        givenSetup()
+                .body(validCardDetails)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is(msg));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
     }
@@ -340,7 +348,13 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
     public void shouldReturnErrorAndDoNotUpdateChargeStatus_IfAuthorisationAlreadyInProgress() {
         String chargeId = createNewChargeWithNoTransactionId(AUTHORISATION_READY);
         String message = format("Authorisation for charge already in progress, %s", chargeId);
-        authoriseAndVerifyFor(chargeId, validCardDetails, message, 202);
+        givenSetup()
+                .body(validCardDetails)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .statusCode(202)
+                .contentType(JSON)
+                .body("message", is(message));
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_READY.getValue());
     }
 
@@ -438,17 +452,24 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
                 .collect(Collectors.toList());
     }
 
-    private void shouldReturnErrorFor(String chargeId, String randomCardNumber, String expectedMessage) {
-        authoriseAndVerifyFor(chargeId, randomCardNumber, expectedMessage, 400);
-    }
-
-    private void authoriseAndVerifyFor(String chargeId, String randomCardNumber, String expectedMessage, int statusCode) {
+    private void shouldReturn_unsupportedCardDetails_errorFor(String chargeId, String randomCardNumber) {
         givenSetup()
                 .body(randomCardNumber)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
-                .statusCode(statusCode)
+                .statusCode(400)
                 .contentType(JSON)
-                .body("message", is(expectedMessage));
+                .body("message", is("Unsupported card details."));
     }
+
+    private void shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(String chargeId, String randomCardNumber) {
+        givenSetup()
+                .body(randomCardNumber)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", containsInAnyOrder("Values do not match expected format/length."));
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -15,9 +15,10 @@ import static org.junit.Assert.assertTrue;
 public class AuthCardDetailsValidatorTest {
 
     private String sneakyCardNumber = "this12card3number4is5hidden6;7 89-0(1+2.";
+    private String over255LongString = "ThisLineIs_TooLong_cbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsa1234567899";
 
     @Test
-    public void validationSucceedForCorrectAuthorisationCardDetails() {
+    public void validationSucceedForWellFormattedAuthorisationCardDetails() {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
         assertThat(AuthCardDetailsValidator.isWellFormatted(authCardDetails), is(true));
@@ -519,5 +520,52 @@ public class AuthCardDetailsValidatorTest {
                 .build();
 
         assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+    }
+
+    @Test
+    public void validationFailsIfCardHolderIsTooLong() {
+        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withCardHolder(over255LongString).build();
+        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
+        assertFalse(isWellFormatted);
+    }
+
+    @Test
+    public void validationFailsIfAddressLineOneIsTooLong() {
+        Address address = AddressFixture.anAddress().withLine1(over255LongString).build();
+        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
+        assertFalse(isWellFormatted);
+    }
+
+    @Test
+    public void validationFailsIfAddressLineTwoIsTooLong() {
+        Address address = AddressFixture.anAddress().withLine2(over255LongString).build();
+        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
+        assertFalse(isWellFormatted);
+    }
+
+    @Test
+    public void validationFailsIfAddressCountyIsTooLong() {
+        Address address = AddressFixture.anAddress().withCounty(over255LongString).build();
+        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
+        assertFalse(isWellFormatted);
+    }
+
+    @Test
+    public void validationFailsIfAddressCountryIsTooLong() {
+        Address address = AddressFixture.anAddress().withCountry(over255LongString).build();
+        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
+        assertFalse(isWellFormatted);
+    }
+
+    @Test
+    public void validationFailsIfAddressCityIsTooLong() {
+        Address address = AddressFixture.anAddress().withCity(over255LongString).build();
+        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
+        assertFalse(isWellFormatted);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -1,27 +1,37 @@
 package uk.gov.pay.connector.resources;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.common.validator.AuthCardDetailsValidator;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertEquals;
 
 public class AuthCardDetailsValidatorTest {
 
     private String sneakyCardNumber = "this12card3number4is5hidden6;7 89-0(1+2.";
     private String over255LongString = "ThisLineIs_TooLong_cbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsaacbstrdnsa1234567899";
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUpValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
 
     @Test
     public void validationSucceedForWellFormattedAuthorisationCardDetails() {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
-
-        assertThat(AuthCardDetailsValidator.isWellFormatted(authCardDetails), is(true));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -30,7 +40,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCvc("1234")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -39,7 +50,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardNo("12345678901234")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -48,7 +60,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCvc(null)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -57,7 +71,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardNo(null)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -66,7 +82,9 @@ public class AuthCardDetailsValidatorTest {
                 .withEndDate(null)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -75,7 +93,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardBrand(null)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -87,7 +107,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardBrand("")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -96,7 +118,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardNo("12345678901")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -105,7 +129,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardNo("123456789012")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -114,7 +139,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardNo("1234567890123456789")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -123,7 +149,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardNo("12345678901234567890")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -132,7 +160,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardNo("123456789012345A")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -141,7 +171,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCvc("45A")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -150,7 +182,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCvc("12345")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -159,7 +193,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCvc("12")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -168,7 +204,9 @@ public class AuthCardDetailsValidatorTest {
                 .withEndDate("1290")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -181,7 +219,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -194,7 +234,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -207,7 +249,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -220,7 +264,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -229,7 +275,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder(sneakyCardNumber)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -238,7 +286,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder("1 Mr John 123456789 Smith 0")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -247,7 +296,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardBrand(sneakyCardNumber)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -256,7 +307,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardBrand("12345678901")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -269,7 +321,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -282,7 +336,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -295,7 +350,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -308,7 +365,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -321,7 +379,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -330,7 +389,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(null)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -343,7 +403,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -356,7 +418,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -369,7 +432,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -382,7 +447,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -395,7 +461,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -408,7 +476,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -421,7 +490,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -434,7 +504,9 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -447,7 +519,8 @@ public class AuthCardDetailsValidatorTest {
                 .withAddress(address)
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -456,7 +529,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder("555")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -465,7 +540,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder("5678")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -474,7 +551,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder(" \t 321 ")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -483,7 +562,9 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder(" 1234 \t")
                 .build();
 
-        assertFalse(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
@@ -492,7 +573,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder("Ms 333")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -501,7 +583,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder("1234 Jr.")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -510,7 +593,8 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder("22")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
@@ -519,53 +603,60 @@ public class AuthCardDetailsValidatorTest {
                 .withCardHolder("12345")
                 .build();
 
-        assertTrue(AuthCardDetailsValidator.isWellFormatted(authCardDetails));
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(0, violations.size());
     }
 
     @Test
     public void validationFailsIfCardHolderIsTooLong() {
-        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withCardHolder(over255LongString).build();
-        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
-        assertFalse(isWellFormatted);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().withCardHolder(over255LongString).build();
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
     public void validationFailsIfAddressLineOneIsTooLong() {
         Address address = AddressFixture.anAddress().withLine1(over255LongString).build();
-        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
-        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
-        assertFalse(isWellFormatted);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
     public void validationFailsIfAddressLineTwoIsTooLong() {
         Address address = AddressFixture.anAddress().withLine2(over255LongString).build();
-        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
-        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
-        assertFalse(isWellFormatted);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
     public void validationFailsIfAddressCountyIsTooLong() {
         Address address = AddressFixture.anAddress().withCounty(over255LongString).build();
-        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
-        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
-        assertFalse(isWellFormatted);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
     public void validationFailsIfAddressCountryIsTooLong() {
         Address address = AddressFixture.anAddress().withCountry(over255LongString).build();
-        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
-        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
-        assertFalse(isWellFormatted);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 
     @Test
     public void validationFailsIfAddressCityIsTooLong() {
         Address address = AddressFixture.anAddress().withCity(over255LongString).build();
-        AuthCardDetails details = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
-        final boolean isWellFormatted = AuthCardDetailsValidator.isWellFormatted(details);
-        assertFalse(isWellFormatted);
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().withAddress(address).build();
+        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
+        assertEquals(1, violations.size());
+        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
     }
 }


### PR DESCRIPTION
## WHAT
- Added length validation for address fields and cardholder. This
validation is valid for the values that we receive in the auth request
- Added annotation type definition for the custom constraint validator
    for AuthCardDetails. This will work with annotation @Valid, instead of
    calling the validator by hand every time we try to map AuthCardDetails
    from external payload
    - Constraint violations are now intercepted by javax and returned into
    an array called `message` which is the default format. This requires a
    small change in the way we assert in tests, as we need to assert that
    the value is present in the array.
    - Small code style changes: in-lined local variables, made default constructor
    private to signal that this class should not be instantiated, removed
    exception declaration from method signature

Behaviour noticed on frontend:
- When `connector` returns status 400, frontend reloads the Card Details page with empty fields. The payment can be resumed and competed successfully.






