### PR TITLE
PP-4992: Expose gateway transaction ID for refunds

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -75,7 +75,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
 
     public List<RefundHistory> searchHistoryByChargeId(Long chargeId) {
 
-        String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, history_start_date, history_end_date, user_external_id " +
+        String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, history_start_date, history_end_date, user_external_id, gateway_transaction_id " +
                 "FROM refunds_history r " +
                 "WHERE charge_id = ?1 AND status != ?2";
 
@@ -88,7 +88,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
 
     public List<RefundHistory> searchAllHistoryByChargeId(Long chargeId) {
 
-        String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, history_start_date, history_end_date, user_external_id " +
+        String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, history_start_date, history_end_date, user_external_id, gateway_transaction_id" +
                 "FROM refunds_history r " +
                 "WHERE charge_id = ?1";
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/builder/AbstractRefundsResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/builder/AbstractRefundsResponseBuilder.java
@@ -16,6 +16,7 @@ public abstract class AbstractRefundsResponseBuilder<T extends AbstractRefundsRe
     protected RefundEntity refundEntity;
     protected String status;
     protected String extChargeId;
+    protected String gatewayTransactionId;
     protected Long amountSubmitted;
 
     protected abstract T thisObject();
@@ -42,6 +43,11 @@ public abstract class AbstractRefundsResponseBuilder<T extends AbstractRefundsRe
 
     public T withAmountSubmitted(Long amountSubmitted) {
         this.amountSubmitted = amountSubmitted;
+        return thisObject();
+    }
+    
+    public T withGatewayTransactionId(String gatewayTransactionId) { 
+        this.gatewayTransactionId = gatewayTransactionId;
         return thisObject();
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -44,7 +44,8 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
                         @ColumnResult(name = "reference", type = String.class),
                         @ColumnResult(name = "history_start_date", type = Timestamp.class),
                         @ColumnResult(name = "history_end_date", type = Timestamp.class),
-                        @ColumnResult(name = "user_external_id", type = String.class)
+                        @ColumnResult(name = "user_external_id", type = String.class),
+                        @ColumnResult(name = "gateway_transaction_id", type = String.class)                        
                 }))
 
 @Entity
@@ -185,6 +186,7 @@ public class RefundEntity extends AbstractVersionedEntity {
                 ", status='" + status + '\'' +
                 ", userExternalId='" + userExternalId + '\'' +
                 ", chargeEntity=" + chargeEntity +
+                ", gatewayTransactionId=" + gatewayTransactionId +
                 ", createdDate=" + createdDate +
                 '}';
     }

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -75,6 +75,9 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     @Column(name = "user_external_id")
     private String userExternalId;
+    
+    @Column(name = "gateway_transaction_id")
+    private String gatewayTransactionId;
 
     @Column(name = "created_date")
     @Convert(converter = UTCDateTimeConverter.class)
