### PR TITLE
PP-4856 Implement `queryPaymentStatus` for Worldpay

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
@@ -4,6 +4,7 @@ public enum GatewayOperation {
     AUTHORISE("auth"),
     CAPTURE("capture"),
     REFUND("refund"),
+    QUERY("query"),
     CANCEL("cancel");
 
     private final String description;

--- a/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/OrderRequestType.java
@@ -7,7 +7,8 @@ public enum OrderRequestType {
     AUTHORISE_GOOGLE_PAY("authoriseGooglePay"),
     CAPTURE("capture"),
     CANCEL("cancel"),
-    REFUND("refund");
+    REFUND("refund"),
+    QUERY("query");
 
     private final String name;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -81,8 +81,8 @@ public class GatewayResponse<T extends BaseResponse> {
         private GatewayResponseBuilder() {
         }
 
-        public static GatewayResponseBuilder responseBuilder() {
-            return new GatewayResponseBuilder();
+        public static <T extends BaseResponse> GatewayResponseBuilder<T> responseBuilder() {
+            return new GatewayResponseBuilder<>();
         }
 
         public GatewayResponseBuilder withResponse(T response) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 import java.util.Optional;
@@ -16,8 +17,12 @@ public interface WorldpayGatewayResponseGenerator {
     Logger logger = LoggerFactory.getLogger(WorldpayGatewayResponseGenerator.class);
 
     default GatewayResponse getWorldpayGatewayResponse(GatewayClient.Response response) throws GatewayConnectionErrorException {
-        GatewayResponse.GatewayResponseBuilder responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
-        responseBuilder.withResponse(unmarshallResponse(response, WorldpayOrderStatusResponse.class));
+        return getWorldpayGatewayResponse(response, WorldpayOrderStatusResponse.class);
+    }
+
+    default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GatewayConnectionErrorException {
+        GatewayResponse.GatewayResponseBuilder<T> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
+        responseBuilder.withResponse(unmarshallResponse(response, target));
         Optional.ofNullable(response.getResponseCookies().get(WORLDPAY_MACHINE_COOKIE_NAME))
                 .ifPresent(responseBuilder::withSessionIdentifier);
         return responseBuilder.build();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -98,13 +98,13 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     public static final TemplateBuilder CAPTURE_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayCaptureOrderTemplate.xml");
     public static final TemplateBuilder CANCEL_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayCancelOrderTemplate.xml");
     public static final TemplateBuilder REFUND_ORDER_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayRefundOrderTemplate.xml");
+    public static final TemplateBuilder INQUIRY_TEMPLATE_BUILDER = new TemplateBuilder("/worldpay/WorldpayInquiryOrderTemplate.xml");
 
     private final WorldpayTemplateData worldpayTemplateData;
 
     public static WorldpayOrderRequestBuilder aWorldpayAuthoriseOrderRequestBuilder() {
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), AUTHORISE_ORDER_TEMPLATE_BUILDER, OrderRequestType.AUTHORISE);
     }
-    
     public static WorldpayOrderRequestBuilder aWorldpayAuthoriseWalletOrderRequestBuilder(WalletType walletType) {
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), walletType.getWorldPayTemplate(), walletType.getOrderRequestType());
     }
@@ -123,6 +123,10 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public static WorldpayOrderRequestBuilder aWorldpayRefundOrderRequestBuilder() {
         return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), REFUND_ORDER_TEMPLATE_BUILDER, OrderRequestType.REFUND);
+    }
+
+    public static WorldpayOrderRequestBuilder aWorldpayInquiryRequestBuilder() {
+        return new WorldpayOrderRequestBuilder(new WorldpayTemplateData(), INQUIRY_TEMPLATE_BUILDER, OrderRequestType.QUERY);
     }
 
     private WorldpayOrderRequestBuilder(WorldpayTemplateData worldpayTemplateData, PayloadBuilder payloadBuilder, OrderRequestType orderRequestType) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -28,6 +28,7 @@ import uk.gov.pay.connector.gateway.worldpay.applepay.WorldpayWalletAuthorisatio
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 import java.net.HttpCookie;
 import java.net.URI;
 import java.util.List;
