### PR TITLE
PP-4926 deprecate service name and service name patch endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -94,6 +94,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Convert(converter = CredentialsConverter.class)
     private Map<String, String> credentials;
 
+    @Deprecated
     @Column(name = "service_name")
     private String serviceName;
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -267,6 +267,7 @@ public class GatewayAccountResource {
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
     @Transactional
+    @Deprecated
     public Response updateGatewayAccountServiceName(@PathParam("accountId") Long gatewayAccountId, Map<String, String> gatewayAccountPayload) {
         if (!gatewayAccountPayload.containsKey(SERVICE_NAME_FIELD_NAME)) {
             return fieldsMissingResponse(Collections.singletonList(SERVICE_NAME_FIELD_NAME));


### PR DESCRIPTION
## WHAT YOU DID
- service name is before the times of the concept of service was introduced in adminusers. We no longer use this field and keeping it in sync with the source of truth (adminusers) is a costly and messy operation.

## How to test

This PR only adds `@Deprecated` tag to the code