@@ -95,6 +98,10 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     public String getExternalId() {
         return externalId;
+    }
+    
+    public String getGatewayTransactionId() { 
+        return gatewayTransactionId;
     }
 
     public String getReference() {
@@ -139,6 +146,10 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     public void setExternalId(String externalId) {
         this.externalId = externalId;
+    }
+    
+    public void setGatewayTransactionId(String gatewayTransactionId) { 
+        this.gatewayTransactionId = gatewayTransactionId;
     }
 
     public void setCreatedDate(ZonedDateTime createdDate) {

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
@@ -16,7 +16,10 @@ public class RefundHistory extends RefundEntity {
     private ZonedDateTime historyStartDate;
     private ZonedDateTime historyEndDate;
 
-    public RefundHistory(Long id, String externalId, Long amount, String status, Long chargeId, Timestamp createdDate, Long version, String reference, Timestamp historyStartDate, Timestamp historyEndDate, String userExternalId) {
+    public RefundHistory(Long id, String externalId, Long amount, String status, Long chargeId, Timestamp createdDate, 
+                         Long version, String reference, Timestamp historyStartDate, Timestamp historyEndDate, 
+                         String userExternalId,
+                         String gatewayTransactionId) {
         super();
         setId(id);
         setExternalId(externalId);
@@ -31,6 +34,7 @@ public class RefundHistory extends RefundEntity {
         setCreatedDate(new UTCDateTimeConverter().convertToEntityAttribute(createdDate));
         setVersion(version);
         setReference(reference);
+        setGatewayTransactionId(gatewayTransactionId);
 
         setHistoryStartDate(new UTCDateTimeConverter().convertToEntityAttribute(historyStartDate));
         setHistoryEndDate(new UTCDateTimeConverter().convertToEntityAttribute(historyEndDate));

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundSearchStrategy.java
@@ -46,12 +46,14 @@ public class RefundSearchStrategy extends AbstractSearchStrategy<RefundEntity, S
         String accountId = String.valueOf(refundEntity.getChargeEntity().getGatewayAccount().getId());
         String externalChargeId = refundEntity.getChargeEntity().getExternalId();
         String externalRefundId = refundEntity.getExternalId();
+        String gatewayTransactionId = refundEntity.getGatewayTransactionId();
 
         return responseBuilder
                 .withRefundId(externalRefundId)
                 .withCreatedDate(refundEntity.getCreatedDate())
                 .withStatus(refundEntity.getStatus().toExternal().getStatus())
                 .withChargeId(externalChargeId)
+                .withGatewayTransactionId(gatewayTransactionId)
                 .withAmountSubmitted(refundEntity.getAmount())
                 .withLink("self", GET, selfUriFor(uriInfo, accountId, externalChargeId, externalRefundId))
                 .withLink("payment_url", GET, paymentLinkFor(uriInfo, accountId, externalChargeId));

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -81,7 +82,7 @@ public class SendRefundEmailTest {
         String refundExternalId = "999999";
 
         long chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper).chargeId;
-        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 100,  REFUND_SUBMITTED, chargeId, ZonedDateTime.now());
+        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 100,  REFUND_SUBMITTED, chargeId, randomAlphanumeric(10), ZonedDateTime.now());
 
         given().port(testContext.getPort())
                 .body(epdqNotificationPayload(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE)))

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -652,6 +652,7 @@ public class  DatabaseFixtures {
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
         TestCharge testCharge;
         String submittedByUserExternalId;
+        String gatewayTransactionId;
 
         public TestRefund withTestCharge(TestCharge charge) {
             this.testCharge = charge;
@@ -688,16 +689,20 @@ public class  DatabaseFixtures {
             return this;
         }
 
-
         public TestRefund withExternalRefundId(String externalRefundId) {
             this.externalRefundId = externalRefundId;
+            return this;
+        }
+        
+        public TestRefund withGatewayTransactionId(String gatewayTransactionId) { 
+            this.gatewayTransactionId = gatewayTransactionId;
             return this;
         }
 
         public TestRefund insert() {
             if (testCharge == null)
                 throw new IllegalStateException("Test charge must be provided.");
-            id = databaseTestHelper.addRefund(externalRefundId, reference, amount, status, testCharge.getChargeId(), createdDate, submittedByUserExternalId);
+            id = databaseTestHelper.addRefund(externalRefundId, reference, amount, status, testCharge.getChargeId(), gatewayTransactionId, createdDate, submittedByUserExternalId);
             return this;
         }
 
@@ -728,6 +733,10 @@ public class  DatabaseFixtures {
 
         public TestCharge getTestCharge() {
             return testCharge;
+        }
+        
+        public String getGatewayTransactionId() {
+            return gatewayTransactionId;
         }
 
         public String getSubmittedByUserExternalId() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaITest.java
@@ -60,6 +60,7 @@ public class RefundDaoJpaITest extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestRefund()
                 .withReference(randomAlphanumeric(10))
+                .withGatewayTransactionId(randomAlphanumeric(10))
                 .withTestCharge(testCharge);
 
         this.sandboxAccount = testAccount.insert();
@@ -81,6 +82,7 @@ public class RefundDaoJpaITest extends DaoITestBase {
         assertThat(refundEntity.getStatus(), is(refundTestRecord.getStatus()));
         assertNotNull(refundEntity.getChargeEntity());
         assertThat(refundEntity.getChargeEntity().getId(), is(refundTestRecord.getTestCharge().getChargeId()));
+        assertThat(refundEntity.getGatewayTransactionId(), is(refundTestRecord.getGatewayTransactionId()));
         assertThat(refundEntity.getCreatedDate(), is(refundTestRecord.getCreatedDate()));
         assertNotNull(refundEntity.getVersion());
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaITest.java
@@ -306,6 +306,7 @@ public class RefundDaoJpaITest extends DaoITestBase {
         RefundEntity refundEntity = new RefundEntity(chargeEntity, 100L, userExternalId);
         refundEntity.setStatus(REFUND_SUBMITTED);
         refundEntity.setReference("test-refund-entity");
+        refundEntity.setGatewayTransactionId(randomAlphanumeric(10));
 
         refundDao.persist(refundEntity);
         List<RefundHistory> refundHistoryList = refundDao.searchHistoryByChargeId(chargeEntity.getId());
@@ -325,6 +326,7 @@ public class RefundDaoJpaITest extends DaoITestBase {
         assertThat(refundHistory.getReference(), is(refundEntity.getReference()));
         assertThat(refundEntity.getUserExternalId(), is(userExternalId));
         assertThat(refundHistory.getUserExternalId(), is(refundEntity.getUserExternalId()));
+        assertThat(refundHistory.getGatewayTransactionId(), is(refundEntity.getGatewayTransactionId()));
     }
 
     // CREATED to REFUND_SUBMITTED happens synchronously so not needed to return history for CREATED status

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -231,7 +231,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         String externalChargeId = RandomIdGenerator.newId();
 
         createCharge(externalChargeId, chargeId);
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", AMOUNT + 150L, REFUNDED, chargeId, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", AMOUNT + 150L, REFUNDED, chargeId, randomAlphanumeric(10), now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiV2ResourceITest.java
@@ -91,8 +91,8 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, randomAlphanumeric(10), now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -169,8 +169,8 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa",
                 returnUrl, email);
 
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, randomAlphanumeric(10), now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -258,8 +258,8 @@ public class ChargesApiV2ResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, randomAlphanumeric(10), now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
@@ -54,9 +54,9 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
         String refundDate1 = "2016-02-03T00:00:00.000Z";
         String refundDate2 = "2016-02-02T00:00:00.000Z";
         
-        databaseTestHelper.addRefund(refundExternalId1, "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId, ZonedDateTime.parse(refundDate1));
-        databaseTestHelper.addRefund(refundExternalId2, "refund-2-provider-reference", 2L, REFUNDED, chargeId, ZonedDateTime.parse(refundDate2));
-        databaseTestHelper.addRefund("shouldnotberetrieved", "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, ZonedDateTime.parse(refundDate1));
+        databaseTestHelper.addRefund(refundExternalId1, "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId, randomAlphanumeric(10), ZonedDateTime.parse(refundDate1));
+        databaseTestHelper.addRefund(refundExternalId2, "refund-2-provider-reference", 2L, REFUNDED, chargeId, randomAlphanumeric(10), ZonedDateTime.parse(refundDate2));
+        databaseTestHelper.addRefund("shouldnotberetrieved", "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), ZonedDateTime.parse(refundDate1));
         databaseTestHelper.addToken(chargeId, "tokenId");
 
         connectorRestApiClient.withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/TransactionsApiResourceITest.java
@@ -84,8 +84,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, randomAlphanumeric(10), now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -165,8 +165,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, referenceCharge2, transactionIdCharge2, now().minusDays(2), "visa",
                 returnUrl, email);
 
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, randomAlphanumeric(10), now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -208,8 +208,8 @@ public class TransactionsApiResourceITest extends ChargingITestBase {
         String externalChargeId2 = addChargeAndCardDetails(chargeId2, CAPTURED, ServicePaymentReference.of("ref-3"), transactionIdCharge2, now().minusDays(2),
                 "visa", returnUrl, email);
 
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, now().minusHours(2));
-        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, now().minusHours(3));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), now().minusHours(2));
+        databaseTestHelper.addRefund(randomAlphanumeric(10), "refund-2-provider-reference", 2L, REFUNDED, chargeId2, randomAlphanumeric(10), now().minusHours(3));
 
         connectorRestApiClient
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceITest.java
@@ -19,6 +19,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
@@ -107,7 +108,7 @@ public class EpdqNotificationResourceITest extends ChargingITestBase {
         int refundAmount = 1000;
 
         ChargeUtils.ExternalChargeId externalChargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
-        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 1000,  REFUND_SUBMITTED, externalChargeId.chargeId, ZonedDateTime.now());
+        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 1000,  REFUND_SUBMITTED, externalChargeId.chargeId, randomAlphanumeric(10), ZonedDateTime.now());
         
         String response = notifyConnector(transactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
                 .statusCode(200)

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthITest.java
@@ -24,6 +24,7 @@ import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
@@ -133,7 +134,7 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthITest extends Ch
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         Long chargeId = Long.parseLong(StringUtils.removeStart(externalChargeId, "charge-"));
         String externalRefundId = "refund-" + RandomUtils.nextInt();
-        int refundId = databaseTestHelper.addRefund(externalRefundId, reference, 10L, REFUND_SUBMITTED, chargeId, ZonedDateTime.now());
+        int refundId = databaseTestHelper.addRefund(externalRefundId, reference, 10L, REFUND_SUBMITTED, chargeId, randomAlphanumeric(10), ZonedDateTime.now());
 
         String response = notifyConnector(notificationPayloadForTransaction(externalRefundId, transactionId, reference, "notification-refund"))
                 .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceITest.java
@@ -18,6 +18,7 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
@@ -191,7 +192,7 @@ public class WorldpayNotificationResourceITest extends ChargingITestBase {
     private String createNewChargeWithRefund(String transactionId, String refundExternalId, long refundAmount) {
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         String chargeId = externalChargeId.substring(externalChargeId.indexOf("-") + 1);
-        databaseTestHelper.addRefund(refundExternalId, refundExternalId, refundAmount, REFUND_SUBMITTED, Long.valueOf(chargeId), ZonedDateTime.now());
+        databaseTestHelper.addRefund(refundExternalId, refundExternalId, refundAmount, REFUND_SUBMITTED, Long.valueOf(chargeId), randomAlphanumeric(10), ZonedDateTime.now());
         return externalChargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 
 @RunWith(PactRunner.class)
@@ -95,7 +96,7 @@ public class TransactionsApiContractTest {
 
         for (int i = 0; i < numberOfRefunds; i++) {
             dbHelper.addRefund("external" + RandomUtils.nextInt(), "reference", 1L, REFUNDED,
-                    chargeId, createdDate);
+                    chargeId, randomAlphanumeric(10), createdDate);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -261,21 +261,22 @@ public class DatabaseTestHelper {
                         .bind("accountId", accountId).execute());
     }
 
-    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, ZonedDateTime createdDate) {
-        return addRefund(externalId, reference, amount, status, chargeId, createdDate, null);
+    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, String gatewayTransactionId, ZonedDateTime createdDate) {
+        return addRefund(externalId, reference, amount, status, chargeId, gatewayTransactionId, createdDate, null);
     }
 
-    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, ZonedDateTime createdDate, String submittedByUserExternalId) {
+    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, String gatewayTransactionId, ZonedDateTime createdDate, String submittedByUserExternalId) {
         int refundId = RandomUtils.nextInt();
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO refunds(id, external_id, reference, amount, status, charge_id, created_date, user_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :created_date, :user_external_id)")
+                        .createStatement("INSERT INTO refunds(id, external_id, reference, amount, status, charge_id, gateway_transaction_id, created_date, user_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, :gateway_transaction_id, :created_date, :user_external_id)")
                         .bind("id", refundId)
                         .bind("external_id", externalId)
                         .bind("reference", reference)
                         .bind("amount", amount)
                         .bind("status", status.getValue())
                         .bind("charge_id", chargeId)
+                        .bind("gateway_transaction_id", gatewayTransactionId)
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
                         .bind("user_external_id", submittedByUserExternalId)
                         .bind("version", 1)


### PR DESCRIPTION
* Links `RefundEntity` & `RefundsHistory` to new `gatway_transaction_id` column
* Doesn't expose details column, this should be updated given a use case

Depends on https://github.com/alphagov/pay-connector/pull/1158

- [x] Update any relevant tests 
- [x] Update any other entities that needs this information