### PR TITLE
PP-5003: Add fee table schema migration

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1024,11 +1024,17 @@
                 <constraints foreignKeyName="fk__charge_fees"
                              referencedTableName="charges"
                              referencedColumnNames="id"
+                             unique="true"
                              nullable="false" />
             </column>
-            <column name="fee_due" type="bigint" />
-            <column name="fee_collected" type="bigint" />
+            <column name="amount_due" type="bigint">
+                <constraints nullable="false" />
+            </column>
+            <column name="amount_collected" type="bigint">
+                <constraints nullable="false" />
+            </column>
             <column name="created_date" type="timestamp without timezone" />
+            <column name="collected_date" type="timestamp without timezone" />
             <column name="gateway_transaction_id"  type="text">
                 <constraints nullable="true" />
             </column>
@@ -1036,7 +1042,7 @@
         </createTable>
     </changeSet>
     
-    <changeSet id="index columns for fee table" author="">
+    <changeSet id="index gateway_transaction_id, external_id and charge_id columns for fee table" author="">
         <createIndex tableName="fees" indexName="idx_fees_gateway_transaction_id">
             <column name="gateway_transaction_id" />
         </createIndex>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1013,5 +1013,33 @@
             alter table gateway_accounts drop column allow_web_payments;
         </sql>
     </changeSet>
+    
+    <changeSet id="add fee table" author="">
+        <createTable tableName="fees">
+            <column name="id" type="bigserial" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="external_id" type="char(26)" />
+            <column name="charge_id" type="bigserial">
+                <constraints foreignKeyName="fk__charge_fees"
+                             referencedTableName="charges"
+                             referencedColumnNames="id"
+                             nullable="false" />
+            </column>
+            <column name="fee_due" type="bigint" />
+            <column name="fee_collected" type="bigint" />
+            <column name="created" type="timestamp without timezone" />
+            <column name="gateway_transaction_id"  type="text">
+                <constraints nullable="true" />
+            </column>
+            <column name="gateway_processing_details" type="jsonb" />
+        </createTable>
+    </changeSet>
+    
+    <changeSet id="index gateway_transaction_id for fee table" author="">
+        <createIndex tableName="fees" indexName="itx_fees_gateway_transaction_id">
+            <column name="gateway_transaction_id"></column>
+        </createIndex>
+    </changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1028,7 +1028,7 @@
             </column>
             <column name="fee_due" type="bigint" />
             <column name="fee_collected" type="bigint" />
-            <column name="created" type="timestamp without timezone" />
+            <column name="created_date" type="timestamp without timezone" />
             <column name="gateway_transaction_id"  type="text">
                 <constraints nullable="true" />
             </column>
@@ -1036,9 +1036,17 @@
         </createTable>
     </changeSet>
     
-    <changeSet id="index gateway_transaction_id for fee table" author="">
-        <createIndex tableName="fees" indexName="itx_fees_gateway_transaction_id">
-            <column name="gateway_transaction_id"></column>
+    <changeSet id="index columns for fee table" author="">
+        <createIndex tableName="fees" indexName="idx_fees_gateway_transaction_id">
+            <column name="gateway_transaction_id" />
+        </createIndex>
+
+        <createIndex tableName="fees" indexName="idx_fees_external_id">
+            <column name="external_id" />
+        </createIndex>
+
+        <createIndex tableName="fees" indexName="idx_fees_charge_id">
+            <column name="charge_id" />
         </createIndex>
     </changeSet>
 


### PR DESCRIPTION
* Adds initial columns required for modelling fees
* Indexing gateway processing details will follow when we know what keys
are required

Fees are modelled separately to reflect the second account debit transaction that is required on the Stripe gateway. For this use case they are 1:1 for a charge which is enforced in https://github.com/alphagov/pay-connector/pull/1161/commits/87c575f81a9dffc417c4c30b721442f282ea9b67. If multiple fees for a given charge become a use case in the future this constraint can be updated along with the "view" code for charges and their fees.