### PR TITLE
PP-4758: Differentiate between 4xx and 5xx exception

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayErrorException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayErrorException.java
@@ -33,18 +33,18 @@ public abstract class GatewayErrorException extends Exception {
         }
     }
 
-    public static class GatewayConnectionErrorException extends GatewayErrorException {
+    public static class ClientErrorException extends GatewayErrorException {
 
         private final String responseFromGateway;
 
-        public GatewayConnectionErrorException(String message, String responseFromGateway) {
+        public ClientErrorException(String message, String responseFromGateway) {
             super(message);
             this.responseFromGateway = responseFromGateway;
         }
 
-        public GatewayConnectionErrorException(String message) {
+        public ClientErrorException(String message) {
             super(message);
-            this.responseFromGateway = "null";
+            responseFromGateway = "null";
         }
 
         public String getResponseFromGateway() {
@@ -52,7 +52,30 @@ public abstract class GatewayErrorException extends Exception {
         }
 
         public GatewayError toGatewayError() {
-            return new GatewayError(getMessage(), ErrorType.GATEWAY_CONNECTION_ERROR);
+            return new GatewayError(getMessage(), ErrorType.CLIENT_ERROR);
+        }
+    }
+
+    public static class DownstreamErrorException extends GatewayErrorException {
+
+        private final String responseFromGateway;
+
+        public DownstreamErrorException(String message, String responseFromGateway) {
+            super(message);
+            this.responseFromGateway = responseFromGateway;
+        }
+
+        public DownstreamErrorException(String message) {
+            super(message);
+            responseFromGateway = "null";
+        }
+
+        public String getResponseFromGateway() {
+            return responseFromGateway;
+        }
+
+        public GatewayError toGatewayError() {
+            return new GatewayError(getMessage(), ErrorType.DOWNSTREAM_ERROR);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayResponseUnmarshaller.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayResponseUnmarshaller.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshallerException;
 
@@ -12,7 +12,7 @@ public class GatewayResponseUnmarshaller {
 
     private static final Logger logger = LoggerFactory.getLogger(GatewayResponseUnmarshaller.class);
     
-    public static <T> T unmarshallResponse(GatewayClient.Response response, Class<T> unmarshallingTarget) throws GatewayConnectionErrorException {
+    public static <T> T unmarshallResponse(GatewayClient.Response response, Class<T> unmarshallingTarget) throws GenericGatewayErrorException {
         String payload = response.getEntity();
         logger.debug("response payload={}", payload);
         try {
@@ -20,7 +20,7 @@ public class GatewayResponseUnmarshaller {
         } catch (XMLUnmarshallerException e) {
             String error = format("Could not unmarshall response %s.", payload);
             logger.error(error, e);
-            throw new GatewayConnectionErrorException("Invalid Response Received From Gateway");
+            throw new GenericGatewayErrorException("Invalid Response Received From Gateway");
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -12,7 +12,6 @@ import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
@@ -125,13 +124,13 @@ public class EpdqPaymentProvider implements PaymentProvider {
         return getEpdqGatewayResponse(response, EpdqAuthorisationResponse.class);
     }
 
-    private static GatewayResponse getEpdqGatewayResponse(GatewayClient.Response response, Class<? extends BaseResponse> responseClass) throws GatewayConnectionErrorException {
+    private static GatewayResponse getEpdqGatewayResponse(GatewayClient.Response response, Class<? extends BaseResponse> responseClass) throws GenericGatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, responseClass));
         return responseBuilder.build();
     }
     
-    private static GatewayResponse getUninterpretedEpdqGatewayResponse(GatewayClient.Response response, Class<? extends BaseResponse> responseClass) throws GatewayConnectionErrorException {
+    private static GatewayResponse getUninterpretedEpdqGatewayResponse(GatewayClient.Response response, Class<? extends BaseResponse> responseClass) throws GenericGatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, responseClass));
         return responseBuilder.buildUninterpreted();

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -1,9 +1,7 @@
 package uk.gov.pay.connector.gateway.epdq;
 
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionTimeoutErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.RefundHandler;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
@@ -43,7 +41,7 @@ public class EpdqRefundHandler implements RefundHandler {
                     buildRefundOrder(request),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, EpdqRefundResponse.class), PENDING);
-        } catch (GenericGatewayErrorException | GatewayConnectionTimeoutErrorException | GatewayConnectionErrorException e) {
+        } catch (GatewayErrorException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/ErrorType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/ErrorType.java
@@ -3,5 +3,6 @@ package uk.gov.pay.connector.gateway.model;
 public enum ErrorType {
     GENERIC_GATEWAY_ERROR,
     GATEWAY_CONNECTION_TIMEOUT_ERROR,
-    GATEWAY_CONNECTION_ERROR
+    CLIENT_ERROR,
+    DOWNSTREAM_ERROR
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/GatewayError.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/GatewayError.java
@@ -7,9 +7,10 @@ import uk.gov.pay.connector.gateway.stripe.GatewayException;
 import java.net.SocketTimeoutException;
 
 import static java.lang.String.format;
+import static uk.gov.pay.connector.gateway.model.ErrorType.DOWNSTREAM_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
 
 public class GatewayError {
     private String message;
@@ -22,8 +23,12 @@ public class GatewayError {
         this.errorType = errorType;
     }
 
-    public static GatewayError gatewayConnectionError(String msg) {
-        return new GatewayError(msg, GATEWAY_CONNECTION_ERROR);
+    public static GatewayError gatewayDownstreamError(String msg) {
+        return new GatewayError(msg, DOWNSTREAM_ERROR);
+    }
+
+    public static GatewayError gatewayClientError(String msg) {
+        return new GatewayError(msg, CLIENT_ERROR);
     }
 
     public static GatewayError genericGatewayError(String msg) {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -4,7 +4,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.DownstreamErrorException;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionTimeoutErrorException;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
 import uk.gov.pay.connector.gateway.model.GatewayError;
@@ -56,7 +57,8 @@ public class GatewayResponse<T extends BaseResponse> {
     public void throwGatewayError() throws GatewayErrorException {
         switch (gatewayError.getErrorType()) {
             case GENERIC_GATEWAY_ERROR: throw new GenericGatewayErrorException(gatewayError.getMessage());
-            case GATEWAY_CONNECTION_ERROR: throw new GatewayConnectionErrorException(gatewayError.getMessage());
+            case CLIENT_ERROR: throw new ClientErrorException(gatewayError.getMessage());
+            case DOWNSTREAM_ERROR: throw new DownstreamErrorException(gatewayError.getMessage());
             case GATEWAY_CONNECTION_TIMEOUT_ERROR: throw new GatewayConnectionTimeoutErrorException(gatewayError.getMessage());
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -9,7 +9,8 @@ import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.DownstreamErrorException;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionTimeoutErrorException;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -81,7 +82,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
         return getSmartpayGatewayResponse(response, SmartpayAuthorisationResponse.class);
     }
 
-    private static GatewayResponse getSmartpayGatewayResponse(GatewayClient.Response response, Class<? extends BaseResponse> responseClass) throws GatewayConnectionErrorException {
+    private static GatewayResponse getSmartpayGatewayResponse(GatewayClient.Response response, Class<? extends BaseResponse> responseClass) throws GenericGatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<BaseResponse> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, responseClass));
         return responseBuilder.build();
@@ -128,7 +129,8 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GenericGatewayErrorException, GatewayConnectionErrorException, GatewayConnectionTimeoutErrorException {
+    public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) 
+            throws GenericGatewayErrorException, ClientErrorException, GatewayConnectionTimeoutErrorException, DownstreamErrorException {
         GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                 request.getGatewayAccount(), buildCancelOrderFor(request),
                 getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCancelHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCancelHandler.java
@@ -26,7 +26,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static java.util.UUID.randomUUID;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
-import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
+import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayDownstreamError;
 import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getStripeAuthHeader;
 
@@ -95,7 +95,7 @@ public class StripeCancelHandler {
         } catch (DownstreamException e) {
             logger.error("Cancel failed for transaction id {}. Reason: {}. Status code from Stripe: {}. Charge External Id: {}",
                     request.getTransactionId(), e.getMessage(), e.getStatusCode(), request.getExternalChargeId());
-            GatewayError gatewayError = gatewayConnectionError("An internal server error occurred while cancelling external charge id: " + request.getExternalChargeId());
+            GatewayError gatewayError = gatewayDownstreamError("An internal server error occurred while cancelling external charge id: " + request.getExternalChargeId());
             return responseBuilder.withGatewayError(gatewayError).build();
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -26,7 +26,7 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 import static uk.gov.pay.connector.gateway.CaptureResponse.ChargeState.COMPLETE;
 import static uk.gov.pay.connector.gateway.CaptureResponse.fromBaseCaptureResponse;
-import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
+import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayDownstreamError;
 
 public class StripeCaptureHandler implements CaptureHandler {
 
@@ -81,7 +81,7 @@ public class StripeCaptureHandler implements CaptureHandler {
         } catch (DownstreamException e) {
             logger.error("Capture failed for transaction id {}. Reason: {}. Status code from Stripe: {}. Charge External Id: {}",
                     transactionId, e.getMessage(), e.getStatusCode(), request.getExternalId());
-            GatewayError gatewayError = gatewayConnectionError("An internal server error occurred when capturing charge_external_id: " + request.getExternalId());
+            GatewayError gatewayError = gatewayDownstreamError("An internal server error occurred when capturing charge_external_id: " + request.getExternalId());
             return CaptureResponse.fromGatewayError(gatewayError);
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
-import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
+import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayDownstreamError;
 import static uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse.fromBaseRefundResponse;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getStripeAuthHeader;
 
@@ -70,7 +70,7 @@ public class StripeRefundHandler {
             return GatewayRefundResponse.fromGatewayError(GatewayError.of(e));
         } catch (DownstreamException e) {
             logger.error("Refund failed for refund gateway request {}. Reason: {}. Status code from Stripe: {}.", request, e.getMessage(), e.getStatusCode());
-            GatewayError gatewayError = gatewayConnectionError("An internal server error occurred while refunding Transaction id: " + request.getTransactionId());
+            GatewayError gatewayError = gatewayDownstreamError("An internal server error occurred while refunding Transaction id: " + request.getTransactionId());
             return GatewayRefundResponse.fromGatewayError(gatewayError);
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
@@ -3,7 +3,9 @@ package uk.gov.pay.connector.gateway.worldpay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
@@ -16,11 +18,11 @@ public interface WorldpayGatewayResponseGenerator {
 
     Logger logger = LoggerFactory.getLogger(WorldpayGatewayResponseGenerator.class);
 
-    default GatewayResponse getWorldpayGatewayResponse(GatewayClient.Response response) throws GatewayConnectionErrorException {
+    default GatewayResponse getWorldpayGatewayResponse(GatewayClient.Response response) throws GenericGatewayErrorException {
         return getWorldpayGatewayResponse(response, WorldpayOrderStatusResponse.class);
     }
 
-    default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GatewayConnectionErrorException {
+    default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GenericGatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<T> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, target));
         Optional.ofNullable(response.getResponseCookies().get(WORLDPAY_MACHINE_COOKIE_NAME))

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -167,7 +167,8 @@ public class CardResource {
     private Response handleError(String chargeId, GatewayError error) {
         switch (error.getErrorType()) {
             case GATEWAY_CONNECTION_TIMEOUT_ERROR:
-            case GATEWAY_CONNECTION_ERROR:
+            case DOWNSTREAM_ERROR:
+            case CLIENT_ERROR:
                 return serviceErrorResponse(error.getMessage());
             default:
                 logger.error("Charge {}: error {}", chargeId, error.getMessage());

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -75,7 +75,8 @@ public class CardAuthoriseBaseService {
     public static ChargeStatus mapFromGatewayErrorException(GatewayErrorException e) {
         if (e instanceof GatewayErrorException.GenericGatewayErrorException) return AUTHORISATION_ERROR;
         if (e instanceof GatewayErrorException.GatewayConnectionTimeoutErrorException) return AUTHORISATION_TIMEOUT;
-        if (e instanceof GatewayErrorException.GatewayConnectionErrorException) return AUTHORISATION_UNEXPECTED_ERROR;
+        if (e instanceof GatewayErrorException.ClientErrorException) return AUTHORISATION_UNEXPECTED_ERROR;
+        if (e instanceof GatewayErrorException.DownstreamErrorException) return AUTHORISATION_UNEXPECTED_ERROR;
         throw new RuntimeException("Unrecognised GatewayErrorException instance " + e.getClass());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -10,7 +10,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.DownstreamErrorException;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -72,8 +73,11 @@ public class WalletAuthoriseService {
                 
                 logger.error("Error occurred authorising charge. Charge external id: {}; message: {}", charge.getExternalId(), e.getMessage());
                 
-                if (e instanceof GatewayConnectionErrorException) {
-                    logger.error("Response from gateway: {}", ((GatewayConnectionErrorException) e).getResponseFromGateway());
+                if (e instanceof ClientErrorException) {
+                    logger.error("Response from gateway: {}", ((ClientErrorException) e).getResponseFromGateway());
+                }
+                if (e instanceof DownstreamErrorException) {
+                    logger.error("Response from gateway: {}", ((DownstreamErrorException) e).getResponseFromGateway());
                 }
                 
                 chargeStatus = CardAuthoriseBaseService.mapFromGatewayErrorException(e);

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletService.java
@@ -53,7 +53,8 @@ public abstract class WalletService {
 
     protected Response handleError(String chargeId, GatewayError error) {
         switch (error.getErrorType()) {
-            case GATEWAY_CONNECTION_ERROR:
+            case CLIENT_ERROR:
+            case DOWNSTREAM_ERROR:
             case GATEWAY_CONNECTION_TIMEOUT_ERROR:
                 return serviceErrorResponse(error.getMessage());
             default:

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
@@ -86,13 +86,13 @@ public class EpdqCaptureHandlerTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() throws Exception {
         when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 400 from gateway"));
         
         CaptureResponse gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(gatewayResponse.isSuccessful(), is(false));
         assertThat(gatewayResponse.getError().isPresent(), is(true));
         assertThat(gatewayResponse.getError().get().getMessage(), is("Unexpected HTTP status code 400 from gateway"));
-        assertThat(gatewayResponse.getError().get().getErrorType(), is(GATEWAY_CONNECTION_ERROR));
+        assertThat(gatewayResponse.getError().get().getErrorType(), is(CLIENT_ERROR));
     }
 
     private CaptureGatewayRequest buildTestCaptureRequest() {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -58,8 +58,8 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         try {
             mockPaymentProviderResponse(400, errorAuthResponse());
             provider.authorise(buildTestAuthorisationRequest());
-        } catch (GatewayErrorException.GatewayConnectionErrorException e) {
-            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_CONNECTION_ERROR));
+        } catch (GatewayErrorException.ClientErrorException e) {
+            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.CLIENT_ERROR));
         }
     }
 
@@ -85,8 +85,8 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         try {
             mockPaymentProviderResponse(400, errorCancelResponse());
             provider.cancel(buildTestCancelRequest());
-        } catch (GatewayErrorException.GatewayConnectionErrorException e) {
-            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_CONNECTION_ERROR));
+        } catch (GatewayErrorException.ClientErrorException e) {
+            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.CLIENT_ERROR));
         }
     }
 
@@ -122,6 +122,6 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         GatewayRefundResponse response = provider.refund(buildTestRefundRequest());
         assertThat(response.isSuccessful(), is(false));
         assertThat(response.getError().isPresent(), is(true));
-        assertEquals(response.getError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_CONNECTION_ERROR));
+        assertEquals(response.getError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.CLIENT_ERROR));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -30,7 +30,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.DOWNSTREAM_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
@@ -90,7 +91,7 @@ public class StripeCancelHandlerTest {
         assertThat(gatewayResponse.isFailed(), is(true));
         assertThat(gatewayResponse.getGatewayError().isPresent(), Is.is(true));
         assertThat(gatewayResponse.getGatewayError().get().getMessage(), containsString("An internal server error occurred while cancelling external charge id: " + request.getExternalChargeId()));
-        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(GATEWAY_CONNECTION_ERROR));
+        assertThat(gatewayResponse.getGatewayError().get().getErrorType(), Is.is(DOWNSTREAM_ERROR));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -31,7 +31,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.DOWNSTREAM_ERROR;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
@@ -109,7 +110,7 @@ public class StripeCaptureHandlerTest {
         assertThat(response.getError().isPresent(), is(true));
         assertThat(response.state(), is(nullValue()));
         assertThat(response.getError().get().getMessage(), containsString("An internal server error occurred when capturing charge_external_id: " + captureGatewayRequest.getExternalId()));
-        assertThat(response.getError().get().getErrorType(), is(GATEWAY_CONNECTION_ERROR));
+        assertThat(response.getError().get().getErrorType(), is(DOWNSTREAM_ERROR));
     }
 
     private GatewayAccountEntity buildGatewayAccountEntity() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -47,8 +47,9 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.ErrorType.DOWNSTREAM_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_SUCCESS_RESPONSE;
@@ -163,7 +164,7 @@ public class StripePaymentProviderTest {
         assertThat(authoriseResponse.getGatewayError().isPresent(), is(true));
         assertThat(authoriseResponse.getGatewayError().get().getMessage(),
                 containsString("There was an internal server error"));
-        assertThat(authoriseResponse.getGatewayError().get().getErrorType(), is(GATEWAY_CONNECTION_ERROR));
+        assertThat(authoriseResponse.getGatewayError().get().getErrorType(), is(DOWNSTREAM_ERROR));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -31,7 +31,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.DOWNSTREAM_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_ERROR_ALREADY_REFUNDED_RESPONSE;
@@ -131,6 +132,6 @@ public class StripeRefundHandlerTest {
         GatewayRefundResponse response = refundHandler.refund(refundRequest);
         assertThat(response.getError().isPresent(), Is.is(true));
         assertThat(response.getError().get().getMessage(), containsString("An internal server error occurred while refunding Transaction id:"));
-        assertThat(response.getError().get().getErrorType(), Is.is(GATEWAY_CONNECTION_ERROR));
+        assertThat(response.getError().get().getErrorType(), Is.is(DOWNSTREAM_ERROR));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -85,13 +85,13 @@ public class WorldpayCaptureHandlerTest {
     @Test
     public void shouldErrorIfWorldpayResponseIsNot200() throws Exception {
         when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayErrorException.GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayErrorException.ClientErrorException("Unexpected HTTP status code 400 from gateway"));
         
         CaptureResponse gatewayResponse = worldpayCaptureHandler.capture(getCaptureRequest());
         assertThat(gatewayResponse.isSuccessful(), is(false));
         assertThat(gatewayResponse.getError().isPresent(), is(true));
         assertThat(gatewayResponse.getError().get().getMessage(), is("Unexpected HTTP status code 400 from gateway"));
-        assertThat(gatewayResponse.getError().get().getErrorType(), is(GATEWAY_CONNECTION_ERROR));
+        assertThat(gatewayResponse.getError().get().getErrorType(), is(CLIENT_ERROR));
     }
 
     private CaptureGatewayRequest getCaptureRequest() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
@@ -84,7 +84,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         chargeEntity.setGatewayAccount(gatewayAccountEntity);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -122,7 +122,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         chargeEntity.setGatewayAccount(gatewayAccountEntity);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any())).thenReturn(mockGatewayClient);
@@ -130,7 +130,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         try {
             WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
             worldpayPaymentProvider.authorise(getCardAuthorisationRequest(chargeEntity));
-        } catch (GatewayConnectionErrorException e) {
+        } catch (ClientErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), anyMap());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS), gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -152,7 +152,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
 
         gatewayAccountEntity.setRequires3ds(true);
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -162,7 +162,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
 
         try {
             worldpayPaymentProvider.authorise(getCardAuthorisationRequest(mockChargeEntity));
-        } catch (GatewayConnectionErrorException e) {
+        } catch (ClientErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), anyMap());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS), gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -178,7 +178,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         when(mockChargeEntity.getGatewayTransactionId()).thenReturn("MyUniqueTransactionId!");
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 401 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 401 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any())).thenReturn(mockGatewayClient);
@@ -212,7 +212,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         when(mockChargeEntity.getProviderSessionId()).thenReturn(providerSessionId);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -247,7 +247,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         when(mockChargeEntity.getProviderSessionId()).thenReturn(providerSessionId);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -284,8 +284,8 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         mockWorldpayErrorResponse(401);
         try {
             provider.authorise(getCardAuthorisationRequest());
-        } catch (GatewayConnectionErrorException e) {
-            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 401 from gateway", ErrorType.GATEWAY_CONNECTION_ERROR));
+        } catch (ClientErrorException e) {
+            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 401 from gateway", ErrorType.CLIENT_ERROR));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
@@ -61,14 +61,14 @@ public class WorldpayWalletAuthorisationHandlerTest {
         chargeEntity.setGatewayAccount(gatewayAccountEntity);
         gatewayAccountEntity.setCredentials(ImmutableMap.of("merchant_id", "MERCHANTCODE"));
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new ClientErrorException("Unexpected HTTP status code 400 from gateway"));
     }
 
     @Test
     public void shouldSendApplePayRequestWhenApplePayDetailsArePresent() throws Exception {
         try {
             worldpayApplePayAuthorisationHandler.authorise(getApplePayAuthorisationRequest());
-        } catch (GatewayConnectionErrorException e) {
+        } catch (ClientErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
@@ -82,7 +82,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
     public void shouldSendGooglePayRequestWhenGooglePayDetailsArePresent() throws Exception {
         try {
             worldpayApplePayAuthorisationHandler.authorise(getGooglePayAuthorisationRequest());
-        } catch (GatewayConnectionErrorException e) {
+        } catch (ClientErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -62,7 +62,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
@@ -615,13 +615,13 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Test
     public void doAuthorise_shouldReportUnexpectedError_whenProviderError() throws Exception {
 
-        providerWillRespondWithError(new GatewayErrorException.GatewayConnectionErrorException("Malformed response received"));
+        providerWillRespondWithError(new GatewayErrorException.ClientErrorException("Malformed response received"));
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
         assertTrue(response.getGatewayError().isPresent());
-        assertThat(response.getGatewayError().get().getErrorType(), is(GATEWAY_CONNECTION_ERROR));
+        assertThat(response.getGatewayError().get().getErrorType(), is(CLIENT_ERROR));
         assertThat(charge.getStatus(), is(AUTHORISATION_UNEXPECTED_ERROR.getValue()));
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -27,8 +27,6 @@ import javax.ws.rs.core.Response;
 import java.net.HttpCookie;
 import java.net.SocketException;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,8 +34,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GatewayClientTest {
@@ -91,7 +87,7 @@ public class GatewayClientTest {
         when(mockGatewayOrder.getMediaType()).thenReturn(mediaType);
     }
 
-    @Test(expected = GatewayErrorException.GatewayConnectionErrorException.class)
+    @Test(expected = GatewayErrorException.DownstreamErrorException.class)
     public void shouldReturnGatewayErrorWhenProviderFails() throws Exception {
         when(mockResponse.getStatus()).thenReturn(500);
         gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, mockGatewayAccountEntity, mockGatewayOrder, emptyMap());

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -25,7 +25,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayErrorException.ClientErrorException;
 import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionTimeoutErrorException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
@@ -331,7 +331,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldReportUnexpectedError_whenProviderError() throws Exception {
-        providerWillRespondWithError(new GatewayConnectionErrorException("Malformed response received"));
+        providerWillRespondWithError(new ClientErrorException("Malformed response received"));
 
         GatewayResponse response = walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayDecryptedPaymentDataFixture.anApplePayDecryptedPaymentData;
 import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixture.anApplePayPaymentInfo;
@@ -76,7 +76,7 @@ public class ApplePayServiceTest {
                 .withGatewayError(gatewayError)
                 .withSessionIdentifier("234")
                 .build();
-        when(gatewayError.getErrorType()).thenReturn(GATEWAY_CONNECTION_ERROR);
+        when(gatewayError.getErrorType()).thenReturn(CLIENT_ERROR);
         when(gatewayError.getMessage()).thenReturn("oops");
         when(mockedApplePayDecrypter.performDecryptOperation(applePayAuthRequest)).thenReturn(validData);
         when(mockedApplePayAuthoriseService.doAuthorise(externalChargeId, validData)).thenReturn(gatewayResponse);

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.CLIENT_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -68,7 +68,7 @@ public class GooglePayServiceTest {
                 .withGatewayError(gatewayError)
                 .withSessionIdentifier("234")
                 .build();
-        when(gatewayError.getErrorType()).thenReturn(GATEWAY_CONNECTION_ERROR);
+        when(gatewayError.getErrorType()).thenReturn(CLIENT_ERROR);
         when(gatewayError.getMessage()).thenReturn("oops");
         when(mockedWalletAuthoriseService.doAuthorise(externalChargeId, googlePayAuthRequest)).thenReturn(gatewayResponse);
 


### PR DESCRIPTION
Callers of StripeGatewayClient handle 4xx and 5xx differently by virtue of
StripeGatewayClient throwing separate exceptions for each. This commit
introduces GatewayErrorException.DownstreamErrorException (for 4xx status
codes) and GatewayErrorException.ClientErrorException (for 5xx status codes) to the GatewayClient to
make deletion of StripeGatewayClient easier later. It's also probably a
good idea so we can tell whether it's connector making a bad request or a
downstream error from a payment provider.
