### PR TITLE
PP-4985: Upgrade Dockerfile JRE + alpine versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM govukpay/openjdk:alpine-3.8.1-jre-base-8.191.12
+FROM govukpay/openjdk:alpine-3.9-jre-base-8.201.08
 
 RUN apk --no-cache upgrade
 


### PR DESCRIPTION
Existing version of OpenJDK based on Alpine < 3.9 causing local building
issues. Bumps OpenJDK base image version to 3.9 using OpenJDK 8u201.

Relates to https://github.com/alphagov/pay-adminusers/pull/433