### PR TITLE
PP-4750: Support larger quantities of transactions in the summary report

### DIFF
--- a/src/main/java/uk/gov/pay/connector/report/model/TransactionsSummaryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/report/model/TransactionsSummaryResponse.java
@@ -12,17 +12,17 @@ public class TransactionsSummaryResponse {
     public static class SuccessfulPayments {
 
         @JsonProperty("count")
-        private int count;
+        private long count;
 
         @JsonProperty("total_in_pence")
         private long totalInPence;
 
-        SuccessfulPayments(int count, long totalInPence) {
+        SuccessfulPayments(long count, long totalInPence) {
             this.count = count;
             this.totalInPence = totalInPence;
         }
 
-        public int getCount() {
+        public long getCount() {
             return count;
         }
 
@@ -36,17 +36,17 @@ public class TransactionsSummaryResponse {
     public static class RefundedPayments {
 
         @JsonProperty("count")
-        private int count;
+        private long count;
 
         @JsonProperty("total_in_pence")
         private long totalInPence;
 
-        RefundedPayments(int count, long totalInPence) {
+        RefundedPayments(long count, long totalInPence) {
             this.count = count;
             this.totalInPence = totalInPence;
         }
 
-        public int getCount() {
+        public long getCount() {
             return count;
         }
 
@@ -81,8 +81,8 @@ public class TransactionsSummaryResponse {
     @JsonProperty("net_income")
     private NetIncome netIncome;
 
-    public TransactionsSummaryResponse(int successfulPaymentsCount, long successfulPaymentsTotalInPence,
-                                       int refundedPaymentsCount, long refundedPaymentsTotalInPence,
+    public TransactionsSummaryResponse(long successfulPaymentsCount, long successfulPaymentsTotalInPence,
+                                       long refundedPaymentsCount, long refundedPaymentsTotalInPence,
                                        long netIncomeTotalInPence) {
         this.successfulPayments = new SuccessfulPayments(successfulPaymentsCount, successfulPaymentsTotalInPence);
         this.refundedPayments = new RefundedPayments(refundedPaymentsCount, refundedPaymentsTotalInPence);

--- a/src/main/java/uk/gov/pay/connector/report/resource/TransactionsSummaryResource.java
+++ b/src/main/java/uk/gov/pay/connector/report/resource/TransactionsSummaryResource.java
@@ -90,8 +90,8 @@ public class TransactionsSummaryResource {
                 .summaryStatistics();
 
         TransactionsSummaryResponse response = new TransactionsSummaryResponse(
-                (int) successfulPaymentStats.getCount(), successfulPaymentStats.getSum(),
-                (int) successfulRefundStats.getCount(), successfulRefundStats.getSum(),
+                successfulPaymentStats.getCount(), successfulPaymentStats.getSum(),
+                successfulRefundStats.getCount(), successfulRefundStats.getSum(),
                 successfulPaymentStats.getSum() - successfulRefundStats.getSum());
 
         return Response.ok(response).build();

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsSummaryResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsSummaryResourceITest.java
@@ -168,10 +168,10 @@ public class TransactionsSummaryResourceITest {
                 .getTransactionsSummary()
                 .statusCode(Response.Status.OK.getStatusCode())
                 .body("successful_payments.count", is(2))
-                .body("successful_payments.total_in_pence", is(30000))
+                .body("successful_payments.total_in_pence", is(300_00L))
                 .body("refunded_payments.count", is(2))
-                .body("refunded_payments.total_in_pence", is(1500))
-                .body("net_income.total_in_pence", is(28500));
+                .body("refunded_payments.total_in_pence", is(15_00L))
+                .body("net_income.total_in_pence", is(285_00L));
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/report/resource/TransactionsSummaryResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/report/resource/TransactionsSummaryResourceTest.java
@@ -106,13 +106,13 @@ public class TransactionsSummaryResourceTest {
 
         TransactionsSummaryResponse response = (TransactionsSummaryResponse) result.getEntity();
 
-        assertThat(response.getSuccessfulPayments().getCount(), is(3));
+        assertThat(response.getSuccessfulPayments().getCount(), is(3L));
         assertThat(response.getSuccessfulPayments().getTotalInPence(),
                 is(GBP_25_00
                         + GBP_50_00
                         + GBP_100_00));
 
-        assertThat(response.getRefundedPayments().getCount(), is(2));
+        assertThat(response.getRefundedPayments().getCount(), is(2L));
         assertThat(response.getRefundedPayments().getTotalInPence(),
                 is(GBP_10_00
                         + GBP_2_50));


### PR DESCRIPTION
`summaryStatistics()` returns longs for the count of elements in a stream.
Rather than cast this to an int, we may as well return a `long` from our API.

