### PR TITLE
PP-4856 WorldpayStatus and WorldPayQueryResponse

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryResponse.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gateway;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.epdq.EpdqStatusMapper;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqQueryResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayQueryResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayStatus;
 
 import java.util.Optional;
 
@@ -15,12 +17,27 @@ public class ChargeQueryResponse {
         this.rawGatewayResponse = rawGatewayResponse;
     }
 
+    public ChargeQueryResponse(WorldpayStatus worldpayStatus, String rawGatewayResponse) {
+        if (worldpayStatus != null) {
+            this.mappedStatus = worldpayStatus.getPayStatus();
+        }
+        
+        this.rawGatewayResponse = rawGatewayResponse;
+    }
+
     public Optional<ChargeStatus> getMappedStatus() {
         return Optional.ofNullable(mappedStatus);
     }
 
     public String getRawGatewayResponse() {
         return rawGatewayResponse;
+    }
+
+    public static ChargeQueryResponse from(WorldpayQueryResponse worldpayInquiryStatusResponse) {
+        return new ChargeQueryResponse(
+                WorldpayStatus.fromString(worldpayInquiryStatusResponse.getLastEvent()).orElse(null),
+                worldpayInquiryStatusResponse.toString()
+        );
     }
 
     public static ChargeQueryResponse from(EpdqQueryResponse epdqQueryResponse) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayQueryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayQueryResponse.java
