### PR TITLE
PP-4877 Increase capture retry count default value

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -101,7 +101,7 @@ captureProcessConfig:
   # the initial attempt. See PP-2627 or commit
   # e931b4dab25284acedeb6d59d4bfd3d29e454b82 for more details.
   retryFailuresEvery: ${CAPTURE_PROCESS_RETRY_FAILURES_EVERY:-60 minutes}
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-96}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}


### PR DESCRIPTION
Increase to 96 as we had some issues with EPDQ not sending the captured notification for over a day.

2 days should be sufficient for this, i.e. CAPTURE_PROCESS_RETRY_FAILURES_EVERY set to 60 and CAPTURE_PROCESS_MAXIMUM_RETRIES set to 48

However due to how the current capture process works, it is possible for more than one connector node to attempt to capture the same charge in an hour, so the number of retries does not equal the number of hours since the first capture attempt.

This change has been made as a temporary solution as we will be looking at changing how the capture process works in the near future.

with @heathd and @cobainc0

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
