### PR TITLE
PP-4819: Only allow enable digital wallet for supported gateway

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/DigitalWalletNotSupportedGatewayException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/DigitalWalletNotSupportedGatewayException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import uk.gov.pay.connector.util.ResponseUtil;
+
+import javax.ws.rs.BadRequestException;
+
+public class DigitalWalletNotSupportedGatewayException extends BadRequestException {
+    public DigitalWalletNotSupportedGatewayException(){
+        super(ResponseUtil.badRequestResponse(("This gateway does not support digital wallets.")));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/DigitalWalletNotSupportedGatewayException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/DigitalWalletNotSupportedGatewayException.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.util.ResponseUtil;
 import javax.ws.rs.BadRequestException;
 
 public class DigitalWalletNotSupportedGatewayException extends BadRequestException {
-    public DigitalWalletNotSupportedGatewayException(){
-        super(ResponseUtil.badRequestResponse(("This gateway does not support digital wallets.")));
+    public DigitalWalletNotSupportedGatewayException(String gatewayName){
+        super(ResponseUtil.badRequestResponse((String.format("Gateway %s does not support digital wallets.", gatewayName))));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -129,7 +129,7 @@ public class GatewayAccountService {
 
     private void throwIfNotDigitalWalletSupportedGateway(GatewayAccountEntity gatewayAccountEntity) {
         if (!PaymentGatewayName.WORLDPAY.getName().equals(gatewayAccountEntity.getGatewayName())) {
-            throw new DigitalWalletNotSupportedGatewayException();
+            throw new DigitalWalletNotSupportedGatewayException(gatewayAccountEntity.getGatewayName());
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
@@ -93,6 +93,20 @@ public class ChargesApiResourceAllowWebPaymentsITest {
                 .body("message", is("Account Credentials are required to set a Gateway Merchant ID"))
                 .and()
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
+    }    
+    @Test
+    public void assertBadRequestResponseIfPatchingDigitalWalletWithNonSupportedGateway() throws JsonProcessingException {
+        String accountIdWithNotDigitalWalletSupportedGateway = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "epdq"));
+        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+                "path", "allow_apple_pay",
+                "value", "true"));
+        given().port(testContext.getPort()).contentType(JSON)
+                .body(payload)
+                .patch("/v1/api/accounts/" + accountIdWithNotDigitalWalletSupportedGateway)
+                .then()
+                .body("message", is("This gateway does not support digital wallets."))
+                .and()
+                .statusCode(HttpStatus.SC_BAD_REQUEST);
     }
 
     private void allowWebPaymentsOnGatewayAccount(String path) throws JsonProcessingException {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
@@ -104,7 +104,7 @@ public class ChargesApiResourceAllowWebPaymentsITest {
                 .body(payload)
                 .patch("/v1/api/accounts/" + accountIdWithNotDigitalWalletSupportedGateway)
                 .then()
-                .body("message", is("This gateway does not support digital wallets."))
+                .body("message", is("Gateway epdq does not support digital wallets."))
                 .and()
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
     }


### PR DESCRIPTION
## WHAT YOU DID
Restrict enabling of digital wallet to supported gateway

## How to test
PATCH to `allow_apple_pay` or `allow_google_pay` should fail if non supported gateway 