### PR TITLE
PP-4462 Add a provider contract test state for a stripe account existing

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -150,6 +150,16 @@ public class TransactionsApiContractTest {
         setUpCharges(2, Long.toString(accountId), ZonedDateTime.of(2018, 5, 14, 1, 1, 1, 1, ZoneId.systemDefault()));
     }
 
+    @State("a stripe gateway account with external id 42 exists in the database")
+    public void stripeAccountExists() {
+        DatabaseFixtures
+                .withDatabaseTestHelper(dbHelper)
+                .aTestAccount()
+                .withAccountId(42L)
+                .withPaymentProvider("stripe")
+                .insert();
+    }
+
     @State({"default", "Card types exist in the database"})
     public void defaultCase() {
     }


### PR DESCRIPTION
Add a state for a stripe account existing for use by selfservice contract tests for the GET and PATCH stripe account setup endpoints