@@ -1,0 +1,117 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.oxm.annotations.XmlPath;
+import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.StringJoiner;
+
+import static org.apache.commons.lang3.StringUtils.trim;
+
+@XmlRootElement(name = "paymentService")
+public class WorldpayQueryResponse implements BaseInquiryResponse {
+
+    @XmlPath("reply/orderStatus/@orderCode")
+    private String transactionId;
+
+    @XmlPath("reply/orderStatus/payment/lastEvent/text()")
+    private String lastEvent;
+
+    @XmlPath("reply/orderStatus/payment/ISO8583ReturnCode/@description")
+    private String refusedReturnCodeDescription;
+
+    @XmlPath("reply/orderStatus/payment/ISO8583ReturnCode/@code")
+    private String refusedReturnCode;
+
+    private String errorCode;
+
+    private String errorMessage;
+
+    private String paRequest;
+    private String issuerUrl;
+
+    @XmlPath("reply/error/@code")
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @XmlPath("reply/orderStatus/error/@code")
+    public void setOrderStatusErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    @XmlPath("reply/error/text()")
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    @XmlPath("reply/orderStatus/error/text()")
+    public void setOrderStatusErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    @XmlPath("/reply/orderStatus/requestInfo/request3DSecure/paRequest/text()")
+    public void set3dsPaRequest(String paRequest) {
+        this.paRequest = paRequest;
+    }
+
+    @XmlPath("/reply/orderStatus/requestInfo/request3DSecure/issuerURL/text()")
+    public void set3dsIssuerUrl(String issuerUrl) {
+        this.issuerUrl = issuerUrl != null ? issuerUrl.trim() : null;
+    }
+
+    public String getLastEvent() {
+        return lastEvent;
+    }
+
+    public String getRefusedReturnCodeDescription() {
+        return refusedReturnCodeDescription;
+    }
+
+    public String getRefusedReturnCode() {
+        return refusedReturnCode;
+    }
+
+    @Override
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    @Override
+    public String getErrorCode() {
+        return trim(errorCode);
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return trim(errorMessage);
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "Worldpay authorisation response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("orderCode: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(getLastEvent())) {
+            joiner.add("lastEvent: "+ getLastEvent());
+        }
+        if (StringUtils.isNotBlank(getRefusedReturnCode())) {
+            joiner.add("ISO8583ReturnCode code: " + getRefusedReturnCode());
+        }
+        if (StringUtils.isNotBlank(getRefusedReturnCodeDescription())) {
+            joiner.add("ISO8583ReturnCode description: " + getRefusedReturnCodeDescription());
+        }
+        if (StringUtils.isNotBlank(issuerUrl)) {
+            joiner.add("issuerURL: " + issuerUrl);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("error code: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("error: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayStatus.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+
+public enum WorldpayStatus {
+    AUTHORISED("AUTHORISED", ChargeStatus.AUTHORISATION_SUCCESS),
+    CANCELLED("CANCELLED", ChargeStatus.AUTHORISATION_CANCELLED),
+    CAPRURED("CAPTURED", ChargeStatus.CAPTURED),
+    REFUSED("REFUSED", ChargeStatus.AUTHORISATION_REJECTED);
+
+    private final String worldpayStatus;
+    private final ChargeStatus payStatus;
+    private static Map<String, WorldpayStatus> stringWorldpayStatusMap = Stream.of(values()).collect(toMap(WorldpayStatus::toString, e -> e));
+
+    WorldpayStatus(String worldpayStatus, ChargeStatus payStatus) {
+        this.worldpayStatus = worldpayStatus;
+        this.payStatus = payStatus;
+    }
+
+    public String getWorldpayStatus() {
+        return worldpayStatus;
+    }
+
+    public ChargeStatus getPayStatus() {
+        return payStatus;
+    }
+    
+    @Override
+    public String toString() {
+        return getWorldpayStatus();
+    }
+    
+    public static Optional<WorldpayStatus> fromString(String status) {
+        return Optional.ofNullable(stringWorldpayStatusMap.get(status));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/ChargeQueryResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/ChargeQueryResponseTest.java
@@ -1,0 +1,72 @@
+package uk.gov.pay.connector.gateway;
+
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayQueryResponse;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISED_INQUIRY_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANCELLED_INQUIRY_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CAPTURED_INQUIRY_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REJECTED_INQUIRY_RESPONSE;
+
+public class ChargeQueryResponseTest {
+    @Test 
+    public void fromWorldpayResponse_shouldCorrectlyConvertFromWorldpayAuthorisedToAuthorised() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_AUTHORISED_INQUIRY_RESPONSE);
+        WorldpayQueryResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayQueryResponse.class);
+        
+        ChargeQueryResponse chargeQueryResponse = ChargeQueryResponse.from(response);
+        
+        assertThat(chargeQueryResponse.getMappedStatus().get(), is(ChargeStatus.AUTHORISATION_SUCCESS));
+        assertNotNull(chargeQueryResponse.getRawGatewayResponse());
+    }
+
+    @Test
+    public void fromWorldpayResponse_shouldCorrectlyConvertFromWorldpayCapturedToCaptured() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_CAPTURED_INQUIRY_RESPONSE);
+        WorldpayQueryResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayQueryResponse.class);
+
+        ChargeQueryResponse chargeQueryResponse = ChargeQueryResponse.from(response);
+
+        assertThat(chargeQueryResponse.getMappedStatus().get(), is(ChargeStatus.CAPTURED));
+        assertNotNull(chargeQueryResponse.getRawGatewayResponse());
+    }
+    @Test
+    public void fromWorldpayResponse_shouldCorrectlyConvertFromWorldpayRefusedToAuthorisationRejected() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_REJECTED_INQUIRY_RESPONSE);
+        WorldpayQueryResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayQueryResponse.class);
+
+        ChargeQueryResponse chargeQueryResponse = ChargeQueryResponse.from(response);
+
+        assertThat(chargeQueryResponse.getMappedStatus().get(), is(ChargeStatus.AUTHORISATION_REJECTED));
+        assertNotNull(chargeQueryResponse.getRawGatewayResponse());
+    }
+    @Test
+    public void fromWorldpayResponse_shouldCorrectlyConvertFromWorldpayCancelledToCancelled() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_CANCELLED_INQUIRY_RESPONSE);
+        WorldpayQueryResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayQueryResponse.class);
+
+        ChargeQueryResponse chargeQueryResponse = ChargeQueryResponse.from(response);
+
+        assertThat(chargeQueryResponse.getMappedStatus().get(), is(ChargeStatus.AUTHORISATION_CANCELLED));
+        assertNotNull(chargeQueryResponse.getRawGatewayResponse());
+    }
+    
+    
+    @Test
+    public void fromWorldpayResponse_shouldReturnEmptyOptionalIfUnknownStatus() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_ERROR_RESPONSE);
+        WorldpayQueryResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayQueryResponse.class);
+
+        ChargeQueryResponse chargeQueryResponse = ChargeQueryResponse.from(response);
+
+        assertFalse(chargeQueryResponse.getMappedStatus().isPresent());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -43,6 +43,11 @@ public class TestTemplateResourceLoader {
 
     public static final String WORLDPAY_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/error-response.xml";
     public static final String WORLDPAY_NOTIFICATION = WORLDPAY_BASE_NAME + "/notification.xml";
+    
+    public static final String WORLDPAY_AUTHORISED_INQUIRY_RESPONSE = WORLDPAY_BASE_NAME + "/inquiry/authorised.xml";
+    public static final String WORLDPAY_CAPTURED_INQUIRY_RESPONSE = WORLDPAY_BASE_NAME + "/inquiry/captured.xml";
+    public static final String WORLDPAY_CANCELLED_INQUIRY_RESPONSE = WORLDPAY_BASE_NAME + "/inquiry/cancelled.xml";
+    public static final String WORLDPAY_REJECTED_INQUIRY_RESPONSE = WORLDPAY_BASE_NAME + "/inquiry/rejected.xml";
 
     // SMARTPAY
 

--- a/src/test/resources/templates/worldpay/inquiry/authorised.xml
+++ b/src/test/resources/templates/worldpay/inquiry/authorised.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the inquiry-->
+    <reply>
+        <orderStatus orderCode="ExampleOrder1"> <!--The orderCode you supplied in the inquiry-->
+            <payment>
+                <paymentMethod>VISA-SSL</paymentMethod>
+                <paymentMethodDetail> <!--Not returned by default - contact us to enable-->
+                    <card number="444433******1111" type="creditcard">
+                        <expiryDate> <!--Not returned by default - contact us to enable-->
+                            <date month="01" year="2020"/>
+                        </expiryDate>
+                    </card>
+                </paymentMethodDetail>
+                <amount value="4000" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>AUTHORISED</lastEvent>
+                <AuthorisationId id="622206"/>
+                <CVCResultCode description="A"/>
+                <AVSResultCode description="A"/>
+                <AAVAddressResultCode description="A"/>
+                <AAVPostcodeResultCode description="A"/>
+                <AAVCardholderNameResultCode description="A"/>
+                <AAVTelephoneResultCode description="A"/>
+                <AAVEmailResultCode description="A"/>
+                <ThreeDSecureResult description="Cardholder authenticated">
+                    <eci>05</eci> <!--Not returned by default - contact us to enable-->
+                    <cavv>MAAAAAAAAAAAAAAAAAAAAAAAAAA=</cavv> <!--Not returned by default - contact us to enable-->
+                </ThreeDSecureResult>
+                <balance accountType="IN_PROCESS_AUTHORISED">
+                    <amount value="4000" currencyCode="EUR" exponent="2"  debitCreditIndicator="credit"/>
+                </balance>
+                <cardNumber>4444********1111</cardNumber>
+                <riskScore value="0"/>
+            </payment>
+        </orderStatus>
+    </reply>
+</paymentService>

--- a/src/test/resources/templates/worldpay/inquiry/cancelled.xml
+++ b/src/test/resources/templates/worldpay/inquiry/cancelled.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the inquiry-->
+    <reply>
+        <orderStatus orderCode="ExampleOrder1"> <!--The orderCode you supplied in the order-->
+            <payment>
+                <paymentMethod>VISA-SSL</paymentMethod>
+                <amount value="1000" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>CANCELLED</lastEvent>
+                <CVCResultCode description="C"/>
+                <AVSResultCode description="E"/>
+                <AAVAddressResultCode description="B"/>
+                <AAVPostcodeResultCode description="B"/>
+                <AAVCardholderNameResultCode description="B"/>
+                <AAVTelephoneResultCode description="B"/>
+                <AAVEmailResultCode description="B"/>
+                <ThreeDSecureResult description="Cardholder authenticated">
+                    <eci>05</eci> <!--Not returned by default - contact us to enable-->
+                    <cavv>MAAAAAAAAAAAAAAAAAAAAAAAAAA=</cavv> <!--Not returned by default - contact us to enable-->
+                </ThreeDSecureResult>
+                <cardNumber>5255********2490</cardNumber>
+                <riskScore value="0"/>
+            </payment>
+            <journal journalType="CANCELLED" sent="n">
+                <bookingDate>
+                    <date dayOfMonth="01" month="01" year="2020"/>
+                </bookingDate>
+                <accountTx accountType="IN_PROCESS_AUTHORISED" batchId="30"/>
+                <amount value="1000" currencyCode="EUR" exponent="2" debitCreditIndicator="debit"/>
+            </journal>
+        </orderStatus>
+    </reply>
+</paymentService>

--- a/src/test/resources/templates/worldpay/inquiry/captured.xml
+++ b/src/test/resources/templates/worldpay/inquiry/captured.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/  paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the inquiry-->
+    <reply>
+        <orderStatus orderCode="ExampleOrder1"> <!--The orderCode you supplied in the inquiry-->
+            <payment>
+                <paymentMethod>AMEX-SSL</paymentMethod>
+                <amount value="4000" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>CAPTURED</lastEvent>
+                <reference>YourReference</reference> <!--Returned if added to capture modifications-->
+                <balance accountType="IN_PROCESS_CAPTURED">
+                    <amount value="4000" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
+                </balance>
+            </payment>
+        </orderStatus>
+    </reply>
+</paymentService>

--- a/src/test/resources/templates/worldpay/inquiry/rejected.xml
+++ b/src/test/resources/templates/worldpay/inquiry/rejected.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the inquiry-->
+    <reply>
+        <orderStatus orderCode="ExampleOrder1"> <!--The orderCode you supplied in the inquiry-->
+            <payment>
+                <paymentMethod>ECMC-SSL</paymentMethod>
+                <amount value="4000" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>REFUSED</lastEvent>
+                <ISO8583ReturnCode code="2" description="REFERRED"/>
+                <CVCResultCode description="C"/>
+                <AVSResultCode description="E"/>
+                <AAVAddressResultCode description="B"/>
+                <AAVPostcodeResultCode description="B"/>
+                <AAVCardholderNameResultCode description="B"/>
+                <AAVTelephoneResultCode description="B"/>
+                <AAVEmailResultCode description="B"/>
+                <ThreeDSecureResult description="Authentication offered but not used"/>
+            </payment>
+        </orderStatus>
+    </reply>
+</paymentService>


### PR DESCRIPTION
This PR adds WorldPayQueryResponse to deserialise responses
to Worldpay status queries. This is based on our other templates,
but I have removed any interpretative code - it should just
convert the XML to a very basic POJO.
The second things introduced is a WorldpayStatus enum. This
can be used to interpret the WorldPayQueryResponse robustly -
it maps the query response to a known Pay status, or returns
an empty Optional.
I have included tests to show this, using the example query
responses provided by Worldpay