### PR TITLE
PP-4949 Change stripe account setup task enum

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetup.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetup.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -15,9 +14,9 @@ public class StripeAccountSetup {
     @JsonProperty("responsible_person")
     private boolean responsiblePersonCompleted = false;
 
-    @JsonProperty("organisation_details")
-    private boolean organisationDetailsCompleted = false;
-    
+    @JsonProperty("vat_number_company_number")
+    private boolean vatNumberCompanyNumberCompleted = false;
+
     public boolean isBankAccountCompleted() {
         return bankAccountCompleted;
     }
@@ -34,12 +33,12 @@ public class StripeAccountSetup {
         this.responsiblePersonCompleted = responsiblePersonCompleted;
     }
 
-    public boolean isOrganisationDetailsCompleted() {
-        return organisationDetailsCompleted;
+    public boolean isVatNumberCompanyNumberCompleted() {
+        return vatNumberCompanyNumberCompleted;
     }
 
-    public void setOrganisationDetailsCompleted(boolean organisationDetailsCompleted) {
-        this.organisationDetailsCompleted = organisationDetailsCompleted;
+    public void setVatNumberCompanyNumberCompleted(boolean vatNumberCompanyNumberCompleted) {
+        this.vatNumberCompanyNumberCompleted = vatNumberCompanyNumberCompleted;
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
@@ -4,8 +4,6 @@ public enum StripeAccountSetupTask {
 
     BANK_ACCOUNT,
     RESPONSIBLE_PERSON,
-    @Deprecated
-    ORGANISATION_DETAILS,
     VAT_NUMBER_COMPANY_NUMBER
 
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
@@ -4,6 +4,8 @@ public enum StripeAccountSetupTask {
 
     BANK_ACCOUNT,
     RESPONSIBLE_PERSON,
-    ORGANISATION_DETAILS
+    @Deprecated
+    ORGANISATION_DETAILS,
+    VAT_NUMBER_COMPANY_NUMBER
 
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
@@ -32,7 +32,7 @@ public class StripeAccountSetupService {
                             stripeAccountSetup.setResponsiblePersonCompleted(true);
                             break;
                         case VAT_NUMBER_COMPANY_NUMBER:
-                            stripeAccountSetup.setOrganisationDetailsCompleted(true);
+                            stripeAccountSetup.setVatNumberCompanyNumberCompleted(true);
                             break;
                         default:
                             // Code doesn’t handle this task

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
@@ -31,7 +31,7 @@ public class StripeAccountSetupService {
                         case RESPONSIBLE_PERSON:
                             stripeAccountSetup.setResponsiblePersonCompleted(true);
                             break;
-                        case ORGANISATION_DETAILS:
+                        case VAT_NUMBER_COMPANY_NUMBER:
                             stripeAccountSetup.setOrganisationDetailsCompleted(true);
                             break;
                         default:

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
@@ -17,7 +17,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 
 public class StripeAccountSetupRequestValidatorTest {
-    
+
     private final StripeAccountSetupRequestValidator validator = new StripeAccountSetupRequestValidator(new RequestValidator());
 
     @Rule
@@ -29,7 +29,7 @@ public class StripeAccountSetupRequestValidatorTest {
                 "op", "replace",
                 "path", "bank_account",
                 "value", true)));
-        
+
         validator.validatePatchRequest(jsonNode);
     }
 
@@ -54,6 +54,36 @@ public class StripeAccountSetupRequestValidatorTest {
     }
 
     @Test
+    public void replaceResponsiblePersonFalseIsValid() {
+        JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
+                "op", "replace",
+                "path", "responsible_person",
+                "value", false)));
+
+        validator.validatePatchRequest(jsonNode);
+    }
+
+    @Test
+    public void replaceVatNumberCompanyNumberTrueIsValid() {
+        JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
+                "op", "replace",
+                "path", "vat_number_company_number",
+                "value", true)));
+
+        validator.validatePatchRequest(jsonNode);
+    }
+
+    @Test
+    public void replaceVatNumberCompanyNumberFalseIsValid() {
+        JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
+                "op", "replace",
+                "path", "vat_number_company_number",
+                "value", false)));
+
+        validator.validatePatchRequest(jsonNode);
+    }
+
+    @Test
     public void multipleUpdatesAreValid() {
         JsonNode jsonNode = new ObjectMapper().valueToTree(Arrays.asList(
                 ImmutableMap.of(
@@ -66,40 +96,9 @@ public class StripeAccountSetupRequestValidatorTest {
                         "value", false),
                 ImmutableMap.of(
                         "op", "replace",
-                        "path", "organisation_details",
+                        "path", "vat_number_company_number",
                         "value", true)
-                ));
-
-        validator.validatePatchRequest(jsonNode);
-
-    }
-
-    @Test
-    public void replaceResponsiblePersonFalseIsValid() {
-        JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
-                "op", "replace",
-                "path", "responsible_person",
-                "value", false)));
-
-        validator.validatePatchRequest(jsonNode);
-    }
-
-    @Test
-    public void replaceOrganisationDetailsTrueIsValid() {
-        JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
-                "op", "replace",
-                "path", "organisation_details",
-                "value", true)));
-
-        validator.validatePatchRequest(jsonNode);
-    }
-
-    @Test
-    public void replaceOrganisationDetailsFalseIsValid() {
-        JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
-                "op", "replace",
-                "path", "organisation_details",
-                "value", false)));
+        ));
 
         validator.validatePatchRequest(jsonNode);
     }