@@ -41,10 +42,12 @@ import static java.util.UUID.randomUUID;
 import static uk.gov.pay.connector.gateway.GatewayOperation.AUTHORISE;
 import static uk.gov.pay.connector.gateway.GatewayOperation.CANCEL;
 import static uk.gov.pay.connector.gateway.GatewayOperation.CAPTURE;
+import static uk.gov.pay.connector.gateway.GatewayOperation.QUERY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayInquiryRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
 public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGatewayResponseGenerator {
@@ -54,6 +57,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     private final GatewayClient authoriseClient;
     private final GatewayClient cancelClient;
     private final GatewayClient captureClient;
+    private final GatewayClient inquiryClient;
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
     private final WorldpayCaptureHandler worldpayCaptureHandler;
     private final WorldpayRefundHandler worldpayRefundHandler;
@@ -69,6 +73,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 .collect(Collectors.toMap(Map.Entry::getKey, v -> URI.create(v.getValue())));
         authoriseClient = gatewayClientFactory.createGatewayClient(WORLDPAY, AUTHORISE, environment.metrics());
         cancelClient = gatewayClientFactory.createGatewayClient(WORLDPAY, CANCEL, environment.metrics());
+        inquiryClient = gatewayClientFactory.createGatewayClient(WORLDPAY, QUERY, environment.metrics());
         captureClient = gatewayClientFactory.createGatewayClient(WORLDPAY, CAPTURE, environment.metrics());
         externalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
         worldpayCaptureHandler = new WorldpayCaptureHandler(captureClient, gatewayUrlMap);
@@ -87,10 +92,27 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
-        throw new UnsupportedOperationException("Querying payment status not currently supported by Worldpay");
+    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge)  throws GatewayErrorException {
+        GatewayClient.Response response = inquiryClient.postRequestFor(gatewayUrlMap.get(charge.getGatewayAccount().getType()), charge.getGatewayAccount(), buildQuery(charge));
+        GatewayResponse<WorldpayQueryResponse> worldpayGatewayResponse = getWorldpayGatewayResponse(response, WorldpayQueryResponse.class);
+
+        return worldpayGatewayResponse.getBaseResponse()
+                .map(ChargeQueryResponse::from)
+                .orElseThrow(() ->
+                        new WebApplicationException(String.format(
+                                "Unable to query charge %s - an error occurred: %s",
+                                charge.getExternalId(),
+                                worldpayGatewayResponse
+                        )));
     }
