### PR TITLE
PP-4750: Have PerformanceReportDao return a Stream of results

### DIFF
--- a/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
@@ -11,6 +11,7 @@ import javax.persistence.EntityManager;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
@@ -42,7 +43,7 @@ public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {
       .getSingleResult();
   }
 
-  public List<GatewayAccountPerformanceReportEntity> aggregateNumberAndValueOfPaymentsByGatewayAccount() {
+  public Stream<GatewayAccountPerformanceReportEntity> aggregateNumberAndValueOfPaymentsByGatewayAccount() {
     return entityManager
       .get()
       .createQuery(
@@ -61,10 +62,11 @@ public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {
         + " AND   g.type = :type"
         + " GROUP BY g.id"
         + " ORDER BY g.id ASC"
+              , GatewayAccountPerformanceReportEntity.class
       )
       .setParameter("status", CAPTURED.toString())
       .setParameter("type", LIVE)
-      .getResultList();
+      .getResultStream();
   }
 
   public PerformanceReportEntity aggregateNumberAndValueOfPaymentsForAGivenDay(ZonedDateTime date) {

--- a/src/main/java/uk/gov/pay/connector/report/resource/PerformanceReportResource.java
+++ b/src/main/java/uk/gov/pay/connector/report/resource/PerformanceReportResource.java
@@ -11,6 +11,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
@@ -67,22 +69,16 @@ public class PerformanceReportResource {
     @Path("/v1/api/reports/gateway-account-performance-report")
     @Produces(APPLICATION_JSON)
     public Response getGatewayAccountPerformanceReport() {
-        HashMap<String, ImmutableMap<String, Object>> response = new HashMap<>();
-
-         performanceReportDao
-           .aggregateNumberAndValueOfPaymentsByGatewayAccount()
-           .forEach(
-             performance -> response.put(
-               performance.getGatewayAccountId().toString(),
-               ImmutableMap.of(
-                 "total_volume", performance.getTotalVolume(),
-                 "total_amount", performance.getTotalAmount(),
-                 "average_amount", performance.getAverageAmount(),
-                 "min_amount", performance.getMinAmount(),
-                 "max_amount", performance.getMaxAmount()
-               )
-             )
-           );
+         Map<String, Map<String, Object>> response = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount()
+                 .collect(Collectors.toMap(
+                         performance -> performance.getGatewayAccountId().toString(),
+                         performance -> ImmutableMap.of(
+                                 "total_volume", performance.getTotalVolume(),
+                                 "total_amount", performance.getTotalAmount(),
+                                 "average_amount", performance.getAverageAmount(),
+                                 "min_amount", performance.getMinAmount(),
+                                 "max_amount", performance.getMaxAmount()
+                 )));
 
          return ok().entity(response).build();
     }

--- a/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoITest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.report.model.domain.PerformanceReportEntity;
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.math.BigDecimal.ZERO;
 import static org.hamcrest.Matchers.is;
@@ -75,14 +76,22 @@ public class PerformanceReportDaoITest extends DaoITestBase {
         insertCharge(anotherGatewayAccount, 6L, ZonedDateTime.now());
         insertCharge(anotherGatewayAccount, 3L, ZonedDateTime.now());
         insertCharge(anotherGatewayAccount, 6L, ZonedDateTime.now());
-        List<GatewayAccountPerformanceReportEntity> gatewayAccountPerformanceReportEntities = performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount();
+
+        List<GatewayAccountPerformanceReportEntity> gatewayAccountPerformanceReportEntities =
+                performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount().collect(Collectors.toList());
+
         assertThat(gatewayAccountPerformanceReportEntities.size(), is(2));
-        assertThat(gatewayAccountPerformanceReportEntities.get(0).getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
-        assertThat(gatewayAccountPerformanceReportEntities.get(0).getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
-        assertThat(gatewayAccountPerformanceReportEntities.get(0).getTotalVolume(), is(2L));
-        assertThat(gatewayAccountPerformanceReportEntities.get(1).getAverageAmount(), is(closeTo(new BigDecimal("5"), ZERO)));
-        assertThat(gatewayAccountPerformanceReportEntities.get(1).getTotalAmount(), is(closeTo(new BigDecimal("15"), ZERO)));
-        assertThat(gatewayAccountPerformanceReportEntities.get(1).getTotalVolume(), is(3L));
+
+        GatewayAccountPerformanceReportEntity first = gatewayAccountPerformanceReportEntities.get(0);
+        GatewayAccountPerformanceReportEntity second = gatewayAccountPerformanceReportEntities.get(1);
+
+        assertThat(first.getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
+        assertThat(first.getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
+        assertThat(first.getTotalVolume(), is(2L));
+
+        assertThat(second.getAverageAmount(), is(closeTo(new BigDecimal("5"), ZERO)));
+        assertThat(second.getTotalAmount(), is(closeTo(new BigDecimal("15"), ZERO)));
+        assertThat(second.getTotalVolume(), is(3L));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/resources/GatewayAccountPerformanceReportResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/GatewayAccountPerformanceReportResourceTest.java
@@ -12,9 +12,8 @@ import uk.gov.pay.connector.report.resource.PerformanceReportResource;
 
 import javax.ws.rs.core.Response;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.core.Is.is;
@@ -27,10 +26,7 @@ public class GatewayAccountPerformanceReportResourceTest {
     @Mock
     private PerformanceReportDao mockPerformanceReportDao;
 
-    @Mock
-    private List<GatewayAccountPerformanceReportEntity> noTransactionsPerformanceReportEntity;
-    @Mock
-    private List<GatewayAccountPerformanceReportEntity> someTransactionsPerformanceReportEntity;
+    private Stream<GatewayAccountPerformanceReportEntity> someTransactionsPerformanceReportEntity;
 
     private final Long totalVolume = 10000L;
     private final BigDecimal totalAmount = new BigDecimal("10000000");
@@ -42,25 +38,22 @@ public class GatewayAccountPerformanceReportResourceTest {
 
     @Before
     public void setUp() {
-        noTransactionsPerformanceReportEntity = new ArrayList<>();
-        someTransactionsPerformanceReportEntity = new ArrayList<>();
-
-        GatewayAccountPerformanceReportEntity mockedGatewayAccountPerformanceReport = new GatewayAccountPerformanceReportEntity(
+        someTransactionsPerformanceReportEntity = Stream.of(new GatewayAccountPerformanceReportEntity(
             totalVolume,
             totalAmount,
             averageAmount,
             minAmount,
             maxAmount,
             3L
-        );
-
-        someTransactionsPerformanceReportEntity.add(mockedGatewayAccountPerformanceReport);
+        ));
 
         resource = new PerformanceReportResource(mockPerformanceReportDao);
     }
 
     @Test
     public void noTransactionsPerformanceReportEntitySerializesCorrectly() {
+        Stream<GatewayAccountPerformanceReportEntity> noTransactionsPerformanceReportEntity
+                = Stream.empty();
         given(mockPerformanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount())
                 .willReturn(noTransactionsPerformanceReportEntity);
 


### PR DESCRIPTION
`PerformanceReportResource`'s transforms of the data returned from this DAO can
be much nicer if it's given a Stream to work with. Refactor the DAO to make
consumers' lives easier.