### PR TITLE
PP-4869 Change Apple Pay secret names to match names used by Apple.

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -27,8 +27,8 @@ worldpay:
   notificationDomain: ${SECURE_WORLDPAY_NOTIFICATION_DOMAIN:-worldpay.com}
   credentials: ['username','password','merchant_id']
   applePay:
-    privateKey: ${WORLDPAY_APPLE_PAY_PRIVATE_KEY:-privateKeyWhichShouldBeBase64Encoded}
-    publicCertificate: ${WORLDPAY_APPLE_PAY_PUBLIC_CERTIFICATE:-publicCertificateWhichShouldBeBase64Encoded}
+    privateKey: ${APPLE_PAY_PAYMENT_PROCESSING_PRIVATE_KEY:-privateKeyWhichShouldBeBase64Encoded}
+    publicCertificate: ${APPLE_PAY_PAYMENT_PROCESSING_CERTIFICATE:-publicCertificateWhichShouldBeBase64Encoded}
   jerseyClientOverrides:
     auth:
       # Auth is run in a background thread which will release the HTTP request from frontend after 1 second


### PR DESCRIPTION
## WHAT YOU DID
We've decided to re-name the env variables relating to apply pay secrets so they match the naming convention used by Apple to avoid confusion when the time comes to renew them.