### PR TITLE
PP 4910 return wallet type in charge response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -248,9 +248,7 @@ public class ChargeResponse {
 
         @Override
         public ChargeResponse build() {
-            return new ChargeResponse(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
-                    description, reference, providerName, createdDate, links, refundSummary, settlementSummary,
-                    cardDetails, auth3dsData, language, delayedCapture, corporateCardSurcharge, totalAmount);
+            return new ChargeResponse(this);
         }
     }
 
@@ -322,31 +320,27 @@ public class ChargeResponse {
     private Long totalAmount;
 
 
-    ChargeResponse(String chargeId, Long amount, ExternalTransactionState state, String cardBrand, String gatewayTransactionId, String returnUrl,
-                   String email, String description, ServicePaymentReference reference, String providerName, ZonedDateTime createdDate,
-                   List<Map<String, Object>> dataLinks, RefundSummary refundSummary, SettlementSummary settlementSummary, PersistedCard cardDetails,
-                   Auth3dsData auth3dsData, SupportedLanguage language, boolean delayedCapture,
-                   Long corporateCardSurcharge, Long totalAmount) {
-        this.dataLinks = dataLinks;
-        this.chargeId = chargeId;
-        this.amount = amount;
-        this.state = state;
-        this.cardBrand = cardBrand;
-        this.gatewayTransactionId = gatewayTransactionId;
-        this.returnUrl = returnUrl;
-        this.description = description;
-        this.reference = reference;
-        this.providerName = providerName;
-        this.createdDate = createdDate;
-        this.email = email;
-        this.refundSummary = refundSummary;
-        this.settlementSummary = settlementSummary;
-        this.cardDetails = cardDetails;
-        this.auth3dsData = auth3dsData;
-        this.language = language;
-        this.delayedCapture = delayedCapture;
-        this.corporateCardSurcharge = corporateCardSurcharge;
-        this.totalAmount = totalAmount;
+    ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
+        this.dataLinks = builder.getLinks();
+        this.chargeId = builder.getChargeId();
+        this.amount = builder.getAmount();
+        this.state = builder.getState();
+        this.cardBrand = builder.getCardBrand();
+        this.gatewayTransactionId = builder.getGatewayTransactionId();
+        this.returnUrl = builder.getReturnUrl();
+        this.description = builder.getDescription();
+        this.reference = builder.getReference();
+        this.providerName = builder.getProviderName();
+        this.createdDate = builder.getCreatedDate();
+        this.email = builder.getEmail();
+        this.refundSummary = builder.getRefundSummary();
+        this.settlementSummary = builder.getSettlementSummary();
+        this.cardDetails = builder.getCardDetails();
+        this.auth3dsData = builder.getAuth3dsData();
+        this.language = builder.getLanguage();
+        this.delayedCapture = builder.isDelayedCapture();
+        this.corporateCardSurcharge = builder.getCorporateCardSurcharge();
+        this.totalAmount = builder.getTotalAmount();
     }
 
     public List<Map<String, Object>> getDataLinks() {

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.util.DateTimeUtils;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -318,6 +319,9 @@ public class ChargeResponse {
 
     @JsonProperty("total_amount")
     private Long totalAmount;
+    
+    @JsonProperty("wallet_type")
+    private WalletType walletType;
 
 
     ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
@@ -341,6 +345,7 @@ public class ChargeResponse {
         this.delayedCapture = builder.isDelayedCapture();
         this.corporateCardSurcharge = builder.getCorporateCardSurcharge();
         this.totalAmount = builder.getTotalAmount();
+        this.walletType = builder.getWalletType();
     }
 
     public List<Map<String, Object>> getDataLinks() {
@@ -419,6 +424,10 @@ public class ChargeResponse {
         return totalAmount;
     }
 
+    public WalletType getWalletType() {
+        return walletType;
+    }
+
     public URI getLink(String rel) {
         return dataLinks.stream()
                 .filter(map -> rel.equals(map.get("rel")))
@@ -449,16 +458,17 @@ public class ChargeResponse {
                 Objects.equals(settlementSummary, that.settlementSummary) &&
                 Objects.equals(auth3dsData, that.auth3dsData) &&
                 Objects.equals(cardDetails, that.cardDetails) &&
+                language == that.language &&
                 Objects.equals(corporateCardSurcharge, that.corporateCardSurcharge) &&
                 Objects.equals(totalAmount, that.totalAmount) &&
-                language == that.language;
+                walletType == that.walletType;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(dataLinks, chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
                 description, reference, providerName, createdDate, refundSummary, settlementSummary, auth3dsData,
-                cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount);
+                cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, walletType);
     }
 
     @Override
@@ -482,6 +492,7 @@ public class ChargeResponse {
                 ", delayedCapture=" + delayedCapture +
                 ", corporateCardSurcharge=" + corporateCardSurcharge +
                 ", totalAmount=" + totalAmount +
+                ", walletType=" + walletType.toString() +
                 '}';
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
@@ -2,17 +2,11 @@ package uk.gov.pay.connector.charge.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
 
 public class FrontendChargeResponse extends ChargeResponse {
     public static class FrontendChargeResponseBuilder extends AbstractChargeResponseBuilder<FrontendChargeResponseBuilder, FrontendChargeResponse> {
@@ -38,10 +32,7 @@ public class FrontendChargeResponse extends ChargeResponse {
 
         @Override
         public FrontendChargeResponse build() {
-            return new FrontendChargeResponse(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl,
-                    email, description, reference, providerName, createdDate, links, status, refundSummary,
-                    settlementSummary, cardDetails, auth3dsData, gatewayAccount, language, delayedCapture,
-                    corporateCardSurcharge, totalAmount);
+            return new FrontendChargeResponse(this);
         }
     }
 
@@ -55,19 +46,10 @@ public class FrontendChargeResponse extends ChargeResponse {
     @JsonProperty(value = "gateway_account")
     private GatewayAccountEntity gatewayAccount;
 
-    private FrontendChargeResponse(String chargeId, Long amount, ExternalTransactionState state, String cardBrand,
-                                   String gatewayTransactionId, String returnUrl, String email, String description,
-                                   ServicePaymentReference reference, String providerName, ZonedDateTime createdDate,
-                                   List<Map<String, Object>> dataLinks, String status, RefundSummary refundSummary,
-                                   SettlementSummary settlementSummary, PersistedCard chargeCardDetails,
-                                   Auth3dsData auth3dsData, GatewayAccountEntity gatewayAccount,
-                                   SupportedLanguage language, boolean delayedCapture,
-                                   Long corporateCardSurcharge, Long totalAmount) {
-        super(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email, description, reference,
-                providerName, createdDate, dataLinks, refundSummary, settlementSummary, chargeCardDetails, auth3dsData,
-                language, delayedCapture, corporateCardSurcharge, totalAmount);
-        this.status = status;
-        this.gatewayAccount = gatewayAccount;
+    private FrontendChargeResponse(FrontendChargeResponseBuilder builder) {
+        super(builder);
+        this.status = builder.status;
+        this.gatewayAccount = builder.gatewayAccount;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
@@ -17,18 +17,12 @@ import java.util.Map;
 public class FrontendChargeResponse extends ChargeResponse {
     public static class FrontendChargeResponseBuilder extends AbstractChargeResponseBuilder<FrontendChargeResponseBuilder, FrontendChargeResponse> {
         private String status;
-        private PersistedCard persistedCard;
         private GatewayAccountEntity gatewayAccount;
 
         public FrontendChargeResponseBuilder withStatus(String status) {
             this.status = status;
             ExternalChargeState externalChargeState = ChargeStatus.fromString(status).toExternal();
             super.withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()));
-            return this;
-        }
-
-        public FrontendChargeResponseBuilder withChargeCardDetails(PersistedCard persistedCard) {
-            this.persistedCard = persistedCard;
             return this;
         }
 
@@ -46,7 +40,7 @@ public class FrontendChargeResponse extends ChargeResponse {
         public FrontendChargeResponse build() {
             return new FrontendChargeResponse(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl,
                     email, description, reference, providerName, createdDate, links, status, refundSummary,
-                    settlementSummary, persistedCard, auth3dsData, gatewayAccount, language, delayedCapture,
+                    settlementSummary, cardDetails, auth3dsData, gatewayAccount, language, delayedCapture,
                     corporateCardSurcharge, totalAmount);
         }
     }

--- a/src/main/java/uk/gov/pay/connector/charge/model/TransactionResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/TransactionResponse.java
@@ -1,15 +1,8 @@
 package uk.gov.pay.connector.charge.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
-import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.charge.model.domain.TransactionType;
-import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
-
-import java.time.ZonedDateTime;
-import java.util.List;
-import java.util.Map;
 
 public class TransactionResponse extends ChargeResponse {
 
@@ -29,9 +22,7 @@ public class TransactionResponse extends ChargeResponse {
 
         @Override
         public TransactionResponse build() {
-            return new TransactionResponse(transactionType, chargeId, amount, state, cardBrand, gatewayTransactionId,
-                    returnUrl, email, description, reference, providerName, createdDate, links, refundSummary,
-                    settlementSummary, cardDetails, auth3dsData, language, delayedCapture, corporateCardSurcharge, totalAmount);
+            return new TransactionResponse(this);
         }
 
     }
@@ -43,17 +34,9 @@ public class TransactionResponse extends ChargeResponse {
     @JsonProperty(value = "transaction_type")
     private String transactionType;
 
-    protected TransactionResponse(String transactionType, String chargeId, Long amount, ExternalTransactionState state,
-                                  String cardBrand, String gatewayTransactionId, String returnUrl, String email,
-                                  String description, ServicePaymentReference reference, String providerName,
-                                  ZonedDateTime createdDate, List<Map<String, Object>> dataLinks, RefundSummary refundSummary,
-                                  SettlementSummary settlementSummary, PersistedCard cardDetails,
-                                  Auth3dsData auth3dsData, SupportedLanguage language,
-                                  boolean delayedCapture, Long corporateCardSurcharge, Long totalAmount) {
-        super(chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email, description, reference,
-                providerName, createdDate, dataLinks, refundSummary, settlementSummary, cardDetails, auth3dsData,
-                language, delayedCapture, corporateCardSurcharge, totalAmount);
-        this.transactionType = transactionType;
+    protected TransactionResponse(TransactionResponseBuilder builder) {
+        super(builder);
+        this.transactionType = builder.transactionType;
     }
 
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.charge.model.ChargeResponse;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -34,6 +35,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected boolean delayedCapture;
     protected Long corporateCardSurcharge;
     protected Long totalAmount;
+    protected WalletType walletType;
 
     protected abstract T thisObject();
 
@@ -147,6 +149,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         this.totalAmount = totalAmount;
         return thisObject();
     }
+    
+    public T withWalletType(WalletType walletType) {
+        this.walletType = walletType;
+        return thisObject();
+    }
 
     public String getChargeId() {
         return chargeId;
@@ -226,6 +233,10 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public Long getTotalAmount() {
         return totalAmount;
+    }
+
+    public WalletType getWalletType() {
+        return walletType;
     }
 
     public abstract R build();

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -148,5 +148,85 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return thisObject();
     }
 
+    public String getChargeId() {
+        return chargeId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public ExternalTransactionState getState() {
+        return state;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public List<Map<String, Object>> getLinks() {
+        return links;
+    }
+
+    public ServicePaymentReference getReference() {
+        return reference;
+    }
+
+    public String getProviderName() {
+        return providerName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public ChargeResponse.RefundSummary getRefundSummary() {
+        return refundSummary;
+    }
+
+    public ChargeResponse.SettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
+    public PersistedCard getCardDetails() {
+        return cardDetails;
+    }
+
+    public ChargeResponse.Auth3dsData getAuth3dsData() {
+        return auth3dsData;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public boolean isDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public Long getCorporateCardSurcharge() {
+        return corporateCardSurcharge;
+    }
+
+    public Long getTotalAmount() {
+        return totalAmount;
+    }
+
     public abstract R build();
 }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -168,7 +168,8 @@ public class ChargesFrontendResource {
                 .withDelayedCapture(charge.isDelayedCapture())
                 .withLink("self", GET, locationUriFor("/v1/frontend/charges/{chargeId}", uriInfo, chargeId))
                 .withLink("cardAuth", POST, locationUriFor("/v1/frontend/charges/{chargeId}/cards", uriInfo, chargeId))
-                .withLink("cardCapture", POST, locationUriFor("/v1/frontend/charges/{chargeId}/capture", uriInfo, chargeId));
+                .withLink("cardCapture", POST, locationUriFor("/v1/frontend/charges/{chargeId}/capture", uriInfo, chargeId))
+                .withWalletType(charge.getWalletType());
         charge.getCorporateSurcharge().ifPresent(surcharge -> {
             if (surcharge > 0) {
                 responseBuilder

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -161,7 +161,7 @@ public class ChargesFrontendResource {
                 .withCreatedDate(charge.getCreatedDate())
                 .withReturnUrl(charge.getReturnUrl())
                 .withEmail(charge.getEmail())
-                .withChargeCardDetails(persistedCard)
+                .withCardDetails(persistedCard)
                 .withAuth3dsData(auth3dsData)
                 .withGatewayAccount(charge.getGatewayAccount())
                 .withLanguage(charge.getLanguage())

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -208,7 +208,8 @@ public class ChargeService {
                 .withCardDetails(persistedCard)
                 .withAuth3dsData(auth3dsData)
                 .withLink("self", GET, selfUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeId))
-                .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()));
+                .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()))
+                .withWalletType(chargeEntity.getWalletType());
 
         if (ChargeStatus.AWAITING_CAPTURE_REQUEST.getValue().equals(chargeEntity.getStatus())) {
             builderOfResponse.withLink("capture", POST, captureUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -309,6 +310,7 @@ public class ChargeServiceTest {
                 .withId(chargeId)
                 .withGatewayAccountEntity(gatewayAccount)
                 .withStatus(status)
+                .withWalletType(WalletType.APPLE_PAY)
                 .build();
 
         Optional<ChargeEntity> chargeEntity = Optional.of(newCharge);
@@ -326,6 +328,7 @@ public class ChargeServiceTest {
         assertThat(tokenEntity.getToken(), is(notNullValue()));
 
         ChargeResponseBuilder chargeResponseWithoutCorporateCardSurcharge = chargeResponseBuilderOf(chargeEntity.get());
+        chargeResponseWithoutCorporateCardSurcharge.withWalletType(WalletType.APPLE_PAY);
         chargeResponseWithoutCorporateCardSurcharge.withLink("self", GET, new URI(SERVICE_HOST + "/v1/api/accounts/10/charges/" + externalId));
         chargeResponseWithoutCorporateCardSurcharge.withLink("refunds", GET, new URI(SERVICE_HOST + "/v1/api/accounts/10/charges/" + externalId + "/refunds"));
         chargeResponseWithoutCorporateCardSurcharge.withLink("next_url", GET, new URI("http://payments.com/secure/" + tokenEntity.getToken()));
@@ -338,6 +341,7 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getCorporateCardSurcharge(), is(nullValue()));
         assertThat(chargeResponse.getTotalAmount(), is(nullValue()));
         assertThat(chargeResponse, is(chargeResponseWithoutCorporateCardSurcharge.build()));
+        assertThat(chargeResponse.getWalletType(), is(WalletType.APPLE_PAY));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.time.ZoneId;
@@ -240,6 +241,39 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("results[1]." + JSON_CHARGE_KEY, is(externalChargeId))
                 .body("results[1]", not(hasKey(JSON_CORPORATE_CARD_SURCHARGE_KEY)))
                 .body("results[1]", not(hasKey(JSON_TOTAL_AMOUNT_KEY)));
+    }
+
+    @Test
+    public void shouldReturnWalletTypeWhenNotNull() {
+        long chargeId = nextInt();
+        String externalChargeId = RandomIdGenerator.newId();
+
+        createCharge(externalChargeId, chargeId);
+        databaseTestHelper.addWalletType(chargeId, WalletType.APPLE_PAY);
+
+        connectorRestApiClient
+                .withAccountId(accountId)
+                .getChargesV1()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results[0].charge_id", is(externalChargeId))
+                .body("results[0].wallet_type", is(WalletType.APPLE_PAY.toString()));
+    }
+
+    @Test
+    public void shouldReturnWalletTypeAsNullWhenNull() {
+        long chargeId = nextInt();
+        String externalChargeId = RandomIdGenerator.newId();
+
+        createCharge(externalChargeId, chargeId);
+
+        connectorRestApiClient
+                .withAccountId(accountId)
+                .getChargesV1()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results[0].charge_id", is(externalChargeId))
+                .body("results[0].wallet_type", is(nullValue()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.RestAssuredClient;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.util.List;
@@ -135,6 +136,19 @@ public class ChargesFrontendResourceITest {
                 .body("links", containsLink("self", GET, expectedLocation))
                 .body("links", containsLink("cardAuth", POST, expectedLocation + "/cards"))
                 .body("links", containsLink("cardCapture", POST, expectedLocation + "/capture"));
+    }
+    
+    @Test
+    public void getChargeShouldIncludeWalletType() {
+        String externalChargeId = postToCreateACharge(expectedAmount);
+        final long chargeId = databaseTestHelper.getChargeIdByExternalId(externalChargeId);
+        databaseTestHelper.addWalletType(chargeId, WalletType.APPLE_PAY);
+        
+        getChargeFromResource(externalChargeId)
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("charge_id", is(externalChargeId))
+                .body("wallet_type", is(WalletType.APPLE_PAY.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -67,6 +67,7 @@ public class ChargeEntityFixture {
 
             chargeEntity.set3dsDetails(auth3dsDetailsEntity);
         }
+        chargeEntity.setWalletType(walletType);
         return chargeEntity;
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -604,6 +605,15 @@ public class DatabaseTestHelper {
         jdbi.withHandle(handle ->
                 handle.createStatement("UPDATE gateway_accounts set allow_apple_pay=true WHERE id=:gatewayAccountId")
                         .bind("gatewayAccountId", accountId)
+                        .execute()
+        );
+    }
+
+    public void addWalletType(long chargeId, WalletType walletType) {
+        jdbi.withHandle(handle ->
+                handle.createStatement("UPDATE CHARGES set wallet=:walletType WHERE id=:chargeId")
+                        .bind("chargeId", chargeId)
+                        .bind("walletType", walletType)
                         .execute()
         );
     }


### PR DESCRIPTION
## WHAT YOU DID
Add wallet type to `ChargeResponse`
    - Add wallet type to `ChargeResponse` and `AbstractChargeResponseBuilder`.
    - Set wallet type when creating the charge response via `v1/api/accounts/{accountId}
    /charges/{chargeId}` and `v1/frontend/charges/{chargeId}`
    - Update tests

 Minor refactoring to simplify charge response and associated builder pattern.
 - Pass the charge response builder into the charge response constructors rather than deconstructing
 it which leads to complicated constructors prone to human error
 and duplication. This also simplifies adding new attributes to the various charge response
 types (which is why it was done prior to implementing the change above).
