### PR TITLE
PP-4758: Pass url to gateway client

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
@@ -5,7 +5,6 @@ import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
-import java.util.Map;
 
 public class GatewayClientFactory {
 
@@ -24,16 +23,14 @@ public class GatewayClientFactory {
 
     public GatewayClient createGatewayClient(PaymentGatewayName gateway,
                                              GatewayOperation operation,
-                                             Map<String, String> gatewayUrlMap,
                                              MetricRegistry metricRegistry) {
         Client client = clientFactory.createWithDropwizardClient(gateway, operation, metricRegistry);
-        return new GatewayClient(client, gatewayUrlMap, metricRegistry);
+        return new GatewayClient(client, metricRegistry);
     }
 
     public GatewayClient createGatewayClient(PaymentGatewayName gateway,
-                                             Map<String, String> gatewayUrlMap,
                                              MetricRegistry metricRegistry) {
         Client client = clientFactory.createWithDropwizardClient(gateway, metricRegistry);
-        return new GatewayClient(client, gatewayUrlMap, metricRegistry);
+        return new GatewayClient(client, metricRegistry);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -8,6 +8,9 @@ import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 
+import java.net.URI;
+import java.util.Map;
+
 import static uk.gov.pay.connector.gateway.CaptureResponse.ChargeState.PENDING;
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.epdq.EpdqOrderRequestBuilder.anEpdqCaptureOrderRequestBuilder;
@@ -20,15 +23,18 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 public class EpdqCaptureHandler implements CaptureHandler {
 
     private final GatewayClient client;
+    private final Map<String, String> gatewayUrlMap;
 
-    public EpdqCaptureHandler(GatewayClient client) {
+    public EpdqCaptureHandler(GatewayClient client, Map<String, String> gatewayUrlMap) {
         this.client = client;
+        this.gatewayUrlMap = gatewayUrlMap;
     }
 
     @Override
     public CaptureResponse capture(CaptureGatewayRequest request) {
         try {
-            GatewayClient.Response response = client.postRequestFor(ROUTE_FOR_MAINTENANCE_ORDER, request.getGatewayAccount(), buildCaptureOrder(request));
+            URI url = URI.create(String.format("%s/%s", gatewayUrlMap.get(request.getGatewayAccount().getType()), ROUTE_FOR_MAINTENANCE_ORDER));
+            GatewayClient.Response response = client.postRequestFor(url, request.getGatewayAccount(), buildCaptureOrder(request));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, EpdqCaptureResponse.class), PENDING);
         } catch (GatewayErrorException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -7,6 +7,9 @@ import uk.gov.pay.connector.gateway.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 
+import java.net.URI;
+import java.util.Map;
+
 import static uk.gov.pay.connector.gateway.CaptureResponse.ChargeState.PENDING;
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -14,15 +17,18 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 public class SmartpayCaptureHandler implements CaptureHandler {
 
     private final GatewayClient client;
+    private final Map<String, URI> gatewayUrlMap;
 
-    public SmartpayCaptureHandler(GatewayClient client) {
+    public SmartpayCaptureHandler(GatewayClient client, Map<String, URI> gatewayUrlMap) {
         this.client = client;
+        this.gatewayUrlMap = gatewayUrlMap;
     }
 
     @Override
     public CaptureResponse capture(CaptureGatewayRequest request) {
         try {
-            GatewayClient.Response response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrderFor(request));
+            GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                    request.getGatewayAccount(), buildCaptureOrderFor(request));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, SmartpayCaptureResponse.class), PENDING);
         } catch (GatewayErrorException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -8,6 +8,9 @@ import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 
+import java.net.URI;
+import java.util.Map;
+
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse.RefundState.PENDING;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -15,15 +18,18 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 public class SmartpayRefundHandler implements RefundHandler {
 
     private final GatewayClient client;
+    private final Map<String, URI> gatewayUrlMap;
 
-    public SmartpayRefundHandler(GatewayClient client) {
+    public SmartpayRefundHandler(GatewayClient client, Map<String, URI> gatewayUrlMap) {
         this.client = client;
+        this.gatewayUrlMap = gatewayUrlMap;
     }
 
     @Override
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
         try {
-            GatewayClient.Response response = client.postRequestFor(null, request.getGatewayAccount(), buildRefundOrderFor(request));
+            GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                    request.getGatewayAccount(), buildRefundOrderFor(request));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, SmartpayRefundResponse.class), PENDING);
         } catch (GatewayErrorException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -9,6 +9,9 @@ import uk.gov.pay.connector.gateway.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 
+import java.net.URI;
+import java.util.Map;
+
 import static uk.gov.pay.connector.gateway.CaptureResponse.ChargeState.PENDING;
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCaptureOrderRequestBuilder;
@@ -17,15 +20,18 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 public class WorldpayCaptureHandler implements CaptureHandler {
 
     private final GatewayClient client;
+    private final Map<String, URI> gatewayUrlMap;
 
-    public WorldpayCaptureHandler(GatewayClient client) {
+    public WorldpayCaptureHandler(GatewayClient client, Map<String, URI> gatewayUrlMap) {
         this.client = client;
+        this.gatewayUrlMap = gatewayUrlMap;
     }
 
     @Override
     public CaptureResponse capture(CaptureGatewayRequest request) {
         try {
-            GatewayClient.Response response = client.postRequestFor(null, request.getGatewayAccount(), buildCaptureOrder(request));
+            GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                    request.getGatewayAccount(), buildCaptureOrder(request));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, WorldpayCaptureResponse.class), PENDING);
         } catch (GatewayErrorException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -7,6 +7,9 @@ import uk.gov.pay.connector.gateway.RefundHandler;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 
+import java.net.URI;
+import java.util.Map;
+
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
 import static uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse.RefundState.PENDING;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayRefundOrderRequestBuilder;
@@ -15,15 +18,18 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 public class WorldpayRefundHandler implements RefundHandler {
 
     private final GatewayClient client;
+    private final Map<String, URI> gatewayUrlMap;
 
-    public WorldpayRefundHandler(GatewayClient client) {
+    public WorldpayRefundHandler(GatewayClient client, Map<String, URI> gatewayUrlMap) {
         this.client = client;
+        this.gatewayUrlMap = gatewayUrlMap;
     }
 
     @Override
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
         try {
-            GatewayClient.Response response = client.postRequestFor(null, request.getGatewayAccount(), buildRefundOrder(request));
+            GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                    request.getGatewayAccount(), buildRefundOrder(request));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, WorldpayRefundResponse.class), PENDING);
         } catch (GatewayErrorException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
@@ -9,21 +9,27 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayGatewayResponseGenerator;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.WalletAuthorisationHandler;
 
+import java.net.URI;
+import java.util.Map;
+
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseWalletOrderRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
 public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHandler, WorldpayGatewayResponseGenerator {
 
     private final GatewayClient authoriseClient;
+    private final Map<String, URI> gatewayUrlMap;
 
-    public WorldpayWalletAuthorisationHandler(GatewayClient authoriseClient) {
+    public WorldpayWalletAuthorisationHandler(GatewayClient authoriseClient, Map<String, URI> gatewayUrlMap) {
         this.authoriseClient = authoriseClient;
+        this.gatewayUrlMap = gatewayUrlMap;
     }
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(WalletAuthorisationGatewayRequest request) throws GatewayErrorException {
         
-        GatewayClient.Response response = authoriseClient.postRequestFor(null, request.getGatewayAccount(), buildWalletAuthoriseOrder(request));
+        GatewayClient.Response response = authoriseClient.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                request.getGatewayAccount(), buildWalletAuthoriseOrder(request));
         return getWorldpayGatewayResponse(response);
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -35,6 +35,8 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import java.net.URI;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
@@ -115,7 +117,7 @@ public abstract class BaseEpdqPaymentProviderTest {
 
         WebTarget mockTarget = mock(WebTarget.class);
         when(mockTarget.request()).thenReturn(mockClientInvocationBuilder);
-        when(mockClient.target(anyString())).thenReturn(mockTarget);
+        when(mockClient.target(any(URI.class))).thenReturn(mockTarget);
 
         return mockClientInvocationBuilder;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -16,12 +16,13 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
+import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -44,7 +45,7 @@ public class EpdqCaptureHandlerTest {
 
     @Before
     public void setup() {
-        epdqCaptureHandler = new EpdqCaptureHandler(client);
+        epdqCaptureHandler = new EpdqCaptureHandler(client, emptyMap());
     }
 
     @Test
@@ -52,7 +53,7 @@ public class EpdqCaptureHandlerTest {
         when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
         when(response.readEntity(String.class)).thenReturn(load("templates/epdq/capture-success-response.xml"));
         TestResponse testResponse = new TestResponse(this.response);
-        when(client.postRequestFor(anyString(), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+        when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
                 .thenReturn(testResponse);
 
         CaptureResponse gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());
@@ -74,7 +75,7 @@ public class EpdqCaptureHandlerTest {
         when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
         when(response.readEntity(String.class)).thenReturn(load("templates/epdq/capture-error-response.xml"));
         TestResponse testResponse = new TestResponse(this.response);
-        when(client.postRequestFor(anyString(), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(testResponse);
+        when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class))).thenReturn(testResponse);
         
         CaptureResponse gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(gatewayResponse.isSuccessful(), is(false));
@@ -83,7 +84,7 @@ public class EpdqCaptureHandlerTest {
 
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() throws Exception {
-        when(client.postRequestFor(anyString(), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+        when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
                 .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
         
         CaptureResponse gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
@@ -19,6 +19,8 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import java.net.URI;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -73,7 +75,7 @@ public abstract class BaseSmartpayPaymentProviderTest {
 
     void mockSmartpayResponse(int httpStatus, String responsePayload) {
         WebTarget mockTarget = mock(WebTarget.class);
-        when(mockClient.target(anyString())).thenReturn(mockTarget);
+        when(mockClient.target(any(URI.class))).thenReturn(mockTarget);
         Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
         when(mockTarget.request()).thenReturn(mockBuilder);
         when(mockBuilder.header(anyString(), any(Object.class))).thenReturn(mockBuilder);

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
@@ -16,12 +16,12 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import javax.ws.rs.core.Response;
+import java.net.URI;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
@@ -39,7 +39,7 @@ public class SmartpayCaptureHandlerTest {
 
     @Before
     public void setup() {
-        smartpayCaptureHandler = new SmartpayCaptureHandler(client);
+        smartpayCaptureHandler = new SmartpayCaptureHandler(client, ImmutableMap.of(TEST.toString(), URI.create("http://worldpay.test")));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class SmartpayCaptureHandlerTest {
         when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
         when(response.readEntity(String.class)).thenReturn(successCaptureResponse());
         TestResponse testResponse = new TestResponse(this.response);
-        when(client.postRequestFor(isNull(), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
+        when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class)))
                 .thenReturn(testResponse);
         
         ChargeEntity chargeEntity = aValidChargeEntity().withGatewayAccountEntity(aServiceAccount()).build();

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayBasePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayBasePaymentProviderTest.java
@@ -23,6 +23,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
+import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 
@@ -110,7 +111,7 @@ public abstract class WorldpayBasePaymentProviderTest {
 
     void mockWorldpayResponse(int httpStatus, String responsePayload) {
         WebTarget mockTarget = mock(WebTarget.class);
-        when(mockClient.target(anyString())).thenReturn(mockTarget);
+        when(mockClient.target(any(URI.class))).thenReturn(mockTarget);
         Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
         when(mockTarget.request()).thenReturn(mockBuilder);
         when(mockBuilder.header(anyString(), any(Object.class))).thenReturn(mockBuilder);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -87,7 +87,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
                 .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any()))
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
                 .thenReturn(mockGatewayClient);
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
@@ -124,7 +124,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
                 .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any())).thenReturn(mockGatewayClient);
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any())).thenReturn(mockGatewayClient);
 
         try {
             WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
@@ -156,7 +156,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
                 .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any()))
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
                 .thenReturn(mockGatewayClient);
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
@@ -184,7 +184,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
                 .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 401 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any())).thenReturn(mockGatewayClient);
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any())).thenReturn(mockGatewayClient);
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
 
@@ -218,7 +218,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
                 .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any(Map.class), any()))
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
                 .thenReturn(mockGatewayClient);
 
         WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -103,12 +103,11 @@ public class EpdqPaymentProviderTest {
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
 
         Client client = TestClientFactory.createJerseyClient();
-        GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
+        GatewayClient gatewayClient = new GatewayClient(client,
                 mockMetricRegistry);
 
         when(mockGatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class),
                 any(GatewayOperation.class),
-                any(Map.class),
                 any())).thenReturn(gatewayClient);
 
         paymentProvider = new EpdqPaymentProvider(mockConnectorConfiguration, mockGatewayClientFactory, mockEnvironment);

--- a/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
@@ -7,7 +7,6 @@ import org.apache.http.HttpStatus;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
@@ -22,7 +21,6 @@ import javax.ws.rs.client.ClientBuilder;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML_TYPE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.it.contract.TrustStoreLoader.getSSLContext;
@@ -72,8 +70,7 @@ public class GooglePayForWorldpayTest {
 
     private GatewayClient getGatewayClient() {
         Client client = ClientBuilder.newBuilder().sslContext(getSSLContext()).build();
-        ConnectorConfiguration configuration = app.getInstanceFromGuiceContainer(ConnectorConfiguration.class);
         Environment environment = app.getInstanceFromGuiceContainer(Environment.class);
-        return new GatewayClient(client, configuration.getGatewayConfigFor(WORLDPAY).getUrls(), environment.metrics());
+        return new GatewayClient(client, environment.metrics());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -244,11 +244,11 @@ public class SmartpayPaymentProviderTest {
     private PaymentProvider getSmartpayPaymentProvider() {
         Client client = TestClientFactory.createJerseyClient();
 
-        GatewayClient gatewayClient = new GatewayClient(client, ImmutableMap.of(TEST.toString(), url),
+        GatewayClient gatewayClient = new GatewayClient(client,
                 mockMetricRegistry);
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(Map.class), any(MetricRegistry.class))).thenReturn(gatewayClient);
+        when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(MetricRegistry.class))).thenReturn(gatewayClient);
 
         GatewayConfig gatewayConfig = mock(GatewayConfig.class);
         when(gatewayConfig.getUrls()).thenReturn(Collections.EMPTY_MAP);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -283,7 +283,6 @@ public class WorldpayPaymentProviderTest {
     private WorldpayPaymentProvider getValidWorldpayPaymentProvider() {
         GatewayClient gatewayClient = new GatewayClient(
                 ClientBuilder.newClient(),
-                getWorldpayConfig().getUrls(),
                 mockMetricRegistry
         );
 
@@ -295,7 +294,6 @@ public class WorldpayPaymentProviderTest {
         when(gatewayClientFactory.createGatewayClient(
                 any(PaymentGatewayName.class),
                 any(GatewayOperation.class),
-                any(Map.class),
                 any(MetricRegistry.class))).thenReturn(gatewayClient);
 
         return new WorldpayPaymentProvider(configuration, gatewayClientFactory, mockEnvironment);

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientFactoryTest.java
@@ -28,7 +28,7 @@ public class GatewayClientFactoryTest {
     MetricRegistry mockMetricRegistry;
     @Test
     public void shouldBuildGatewayClient() {
-        GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, AUTHORISE, emptyMap(), mockMetricRegistry);
+        GatewayClient gatewayClient = gatewayClientFactory.createGatewayClient(PaymentGatewayName.WORLDPAY, AUTHORISE, mockMetricRegistry);
 
         assertNotNull(gatewayClient);
         verify(mockClientFactory).createWithDropwizardClient(PaymentGatewayName.WORLDPAY, AUTHORISE, mockMetricRegistry);


### PR DESCRIPTION
This will make the gateway client more generic by passing a url to the `postRequest` method and shifts responsibility of what that url is to the calling clients. This will
allow StripeGatewayClient to be deprecated as that also receives a url in its
`postRequest` method.

