### PR TITLE
Make PaymentGatewayStateTransitions fully static

### DIFF
--- a/src/main/java/uk/gov/pay/connector/command/RenderStateTransitionGraphCommand.java
+++ b/src/main/java/uk/gov/pay/connector/command/RenderStateTransitionGraphCommand.java
@@ -4,7 +4,6 @@ import io.dropwizard.cli.Command;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
-import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -26,7 +25,7 @@ public class RenderStateTransitionGraphCommand extends Command {
 
     @Override
     public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
-        String data = new StateTransitionGraphVizRenderer(PaymentGatewayStateTransitions.getInstance()).toString();
+        String data = new StateTransitionGraphVizRenderer().toString();
 
         Path path = Paths.get("states.dot");
         writeToFile(data, path);

--- a/src/main/java/uk/gov/pay/connector/command/StateTransitionGraphVizRenderer.java
+++ b/src/main/java/uk/gov/pay/connector/command/StateTransitionGraphVizRenderer.java
@@ -11,12 +11,6 @@ import java.util.StringJoiner;
  * Render a graph - either install graphviz or use http://www.webgraphviz.com/
  */
 public class StateTransitionGraphVizRenderer {
-    private final PaymentGatewayStateTransitions transitions;
-
-    public StateTransitionGraphVizRenderer(PaymentGatewayStateTransitions transitions) {
-        this.transitions = transitions;
-    }
-
     public String toString() {
         StringJoiner s = new StringJoiner("\n", "", "\n");
         s.add("digraph PaymentGatewayStateTransitions {");
@@ -24,7 +18,7 @@ public class StateTransitionGraphVizRenderer {
         s.add("rankdir=TB overlap=false splines=true");
         s.add("node [style=filled shape=box color=\"0.650 0.200 1.000\"]");
 
-        transitions.allTransitions().forEach(edge ->
+        PaymentGatewayStateTransitions.allTransitions().forEach(edge ->
             s.add(formatEdge(edge))
         );
 
@@ -42,7 +36,7 @@ public class StateTransitionGraphVizRenderer {
     }
 
     private void nodeColours(StringJoiner s) {
-        transitions.allStatuses().forEach(c -> {
+        PaymentGatewayStateTransitions.allStatuses().forEach(c -> {
             s.add(String.format("%s [color=\"%s\" shape=%s] ;", nameFor(c), colourFor(c), shapeFor(c)));
         });
     }

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -43,22 +43,12 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_SUBMITTED;
 
 public class PaymentGatewayStateTransitions {
-    private static PaymentGatewayStateTransitions instance;
 
-    public static PaymentGatewayStateTransitions getInstance() {
-        if (instance == null) {
-            instance = new PaymentGatewayStateTransitions();
-        }
-        return instance;
-    }
+    private static ImmutableValueGraph<ChargeStatus, String> graph;
 
-    private ImmutableValueGraph<ChargeStatus, String> graph;
+    private PaymentGatewayStateTransitions() { }
 
-    private PaymentGatewayStateTransitions() {
-        graph = buildGraph();
-    }
-
-    private static ImmutableValueGraph<ChargeStatus, String> buildGraph() {
+    static {
         MutableValueGraph<ChargeStatus, String> graph = ValueGraphBuilder
                 .directed()
                 .build();
@@ -135,14 +125,14 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCEL_ERROR, "");
         graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCELLED, "");
 
-        return ImmutableValueGraph.copyOf(graph);
+        PaymentGatewayStateTransitions.graph = ImmutableValueGraph.copyOf(graph);
     }
 
-    public Set<ChargeStatus> allStatuses() {
+    public static Set<ChargeStatus> allStatuses() {
         return graph.nodes();
     }
 
-    public Set<Triple<ChargeStatus, ChargeStatus, String>> allTransitions() {
+    public static Set<Triple<ChargeStatus, ChargeStatus, String>> allTransitions() {
         return graph
                 .edges()
                 .stream()
@@ -154,10 +144,6 @@ public class PaymentGatewayStateTransitions {
     }
 
     public static boolean isValidTransition(ChargeStatus state, ChargeStatus targetState) {
-        return getInstance().isValidTransitionImpl(state, targetState);
-    }
-
-    private boolean isValidTransitionImpl(ChargeStatus state, ChargeStatus targetState) {
         return graph.edgeValueOrDefault(state, targetState, null) != null;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -9,7 +9,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READY;
@@ -18,23 +18,21 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 
 public class PaymentGatewayStateTransitionsTest {
-    PaymentGatewayStateTransitions transitions = PaymentGatewayStateTransitions.getInstance();
-
     @Test
     public void allStatuses_hasEveryValidChargeStatus() {
         Set<ChargeStatus> expected = new HashSet<>(Arrays.asList(ChargeStatus.values()));
-        assertThat(transitions.allStatuses(), is(expected));
+        assertThat(PaymentGatewayStateTransitions.allStatuses(), is(expected));
     }
 
     @Test
     public void allTransitions_containsAValidTransitionAnnotatedWithEventDescription() {
-        Set<Triple<ChargeStatus, ChargeStatus, String>> actual = transitions.allTransitions();
+        Set<Triple<ChargeStatus, ChargeStatus, String>> actual = PaymentGatewayStateTransitions.allTransitions();
         assertThat(actual, hasItem(Triple.of(CREATED, EXPIRED, "ChargeExpiryService")));
     }
 
     @Test
     public void isValidTransition_indicatesValidAndInvalidTransition() {
-        assertThat(transitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED), is(true));
-        assertThat(transitions.isValidTransition(CREATED, AUTHORISATION_READY), is(false));
+        assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED), is(true));
+        assertThat(PaymentGatewayStateTransitions.isValidTransition(CREATED, AUTHORISATION_READY), is(false));
     }
 }


### PR DESCRIPTION
❗️This PR contains an opinion

This singleton class only contains fixed data and takes no inputs. We can make
it fully static and simplify both callers and tests.


