### PR TITLE
PP-4560 Make PatchRequest less gateway account-specific

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchKeys.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchKeys.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.common.model.api.jsonpatch;
+
+public interface JsonPatchKeys {
+
+    String FIELD_OPERATION = "op";
+    String FIELD_OPERATION_PATH = "path";
+    String FIELD_VALUE = "value";
+
+}

--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchOp.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchOp.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.common.model.api.jsonpatch;
+
+public enum JsonPatchOp {
+    
+    ADD, REPLACE, REMOVE;
+    
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
@@ -11,9 +11,6 @@ public class GatewayAccount {
     public static final String CREDENTIALS_PASSWORD = "password";
     public static final String CREDENTIALS_SHA_IN_PASSPHRASE = "sha_in_passphrase";
     public static final String CREDENTIALS_SHA_OUT_PASSPHRASE = "sha_out_passphrase";
-    public static final String FIELD_OPERATION = "op";
-    public static final String FIELD_OPERATION_PATH = "path";
-    public static final String FIELD_VALUE = "value";
     public static final String FIELD_NOTIFY_API_TOKEN = "api_token";
     public static final String FIELD_NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID = "template_id";
     public static final String FIELD_NOTIFY_REFUND_ISSUED_TEMPLATE_ID = "refund_issued_template_id";

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountPatchRequest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gatewayaccount.model;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchOp;
 
 import java.io.IOException;
 import java.util.List;
@@ -12,17 +13,17 @@ import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_OPERATION;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_OPERATION_PATH;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_VALUE;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_VALUE;
 
-public class PatchRequest {
+public class GatewayAccountPatchRequest {
 
-    private String op;
+    private JsonPatchOp op;
     private String path;
     private JsonNode value;
 
-    public String getOp() {
+    public JsonPatchOp getOp() {
         return op;
     }
 
@@ -68,15 +69,15 @@ public class PatchRequest {
     }
 
 
-    private PatchRequest(String op, String path, JsonNode value) {
+    private GatewayAccountPatchRequest(JsonPatchOp op, String path, JsonNode value) {
         this.op = op;
         this.path = path;
         this.value = value;
     }
 
-    public static PatchRequest from(JsonNode payload) {
-        return new PatchRequest(
-                payload.get(FIELD_OPERATION).asText(),
+    public static GatewayAccountPatchRequest from(JsonNode payload) {
+        return new GatewayAccountPatchRequest(
+                JsonPatchOp.valueOf(payload.get(FIELD_OPERATION).asText().toUpperCase()),
                 payload.get(FIELD_OPERATION_PATH).asText(),
                 payload.get(FIELD_VALUE));
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -16,10 +16,10 @@ import uk.gov.pay.connector.common.exception.CredentialsException;
 import uk.gov.pay.connector.common.model.domain.UuidAbstractEntity;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountPatchRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
-import uk.gov.pay.connector.gatewayaccount.model.PatchRequest;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.usernotification.service.GatewayAccountNotificationCredentialsService;
@@ -229,7 +229,7 @@ public class GatewayAccountResource {
         validator.validatePatchRequest(payload);
 
         return gatewayAccountServicesFactory.getUpdateService()
-                .doPatch(gatewayAccountId, PatchRequest.from(payload))
+                .doPatch(gatewayAccountId, GatewayAccountPatchRequest.from(payload))
                 .map(gatewayAccount -> Response.ok().build())
                 .orElseGet(() -> Response.status(NOT_FOUND).build());
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -8,10 +8,10 @@ import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountPatchRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
-import uk.gov.pay.connector.gatewayaccount.model.PatchRequest;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.UriInfo;
@@ -58,7 +58,7 @@ public class GatewayAccountService {
     }
 
     @Transactional
-    public Optional<GatewayAccount> doPatch(Long gatewayAccountId, PatchRequest gatewayAccountRequest) {
+    public Optional<GatewayAccount> doPatch(Long gatewayAccountId, GatewayAccountPatchRequest gatewayAccountRequest) {
         return gatewayAccountDao.findById(gatewayAccountId)
                 .flatMap(gatewayAccountEntity -> {
                     attributeUpdater.get(gatewayAccountRequest.getPath())
@@ -83,8 +83,8 @@ public class GatewayAccountService {
         return GatewayAccountObjectConverter.createResponseFrom(gatewayAccountEntity, uriInfo);
     }
     
-    private final Map<String, BiConsumer<PatchRequest, GatewayAccountEntity>> attributeUpdater =
-            new HashMap<String, BiConsumer<PatchRequest, GatewayAccountEntity>>() {{
+    private final Map<String, BiConsumer<GatewayAccountPatchRequest, GatewayAccountEntity>> attributeUpdater =
+            new HashMap<String, BiConsumer<GatewayAccountPatchRequest, GatewayAccountEntity>>() {{
                 put(CREDENTIALS_GATEWAY_MERCHANT_ID,
                         (gatewayAccountRequest, gatewayAccountEntity) -> {
                             Map<String, String> credentials = gatewayAccountEntity.getCredentials();

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -19,12 +19,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_VALUE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_NOTIFY_API_TOKEN;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_NOTIFY_REFUND_ISSUED_TEMPLATE_ID;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_OPERATION;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_OPERATION_PATH;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_VALUE;
 
 @RunWith(JUnitParamsRunner.class)
 public class GatewayAccountRequestValidatorTest {

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -14,8 +14,8 @@ import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountPatchRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
-import uk.gov.pay.connector.gatewayaccount.model.PatchRequest;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 
 import java.util.Arrays;
@@ -85,7 +85,7 @@ public class GatewayAccountServiceTest {
         Long gatewayAccountId = 100L;
         Map<String, String> settings = ImmutableMap.of("api_token", "anapitoken",
                 "template_id", "atemplateid");
-        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        GatewayAccountPatchRequest request = GatewayAccountPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "notify_settings",
                 "value", settings)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
@@ -102,7 +102,7 @@ public class GatewayAccountServiceTest {
     @Test
     public void shouldUpdateNotifySettingsWhenRemove() {
         Long gatewayAccountId = 100L;
-        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        GatewayAccountPatchRequest request = GatewayAccountPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "notify_settings")));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
@@ -118,7 +118,7 @@ public class GatewayAccountServiceTest {
     @Test
     public void shouldUpdateEmailCollectionMode() {
         Long gatewayAccountId = 100L;
-        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        GatewayAccountPatchRequest request = GatewayAccountPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "email_collection_mode",
                 "value", "off")));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
@@ -136,7 +136,7 @@ public class GatewayAccountServiceTest {
     @Test
     public void shouldUpdateCorporateCreditCardSurchargeAmount() {
         Long gatewayAccountId = 100L;
-        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        GatewayAccountPatchRequest request = GatewayAccountPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "corporate_credit_card_surcharge_amount",
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
@@ -151,7 +151,7 @@ public class GatewayAccountServiceTest {
     @Test
     public void shouldUpdateCorporateDebitCardSurchargeAmount() {
         Long gatewayAccountId = 100L;
-        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        GatewayAccountPatchRequest request = GatewayAccountPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "corporate_debit_card_surcharge_amount",
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
@@ -166,7 +166,7 @@ public class GatewayAccountServiceTest {
     @Test
     public void shouldUpdateCorporatePrepaidDebitCardSurchargeAmount() {
         Long gatewayAccountId = 100L;
-        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        GatewayAccountPatchRequest request = GatewayAccountPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "corporate_prepaid_debit_card_surcharge_amount",
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
@@ -181,7 +181,7 @@ public class GatewayAccountServiceTest {
     @Test
     public void shouldUpdateCorporatePrepaidCreditCardSurchargeAmount() {
         Long gatewayAccountId = 100L;
-        PatchRequest request = PatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+        GatewayAccountPatchRequest request = GatewayAccountPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
                 "path", "corporate_prepaid_credit_card_surcharge_amount",
                 "value", 100)));
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);


### PR DESCRIPTION
Rename `PatchRequest` to `GatewayAccountPatchRequest`.

Move constants for `"op"`, `"path"` and `"value"` from `GatewayAccount` to new `JsonPatchKeys` interface.

Move stringly-typed `"op"` values (`"add"`, `"replace"`, `"remove"`) to new `JsonPatchOp` enum.

with @stephencdaly