### PR TITLE
PP-4560 Resource to update Stripe account setup flags

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
@@ -41,6 +41,13 @@ public class JsonPatchRequest {
         throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type number");
     }
 
+    public boolean valueAsBoolean() {
+        if (value != null && value.isBoolean()) {
+            return Boolean.valueOf(value.asText());
+        }
+        throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type boolean");
+    }
+
     public Map<String, String> valueAsObject() {
         if (value != null) {
             if ((value.isTextual() && !isEmpty(value.asText())) || (!value.isNull() && value.isObject())) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupUpdateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupUpdateRequest.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchRequest;
+
 public class StripeAccountSetupUpdateRequest {
     private final StripeAccountSetupTask task;
     private final boolean completed;
@@ -9,6 +11,11 @@ public class StripeAccountSetupUpdateRequest {
         this.completed = completed;
     }
 
+    public static StripeAccountSetupUpdateRequest from(JsonPatchRequest jsonPatchRequest) {
+        StripeAccountSetupTask task = StripeAccountSetupTask.valueOf(jsonPatchRequest.getPath().toUpperCase());
+        return new StripeAccountSetupUpdateRequest(task, jsonPatchRequest.valueAsBoolean());
+    }
+    
     public StripeAccountSetupTask getTask() {
         return task;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
@@ -1,16 +1,26 @@
 package uk.gov.pay.connector.gatewayaccount.resource;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
+import io.dropwizard.jersey.PATCH;
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchRequest;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetup;
+import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupUpdateRequest;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.StripeAccountSetupService;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -18,12 +28,15 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 public class StripeAccountSetupResource {
     private final StripeAccountSetupService stripeAccountSetupService;
     private final GatewayAccountService gatewayAccountService;
+    private final StripeAccountSetupRequestValidator stripeAccountSetupRequestValidator;
 
     @Inject
     public StripeAccountSetupResource(StripeAccountSetupService stripeAccountSetupService,
-                                      GatewayAccountService gatewayAccountService) {
+                                      GatewayAccountService gatewayAccountService,
+                                      StripeAccountSetupRequestValidator stripeAccountSetupRequestValidator) {
         this.stripeAccountSetupService = stripeAccountSetupService;
         this.gatewayAccountService = gatewayAccountService;
+        this.stripeAccountSetupRequestValidator = stripeAccountSetupRequestValidator;
     }
 
     @GET
@@ -31,8 +44,31 @@ public class StripeAccountSetupResource {
     @Produces(APPLICATION_JSON)
     public StripeAccountSetup getStripeAccountSetup(@PathParam("accountId") Long accountId) {
         return gatewayAccountService.getGatewayAccount(accountId)
-                .filter(gatewayAccountEntity -> PaymentGatewayName.STRIPE.getName().equals(gatewayAccountEntity.getGatewayName()))
+                .filter(this::isStripeGatewayAccount)
                 .map(gatewayAccountEntity -> stripeAccountSetupService.getCompletedTasks(gatewayAccountEntity.getId()))
                 .orElseThrow(NotFoundException::new);
+    }
+
+    @PATCH
+    @Path("/v1/api/accounts/{accountId}/stripe-setup")
+    @Consumes(APPLICATION_JSON)
+    public Response patchStripeAccountSetup(@PathParam("accountId") Long accountId, JsonNode payload) {
+        return gatewayAccountService.getGatewayAccount(accountId)
+                .filter(this::isStripeGatewayAccount)
+                .map(gatewayAccountEntity -> {
+                    stripeAccountSetupRequestValidator.validatePatchRequest(payload);
+                    List<StripeAccountSetupUpdateRequest> updateRequests = StreamSupport
+                            .stream(payload.spliterator(), false)
+                            .map(JsonPatchRequest::from)
+                            .map(StripeAccountSetupUpdateRequest::from)
+                            .collect(Collectors.toList());
+
+                    stripeAccountSetupService.update(gatewayAccountEntity, updateRequests);
+                    return Response.ok().build();
+                }).orElseThrow(NotFoundException::new);
+    }
+
+    private boolean isStripeGatewayAccount(GatewayAccountEntity gatewayAccountEntity) {
+        return PaymentGatewayName.STRIPE.getName().equals(gatewayAccountEntity.getGatewayName());
     }
 }


### PR DESCRIPTION
Add `/v1/api/accounts/ACCOUNT_ID/stripe-setup` patch endpoint that takes a JSON body like the following:

```json
[
  {
    "op": "replace",
    "path": "bank_account",
    "value": true
  }
]
```

If the gateway account does not exist or is not a Stripe gateway account, return a 404.

with @stephencdaly