### PR TITLE
PP-4806 Enable Pact verification at all times

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/WalletApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/WalletApiContractTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.pact;
 
-import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
@@ -25,7 +24,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @RunWith(PactRunner.class)
 @Provider("connector")
-@IgnoreNoPactsToVerify()
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"frontend"})


### PR DESCRIPTION
## WHAT

- Removed annotation `@IgnoreNoPactsToVerify` on WalletApiContractTest which means pacts must be available for WalletApiContractTest state. 