@@ -113,7 +112,7 @@ public class StripeAccountSetupRequestValidatorTest {
 
         expectedException.expect(ValidationException.class);
         expectedException.expect(hasProperty("errors", contains("Operation [add] not supported for path [bank_account]")));
-        
+
         validator.validatePatchRequest(jsonNode);
     }
 
@@ -177,7 +176,7 @@ public class StripeAccountSetupRequestValidatorTest {
                 "value", true)));
 
         expectedException.expect(ValidationException.class);
-        expectedException.expect(hasProperty("errors", contains("Field [path] must be one of [bank_account, organisation_details, responsible_person]")));
+        expectedException.expect(hasProperty("errors", contains("Field [path] must be one of [bank_account, responsible_person, vat_number_company_number]")));
 
         validator.validatePatchRequest(jsonNode);
     }
@@ -233,7 +232,7 @@ public class StripeAccountSetupRequestValidatorTest {
 
         validator.validatePatchRequest(jsonNode);
     }
-    
+
     @Test
     public void valueIsNotBooleanIsInvalid() {
         JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
@@ -246,7 +245,7 @@ public class StripeAccountSetupRequestValidatorTest {
 
         validator.validatePatchRequest(jsonNode);
     }
-    
+
     @Test
     public void valueIsNullIsInvalid() {
         JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(new HashMap<String, Object>() {{

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
@@ -25,7 +25,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.BANK_ACCOUNT;
-import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.ORGANISATION_DETAILS;
+import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.RESPONSIBLE_PERSON;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -54,7 +54,7 @@ public class StripeAccountSetupServiceTest {
 
         given(mockBankDetailsCompletedTaskEntity.getTask()).willReturn(BANK_ACCOUNT);
         given(mockResponsiblePersonCompletedTaskEntity.getTask()).willReturn(StripeAccountSetupTask.RESPONSIBLE_PERSON);
-        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(StripeAccountSetupTask.ORGANISATION_DETAILS);
+        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER);
 
         this.stripeAccountSetupService = new StripeAccountSetupService(mockStripeAccountSetupDao);
     }
@@ -137,11 +137,11 @@ public class StripeAccountSetupServiceTest {
         List<StripeAccountSetupUpdateRequest> patchRequests = Arrays.asList(
                 new StripeAccountSetupUpdateRequest(BANK_ACCOUNT, true),
                 new StripeAccountSetupUpdateRequest(RESPONSIBLE_PERSON, true),
-                new StripeAccountSetupUpdateRequest(ORGANISATION_DETAILS, true));
+                new StripeAccountSetupUpdateRequest(VAT_NUMBER_COMPANY_NUMBER, true));
 
         given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, BANK_ACCOUNT)).willReturn(false);
         given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, RESPONSIBLE_PERSON)).willReturn(false);
-        given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, ORGANISATION_DETAILS)).willReturn(false);
+        given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, VAT_NUMBER_COMPANY_NUMBER)).willReturn(false);
 
         stripeAccountSetupService.update(mockGatewayAccountEntity, patchRequests);
 
