### PR TITLE
PP-4758: Goodbye to the session identifier bifunction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
@@ -5,9 +5,7 @@ import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation.Builder;
 import java.util.Map;
-import java.util.function.BiFunction;
 
 public class GatewayClientFactory {
 
@@ -27,17 +25,15 @@ public class GatewayClientFactory {
     public GatewayClient createGatewayClient(PaymentGatewayName gateway,
                                              GatewayOperation operation,
                                              Map<String, String> gatewayUrlMap,
-                                             BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier,
                                              MetricRegistry metricRegistry) {
         Client client = clientFactory.createWithDropwizardClient(gateway, operation, metricRegistry);
-        return new GatewayClient(client, gatewayUrlMap, sessionIdentifier, metricRegistry);
+        return new GatewayClient(client, gatewayUrlMap, metricRegistry);
     }
 
     public GatewayClient createGatewayClient(PaymentGatewayName gateway,
                                              Map<String, String> gatewayUrlMap,
-                                             BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier,
                                              MetricRegistry metricRegistry) {
         Client client = clientFactory.createWithDropwizardClient(gateway, metricRegistry);
-        return new GatewayClient(client, gatewayUrlMap, sessionIdentifier, metricRegistry);
+        return new GatewayClient(client, gatewayUrlMap, metricRegistry);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -37,10 +37,8 @@ import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.Invocation;
 import java.nio.charset.Charset;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
 import static java.lang.String.format;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
@@ -92,10 +90,10 @@ public class EpdqPaymentProvider implements PaymentProvider {
     public EpdqPaymentProvider(ConnectorConfiguration configuration,
                                GatewayClientFactory gatewayClientFactory,
                                Environment environment) {
-        authoriseClient = gatewayClientFactory.createGatewayClient(EPDQ, AUTHORISE, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
-        cancelClient = gatewayClientFactory.createGatewayClient(EPDQ, CANCEL, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
-        captureClient = gatewayClientFactory.createGatewayClient(EPDQ, CAPTURE, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
-        refundClient = gatewayClientFactory.createGatewayClient(EPDQ, REFUND, configuration.getGatewayConfigFor(EPDQ).getUrls(), includeSessionIdentifier(), environment.metrics());
+        authoriseClient = gatewayClientFactory.createGatewayClient(EPDQ, AUTHORISE, configuration.getGatewayConfigFor(EPDQ).getUrls(), environment.metrics());
+        cancelClient = gatewayClientFactory.createGatewayClient(EPDQ, CANCEL, configuration.getGatewayConfigFor(EPDQ).getUrls(), environment.metrics());
+        captureClient = gatewayClientFactory.createGatewayClient(EPDQ, CAPTURE, configuration.getGatewayConfigFor(EPDQ).getUrls(), environment.metrics());
+        refundClient = gatewayClientFactory.createGatewayClient(EPDQ, REFUND, configuration.getGatewayConfigFor(EPDQ).getUrls(), environment.metrics());
         this.frontendUrl = configuration.getLinks().getFrontendUrl();
         this.metricRegistry = environment.metrics();
         this.externalRefundAvailabilityCalculator = new EpdqExternalRefundAvailabilityCalculator();
@@ -298,9 +296,5 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withTransactionId(request.getTransactionId())
                 .build();
-    }
-
-    public static BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> includeSessionIdentifier() {
-        return (order, builder) -> builder;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -32,9 +32,7 @@ import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
-import javax.ws.rs.client.Invocation;
 import java.util.Optional;
-import java.util.function.BiFunction;
 
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
@@ -53,7 +51,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
                                    GatewayClientFactory gatewayClientFactory,
                                    Environment environment) {
         externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
-        client = gatewayClientFactory.createGatewayClient(SMARTPAY, configuration.getGatewayConfigFor(SMARTPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
+        client = gatewayClientFactory.createGatewayClient(SMARTPAY, configuration.getGatewayConfigFor(SMARTPAY).getUrls(), environment.metrics());
         this.smartpayCaptureHandler = new SmartpayCaptureHandler(client);
         this.smartpayRefundHandler = new SmartpayRefundHandler(client);
     }
@@ -169,9 +167,5 @@ public class SmartpayPaymentProvider implements PaymentProvider {
 
     private String getMerchantCode(GatewayRequest request) {
         return request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID);
-    }
-
-    public static BiFunction<GatewayOrder, Invocation.Builder, Invocation.Builder> includeSessionIdentifier() {
-        return (order, builder) -> builder;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -44,7 +44,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.BiFunction;
 
 import static java.util.UUID.randomUUID;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -105,12 +104,11 @@ public class EpdqPaymentProviderTest {
 
         Client client = TestClientFactory.createJerseyClient();
         GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
-                EpdqPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
+                mockMetricRegistry);
 
         when(mockGatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class),
                 any(GatewayOperation.class),
                 any(Map.class),
-                any(BiFunction.class),
                 any())).thenReturn(gatewayClient);
 
         paymentProvider = new EpdqPaymentProvider(mockConnectorConfiguration, mockGatewayClientFactory, mockEnvironment);

--- a/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
@@ -23,7 +23,6 @@ import static io.dropwizard.testing.ConfigOverride.config;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML_TYPE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.includeSessionIdentifier;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.it.contract.TrustStoreLoader.getSSLContext;
@@ -75,6 +74,6 @@ public class GooglePayForWorldpayTest {
         Client client = ClientBuilder.newBuilder().sslContext(getSSLContext()).build();
         ConnectorConfiguration configuration = app.getInstanceFromGuiceContainer(ConnectorConfiguration.class);
         Environment environment = app.getInstanceFromGuiceContainer(Environment.class);
-        return new GatewayClient(client, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), includeSessionIdentifier(), environment.metrics());
+        return new GatewayClient(client, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), environment.metrics());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.BiFunction;
 
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -246,10 +245,10 @@ public class SmartpayPaymentProviderTest {
         Client client = TestClientFactory.createJerseyClient();
 
         GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
-                SmartpayPaymentProvider.includeSessionIdentifier(), mockMetricRegistry);
+                mockMetricRegistry);
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(Map.class), any(BiFunction.class), any(MetricRegistry.class))).thenReturn(gatewayClient);
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(Map.class), any(MetricRegistry.class))).thenReturn(gatewayClient);
 
         GatewayConfig gatewayConfig = mock(GatewayConfig.class);
         when(gatewayConfig.getUrls()).thenReturn(Collections.EMPTY_MAP);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -36,7 +36,6 @@ import javax.ws.rs.client.ClientBuilder;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
-import java.util.function.BiFunction;
 
 import static java.util.UUID.randomUUID;
 import static org.hamcrest.CoreMatchers.not;
@@ -285,7 +284,6 @@ public class WorldpayPaymentProviderTest {
         GatewayClient gatewayClient = new GatewayClient(
                 ClientBuilder.newClient(),
                 getWorldpayConfig().getUrls(),
-                WorldpayPaymentProvider.includeSessionIdentifier(),
                 mockMetricRegistry
         );
 
@@ -298,7 +296,6 @@ public class WorldpayPaymentProviderTest {
                 any(PaymentGatewayName.class),
                 any(GatewayOperation.class),
                 any(Map.class),
-                any(BiFunction.class),
                 any(MetricRegistry.class))).thenReturn(gatewayClient);
 
         return new WorldpayPaymentProvider(configuration, gatewayClientFactory, mockEnvironment);

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
@@ -9,15 +9,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.ClientFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
-import javax.ws.rs.client.Invocation.Builder;
-import java.util.Map;
-import java.util.function.BiFunction;
-
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 
@@ -33,12 +28,7 @@ public class GatewayClientFactoryTest {
     MetricRegistry mockMetricRegistry;
     @Test
     public void shouldBuildGatewayClient() {
-        Map<String, String> gatewayUrlMap = mock(Map.class);
-        Builder mockBuilder = mock(Builder.class);
-        BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier = (GatewayOrder o, Builder b) -> mockBuilder;
-
-        GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, AUTHORISE,
-                gatewayUrlMap, sessionIdentifier, mockMetricRegistry);
+        GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, AUTHORISE, emptyMap(), mockMetricRegistry);
 
         assertNotNull(gatewayClient);
         verify(mockClientFactory).createWithDropwizardClient(PaymentGatewayName.WORLDPAY, AUTHORISE, mockMetricRegistry);


### PR DESCRIPTION
All the session identifier bifunction does is add a cookie to the http request. This is only useful for worldpay auth requests. Removing the `BiFunction<GatewayOrder, Builder, Builder> sessionIdentifier` field in GatewayClient will make it easier to deprecate StripeGatewayClient.