### PR TITLE
PP-4868 add a try-catch block to avoid the scheduler blowing up

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CaptureProcessScheduler.java
@@ -62,8 +62,12 @@ public class CaptureProcessScheduler implements Managed {
         logger.info("Scheduling CardCaptureProcess to run every {} seconds (will start in {} seconds)", interval, initialDelayInSeconds);
 
         scheduledExecutorService.scheduleAtFixedRate(() -> {
-            cardCaptureProcess.loadCaptureQueue();
-            scheduleCaptureThreads();
+            try {
+                cardCaptureProcess.loadCaptureQueue();
+                scheduleCaptureThreads();
+            } catch (Exception ex) {
+                logger.error("An exception was caught while running Capture Process: " + ex.getMessage());
+            }
         }, initialDelayInSeconds, interval, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
## WHAT
- add a try/catch block around the capture charges scheduler process to avoid the scheduler blowing up by an unchecked exception when the DB is not available


