### PR TITLE
PP-4898 Remove withoutCredentials method on GatewayAccountEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Maps.newHashMap;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Entity
@@ -331,35 +330,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         this.emailCollectionMode = emailCollectionMode;
     }
 
-    public Map<String, String> getNotifySettings() {
-        return notifySettings;
+    public void setEmailNotifications(Map<EmailNotificationType, EmailNotificationEntity> emailNotifications) {
+        this.emailNotifications = emailNotifications;
     }
 
-    public Map<String, Object> withoutCredentials() {
-        Map<String, Object> account = newHashMap();
-        account.put("gateway_account_id", String.valueOf(getId()));
-        account.put("payment_provider", getGatewayName());
-        account.put("email_notifications", getEmailNotifications());
-        account.put("email_collection_mode", getEmailCollectionMode().toString());
-        account.put("type", getType());
-        if (isNotBlank(getDescription())) {
-            account.put("description", getDescription());
-        }
-        if (isNotBlank(getAnalyticsId())) {
-            account.put("analytics_id", getAnalyticsId());
-        }
-        if (isNotBlank(getServiceName())) {
-            account.put("service_name", getServiceName());
-        }
-        account.put("toggle_3ds", String.valueOf(isRequires3ds()));
-        account.put("corporate_credit_card_surcharge_amount", getCorporateNonPrepaidCreditCardSurchargeAmount());
-        account.put("corporate_debit_card_surcharge_amount", getCorporateNonPrepaidDebitCardSurchargeAmount());
-        account.put("corporate_prepaid_credit_card_surcharge_amount", getCorporatePrepaidCreditCardSurchargeAmount());
-        account.put("corporate_prepaid_debit_card_surcharge_amount", getCorporatePrepaidDebitCardSurchargeAmount());
-        account.put("allow_web_payments", String.valueOf(allowWebPayments));
-        account.put("allow_apple_pay", isAllowApplePay());
-        account.put("allow_google_pay", isAllowGooglePay());
-        return account;
+    public Map<String, String> getNotifySettings() {
+        return notifySettings;
     }
 
     public boolean hasAnyAcceptedCardType3dsRequired() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gatewayaccount.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -37,13 +39,13 @@ public class GatewayAccountResourceDTO {
 
     @JsonProperty("_links")
     private Map<String, Map<String, URI>> links = new HashMap<>();
-    
+
     @JsonProperty("allow_web_payments")
-    private boolean allowWebPayments;    
-    
+    private boolean allowWebPayments;
+
     @JsonProperty("allow_apple_pay")
-    private boolean allowApplePay;    
-    
+    private boolean allowApplePay;
+
     @JsonProperty("allow_google_pay")
     private boolean allowGooglePay;
 
@@ -52,6 +54,15 @@ public class GatewayAccountResourceDTO {
 
     @JsonProperty("corporate_prepaid_debit_card_surcharge_amount")
     private long corporatePrepaidDebitCardSurchargeAmount;
+
+    @JsonProperty("email_notifications")
+    private Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
+
+    @JsonProperty("email_collection_mode")
+    private EmailCollectionMode emailCollectionMode = EmailCollectionMode.MANDATORY;
+
+    @JsonProperty("toggle_3ds")
+    private boolean requires3ds;
 
     public GatewayAccountResourceDTO() {
     }
@@ -63,12 +74,15 @@ public class GatewayAccountResourceDTO {
                                      String serviceName,
                                      String analyticsId,
                                      long corporateCreditCardSurchargeAmount,
-                                     long corporateDebitCardSurchargeAmount, 
+                                     long corporateDebitCardSurchargeAmount,
                                      boolean allowWebPayments,
                                      boolean allowApplePay,
                                      boolean allowGooglePay,
                                      long corporatePrepaidCreditCardSurchargeAmount,
-                                     long corporatePrepaidDebitCardSurchargeAmount) {
+                                     long corporatePrepaidDebitCardSurchargeAmount,
+                                     Map<EmailNotificationType, EmailNotificationEntity> emailNotifications,
+                                     EmailCollectionMode emailCollectionMode,
+                                     boolean requires3ds) {
         this.accountId = accountId;
         this.paymentProvider = paymentProvider;
         this.type = type;
@@ -82,23 +96,29 @@ public class GatewayAccountResourceDTO {
         this.allowGooglePay = allowGooglePay;
         this.corporatePrepaidCreditCardSurchargeAmount = corporatePrepaidCreditCardSurchargeAmount;
         this.corporatePrepaidDebitCardSurchargeAmount = corporatePrepaidDebitCardSurchargeAmount;
+        this.emailNotifications = emailNotifications;
+        this.emailCollectionMode = emailCollectionMode;
+        this.requires3ds = requires3ds;
     }
-    
+
     public static GatewayAccountResourceDTO fromEntity(GatewayAccountEntity gatewayAccountEntity) {
         return new GatewayAccountResourceDTO(
-            gatewayAccountEntity.getId(),
-            gatewayAccountEntity.getGatewayName(),
-            GatewayAccountEntity.Type.fromString(gatewayAccountEntity.getType()),
-            gatewayAccountEntity.getDescription(),
-            gatewayAccountEntity.getServiceName(),
-            gatewayAccountEntity.getAnalyticsId(),
-            gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount(),
-            gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount(),
-            gatewayAccountEntity.isAllowWebPayments(),
-            gatewayAccountEntity.isAllowApplePay(),
-            gatewayAccountEntity.isAllowGooglePay(),
-            gatewayAccountEntity.getCorporatePrepaidCreditCardSurchargeAmount(),
-            gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount()
+                gatewayAccountEntity.getId(),
+                gatewayAccountEntity.getGatewayName(),
+                GatewayAccountEntity.Type.fromString(gatewayAccountEntity.getType()),
+                gatewayAccountEntity.getDescription(),
+                gatewayAccountEntity.getServiceName(),
+                gatewayAccountEntity.getAnalyticsId(),
+                gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount(),
+                gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount(),
+                gatewayAccountEntity.isAllowWebPayments(),
+                gatewayAccountEntity.isAllowApplePay(),
+                gatewayAccountEntity.isAllowGooglePay(),
+                gatewayAccountEntity.getCorporatePrepaidCreditCardSurchargeAmount(),
+                gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount(),
+                gatewayAccountEntity.getEmailNotifications(),
+                gatewayAccountEntity.getEmailCollectionMode(),
+                gatewayAccountEntity.isRequires3ds()
         );
     }
 
@@ -141,7 +161,7 @@ public class GatewayAccountResourceDTO {
     public void addLink(String key, URI uri) {
         links.put(key, ImmutableMap.of("href", uri));
     }
-    
+
     public long getCorporatePrepaidCreditCardSurchargeAmount() {
         return corporatePrepaidCreditCardSurchargeAmount;
     }
@@ -160,5 +180,17 @@ public class GatewayAccountResourceDTO {
 
     public boolean isAllowGooglePay() {
         return allowGooglePay;
+    }
+
+    public Map<EmailNotificationType, EmailNotificationEntity> getEmailNotifications() {
+        return emailNotifications;
+    }
+
+    public EmailCollectionMode getEmailCollectionMode() {
+        return emailCollectionMode;
+    }
+
+    public boolean isRequires3ds() {
+        return requires3ds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -103,9 +103,9 @@ public class GatewayAccountResource {
         logger.debug("Getting gateway account for account id {}", accountId);
         return gatewayAccountService
                 .getGatewayAccount(accountId)
-                .map(gatewayAccount -> Response.ok().entity(gatewayAccount.withoutCredentials()).build())
+                .map(GatewayAccountResourceDTO::fromEntity)
+                .map(gatewayAccountDTO -> Response.ok().entity(gatewayAccountDTO).build())
                 .orElseGet(() -> notFoundResponse(format("Account with id %s not found.", accountId)));
-
     }
 
     // This private method, instead of using a regex Path is due to, as far as

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -1,8 +1,12 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import org.junit.Test;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
+import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -27,6 +31,12 @@ public class GatewayAccountResourceDTOTest {
         entity.setAllowApplePay(false);
         entity.setAllowGooglePay(true);
         entity.setCredentials(Collections.emptyMap());
+        entity.setEmailCollectionMode(EmailCollectionMode.MANDATORY);
+        entity.setRequires3ds(true);
+
+        Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
+        emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
+        entity.setEmailNotifications(emailNotifications);
         
         GatewayAccountResourceDTO dto = GatewayAccountResourceDTO.fromEntity(entity);
         assertThat(dto.getAccountId(), is(entity.getId()));
@@ -42,5 +52,9 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.isAllowWebPayments(), is(entity.isAllowWebPayments()));
         assertThat(dto.isAllowApplePay(), is(entity.isAllowApplePay()));
         assertThat(dto.isAllowGooglePay(), is(entity.isAllowGooglePay()));
+        assertThat(dto.isRequires3ds(), is(entity.isRequires3ds()));
+        assertThat(dto.getEmailCollectionMode(), is(entity.getEmailCollectionMode()));
+        assertThat(dto.getEmailNotifications().size(), is(1));
+        assertThat(dto.getEmailNotifications().get(EmailNotificationType.PAYMENT_CONFIRMED).getTemplateBody(), is("testTemplate"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -98,7 +98,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .get(ACCOUNTS_API_URL + gatewayAccountId)
                 .then()
                 .statusCode(200)
-                .body("toggle_3ds", is("true"));
+                .body("toggle_3ds", is(true));
     }
 
     @Test
@@ -151,7 +151,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .then()
                 .statusCode(200)
                 .body("payment_provider", is("sandbox"))
-                .body("gateway_account_id", is(String.valueOf(defaultTestAccount.getAccountId())))
+                .body("gateway_account_id", is(Math.toIntExact(defaultTestAccount.getAccountId())))
                 .body("type", is(TEST.toString()))
                 .body("description", is("a description"))
                 .body("analytics_id", is("an analytics id"))
@@ -341,7 +341,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()
-                .body("toggle_3ds", is("true"));
+                .body("toggle_3ds", is(true));
     }
 
     @Test
@@ -356,7 +356,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()
-                .body("toggle_3ds", is("false"));
+                .body("toggle_3ds", is(false));
     }
 
     @Test
@@ -517,7 +517,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()
-                .body("allow_web_payments", is("false"));
+                .body("allow_web_payments", is(false));
     }
 
     @Test
@@ -535,7 +535,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()
-                .body("allow_web_payments", is("true"));
+                .body("allow_web_payments", is(true));
     }
 
     @Test


### PR DESCRIPTION
Remove the use of `GatewayAccountEntity.withoutCredentials()` within the end-point of `GET v1/api/accounts/{accountId}` in favour of the existing `GatewayAccountResourceDTO` to rationalise the number of return type objects and processes surrounding gateway accounts in Connector (also because its now a proper type).
- Add "email_notifications", "email_collection_mode" and "toggle_3ds" to `GatewayAccountResourceDTO`
so that this type returns the same information as the `Map` produced by `withoutCredentials`.
- This changes the type of the values contained within the response since `withoutCredentials`
was converting each type to String instead of using `boolean` for example.
- Where necessary update tests to assert on type boolean rather than expecting the String equivalent e.g. `"true"`.
- Update CardResource to use `GatewayAccountResourceDTO.fromEntity()` in place
of calling `withoutCredentials()`.

## WHAT
`GET v1/api/accounts/{accountId}` appears to only be used by the `pay-toolbox` within 
```
pay-toolbox//app/lib/pay-request/api_utils/connector.js:9:    return axiosInstance.get("/v1/api/accounts/${id}").then(utilExtractData)
```
SelfService uses the `v1/frontend/accounts/{accountId}` to GET accounts and only PATCHES to `v1/api/accounts/{accountId}`. Therefore I am reasonably confident that the change to returning boolean as boolean rather than wrapping in a String is safe.


