### PR TITLE
PP-4560 Make JsonPatch.valueAs… methods not return null

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
@@ -5,12 +5,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
@@ -34,24 +31,14 @@ public class JsonPatchRequest {
         if (value != null && value.isTextual()) {
             return value.asText();
         }
-        return null;
+        throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type string");
     }
     
-    public Long valueAsLong() {
+    public long valueAsLong() {
         if (value != null && value.isNumber()) {
-            return new Long(value.asText());
+            return Long.valueOf(value.asText());
         }
-        return null;
-    }
-
-    public List<String> valueAsList() {
-        if (value != null && value.isArray()) {
-            return newArrayList(value.elements())
-                    .stream()
-                    .map(JsonNode::textValue)
-                    .collect(toList());
-        }
-        return null;
+        throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type number");
     }
 
     public Map<String, String> valueAsObject() {
@@ -80,5 +67,11 @@ public class JsonPatchRequest {
                 payload.get(FIELD_OPERATION_PATH).asText(),
                 payload.get(FIELD_VALUE));
 
+    }
+    
+    public class JsonNodeNotCorrectTypeException extends RuntimeException {
+        public JsonNodeNotCorrectTypeException(String message) {
+            super(message);
+        }
     }
 }


### PR DESCRIPTION
Make `JsonPatch.valueAsString()` and `JsonPatch.valueAsLong()` throw exceptions rather than return null if the node cannot be converted to the appropriate type.

Remove `JsonNode.valueAsList()` because it’s unused.

This change is safe to make because the validation in `GatewayAccountRequestValidator` (which everything that is used to construct a `JsonPatchRequest` goes through) ensures that the nodes
of appropriate types as described below.

`valueAsString()`:

- `"credentials/gateway_merchant_id"` — checks not null
- `"allow_google_pay"` — checks `"true"` or `"false"`
- `"allow_apple_pay"` — checks `"true"` or `"false"`
- `"allow_web_payments"` — checks `"true"` or `"false"`
- `"email_collection_mode"` — checks if `EmailCollectionMode` variant

`valueAsLong()`:

- `"corporate_credit_card_surcharge_amount"` — checks +ve number
- `"corporate_debit_card_surcharge_amount"` — checks +ve number
- `"corporate_prepaid_credit_card_surcharge_amount"` — checks +ve num
- `"corporate_prepaid_debit_card_surcharge_amount"` — checks +ve num

with @stephencdaly