### PR TITLE
PP-4819: add google pay and apple pay booleans to /frontend/accounts endpoints

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -36,7 +36,7 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
 
     public List<GatewayAccountResourceDTO> list(List<Long> accountIds) {
         String query = "SELECT NEW uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO"
-                       + " (gae.id, gae.gatewayName, gae.type, gae.description, gae.serviceName, gae.analyticsId, gae.corporateCreditCardSurchargeAmount, gae.corporateDebitCardSurchargeAmount, gae.allowWebPayments, gae.corporatePrepaidCreditCardSurchargeAmount, gae.corporatePrepaidDebitCardSurchargeAmount)"
+                       + " (gae.id, gae.gatewayName, gae.type, gae.description, gae.serviceName, gae.analyticsId, gae.corporateCreditCardSurchargeAmount, gae.corporateDebitCardSurchargeAmount, gae.allowWebPayments, gae.allowApplePay, gae.allowGooglePay, gae.corporatePrepaidCreditCardSurchargeAmount, gae.corporatePrepaidDebitCardSurchargeAmount)"
                        + " FROM GatewayAccountEntity gae"
                        + " WHERE gae.id IN :accountIds"
                        + " ORDER BY gae.id";
@@ -50,7 +50,7 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
 
     public List<GatewayAccountResourceDTO> listAll() {
         String query = "SELECT NEW uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO" +
-                "(gae.id, gae.gatewayName, gae.type, gae.description, gae.serviceName, gae.analyticsId, gae.corporateCreditCardSurchargeAmount, gae.corporateDebitCardSurchargeAmount, gae.allowWebPayments, gae.corporatePrepaidCreditCardSurchargeAmount, gae.corporatePrepaidDebitCardSurchargeAmount) " +
+                "(gae.id, gae.gatewayName, gae.type, gae.description, gae.serviceName, gae.analyticsId, gae.corporateCreditCardSurchargeAmount, gae.corporateDebitCardSurchargeAmount, gae.allowWebPayments, gae.allowApplePay, gae.allowGooglePay, gae.corporatePrepaidCreditCardSurchargeAmount, gae.corporatePrepaidDebitCardSurchargeAmount) " +
                 "FROM GatewayAccountEntity gae order by gae.id";
 
         return entityManager

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -240,13 +240,13 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     }
 
     @JsonProperty("allow_google_pay")
-    @JsonView(Views.FrontendView.class)
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public boolean isAllowGooglePay() {
         return allowGooglePay && isNotBlank(credentials.get("gateway_merchant_id"));
     }
 
     @JsonProperty("allow_apple_pay")
-    @JsonView(Views.FrontendView.class)
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public boolean isAllowApplePay() {
         return allowApplePay;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -39,7 +39,13 @@ public class GatewayAccountResourceDTO {
     private Map<String, Map<String, URI>> links = new HashMap<>();
     
     @JsonProperty("allow_web_payments")
-    private boolean allowWebPayments;
+    private boolean allowWebPayments;    
+    
+    @JsonProperty("allow_apple_pay")
+    private boolean allowApplePay;    
+    
+    @JsonProperty("allow_google_pay")
+    private boolean allowGooglePay;
 
     @JsonProperty("corporate_prepaid_credit_card_surcharge_amount")
     private long corporatePrepaidCreditCardSurchargeAmount;
@@ -59,6 +65,8 @@ public class GatewayAccountResourceDTO {
                                      long corporateCreditCardSurchargeAmount,
                                      long corporateDebitCardSurchargeAmount, 
                                      boolean allowWebPayments,
+                                     boolean allowApplePay,
+                                     boolean allowGooglePay,
                                      long corporatePrepaidCreditCardSurchargeAmount,
                                      long corporatePrepaidDebitCardSurchargeAmount) {
         this.accountId = accountId;
@@ -70,6 +78,8 @@ public class GatewayAccountResourceDTO {
         this.corporateCreditCardSurchargeAmount = corporateCreditCardSurchargeAmount;
         this.corporateDebitCardSurchargeAmount = corporateDebitCardSurchargeAmount;
         this.allowWebPayments = allowWebPayments;
+        this.allowApplePay = allowApplePay;
+        this.allowGooglePay = allowGooglePay;
         this.corporatePrepaidCreditCardSurchargeAmount = corporatePrepaidCreditCardSurchargeAmount;
         this.corporatePrepaidDebitCardSurchargeAmount = corporatePrepaidDebitCardSurchargeAmount;
     }
@@ -113,11 +123,7 @@ public class GatewayAccountResourceDTO {
     public void addLink(String key, URI uri) {
         links.put(key, ImmutableMap.of("href", uri));
     }
-
-    public boolean isAllowWebPayments() {
-        return allowWebPayments;
-    }
-
+    
     public long getCorporatePrepaidCreditCardSurchargeAmount() {
         return corporatePrepaidCreditCardSurchargeAmount;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -182,10 +182,10 @@ public class GatewayAccountResource {
     public Response getGatewayAccountWithCredentials(@PathParam("accountId") Long gatewayAccountId) {
 
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
-                .map(serviceAccount ->
+                .map(gatewayAccount ->
                 {
-                    serviceAccount.getCredentials().remove("password");
-                    return Response.ok(serviceAccount).build();
+                    gatewayAccount.getCredentials().remove("password");
+                    return Response.ok(gatewayAccount).build();
                 })
                 .orElseGet(() -> notFoundResponse(format("Account with id '%s' not found", gatewayAccountId)));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -70,7 +70,9 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .body("analytics_id", is(nullValue()))
                 .body("service_name", is(gatewayAccountPayload.getServiceName()))
                 .body("corporate_credit_card_surcharge_amount", is(250))
-                .body("corporate_debit_card_surcharge_amount", is(50));
+                .body("corporate_debit_card_surcharge_amount", is(50))
+                .body("allow_apple_pay", is(false))
+                .body("allow_google_pay", is(false));
     }
 
     @Test
@@ -124,7 +126,9 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .body("accounts[0].service_name", is(gatewayAccountPayload.getServiceName()))
                 .body("accounts[0].corporate_credit_card_surcharge_amount", is(250))
                 .body("accounts[0].corporate_debit_card_surcharge_amount", is(50))
-                .body("accounts[0].allow_web_payments", is(false));
+                .body("accounts[0].allow_web_payments", is(false))
+                .body("accounts[0].allow_apple_pay", is(false))
+                .body("accounts[0].allow_google_pay", is(false));
     }
 
     private void validateNon3dsCardType(ValidatableResponse response, String brand, String label, String... type) {


### PR DESCRIPTION
## WHAT
Exposes `allow_apple_pay` and `allow_google_pay` in the `/v1/frontend/accounts` endpoints.
This is required to allow selfservice to GET the status of these booleans.

## HOW 
`/v1/frontend/accounts/{accountId}` should include `allow_apple_pay` and `allow_google_pay` booleans


