### PR TITLE
PP-4735 Context Only / Relative URI for pagination links

### DIFF
--- a/src/test/java/uk/gov/pay/connector/common/service/PaginationResponseBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/service/PaginationResponseBuilderTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.common.service;
 
 import com.jayway.jsonassert.JsonAssert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -22,15 +23,11 @@ public class PaginationResponseBuilderTest {
 
     @Mock
     private UriInfo mockUriInfo;
+    private SearchParams searchParams;
 
-    @Test
-    public void shouldBuildChargesPaginationWithExpectedHalResponseLinks() {
-
-        // Only tests hal properties and _links,
-        // pending work to convert charge responses in _embedded entities.
-
-        // given
-        SearchParams searchParams = new SearchParams()
+    @Before
+    public void setUp() {
+        searchParams = new SearchParams()
                 .withGatewayAccountId(1L)
                 .withExternalState(ExternalChargeState.EXTERNAL_STARTED.getStatus())
                 .withDisplaySize(100L)
@@ -39,7 +36,14 @@ public class PaginationResponseBuilderTest {
         when(mockUriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://app.com"),
                 UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"),
                 UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"));
+    }
 
+    @Test
+    public void shouldBuildChargesPaginationWithExpectedHalResponseLinks() {
+        // Only tests hal properties and _links,
+        // pending work to convert charge responses in _embedded entities.
+
+        //given
         when(mockUriInfo.getPath()).thenReturn("/v1/api/accounts/1/charges");
 
         // when
@@ -58,6 +62,31 @@ public class PaginationResponseBuilderTest {
                 .assertThat("$._links.last_page.href", is("http://app.com/v1/api/accounts/1/charges?page=5&display_size=100&state=started"))
                 .assertThat("$._links.first_page.href", is("http://app.com/v1/api/accounts/1/charges?page=1&display_size=100&state=started"))
                 .assertThat("$._links.self.href", is("http://app.com/v1/api/accounts/1/charges?page=2&display_size=100&state=started"))
+                .assertThat("$.results.*", hasSize(0));
+    }
+
+    @Test
+    public void shouldBuildV2ChargesPaginationWithContextOnlyLinks() {
+
+        // given
+        when(mockUriInfo.getPath()).thenReturn("/v2/api/accounts/1/charges");
+
+        // when
+        Response response = new PaginationResponseBuilder(searchParams, mockUriInfo)
+                .withResponses(newArrayList())
+                .withTotalCount(500L)
+                .buildResponse();
+
+        // then
+        JsonAssert.with((String) response.getEntity())
+                .assertThat("$.total", is(500))
+                .assertThat("$.count", is(0))
+                .assertThat("$.page", is(2))
+                .assertThat("$._links.next_page.href", is("/v2/api/accounts/1/charges?page=3&display_size=100&state=started"))
+                .assertThat("$._links.prev_page.href", is("/v2/api/accounts/1/charges?page=1&display_size=100&state=started"))
+                .assertThat("$._links.last_page.href", is("/v2/api/accounts/1/charges?page=5&display_size=100&state=started"))
+                .assertThat("$._links.first_page.href", is("/v2/api/accounts/1/charges?page=1&display_size=100&state=started"))
+                .assertThat("$._links.self.href", is("/v2/api/accounts/1/charges?page=2&display_size=100&state=started"))
                 .assertThat("$.results.*", hasSize(0));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
@@ -304,8 +304,7 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
     }
 
     private String expectedChargesLocationFor(String accountId, String queryParams) {
-        return "https://localhost:" + testContext.getPort()
-                + "/v2/api/accounts/{accountId}/charges".replace("{accountId}", accountId)
+        return "/v2/api/accounts/{accountId}/charges".replace("{accountId}", accountId)
                 + queryParams;
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Changes full URLs for pagination to relative links for endpoint `/v2/api/accounts` ( which is used by selfservice to download transactions ) as full URLs are generated with incorrect port number
- Selfservice can resolve relative URLs as it has knowledge of connector URL (https://github.com/alphagov/pay-selfservice/pull/1265)

_**Note:**_
- All pagination links generated by connector are using `UriInfo` which means links are all generated with incorrect port number. But URLs are probably not actively used or transformed (publicapi transforms URLs to publicapi's baseURL and selfservice web pages uses baseUrl to start journey to connector except while downloading transactions)


## How to test
- All tests should pass
- Any suggestions to how the solution can be better?
