### PR TITLE
PP-4806 Correct state name for Frontend wallet contract test.

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/WalletApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/WalletApiContractTest.java
@@ -65,7 +65,7 @@ public class WalletApiContractTest {
         }
     }
 
-    @State("a charge exists with id testChargeId and is in state ENTERING_CARD_DETAILS.")
+    @State("a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
     public void aChangeExistsAwaitingAuthorisation(Map<String, String> params) {
         long gatewayAccountId = 666L;
         setUpGatewayAccount(gatewayAccountId);


### PR DESCRIPTION
Correct the state name for the Frontend wallet contract test to match the updated value now being used by Frontend. This new value signals that the state should use an account set-up for sandbox.

@kbottla



