### PR TITLE
PP-4992: Add refunds gateway ID, processing column

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1020,9 +1020,12 @@
                 <constraints nullable="true" unique="true" />
             </column>
         </addColumn>
-        <createIndex tableName="refunds" indexName="idx_refunds_gateway_transaction_id" unique="true">
-            <column name="gateway_transaction_id" type="text" />
-        </createIndex>
+    </changeSet>
+    
+    <changeSet id="add index concurrently to new refunds gateway_transaction_id column" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_refunds_gateway_transaction_id on refunds(gateway_transaction_id);
+        </sql>
     </changeSet>
 
     <changeSet id="add generic gateway processing details column" author="">

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1014,4 +1014,23 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add column and index for refunds gateway transaction ID" author="">
+        <addColumn tableName="refunds">
+            <column name="gateway_transaction_id" type="text">
+                <constraints nullable="true" unique="true" />
+            </column>
+        </addColumn>
+        <createIndex tableName="refunds" indexName="idx_refunds_gateway_transaction_id" unique="true">
+            <column name="gateway_transaction_id" type="text" />
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="add generic gateway processing details column" author="">
+        <addColumn tableName="refunds">
+            <column name="gateway_processing_details" type="jsonb">
+                <constraints nullable="true" unique="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
* Add `gateway_transaction_id` to bring this entity in line with charges
(and upcoming fees)
* Index on `gatway_transaction_id` as this value should be searchable
for payout reconiciliation
* Add `gateway_processing_details` column to allow unkown gateway
details to be recorded (metatdata about gateway transactions, process
specific timestamps)
* Gateway processing details is JSONB to allow unkown structure to be
used, indexes should be addded in the future for any commonly used
attributes
