### PR TITLE
PP-4937 Add Stripe Account endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.filters.SchemeRewriteFilter;
 import uk.gov.pay.connector.gateway.smartpay.auth.BasicAuthUser;
 import uk.gov.pay.connector.gateway.smartpay.auth.SmartpayAccountSpecificAuthenticator;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountResource;
+import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountResource;
 import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountSetupResource;
 import uk.gov.pay.connector.healthcheck.CardExecutorServiceHealthCheck;
 import uk.gov.pay.connector.healthcheck.DatabaseHealthCheck;
@@ -96,16 +97,18 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         injector.getInstance(PersistenceServiceInitialiser.class);
 
         initialiseMetrics(configuration, environment);
-        
+
         environment.jersey().register(new ConstraintViolationExceptionMapper());
         environment.jersey().register(new ValidationExceptionMapper());
         environment.jersey().register(new UnsupportedOperationExceptionMapper());
-        environment.jersey().register(new LoggingExceptionMapper<Throwable>() {});
+        environment.jersey().register(new LoggingExceptionMapper<Throwable>() {
+        });
         environment.jersey().register(new JsonProcessingExceptionMapper());
         environment.jersey().register(new EarlyEofExceptionMapper());
-        
+
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));
+        environment.jersey().register(injector.getInstance(StripeAccountResource.class));
         environment.jersey().register(injector.getInstance(ChargeEventsResource.class));
         environment.jersey().register(injector.getInstance(SecurityTokensResource.class));
         environment.jersey().register(injector.getInstance(ChargesApiResource.class));
@@ -128,7 +131,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
         environment.servlets().addFilter("LoggingFilter", injector.getInstance(LoggingFilter.class))
                 .addMappingForUrlPatterns(of(REQUEST), true, "/v1/*");
-        
+
         environment.healthChecks().register("ping", new Ping());
         environment.healthChecks().register("database", injector.getInstance(DatabaseHealthCheck.class));
         environment.healthChecks().register("cardExecutorService", injector.getInstance(CardExecutorServiceHealthCheck.class));
@@ -136,7 +139,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         HttpsURLConnection.setDefaultSSLSocketFactory(new TrustingSSLSocketFactory());
 
         if (configuration.isXrayEnabled())
-            Xray.init(environment, "pay-connector", Optional.empty(),"/v1/*");
+            Xray.init(environment, "pay-connector", Optional.empty(), "/v1/*");
     }
 
     protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
