### PR TITLE
PP-4860: Log successful/unsuccessful Google payments

### DIFF
--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -58,7 +58,6 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     @Before
     public void setUpCardAuthorisationService() {
         Environment mockEnvironment = mock(Environment.class);
-        mockMetricRegistry = mock(MetricRegistry.class);
         Counter mockCounter = mock(Counter.class);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -93,7 +93,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Before
     public void setUpCardAuthorisationService() {
-        mockMetricRegistry = mock(MetricRegistry.class);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -94,7 +94,6 @@ public class CardCaptureServiceTest extends CardServiceTest {
     @Before
     public void beforeTest() {
         Environment mockEnvironment = mock(Environment.class);
-        mockMetricRegistry = mock(MetricRegistry.class);
         Counter mockCounter = mock(Counter.class);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
 import com.codahale.metrics.MetricRegistry;
+import org.mockito.Mock;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
@@ -19,6 +20,7 @@ public abstract class CardServiceTest {
 
     protected final PaymentProvider mockedPaymentProvider = mock(PaymentProvider.class);
     protected PaymentProviders mockedProviders = mock(PaymentProviders.class);
+    @Mock
     protected MetricRegistry mockMetricRegistry;
     protected ChargeDao mockedChargeDao = mock(ChargeDao.class);
     protected ChargeService chargeService;


### PR DESCRIPTION
At present we aren't able to introduce smoke tests for Google payments, so we
need to introduce some monitoring. These log messages are inteded to be
searched for by our logging provider so as to build up some form of metric over
time.
