### PR TITLE
PP-4990 Add gateway_processing_details column

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1036,4 +1036,12 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add column gateway_processing_details to charges" author="">
+        <addColumn tableName="charges">
+            <column name="gateway_processing_details" type="jsonb">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Adds a new column to `charges` table - `gateway_processing_details` 
The purpose will be to record various gateway specific ids and details
in order to be able to map the charge on to various Stripe entities and processes.
We don't currently know exactly what's going in there, so no indexes needed at this point.