@@ -174,7 +177,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
     }
 
     private void setupSchedulers(ConnectorConfiguration configuration, Environment environment, Injector injector) {
-        CaptureProcessScheduler captureProcessScheduler = new CaptureProcessScheduler(configuration, 
+        CaptureProcessScheduler captureProcessScheduler = new CaptureProcessScheduler(configuration,
                 environment, injector.getInstance(CardCaptureProcess.class), injector.getInstance(XrayUtils.class));
         environment.lifecycle().manage(captureProcessScheduler);
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountResponse.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StripeAccountResponse {
+
+    @JsonProperty("stripe_account_id")
+    private final String stripeAccountId;
+
+    public StripeAccountResponse(String stripeAccountId) {
+        this.stripeAccountId = Objects.requireNonNull(stripeAccountId);
+    }
+
+    public String getStripeAccountId() {
+        return stripeAccountId;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountResource.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.gatewayaccount.resource;
+
+import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
+import uk.gov.pay.connector.gatewayaccount.resource.support.StripeAccountUtils;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccount.service.StripeAccountService;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Path("/")
+public class StripeAccountResource {
+
+    private final StripeAccountService stripeAccountService;
+    private final GatewayAccountService gatewayAccountService;
+
+    @Inject
+    public StripeAccountResource(StripeAccountService stripeAccountService,
+                                 GatewayAccountService gatewayAccountService) {
+        this.stripeAccountService = stripeAccountService;
+        this.gatewayAccountService = gatewayAccountService;
+    }
+
+    @GET
+    @Path("/v1/api/accounts/{accountId}/stripe-account")
+    @Produces(APPLICATION_JSON)
+    public StripeAccountResponse getStripeAccount(@PathParam("accountId") Long accountId) {
+        return gatewayAccountService.getGatewayAccount(accountId)
+                .filter(StripeAccountUtils::isStripeGatewayAccount)
+                .flatMap(stripeAccountService::buildStripeAccountResponse)
+                .orElseThrow(NotFoundException::new);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import io.dropwizard.jersey.PATCH;
 import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchRequest;
-import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetup;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupUpdateRequest;
+import uk.gov.pay.connector.gatewayaccount.resource.support.StripeAccountUtils;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.StripeAccountSetupService;
 
@@ -44,7 +43,7 @@ public class StripeAccountSetupResource {
     @Produces(APPLICATION_JSON)
     public StripeAccountSetup getStripeAccountSetup(@PathParam("accountId") Long accountId) {
         return gatewayAccountService.getGatewayAccount(accountId)
-                .filter(this::isStripeGatewayAccount)
+                .filter(StripeAccountUtils::isStripeGatewayAccount)
                 .map(gatewayAccountEntity -> stripeAccountSetupService.getCompletedTasks(gatewayAccountEntity.getId()))
                 .orElseThrow(NotFoundException::new);
     }
@@ -54,7 +53,7 @@ public class StripeAccountSetupResource {
     @Consumes(APPLICATION_JSON)
     public Response patchStripeAccountSetup(@PathParam("accountId") Long accountId, JsonNode payload) {
         return gatewayAccountService.getGatewayAccount(accountId)
-                .filter(this::isStripeGatewayAccount)
+                .filter(StripeAccountUtils::isStripeGatewayAccount)
                 .map(gatewayAccountEntity -> {
                     stripeAccountSetupRequestValidator.validatePatchRequest(payload);
                     List<StripeAccountSetupUpdateRequest> updateRequests = StreamSupport
@@ -68,7 +67,4 @@ public class StripeAccountSetupResource {
                 }).orElseThrow(NotFoundException::new);
     }
 
-    private boolean isStripeGatewayAccount(GatewayAccountEntity gatewayAccountEntity) {
-        return PaymentGatewayName.STRIPE.getName().equals(gatewayAccountEntity.getGatewayName());
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/support/StripeAccountUtils.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/support/StripeAccountUtils.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.gatewayaccount.resource.support;
+
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+public class StripeAccountUtils {
+
+    public static boolean isStripeGatewayAccount(GatewayAccountEntity gatewayAccountEntity) {
+        return PaymentGatewayName.STRIPE.getName().equals(gatewayAccountEntity.getGatewayName());
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.gatewayaccount.service;
+
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
+
+import java.util.Optional;
+
+public class StripeAccountService {
+
+    public Optional<StripeAccountResponse> buildStripeAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
+        return Optional.ofNullable(gatewayAccountEntity.getCredentials())
+                .map(credentials -> credentials.get("stripe_account_id"))
+                .map(StripeAccountResponse::new);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.gatewayaccount.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeAccountServiceTest {
+
+    private StripeAccountService stripeAccountService;
+
+    @Mock
+    private GatewayAccountEntity mockGatewayAccountEntity;
+
+    @Before
+    public void setUp() {
+        stripeAccountService = new StripeAccountService();
+    }
+
+    @Test
+    public void buildStripeAccountResponseShouldReturnStripeAccountResponse() {
+        String stripeAccountId = "acct_123example123";
+        given(mockGatewayAccountEntity.getCredentials())
+                .willReturn(Collections.singletonMap("stripe_account_id", stripeAccountId));
+
+        Optional<StripeAccountResponse> stripeAccountResponseOptional =
+                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
+
+        assertThat(stripeAccountResponseOptional.get().getStripeAccountId(), is(stripeAccountId));
+    }
+
+    @Test
+    public void buildStripeAccountResponseShouldReturnEmptyOptionalWhenCredentialsIsNull() {
+        given(mockGatewayAccountEntity.getCredentials()).willReturn(null);
+
+        Optional<StripeAccountResponse> stripeAccountResponseOptional =
+                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
+
+        assertThat(stripeAccountResponseOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void buildStripeAccountResponseShouldReturnEmptyOptionalWhenCredentialsAreEmpty() {
+        given(mockGatewayAccountEntity.getCredentials()).willReturn(Collections.emptyMap());
+
+        Optional<StripeAccountResponse> stripeAccountResponseOptional =
+                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
+
+        assertThat(stripeAccountResponseOptional.isPresent(), is(false));
+    }
+
+    @Test
+    public void buildStripeAccountResponseShouldReturnEmptyOptionalWhenCredentialsPropertyIsNull() {
+        given(mockGatewayAccountEntity.getCredentials())
+                .willReturn(Collections.singletonMap("stripe_account_id", null));
+
+        Optional<StripeAccountResponse> stripeAccountResponseOptional =
+                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
+
+        assertThat(stripeAccountResponseOptional.isPresent(), is(false));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountResourceITest.java
@@ -1,0 +1,71 @@
+package uk.gov.pay.connector.it.resources;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.is;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class StripeAccountResourceITest extends GatewayAccountResourceTestBase {
+
+    private static final String STRIPE_ACCOUNT_ID = "acct_123example123";
+
+    @Test
+    public void getStripeAccountReturnsSuccessfulResponse() {
+        DatabaseFixtures.TestAccount testAccount = databaseFixtures
+                .aTestAccount()
+                .withPaymentProvider("stripe")
+                .withCredentials(Collections.singletonMap("stripe_account_id", STRIPE_ACCOUNT_ID))
+                .insert();
+
+        givenSetup()
+                .get("/v1/api/accounts/" + testAccount.getAccountId() + "/stripe-account")
+                .then()
+                .statusCode(200)
+                .body("stripe_account_id", is(STRIPE_ACCOUNT_ID));
+    }
+
+    @Test
+    public void getStripeAccountReturnsNotFoundResponseWhenGatewayAccountNotFound() {
+        givenSetup()
+                .get("/v1/api/accounts/1337/stripe-account")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void getStripeAccountReturnsNotFoundResponseWhenGatewayAccountIsNotStripe() {
+        DatabaseFixtures.TestAccount testAccount = databaseFixtures
+                .aTestAccount()
+                .withPaymentProvider("sandbox")
+                .withCredentials(Collections.singletonMap("stripe_account_id", STRIPE_ACCOUNT_ID))
+                .insert();
+
+        givenSetup()
+                .get("/v1/api/accounts/" + testAccount.getAccountId() + "/stripe-account")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void getStripeAccountReturnsNotFoundResponseWhenGatewayAccountCredentialsAreEmpty() {
+        DatabaseFixtures.TestAccount testAccount = databaseFixtures
+                .aTestAccount()
+                .withPaymentProvider("stripe")
+                .withCredentials(Collections.emptyMap())
+                .insert();
+
+        givenSetup()
+                .get("/v1/api/accounts/" + testAccount.getAccountId() + "/stripe-account")
+                .then()
+                .statusCode(404);
+    }
+
+}


### PR DESCRIPTION
## WHAT YOU DID

Add `/v1/api/accounts/{accountId}/stripe-account` endpoint which can be used to query the `stripe_account_id` stored in `GatewayAccount` credentials.