@@ -159,6 +159,6 @@ public class StripeAccountSetupServiceTest {
         assertThat(entities.get(1).getTask(), is(RESPONSIBLE_PERSON));
 
         assertThat(entities.get(2).getGatewayAccount(), is(mockGatewayAccountEntity));
-        assertThat(entities.get(2).getTask(), is(ORGANISATION_DETAILS));
+        assertThat(entities.get(2).getTask(), is(VAT_NUMBER_COMPANY_NUMBER));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.BANK_ACCOUNT;
-import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.RESPONSIBLE_PERSON;
+import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeAccountSetupServiceTest {
@@ -68,7 +68,7 @@ public class StripeAccountSetupServiceTest {
 
         assertThat(tasks.isBankAccountCompleted(), is(false));
         assertThat(tasks.isResponsiblePersonCompleted(), is(false));
-        assertThat(tasks.isOrganisationDetailsCompleted(), is(false));
+        assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(false));
     }
 
     @Test
@@ -81,7 +81,7 @@ public class StripeAccountSetupServiceTest {
 
         assertThat(tasks.isBankAccountCompleted(), is(true));
         assertThat(tasks.isResponsiblePersonCompleted(), is(true));
-        assertThat(tasks.isOrganisationDetailsCompleted(), is(true));
+        assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(true));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class StripeAccountSetupServiceTest {
 
         assertThat(tasks.isBankAccountCompleted(), is(false));
         assertThat(tasks.isResponsiblePersonCompleted(), is(true));
-        assertThat(tasks.isOrganisationDetailsCompleted(), is(true));
+        assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/StripeAccountSetupDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/StripeAccountSetupDaoITest.java
@@ -15,7 +15,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.BANK_ACCOUNT;
-import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.ORGANISATION_DETAILS;
+import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.RESPONSIBLE_PERSON;
 
 public class StripeAccountSetupDaoITest extends DaoITestBase {
@@ -42,7 +42,7 @@ public class StripeAccountSetupDaoITest extends DaoITestBase {
         databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, BANK_ACCOUNT);
         databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, RESPONSIBLE_PERSON);
         databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, BANK_ACCOUNT);
-        databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, ORGANISATION_DETAILS);
+        databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, VAT_NUMBER_COMPANY_NUMBER);
 
         List<StripeAccountSetupTaskEntity> tasks = stripeAccountSetupDao.findByGatewayAccountId(gatewayAccountId);
         assertThat(tasks, hasSize(2));

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
@@ -40,10 +40,10 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
     }
 
     @Test
-    public void getStripeSetupWithSomeTasksCompletedReturnsAppopriateFlags() {
+    public void getStripeSetupWithSomeTasksCompletedReturnsAppropriateFlags() {
         long gatewayAccountId = Long.valueOf(createAGatewayAccountFor("stripe"));
         addCompletedTask(gatewayAccountId, StripeAccountSetupTask.BANK_ACCOUNT);
-        addCompletedTask(gatewayAccountId, StripeAccountSetupTask.ORGANISATION_DETAILS);
+        addCompletedTask(gatewayAccountId, StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER);
 
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
@@ -21,7 +21,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestBase {
- 
+
     protected RequestSpecification givenSetup() {
         return given().port(testContext.getPort()).contentType(JSON);
     }
@@ -36,7 +36,7 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
                 .statusCode(200)
                 .body("bank_account", is(false))
                 .body("responsible_person", is(false))
-                .body("organisation_details", is(false));
+                .body("vat_number_company_number", is(false));
     }
 
     @Test
@@ -51,13 +51,13 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
                 .statusCode(200)
                 .body("bank_account", is(true))
                 .body("responsible_person", is(false))
-                .body("organisation_details", is(true));
+                .body("vat_number_company_number", is(true));
     }
 
     @Test
     public void getStripeSetupGatewayAccountDoesNotExist() {
         long notFoundGatewayAccountId = 13;
-        
+
         givenSetup()
                 .get("/v1/api/accounts/" + notFoundGatewayAccountId + "/stripe-setup")
                 .then()
@@ -91,7 +91,7 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
                 .statusCode(200)
                 .body("bank_account", is(true))
                 .body("responsible_person", is(false))
-                .body("organisation_details", is(false));
+                .body("vat_number_company_number", is(false));
     }
 
     @Test
@@ -109,7 +109,7 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
                                 "value", true),
                         ImmutableMap.of(
                                 "op", "replace",
-                                "path", "organisation_details",
+                                "path", "vat_number_company_number",
                                 "value", true)
                 )))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
@@ -122,7 +122,7 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
                 .statusCode(200)
                 .body("bank_account", is(true))
                 .body("responsible_person", is(true))
-                .body("organisation_details", is(true));
+                .body("vat_number_company_number", is(true));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID

This PR contains changes related to StripeAccountSetupTask enum, it renames `ORGANISATION_DETAILS` to `VAT_NUMBER_COMPANY_NUMBER`

Currently, `ORGANISATION_DETAILS` is not in use and can be renamed safely without backward compatibility, except the Pact tests which were ignored temporary in https://github.com/alphagov/pay-selfservice/pull/1275