### PR TITLE
PP-5010 Add fee entity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -317,6 +317,9 @@ public class ChargeResponse {
     @JsonProperty("corporate_card_surcharge")
     private Long corporateCardSurcharge;
 
+    @JsonProperty("fee")
+    private Long fee;
+
     @JsonProperty("total_amount")
     private Long totalAmount;
     
@@ -344,6 +347,7 @@ public class ChargeResponse {
         this.language = builder.getLanguage();
         this.delayedCapture = builder.isDelayedCapture();
         this.corporateCardSurcharge = builder.getCorporateCardSurcharge();
+        this.fee = builder.getFee();
         this.totalAmount = builder.getTotalAmount();
         this.walletType = builder.getWalletType();
     }
@@ -418,6 +422,9 @@ public class ChargeResponse {
 
     public Long getCorporateCardSurcharge() {
         return corporateCardSurcharge;
+    }
+    public Long getFee() {
+        return fee;
     }
 
     public Long getTotalAmount() {

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -34,6 +34,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected SupportedLanguage language;
     protected boolean delayedCapture;
     protected Long corporateCardSurcharge;
+    protected Long fee;
     protected Long totalAmount;
     protected WalletType walletType;
 
@@ -145,6 +146,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return thisObject();
     }
     
+    public T withFee(Long fee) {
+        this.fee = fee;
+        return thisObject();
+    }
+    
     public T withTotalAmount(Long totalAmount) {
         this.totalAmount = totalAmount;
         return thisObject();
@@ -240,4 +246,8 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     }
 
     public abstract R build();
+
+    public Long getFee() {
+        return fee;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.SupportedLanguageJpaConverter;
-import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
@@ -19,6 +18,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.pay.connector.wallets.WalletType;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -35,6 +35,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
@@ -42,7 +43,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -96,8 +96,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @JoinColumn(name = "gateway_account_id", updatable = false)
     private GatewayAccountEntity gatewayAccount;
 
-    @OneToMany(mappedBy = "chargeEntity", fetch = FetchType.EAGER)
-    private List<FeeEntity> fees = Collections.emptyList();
+    @OneToOne(mappedBy = "chargeEntity", fetch = FetchType.EAGER)
+    private FeeEntity fee;
 
     @OneToMany(mappedBy = "chargeEntity", fetch = FetchType.EAGER)
     @OrderBy("createdDate")
@@ -331,8 +331,6 @@ public class ChargeEntity extends AbstractVersionedEntity {
     }
 
     public Optional<Long> getFeeAmount() {
-        return fees.stream()
-                .findFirst()
-                .map(FeeEntity::getAmountCollected);
+        return Optional.ofNullable(fee).map(FeeEntity::getAmountCollected);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -42,6 +42,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -94,6 +95,9 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @ManyToOne
     @JoinColumn(name = "gateway_account_id", updatable = false)
     private GatewayAccountEntity gatewayAccount;
+
+    @OneToMany(mappedBy = "chargeEntity", fetch = FetchType.EAGER)
+    private List<FeeEntity> fees = Collections.emptyList();
 
     @OneToMany(mappedBy = "chargeEntity", fetch = FetchType.EAGER)
     @OrderBy("createdDate")
@@ -324,5 +328,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public void setCorporateSurcharge(Long corporateSurcharge) {
         this.corporateSurcharge = corporateSurcharge;
+    }
+
+    public Optional<Long> getFeeAmount() {
+        return fees.stream()
+                .findFirst()
+                .map(FeeEntity::getAmountCollected);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.connector.charge.model.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import java.time.ZonedDateTime;
+
+@Entity
+@Table(name = "fees")
+@Access(AccessType.FIELD)
+@SequenceGenerator(name = "charges_charge_id_seq",
+        sequenceName = "charges_charge_id_seq", allocationSize = 1)
+public class FeeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "charges_charge_id_seq")
+    @JsonIgnore
+    private long id;
+
+    @Column(name = "external_id")
+    private String externalId;
+
+    @JsonIgnore
+    @ManyToOne
+    @JoinColumn(name = "charge_id", updatable = false)
+    private ChargeEntity chargeEntity;
+
+    @Column(name = "amount_due")
+    private long amountDue;
+
+    @Column(name = "amount_collected")
+    private long amountCollected;
+
+    @Column(name = "created_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime createdDate;
+
+    @Column(name = "collected_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime collectedDate;
+    
+    @Column(name = "gateway_transaction_id")
+    private String gatewayTransactionId;
+    
+    public long getAmountCollected() {
+        return amountCollected;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
@@ -12,7 +12,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import java.time.ZonedDateTime;
@@ -33,7 +33,7 @@ public class FeeEntity {
     private String externalId;
 
     @JsonIgnore
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "charge_id", updatable = false)
     private ChargeEntity chargeEntity;
 

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -163,6 +163,7 @@ public class ChargesFrontendResource {
                 .withEmail(charge.getEmail())
                 .withCardDetails(persistedCard)
                 .withAuth3dsData(auth3dsData)
+                .withFee(charge.getFeeAmount().orElse(null))
                 .withGatewayAccount(charge.getGatewayAccount())
                 .withLanguage(charge.getLanguage())
                 .withDelayedCapture(charge.isDelayedCapture())

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -209,7 +209,8 @@ public class ChargeService {
                 .withAuth3dsData(auth3dsData)
                 .withLink("self", GET, selfUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeId))
                 .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()))
-                .withWalletType(chargeEntity.getWalletType());
+                .withWalletType(chargeEntity.getWalletType())
+                .withFee(chargeEntity.getFeeAmount().orElse(null));
 
         if (ChargeStatus.AWAITING_CAPTURE_REQUEST.getValue().equals(chargeEntity.getStatus())) {
             builderOfResponse.withLink("capture", POST, captureUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()));

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoITest.java
@@ -1536,6 +1536,26 @@ public class ChargeDaoITest extends DaoITestBase {
         assertThat(chargeDao.findByIdAndLimit(0L, 2).size(), is(2));
     }
 
+    @Test
+    public void getChargeWithAFee_shouldReturnFeeOnCharge() {
+        insertTestCharge();
+        
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestFee()
+                .withFeeDue(100L)
+                .withFeeCollected(10L)
+                .withTestCharge(defaultTestCharge)
+                .insert();
+
+        assertThat(chargeDao
+                .findById(defaultTestCharge.getChargeId())
+                .flatMap(ChargeEntity::getFeeAmount)
+                .get(), 
+                is(10L)
+        );
+    }
+
     private void insertTestAccount() {
         this.defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -63,6 +63,10 @@ public class  DatabaseFixtures {
     public TestRefund aTestRefund() {
         return new TestRefund();
     }
+    
+    public TestFee aTestFee() {
+        return new TestFee();
+    }
 
     public TestCardDetails aTestCardDetails() {
         return new TestCardDetails();
@@ -728,6 +732,42 @@ public class  DatabaseFixtures {
 
         public String getSubmittedByUserExternalId() {
             return submittedByUserExternalId;
+        }
+    }
+
+    public class TestFee {
+        String externalId = RandomIdGenerator.newId();
+        ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+        TestCharge testCharge;
+        private long feeDue = 100L;
+        private long feeCollected = 100L;
+        private String gatewayTransactionId = "transaction_id";
+
+        public TestFee withTestCharge(TestCharge charge) {
+            this.testCharge = charge;
+            return this;
+        }
+        
+        public TestFee withFeeDue(long feeDue) {
+            this.feeDue = feeDue;
+            return this;
+        }
+
+        public TestFee withFeeCollected(long feeCollected) {
+            this.feeCollected = feeCollected;
+            return this;
+        }
+
+        public TestFee withGatewayTransactionId(String gatewayTransactionId) {
+            this.gatewayTransactionId = gatewayTransactionId;
+            return this;
+        }
+        
+        public TestFee insert() {
+            if (testCharge == null)
+                throw new IllegalStateException("Test charge must be provided.");
+            databaseTestHelper.addFee(externalId, testCharge.getChargeId(), feeDue, feeCollected, createdDate, gatewayTransactionId);
+            return this;
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -261,6 +261,25 @@ public class ChargesApiResourceITest extends ChargingITestBase {
     }
 
     @Test
+    public void shouldReturnFeeIfItExists() {
+        long chargeId = nextInt();
+        String externalChargeId = RandomIdGenerator.newId();
+        long feeCollected = 100;
+
+        createCharge(externalChargeId, chargeId);
+        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
+
+        connectorRestApiClient
+                .withAccountId(accountId)
+                .withChargeId(externalChargeId)
+                .getCharge()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("fee", is(100));
+    }
+
+
+        @Test
     public void shouldReturnWalletTypeWhenNotNull_v2() {
         long chargeId = nextInt();
         String externalChargeId = RandomIdGenerator.newId();

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceITest.java
@@ -20,6 +20,7 @@ import uk.gov.pay.connector.util.RestAssuredClient;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import javax.ws.rs.core.HttpHeaders;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
@@ -149,6 +150,20 @@ public class ChargesFrontendResourceITest {
                 .contentType(JSON)
                 .body("charge_id", is(externalChargeId))
                 .body("wallet_type", is(WalletType.APPLE_PAY.toString()));
+    }
+    
+    @Test
+    public void getChargeShouldIncludeFeeIfItExists() {
+        String externalChargeId = postToCreateACharge(expectedAmount);
+        final long chargeId = databaseTestHelper.getChargeIdByExternalId(externalChargeId);
+        final long feeCollected = 100L;
+        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
+        
+        getChargeFromResource(externalChargeId)
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("charge_id", is(externalChargeId))
+                .body("fee", is(100));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -744,4 +744,17 @@ public class DatabaseTestHelper {
         );
     }
 
+    public void addFee(String externalId, long chargeId, long feeDue, long feeCollected, ZonedDateTime createdDate, String gatewayTransactionId) {
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("INSERT INTO fees(external_id, charge_id, amount_due, amount_collected, created_date, gateway_transaction_id) VALUES (:external_id, :charge_id, :amount_due, :amount_collected, :created_date, :gateway_transaction_id)")
+                        .bind("external_id", externalId)
+                        .bind("charge_id", chargeId)
+                        .bind("amount_due", feeDue)
+                        .bind("amount_collected", feeCollected)
+                        .bind("created_date", Timestamp.from(createdDate.toInstant()))
+                        .bind("gateway_transaction_id", gatewayTransactionId)
+                        .execute()
+        );
+    }
 }


### PR DESCRIPTION
Adds FeeEntity, and mapping to ChargeEntity.

At present the only way we want to expose the fee is as part of the
charge, so this commit adds a `getFeeAmount` method to the charge.

Passes through fee from ChargeEntity to ChargesFrontendResource and
ChargeApiResource.