### PR TITLE
PP-4819 add allow_google_pay and allow_apple_pay to GET account by ID

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -357,6 +357,8 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         account.put("corporate_prepaid_credit_card_surcharge_amount", getCorporatePrepaidCreditCardSurchargeAmount());
         account.put("corporate_prepaid_debit_card_surcharge_amount", getCorporatePrepaidDebitCardSurchargeAmount());
         account.put("allow_web_payments", String.valueOf(allowWebPayments));
+        account.put("allow_apple_pay", isAllowApplePay());
+        account.put("allow_google_pay", isAllowGooglePay());
         return account;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -162,7 +162,8 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .body("email_notifications.REFUND_ISSUED.enabled", is(true))
                 .body("service_name", is("service_name"))
                 .body("corporate_credit_card_surcharge_amount", is(0))
-                .body("corporate_debit_card_surcharge_amount", is(0));
+                .body("allow_google_pay", is(false))
+                .body("allow_apple_pay", is(false));
     }
 
     @Test


### PR DESCRIPTION
## WHAT
add `allow_google_pay` and `allow_apple_pay` to `GET /v1/frontend/accounts/{accountId}` this is required by selfservice to display the status of these flags.

## HOW 
check `/v1/frontend/accounts/{accountId}` shows these booleans. 


