### PR TITLE
PP-4910 Add wallet type to Transaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/TransactionDao.java
@@ -74,7 +74,8 @@ public class TransactionDao {
                         field("amount"),
                         field("language"),
                         field("delayed_capture"),
-                        field("corporate_surcharge"))
+                        field("corporate_surcharge"),
+                        field("wallet"))
                 .from(buildQueryFor(gatewayAccountId, QueryType.SELECT, params))
                 .orderBy(field("date_created").desc());
 
@@ -209,7 +210,8 @@ public class TransactionDao {
                 field("c.amount"),
                 field("c.language"),
                 field("c.delayed_capture"),
-                field("c.corporate_surcharge"))
+                field("c.corporate_surcharge"),
+                field("c.wallet"))
                 .from(table("charges").as("c").leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))
                 .where(queryFiltersForCharges);
 
@@ -240,7 +242,8 @@ public class TransactionDao {
                 field("r.amount"),
                 field("c.language"),
                 field("c.delayed_capture"),
-                field("c.corporate_surcharge"))
+                field("c.corporate_surcharge"),
+                field("c.wallet"))
                 .from(table("charges").as("c").leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))
                 .join(table("refunds").as("r"))
                 .on(field("c.id").eq(field("r.charge_id")))

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Transaction.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Transaction.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumberConverter;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import javax.persistence.ColumnResult;
 import javax.persistence.ConstructorResult;
@@ -50,7 +51,8 @@ import java.util.Optional;
                         @ColumnResult(name = "amount", type = Long.class),
                         @ColumnResult(name = "language", type = String.class),
                         @ColumnResult(name = "delayed_capture", type = Boolean.class),
-                        @ColumnResult(name = "corporate_surcharge", type = Long.class)}))
+                        @ColumnResult(name = "corporate_surcharge", type = Long.class),
+                        @ColumnResult(name = "wallet", type = String.class)}))
 @Entity
 @ReadOnly
 public class Transaction {
@@ -87,6 +89,7 @@ public class Transaction {
     private String addressPostcode;
     private long amount;
     private Long corporateSurcharge;
+    private WalletType walletType;
 
     public Transaction() {
     }
@@ -117,7 +120,8 @@ public class Transaction {
                        long amount,
                        String language,
                        boolean delayedCapture,
-                       Long corporateSurcharge) {
+                       Long corporateSurcharge,
+                       String walletType) {
         this.chargeId = chargeId;
         this.externalId = externalId;
         this.reference = reference;
@@ -145,6 +149,7 @@ public class Transaction {
         this.language = SupportedLanguage.fromIso639AlphaTwoCode(language);
         this.delayedCapture = delayedCapture;
         this.corporateSurcharge = corporateSurcharge;
+        this.walletType = walletType == null ? null : WalletType.valueOf(walletType);
     }
 
     public Long getChargeId() {
@@ -253,5 +258,9 @@ public class Transaction {
 
     public Optional<Long> getCorporateCardSurcharge() {
         return Optional.ofNullable(corporateSurcharge);
+    }
+
+    public WalletType getWalletType() {
+        return walletType;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/TransactionSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/TransactionSearchStrategy.java
@@ -82,7 +82,8 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
                         .build(transaction.getGatewayAccountId(), transaction.getExternalId()))
                 .withLink("refunds", GET, uriInfo.getBaseUriBuilder()
                         .path("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds")
-                        .build(transaction.getGatewayAccountId(), transaction.getExternalId()));
+                        .build(transaction.getGatewayAccountId(), transaction.getExternalId()))
+                .withWalletType(transaction.getWalletType());
 
         if (ChargeStatus.AWAITING_CAPTURE_REQUEST.getValue().equals(transaction.getStatus())) {
             transactionResponseBuilder

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -471,6 +472,7 @@ public class  DatabaseFixtures {
 
         TestAccount testAccount;
         TestCardDetails cardDetails;
+        WalletType walletType;
 
         public TestCardDetails getCardDetails() {
             return cardDetails;

--- a/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.charge.model.domain.TransactionType;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures.TestCharge;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.DateTimeUtils;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -154,6 +155,20 @@ public class TransactionDaoITest extends DaoITestBase {
         assertThat(transactions.get(1).getAmount(), is(testCharge.getAmount()));
         assertThat(transactions.get(1).getTransactionType(), is(TransactionType.CHARGE));
         assertThat(transactions.get(1).getUserExternalId(), is(nullValue()));
+    }
+    
+    @Test
+    public void shouldReturnWalletType() {
+        TestCharge testCharge = withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .insert();
+        databaseTestHelper.addWalletType(testCharge.getChargeId(), WalletType.APPLE_PAY);
+        
+
+        List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), new SearchParams());
+        assertThat(transactions.get(0).getWalletType(), is(WalletType.APPLE_PAY));
+        
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -261,7 +261,24 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturnWalletTypeAsNullWhenNull() {
+    public void shouldReturnWalletTypeWhenNotNull_v2() {
+        long chargeId = nextInt();
+        String externalChargeId = RandomIdGenerator.newId();
+
+        createCharge(externalChargeId, chargeId);
+        databaseTestHelper.addWalletType(chargeId, WalletType.APPLE_PAY);
+
+        connectorRestApiClient
+                .withAccountId(accountId)
+                .getChargesV2()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("results[0].charge_id", is(externalChargeId))
+                .body("results[0].wallet_type", is(WalletType.APPLE_PAY.toString()));
+    }
+
+    @Test
+    public void shouldNotReturnWalletTypeWhenNull() {
         long chargeId = nextInt();
         String externalChargeId = RandomIdGenerator.newId();
 


### PR DESCRIPTION
- Add wallet type to `Transaction`, `TransactionDao` and associated tests. This
will return `wallet_type` in the response to `v2/api/accounts/{accountsId}/charges`
when the charge is a wallet payment.



N.B. `databaseTestHelper.addCharge()` warrants refactoring to remove the many overloaded methods with vast lists of arguments. I'll do this afterwards rather than mix with this PR and hold up progress (thus this makes do with existing patterns).