### PR TITLE
PP-4653: Card holder name and email validation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -62,7 +62,8 @@ public class CardResource {
     @Path("/v1/frontend/charges/{chargeId}/wallets/apple")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public Response authoriseCharge(@PathParam("chargeId") String chargeId, ApplePayAuthRequest applePayAuthRequest) {
+    public Response authoriseCharge(@PathParam("chargeId") String chargeId, 
+                                    @NotNull @Valid ApplePayAuthRequest applePayAuthRequest) {
         logger.info("Received encrypted payload for charge with id {} ", chargeId);
         return applePayService.authorise(chargeId, applePayAuthRequest);
     }

--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
@@ -6,9 +6,12 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
 import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class ApplePayAuthRequest implements WalletAuthorisationRequest {
-    private WalletPaymentInfo paymentInfo;
+    @NotNull @Valid private WalletPaymentInfo paymentInfo;
     private EncryptedPaymentData encryptedPaymentData;
 
     @JsonProperty("payment_info")

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.wallets.model;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -10,7 +11,9 @@ public class WalletPaymentInfo {
     private String lastDigitsCardNumber;
     private String brand;
     private PayersCardType cardType;
+    @Length(max = 255, message = "Card holder name must be a maximum of 255 chars") 
     private String cardholderName;
+    @Length(max = 254, message = "Email must be a maximum of 254 chars")
     private String email;
 
     public WalletPaymentInfo() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayITest.java
@@ -1,0 +1,118 @@
+package uk.gov.pay.connector.it.resources;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class CardResourceAuthoriseApplePayITest extends ChargingITestBase {
+
+    private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+    
+    public CardResourceAuthoriseApplePayITest() {
+        super("sandbox");
+    }
+
+    @Before
+    public void setUp() {
+        Logger root = (Logger) LoggerFactory.getLogger(CardResource.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+    
+    @Test
+    public void shouldAuthoriseCharge_ForApplePay() {
+        shouldAuthoriseChargeForApplePay("mr payment", "mr@payment.test");
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(true));
+    }
+
+    @Test
+    public void shouldAuthoriseCharge_ForApplePay_withMinData() {
+        shouldAuthoriseChargeForApplePay(null, null);
+    }
+
+    private String shouldAuthoriseChargeForApplePay(String cardHolderName, String email) {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+
+        givenSetup()
+                .body(buildJsonApplePayAuthorisationDetails(cardHolderName, email))
+                .post(authoriseChargeUrlForApplePay(chargeId))
+                .then()
+                .statusCode(200);
+
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
+        Map<String, Object> charge = databaseTestHelper.getChargeByExternalId(chargeId);
+        assertThat(charge.get("email"), is(email));
+        return chargeId;
+    }
+
+    @Test
+    public void tooLongCardHolderName_shouldResultInBadRequest() {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        String payload = buildJsonApplePayAuthorisationDetails(
+                "tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars " +
+                        "12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12",
+                "mr@payment.test");
+
+        givenSetup()
+                .body(payload)
+                .post(authoriseChargeUrlForApplePay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("message", contains("Card holder name must be a maximum of 255 chars"));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+
+    @Test
+    public void tooLongEmail_shouldResultInBadRequest() {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        String payload = buildJsonApplePayAuthorisationDetails("Example Name",
+                "tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars@" +
+                        "12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12");
+
+        givenSetup()
+                .body(payload)
+                .post(authoriseChargeUrlForApplePay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("message", contains("Email must be a maximum of 254 chars"));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayITest.java
@@ -1,0 +1,114 @@
+package uk.gov.pay.connector.it.resources;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import com.amazonaws.util.json.Jackson;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
+
+    private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+    
+    public CardResourceAuthoriseGooglePayITest() {
+        super("sandbox");
+    }
+
+    @Before
+    public void setUp() {
+        Logger root = (Logger) LoggerFactory.getLogger(CardResource.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+    
+    @Test
+    public void authoriseChargeSuccess() throws IOException {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(fixture("googlepay/example-auth-request.json"));
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePay(chargeId))
+                .then()
+                .statusCode(200);
+
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
+        Map<String, Object> charge = databaseTestHelper.getChargeByExternalId(chargeId);
+        assertThat(charge.get("email"), is(googlePayload.get("payment_info").get("email").asText()));
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(true));
+    }
+
+    @Test
+    public void tooLongCardHolderName_shouldResultInBadRequest() throws Exception {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        String payload = fixture("googlepay/example-auth-request.json").replace("Example Name", 
+                "tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars " +
+                        "12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12");
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(payload);
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("message", contains("Card holder name must be a maximum of 255 chars"));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+
+    @Test
+    public void tooLongEmail_shouldResultInBadRequest() throws Exception {
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        String payload = fixture("googlepay/example-auth-request.json").replace("example@test.example",
+                "tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars@" +
+                        "12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12");
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(payload);
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePay(chargeId))
+                .then()
+                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .body("message", contains("Email must be a maximum of 254 chars"));
+
+        verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(false));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class GooglePayAuthRequestTest {
 
-
     @Test
     public void shouldDeserializeFromJsonCorrectly() throws IOException {
         ObjectMapper objectMapper = Jackson.getObjectMapper();


### PR DESCRIPTION
These must be validated before being passed to worldpay, lest we end up in a
situation where worldpay processes the payment, but connector throws an
error due to the card holder name and/or being over 255 characters limit as
specified in the database.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
