### PR TITLE
PP-4758: Remove session identifier from GatewayOrder

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayOrder.java
@@ -9,15 +9,11 @@ public class GatewayOrder {
 
     private OrderRequestType orderRequestType;
     private String payload;
-    // Wordldpay specific property, not needed for everyone
-    private String providerSessionId;
     private MediaType mediaType;
 
-    public GatewayOrder(OrderRequestType orderRequestType, String payload, String providerSessionId,
-        MediaType mediaType) {
+    public GatewayOrder(OrderRequestType orderRequestType, String payload, MediaType mediaType) {
         this.orderRequestType = orderRequestType;
         this.payload = payload;
-        this.providerSessionId = providerSessionId;
         this.mediaType = mediaType;
     }
 
@@ -27,10 +23,6 @@ public class GatewayOrder {
 
     public String getPayload() {
         return payload;
-    }
-
-    public Optional<String> getProviderSessionId() {
-        return Optional.ofNullable(providerSessionId);
     }
 
     public MediaType getMediaType() {

--- a/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
@@ -81,7 +81,6 @@ public abstract class OrderRequestBuilder {
 
     private PayloadBuilder payloadBuilder;
     private OrderRequestType orderRequestType;
-    private String providerSessionId;
 
     public OrderRequestBuilder(TemplateData templateData, PayloadBuilder payloadBuilder, OrderRequestType orderRequestType) {
         this.templateData = templateData;
@@ -122,14 +121,9 @@ public abstract class OrderRequestBuilder {
         return this;
     }
 
-    public OrderRequestBuilder withProviderSessionId(String providerSessionId) {
-        this.providerSessionId = providerSessionId;
-        return this;
-    }
-
     public GatewayOrder build() {
         return new GatewayOrder(
                 orderRequestType,
-                payloadBuilder.buildWith(templateData), providerSessionId, getMediaType());
+                payloadBuilder.buildWith(templateData), getMediaType());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -12,9 +12,7 @@ import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseWalletOrderRequestBuilder;
@@ -161,12 +159,10 @@ public class WorldpayOrderRequestBuilderTest {
                 .withSessionId("uniqueSessionId")
                 .withTransactionId("MyUniqueTransactionId!")
                 .withMerchantCode("MERCHANTCODE")
-                .withProviderSessionId(providerSessionId)
                 .build();
 
         assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
-        assertThat(actualRequest.getProviderSessionId().get(), is(providerSessionId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
@@ -61,7 +61,7 @@ public class GooglePayForWorldpayTest {
 
         GatewayClient authoriseClient = getGatewayClient();
         
-        GatewayOrder gatewayOrder = new GatewayOrder(OrderRequestType.AUTHORISE, payload, "", APPLICATION_XML_TYPE);
+        GatewayOrder gatewayOrder = new GatewayOrder(OrderRequestType.AUTHORISE, payload, APPLICATION_XML_TYPE);
         GatewayClient.Response response = authoriseClient.postRequestFor(null, gatewayAccount, gatewayOrder);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
         String entity = response.getEntity();


### PR DESCRIPTION
The sesssion identifier is now passed in as a cookie list in
`GatewayClient.postRequestFor` so it's no longer needed in the GatewayOrder
class.

