### PR TITLE
PP-4882 Refactor GatewayAccountDao to not return GatwayAccountResourceDTO

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -34,28 +34,27 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
                 .getResultList().stream().findFirst();
     }
 
-    public List<GatewayAccountResourceDTO> list(List<Long> accountIds) {
-        String query = "SELECT NEW uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO"
-                       + " (gae.id, gae.gatewayName, gae.type, gae.description, gae.serviceName, gae.analyticsId, gae.corporateCreditCardSurchargeAmount, gae.corporateDebitCardSurchargeAmount, gae.allowWebPayments, gae.allowApplePay, gae.allowGooglePay, gae.corporatePrepaidCreditCardSurchargeAmount, gae.corporatePrepaidDebitCardSurchargeAmount)"
+    public List<GatewayAccountEntity> list(List<Long> accountIds) {
+        String query = "SELECT gae"
                        + " FROM GatewayAccountEntity gae"
                        + " WHERE gae.id IN :accountIds"
                        + " ORDER BY gae.id";
 
         return entityManager
                 .get()
-                .createQuery(query, GatewayAccountResourceDTO.class)
+                .createQuery(query, GatewayAccountEntity.class)
                 .setParameter("accountIds", accountIds)
                 .getResultList();
     }
 
-    public List<GatewayAccountResourceDTO> listAll() {
-        String query = "SELECT NEW uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO" +
-                "(gae.id, gae.gatewayName, gae.type, gae.description, gae.serviceName, gae.analyticsId, gae.corporateCreditCardSurchargeAmount, gae.corporateDebitCardSurchargeAmount, gae.allowWebPayments, gae.allowApplePay, gae.allowGooglePay, gae.corporatePrepaidCreditCardSurchargeAmount, gae.corporatePrepaidDebitCardSurchargeAmount) " +
-                "FROM GatewayAccountEntity gae order by gae.id";
+    public List<GatewayAccountEntity> listAll() {
+        String query = "SELECT gae " +
+                "FROM GatewayAccountEntity gae " +
+                "ORDER BY gae.id";
 
         return entityManager
                 .get()
-                .createQuery(query, GatewayAccountResourceDTO.class)
+                .createQuery(query, GatewayAccountEntity.class)
                 .getResultList();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -83,6 +83,24 @@ public class GatewayAccountResourceDTO {
         this.corporatePrepaidCreditCardSurchargeAmount = corporatePrepaidCreditCardSurchargeAmount;
         this.corporatePrepaidDebitCardSurchargeAmount = corporatePrepaidDebitCardSurchargeAmount;
     }
+    
+    public static GatewayAccountResourceDTO fromEntity(GatewayAccountEntity gatewayAccountEntity) {
+        return new GatewayAccountResourceDTO(
+            gatewayAccountEntity.getId(),
+            gatewayAccountEntity.getGatewayName(),
+            GatewayAccountEntity.Type.fromString(gatewayAccountEntity.getType()),
+            gatewayAccountEntity.getDescription(),
+            gatewayAccountEntity.getServiceName(),
+            gatewayAccountEntity.getAnalyticsId(),
+            gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount(),
+            gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount(),
+            gatewayAccountEntity.isAllowWebPayments(),
+            gatewayAccountEntity.isAllowApplePay(),
+            gatewayAccountEntity.isAllowGooglePay(),
+            gatewayAccountEntity.getCorporatePrepaidCreditCardSurchargeAmount(),
+            gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount()
+        );
+    }
 
     public long getAccountId() {
         return accountId;
@@ -130,5 +148,17 @@ public class GatewayAccountResourceDTO {
 
     public long getCorporatePrepaidDebitCardSurchargeAmount() {
         return corporatePrepaidDebitCardSurchargeAmount;
+    }
+
+    public boolean isAllowWebPayments() {
+        return allowWebPayments;
+    }
+
+    public boolean isAllowApplePay() {
+        return allowApplePay;
+    }
+
+    public boolean isAllowGooglePay() {
+        return allowGooglePay;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.CREDENTIALS_GATEWAY_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
@@ -51,11 +52,15 @@ public class GatewayAccountService {
     }
 
     public List<GatewayAccountResourceDTO> getAllGatewayAccounts() {
-        return gatewayAccountDao.listAll();
+        return gatewayAccountDao.listAll().stream()
+                .map(GatewayAccountResourceDTO::fromEntity)
+                .collect(Collectors.toList());
     }
 
     public List<GatewayAccountResourceDTO> getGatewayAccounts(List<Long> gatewayAccountIds) {
-        return gatewayAccountDao.list(gatewayAccountIds);
+        return gatewayAccountDao.list(gatewayAccountIds).stream()
+                .map(GatewayAccountResourceDTO::fromEntity)
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+
+public class GatewayAccountResourceDTOTest {
+
+    @Test
+    public void fromEntity() {
+        GatewayAccountEntity entity = new GatewayAccountEntity();
+        entity.setId(100L);
+        entity.setGatewayName("testGatewayName");
+        entity.setType(GatewayAccountEntity.Type.fromString("test"));
+        entity.setDescription("aDescription");
+        entity.setServiceName("aServiceName");
+        entity.setAnalyticsId("123");
+        entity.setCorporateDebitCardSurchargeAmount(200L);
+        entity.setCorporateCreditCardSurchargeAmount(300L);
+        entity.setCorporatePrepaidCreditCardSurchargeAmount(400L);
+        entity.setCorporatePrepaidDebitCardSurchargeAmount(500L);
+        entity.setAllowWebPayments(true);
+        entity.setAllowApplePay(false);
+        entity.setAllowGooglePay(true);
+        entity.setCredentials(Collections.emptyMap());
+        
+        GatewayAccountResourceDTO dto = GatewayAccountResourceDTO.fromEntity(entity);
+        assertThat(dto.getAccountId(), is(entity.getId()));
+        assertThat(dto.getPaymentProvider(), is(entity.getGatewayName()));
+        assertThat(dto.getType(), is(entity.getType()));
+        assertThat(dto.getDescription(), is(entity.getDescription()));
+        assertThat(dto.getServiceName(), is(entity.getServiceName()));
+        assertThat(dto.getAnalyticsId(), is(entity.getAnalyticsId()));
+        assertThat(dto.getCorporateCreditCardSurchargeAmount(), is(entity.getCorporateNonPrepaidCreditCardSurchargeAmount()));
+        assertThat(dto.getCorporateDebitCardSurchargeAmount(), is(entity.getCorporateNonPrepaidDebitCardSurchargeAmount()));
+        assertThat(dto.getCorporatePrepaidCreditCardSurchargeAmount(), is(entity.getCorporatePrepaidCreditCardSurchargeAmount()));
+        assertThat(dto.getCorporatePrepaidDebitCardSurchargeAmount(), is(entity.getCorporatePrepaidDebitCardSurchargeAmount()));
+        assertThat(dto.isAllowWebPayments(), is(entity.isAllowWebPayments()));
+        assertThat(dto.isAllowApplePay(), is(entity.isAllowApplePay()));
+        assertThat(dto.isAllowGooglePay(), is(entity.isAllowGooglePay()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoITest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
 import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
 
 import java.util.Arrays;
@@ -302,10 +301,10 @@ public class GatewayAccountDaoITest extends DaoITestBase {
                 TEST,
                 "description-1",
                 "analytics-id-1",
-                0,
-                0,
-                0,
-                0);
+                100,
+                200,
+                300,
+                400);
         final long gatewayAccountId_2 = nextLong();
         databaseTestHelper.addGatewayAccount(String.valueOf(gatewayAccountId_2),
                 "provider-2",
@@ -331,41 +330,42 @@ public class GatewayAccountDaoITest extends DaoITestBase {
                 0,
                 0);
 
-        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountDao.listAll();
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.listAll();
 
         assertEquals(3, gatewayAccounts.size());
 
-        List<GatewayAccountResourceDTO> gatewayAccountWithId_1 = gatewayAccounts.stream().filter(ga -> ga.getAccountId() == gatewayAccountId_1).collect(Collectors.toList());
+        List<GatewayAccountEntity> gatewayAccountWithId_1 = gatewayAccounts.stream().filter(ga -> ga.getId() == gatewayAccountId_1).collect(Collectors.toList());
         assertEquals(gatewayAccountWithId_1.size(), 1);
-        GatewayAccountResourceDTO gatewayAccountResourceDTO = gatewayAccountWithId_1.get(0);
-        assertThat(gatewayAccountResourceDTO.getAccountId(), is(gatewayAccountId_1));
-        assertEquals("provider-1", gatewayAccountResourceDTO.getPaymentProvider());
-        assertEquals("description-1", gatewayAccountResourceDTO.getDescription());
-        assertEquals("service-name-1", gatewayAccountResourceDTO.getServiceName());
-        assertEquals(TEST.toString(), gatewayAccountResourceDTO.getType());
-        assertEquals("analytics-id-1", gatewayAccountResourceDTO.getAnalyticsId());
-        assertEquals(0L, gatewayAccountResourceDTO.getCorporateCreditCardSurchargeAmount());
-        assertEquals(0L, gatewayAccountResourceDTO.getCorporateDebitCardSurchargeAmount());
-        assertEquals(0L, gatewayAccountResourceDTO.getCorporatePrepaidCreditCardSurchargeAmount());
-        assertEquals(0L, gatewayAccountResourceDTO.getCorporatePrepaidDebitCardSurchargeAmount());
+        GatewayAccountEntity gatewayAccountEntity = gatewayAccountWithId_1.get(0);
+        assertThat(gatewayAccountEntity.getId(), is(gatewayAccountId_1));
+        assertEquals("provider-1", gatewayAccountEntity.getGatewayName());
+        assertEquals("description-1", gatewayAccountEntity.getDescription());
+        assertEquals("service-name-1", gatewayAccountEntity.getServiceName());
+        assertEquals(TEST.toString(), gatewayAccountEntity.getType());
+        assertEquals("analytics-id-1", gatewayAccountEntity.getAnalyticsId());
+        assertEquals(100L, gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount());
+        assertEquals(200L, gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount());
+        assertEquals(300L, gatewayAccountEntity.getCorporatePrepaidCreditCardSurchargeAmount());
+        assertEquals(400L, gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount());
 
-        List<GatewayAccountResourceDTO> gatewayAccountWithId_2 = gatewayAccounts.stream().filter(ga -> ga.getAccountId() == gatewayAccountId_2).collect(Collectors.toList());
+        List<GatewayAccountEntity> gatewayAccountWithId_2 = gatewayAccounts.stream().filter(ga -> ga.getId() == gatewayAccountId_2).collect(Collectors.toList());
         assertEquals(gatewayAccountWithId_2.size(), 1);
-        gatewayAccountResourceDTO = gatewayAccountWithId_2.get(0);
-        assertEquals("provider-2", gatewayAccountResourceDTO.getPaymentProvider());
-        assertEquals(250L, gatewayAccountResourceDTO.getCorporateCreditCardSurchargeAmount());
-        assertEquals(50L, gatewayAccountResourceDTO.getCorporateDebitCardSurchargeAmount());
-        assertThat(gatewayAccountResourceDTO.getAccountId(), is(gatewayAccountId_2));
+        gatewayAccountEntity = gatewayAccountWithId_2.get(0);
+        assertEquals("provider-2", gatewayAccountEntity.getGatewayName());
+        assertEquals(250L, gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount());
+        assertEquals(50L, gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount());
+        assertThat(gatewayAccountEntity.getId(), is(gatewayAccountId_2));
 
-        List<GatewayAccountResourceDTO> gatewayAccountWithId_3 = gatewayAccounts.stream().filter(ga -> ga.getAccountId() == gatewayAccountId_3).collect(Collectors.toList());
+        List<GatewayAccountEntity> gatewayAccountWithId_3 = gatewayAccounts.stream().filter(ga -> ga.getId() == gatewayAccountId_3).collect(Collectors.toList());
         assertEquals(gatewayAccountWithId_3.size(), 1);
-        gatewayAccountResourceDTO = gatewayAccountWithId_3.get(0);
-        assertEquals("provider-3", gatewayAccountResourceDTO.getPaymentProvider());
-        assertEquals(0L, gatewayAccountResourceDTO.getCorporatePrepaidCreditCardSurchargeAmount());
-        assertEquals(0L, gatewayAccountResourceDTO.getCorporatePrepaidDebitCardSurchargeAmount());
-        assertThat(gatewayAccountResourceDTO.getAccountId(), is(gatewayAccountId_3));
+        gatewayAccountEntity = gatewayAccountWithId_3.get(0);
+        assertEquals("provider-3", gatewayAccountEntity.getGatewayName());
+        assertEquals(0L, gatewayAccountEntity.getCorporatePrepaidCreditCardSurchargeAmount());
+        assertEquals(0L, gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount());
+        assertThat(gatewayAccountEntity.getId(), is(gatewayAccountId_3));
     }
-
+    
+    
     @Test
     public void shouldListASubsetOfAccountsSingle() {
         long gatewayAccountId_1 = nextLong();
@@ -401,11 +401,11 @@ public class GatewayAccountDaoITest extends DaoITestBase {
         );
 
         List<Long> accountIds = Collections.singletonList(gatewayAccountId_2);
-        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountDao.list(accountIds);
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.list(accountIds);
 
         assertEquals(1, gatewayAccounts.size());
-        assertThat(gatewayAccounts.get(0).getAccountId(), is(gatewayAccountId_2));
-        assertEquals("provider-2", gatewayAccounts.get(0).getPaymentProvider());
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+        assertEquals("provider-2", gatewayAccounts.get(0).getGatewayName());
         assertEquals("description-2", gatewayAccounts.get(0).getDescription());
         assertEquals("service-name-2", gatewayAccounts.get(0).getServiceName());
         assertEquals(TEST.toString(), gatewayAccounts.get(0).getType());
@@ -441,10 +441,10 @@ public class GatewayAccountDaoITest extends DaoITestBase {
                 TEST,
                 "description-2",
                 "analytics-id-2",
-                250,
-                50,
-                250,
-                50
+                100,
+                200,
+                300,
+                400
         );
         final long gatewayAccountId_3 = gatewayAccountId_2 + 1;
 
@@ -463,23 +463,23 @@ public class GatewayAccountDaoITest extends DaoITestBase {
         );
 
         List<Long> accountIds = Arrays.asList(gatewayAccountId_2, gatewayAccountId_3);
-        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountDao.list(accountIds);
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.list(accountIds);
 
         assertEquals(2, gatewayAccounts.size());
 
-        assertThat(gatewayAccounts.get(0).getAccountId(), is(gatewayAccountId_2));
-        assertEquals("provider-2", gatewayAccounts.get(0).getPaymentProvider());
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+        assertEquals("provider-2", gatewayAccounts.get(0).getGatewayName());
         assertEquals("description-2", gatewayAccounts.get(0).getDescription());
         assertEquals("service-name-2", gatewayAccounts.get(0).getServiceName());
         assertEquals(TEST.toString(), gatewayAccounts.get(0).getType());
         assertEquals("analytics-id-2", gatewayAccounts.get(0).getAnalyticsId());
-        assertEquals(250L, gatewayAccounts.get(0).getCorporateCreditCardSurchargeAmount());
-        assertEquals(50L, gatewayAccounts.get(0).getCorporateDebitCardSurchargeAmount());
-        assertEquals(250L, gatewayAccounts.get(0).getCorporateCreditCardSurchargeAmount());
-        assertEquals(50L, gatewayAccounts.get(0).getCorporateDebitCardSurchargeAmount());
+        assertEquals(100, gatewayAccounts.get(0).getCorporateNonPrepaidCreditCardSurchargeAmount());
+        assertEquals(200L, gatewayAccounts.get(0).getCorporateNonPrepaidDebitCardSurchargeAmount());
+        assertEquals(300L, gatewayAccounts.get(0).getCorporatePrepaidCreditCardSurchargeAmount());
+        assertEquals(400L, gatewayAccounts.get(0).getCorporatePrepaidDebitCardSurchargeAmount());
 
-        assertThat(gatewayAccounts.get(1).getAccountId(), is(gatewayAccountId_3));
-        assertEquals("provider-3", gatewayAccounts.get(1).getPaymentProvider());
+        assertThat(gatewayAccounts.get(1).getId(), is(gatewayAccountId_3));
+        assertEquals("provider-3", gatewayAccounts.get(1).getGatewayName());
         assertEquals("description-3", gatewayAccounts.get(1).getDescription());
         assertEquals("service-name-3", gatewayAccounts.get(1).getServiceName());
         assertEquals(TEST.toString(), gatewayAccounts.get(1).getType());

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,13 +40,19 @@ public class GatewayAccountServiceTest {
     @Mock
     private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock
-    private GatewayAccountResourceDTO mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2;
+    private GatewayAccountEntity getMockGatewayAccountEntity1;
+    @Mock
+    private GatewayAccountEntity getMockGatewayAccountEntity2;
 
     private GatewayAccountService gatewayAccountService;
 
     @Before
     public void setUp() {
         gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao);
+        when(getMockGatewayAccountEntity1.getType()).thenReturn("test");
+        when(getMockGatewayAccountEntity1.getServiceName()).thenReturn("service one");
+        when(getMockGatewayAccountEntity2.getType()).thenReturn("test");
+        when(getMockGatewayAccountEntity2.getServiceName()).thenReturn("service two");
     }
 
     @Test
@@ -62,22 +68,24 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldGetAllGatewayAccounts() {
-        when(mockGatewayAccountDao.listAll()).thenReturn(Arrays.asList(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
-
+        when(mockGatewayAccountDao.listAll()).thenReturn(Arrays.asList(getMockGatewayAccountEntity1, getMockGatewayAccountEntity2));
         List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.getAllGatewayAccounts();
 
-        assertThat(gatewayAccounts, contains(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
+        assertThat(gatewayAccounts, hasSize(2));
+        assertThat(gatewayAccounts.get(0).getServiceName(), is("service one"));
+        assertThat(gatewayAccounts.get(1).getServiceName(), is("service two"));
     }
 
     @Test
     public void shouldGetGatewayAccountsByIds() {
         List<Long> accountIds = Arrays.asList(1L, 2L);
-
-        when(mockGatewayAccountDao.list(accountIds)).thenReturn(Arrays.asList(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
+        when(mockGatewayAccountDao.list(accountIds)).thenReturn(Arrays.asList(getMockGatewayAccountEntity1, getMockGatewayAccountEntity2));
 
         List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.getGatewayAccounts(accountIds);
 
-        assertThat(gatewayAccounts, contains(mockGatewayAccountResourceDto1, mockGatewayAccountResourceDto2));
+        assertThat(gatewayAccounts, hasSize(2));
+        assertThat(gatewayAccounts.get(0).getServiceName(), is("service one"));
+        assertThat(gatewayAccounts.get(1).getServiceName(), is("service two"));
     }
 
     @Test


### PR DESCRIPTION
GatewayAccountDao is a JPA dao paramaterized to type GatewayAccountEntity. This
changes the `list` and `listAll` methods to return `GatewayAccountEntity` and
remove the concern of converting `GatewayAccountEntity` to a `GatewayAccountResponseDTO`.
This is in the interest of maintaining a sensible separation of concerns, to
permit future refactoring of the numerous Gateway Account return type objects and move
towards a common means of fetching Gateway Accounts from the database and converting
to the required return type object (at the time of this change there are numerous ways
which causes confusion to new team members, especially when adding a new attribute
to Gateway Account.
- Change `list` and `listAll` methods to return a list of `GatewayAccountEntity`
- Add `.fromEntity` static method to `GatewayAccountResourceDTO`.
- Move responsibility for converting between the entity and DTO into the
`GatewayAccountService`.
- Update test and add new test for `.fromEntity` method.

## WHAT
Whilst helping Gideon with a story to introduce a new attribute to the Gateway Account model it was evident that the current numerous ways of fetching a gateway account and converting to the various return types is confusing. Broadly speaking at present we either (cannot guarantee this is exhaustive):
1. Use the dao to query and directly convert to `GatewayAccountResponseDTO` - which this PR addresses.
2. Use the dao to fetch a `GatewayAccountEntity` and return it.
3. As above but remove the password from the credentials.
4. Use the dao to fetch a `GatewayAccountEntity` then call `withoutCredtentials()` to convert to a `Map` before returning it (seems this should be a sub-type of its own).
5. Upon patching a gateway account it returns a `GatewayAccount` type.
6. The gateway account can also be retrieved on a `FrontendChargeResponse` as a `GatewayAccountEntity`.

Most of the confusion was centred on not knowing why the different types are returned (`GatewayAccount`, `GatwayAccountResourceDTO`, `GatewayAccountEntity`, `GatewayAccountEntity.withoutCredentials`)  exist and which ones to add a new attribute to, along with the process of fetching, transforming and returning them not being clear.

## HOW 
This PR removes the concern from the `GatewayAccountDao` of converting between `GatewayAccountEntity` to a `GatewayAccountResourceDTO` as a stepping stone towards creating a more common and understandable process surrounding gateway accounts. Following this PR if approved I would like to look at the various return types for a gateway account and understand how it can be simplified and in the case of `public Map<String, Object> withoutCredentials()` look to make this a proper sub-type, e.g. `GatewayAccountWithoutCredentials`.

Please let me know your thoughts both on this specific PR and whether you're in agreement that process/types around GatewayAccount should be made clearer. If you feel its ok as-is and this is just a result of us lacking experience with this area of the code-base then that's ok, please let me know 👍 