-    
+
+    private GatewayOrder buildQuery(ChargeEntity charge) {
+        return aWorldpayInquiryRequestBuilder()
+                .withTransactionId(charge.getGatewayTransactionId())
+                .withMerchantCode(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .build();
+    }
+
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) throws GatewayErrorException {
         GatewayOrder gatewayOrder = buildAuthoriseOrder(request);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
@@ -26,13 +27,16 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCancelResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.paymentprocessor.service.QueryService;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,7 +67,10 @@ public class ChargeExpiryServiceTest {
     private PaymentProviders mockPaymentProviders;
 
     @Mock
-    private PaymentProvider mockPaymentProvider;
+    private PaymentProvider mockPaymentProvider; 
+    
+    @Mock
+    private QueryService mockQueryService;
 
     @Mock
     private WorldpayCancelResponse mockWorldpayCancelResponse;
@@ -99,7 +106,7 @@ public class ChargeExpiryServiceTest {
     @Before
     public void setup() {
         when(mockedConfig.getChargeSweepConfig()).thenReturn(mockedChargeSweepConfig);
-        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, mockedConfig);
+        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, mockQueryService, mockedConfig);
         when(mockPaymentProviders.byName(PaymentGatewayName.WORLDPAY)).thenReturn(mockPaymentProvider);
         GatewayResponseBuilder<BaseCancelResponse> gatewayResponseBuilder = responseBuilder();
         gatewayResponse = gatewayResponseBuilder.withResponse(mockWorldpayCancelResponse).build();
@@ -230,5 +237,31 @@ public class ChargeExpiryServiceTest {
 
         assertThat(chargeEntityAwaitingCapture.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
         assertThat(chargeEntityAuthorisationSuccess.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
+    }
+
+    @Test
+    public void shouldCancelChargeWithGatewayWhenChargeInPreAuthorisedStateAndExistsWithGateway() throws Exception {
+        ChargeEntity preAuthorisationCharge = ChargeEntityFixture.aValidChargeEntity()
+                .withAmount(200L)
+                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        when(mockChargeDao.findByExternalId(preAuthorisationCharge.getExternalId())).thenReturn(Optional.of(preAuthorisationCharge));
+
+        when(mockQueryService.getChargeGatewayStatus(preAuthorisationCharge)).thenReturn(new ChargeQueryResponse(ChargeStatus.AUTHORISATION_SUCCESS, "Raw response"));
+        when(mockWorldpayCancelResponse.cancelStatus()).thenReturn(CancelStatus.CANCELLED);
+
+        when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
+
+        doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
+        when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(preAuthorisationCharge));
+
+        Map<String, Integer> sweepResult = chargeExpiryService.sweepAndExpireCharges();
+
+        assertThat(sweepResult.get("expiry-success"), is(1));
+        assertNull(sweepResult.get("expiry-failure"));
+        assertThat(preAuthorisationCharge.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.base;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
@@ -12,6 +13,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.junit.DropwizardTestContext;

--- a/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceITest.java
@@ -76,6 +76,25 @@ public class DiscrepancyResourceITest extends ChargingITestBase {
         assertEquals( "EXTERNAL_FAILED_REJECTED", results.get(0).get("gatewayExternalStatus").asText());
         assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
     }
+
+    @Test
+    public void shouldHandleCaseWhereChargeIsInUnknownState() {
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusDays(8), "irrelevant");
+        epdqMockClient.mockUnknown();
+
+        List<JsonNode> results = connectorRestApiClient
+                .getDiscrepancyReport(toJson(Arrays.asList(chargeId)))
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().body().jsonPath().getList(".", JsonNode.class);
+
+        assertEquals(1, results.size());
+
+        assertEquals( null, results.get(0).get("gatewayStatus"));
+        assertEquals( "EXPIRED", results.get(0).get("payStatus").asText());
+        assertEquals( chargeId, results.get(0).get("chargeId").asText());
+        assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
+    }
     
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -91,14 +91,20 @@ public class WorldpayMockClient {
                         )
         );
     }
-    
+
+    public void mockAuthorisationQuerySuccess(String gatewayTransactionId) {
+        String authSuccessResponse = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE);
+        String bodyMatchXpath = "//orderInquiry[@orderCode]";
+        bodyMatchingPaymentServiceResponse(bodyMatchXpath, authSuccessResponse);    
+    }
+
     public void mockServerFault() {
         stubFor(
                 post(urlPathEqualTo("/jsp/merchant/xml/paymentService.jsp"))
                         .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
         );
     }
-    
+
     private void paymentServiceResponse(String responseBody) {
         //FIXME - This mocking approach is very poor. Needs to be revisited. Story PP-900 created.
         stubFor(


### PR DESCRIPTION
Adds ability to query worldpay for a payment status. This will have an affect both on ChargeExpiryService and on DiscrepancyService. 
The main change is in `WorldpayPaymentProvider`, and I have added tests for this.
I have also added  second overloaded method in `WorldpayGatewayResponseGenerator` that deserialises a worldpay response to an object of a type passed in. As a bonus it doesn't use raw types \o/