### PR TITLE
PP-4993 Add Stripe Fee Processor

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -18,6 +18,10 @@ public class StripeGatewayConfig extends Configuration {
     @Valid
     @NotNull
     private StripeWebhookSigningSecrets webhookSigningSecrets;
+    
+    @Valid
+    @NotNull
+    private Double feePercentage;
 
     public String getUrl() {
         return url;
@@ -29,5 +33,9 @@ public class StripeGatewayConfig extends Configuration {
 
     public StripeWebhookSigningSecrets getWebhookSigningSecrets() {
         return webhookSigningSecrets;
+    }
+
+    public Double getFeePercentage() {
+        return feePercentage;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.charge.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -15,6 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @Entity
@@ -23,6 +25,17 @@ import java.time.ZonedDateTime;
 @SequenceGenerator(name = "charges_charge_id_seq",
         sequenceName = "charges_charge_id_seq", allocationSize = 1)
 public class FeeEntity {
+    public FeeEntity() {
+        
+    }
+    
+    public FeeEntity(ChargeEntity chargeEntity, Long amountDue) {
+        this.externalId = RandomIdGenerator.newId();
+        this.chargeEntity = chargeEntity;
+        this.amountDue = amountDue;
+        this.amountCollected = 0L;
+        this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "charges_charge_id_seq")
@@ -38,10 +51,10 @@ public class FeeEntity {
     private ChargeEntity chargeEntity;
 
     @Column(name = "amount_due")
-    private long amountDue;
+    private Long amountDue;
 
     @Column(name = "amount_collected")
-    private long amountCollected;
+    private Long amountCollected;
 
     @Column(name = "created_date")
     @Convert(converter = UTCDateTimeConverter.class)
@@ -57,4 +70,13 @@ public class FeeEntity {
     public long getAmountCollected() {
         return amountCollected;
     }
+
+    public Long getAmountDue() {
+        return amountDue;
+    }
+
+    public void setAmountCollected(Long amountCollected) {
+        this.amountCollected = amountCollected;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/FeeProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/FeeProcessor.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.gateway;
+
+import uk.gov.pay.connector.gateway.model.request.RecoupFeeRequest;
+import uk.gov.pay.connector.gateway.model.response.RecoupFeeResponse;
+
+public interface FeeProcessor {
+    Long calculateFee(Long chargeAmount, Long baseFee);
+    RecoupFeeResponse recoupFee(RecoupFeeRequest recoupFeeRequest);
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClientFactory.java
@@ -21,6 +21,13 @@ public class GatewayClientFactory {
         return new StripeGatewayClient(client, metricRegistry);
     }
 
+    public StripeGatewayClient createStripeGatewayClient(PaymentGatewayName gateway,
+                                                         GatewayOperation operation,
+                                                         MetricRegistry metricRegistry) {
+        Client client = clientFactory.createWithDropwizardClient(gateway, operation, metricRegistry);
+        return new StripeGatewayClient(client, metricRegistry);
+    }
+
     public GatewayClient createGatewayClient(PaymentGatewayName gateway,
                                              GatewayOperation operation,
                                              MetricRegistry metricRegistry) {

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
@@ -5,7 +5,8 @@ public enum GatewayOperation {
     CAPTURE("capture"),
     REFUND("refund"),
     QUERY("query"),
-    CANCEL("cancel");
+    CANCEL("cancel"), 
+    RECOUP_FEE("recoup_fee");
 
     private final String description;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RecoupFeeRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RecoupFeeRequest.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.connector.gateway.model.request;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+
+public class RecoupFeeRequest {
+    private final ChargeEntity charge;
+    private final FeeEntity fee;
+
+    public static RecoupFeeRequest of(ChargeEntity charge, FeeEntity fee) {
+        return new RecoupFeeRequest(charge, fee);
+    }
+    
+    private RecoupFeeRequest(ChargeEntity charge, FeeEntity fee) {
+        this.charge = charge;
+        this.fee = fee;
+    }
+
+    public ChargeEntity getCharge() {
+        return charge;
+    }
+
+    public FeeEntity getFee() {
+        return fee;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/RecoupFeeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/RecoupFeeResponse.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.gateway.model.response;
+
+public class RecoupFeeResponse {
+    private final boolean successful;
+    private final Long amountCollected;
+    private final String errorMessage;
+
+    public static RecoupFeeResponse fromException(Exception e) {
+        return new RecoupFeeResponse(false, null, e.getMessage());
+    }
+
+    public RecoupFeeResponse(boolean successful, Long amountCollected, String errorMessage) {
+        this.successful = successful;
+        this.amountCollected = amountCollected;
+        this.errorMessage = errorMessage;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
+    }
+
+    public Long getAmountCollected() {
+        return amountCollected;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/GatewayException.java
@@ -7,7 +7,7 @@ package uk.gov.pay.connector.gateway.stripe;
 public class GatewayException extends Exception {
     private final transient String url;
 
-    GatewayException(String url, final Throwable throwable) {
+    public GatewayException(String url, final Throwable throwable) {
         super(throwable);
         this.url = url;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClientResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeGatewayClientResponse.java
@@ -8,7 +8,7 @@ public class StripeGatewayClientResponse {
     private String payload;
     private int status;
 
-    StripeGatewayClientResponse(Response response) {
+    public StripeGatewayClientResponse(Response response) {
         this.payload = response.readEntity(String.class);
         this.statusFamily = response.getStatusInfo().getFamily();
         this.status = response.getStatus();

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/fee/StripeFeeProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/fee/StripeFeeProcessor.java
@@ -1,0 +1,105 @@
+package uk.gov.pay.connector.gateway.stripe.fee;
+
+import com.google.common.collect.ImmutableMap;
+import io.dropwizard.setup.Environment;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.FeeProcessor;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.request.RecoupFeeRequest;
+import uk.gov.pay.connector.gateway.model.response.RecoupFeeResponse;
+import uk.gov.pay.connector.gateway.stripe.DownstreamException;
+import uk.gov.pay.connector.gateway.stripe.GatewayClientException;
+import uk.gov.pay.connector.gateway.stripe.GatewayException;
+import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
+import uk.gov.pay.connector.gateway.stripe.response.StripeRecoupFeeResponse;
+import uk.gov.pay.connector.gateway.util.AuthUtil;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import javax.inject.Inject;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+public class StripeFeeProcessor implements FeeProcessor {
+    private StripeGatewayClient client;
+    private final JsonObjectMapper jsonObjectMapper;
+    private final StripeGatewayConfig stripeGatewayConfig;
+
+    @Inject
+    public StripeFeeProcessor(GatewayClientFactory clientFactory,
+                              ConnectorConfiguration configuration,
+                              JsonObjectMapper jsonObjectMapper,
+                              Environment environment
+    ) {
+        this.stripeGatewayConfig = configuration.getStripeConfig();
+        this.client = clientFactory.createStripeGatewayClient(
+                PaymentGatewayName.STRIPE,
+                GatewayOperation.RECOUP_FEE,
+                environment.metrics());
+        this.jsonObjectMapper = jsonObjectMapper;
+    }
+
+    @Override
+    public Long calculateFee(Long chargeAmount, Long baseFee) {
+        long percentageBasedFee = (long) Math.ceil(stripeGatewayConfig.getFeePercentage() * chargeAmount / 100);
+        return percentageBasedFee + baseFee;
+    }
+
+    @Override
+    public RecoupFeeResponse recoupFee(RecoupFeeRequest recoupFeeRequest) {
+        GatewayAccountEntity gatewayAccount = recoupFeeRequest.getCharge().getGatewayAccount();
+        try {
+            String response = client.postRequest(
+                    URI.create(stripeGatewayConfig.getUrl() + "/v1/transfers"), 
+                    recoupFeePayload(recoupFeeRequest),
+                    recoupFeeHeaders(recoupFeeRequest),
+                    APPLICATION_FORM_URLENCODED_TYPE,
+                    format("gateway-operations.%s.%s.authorise.create_token",
+                            gatewayAccount.getGatewayName(),
+                            gatewayAccount.getType())
+            );
+
+            StripeRecoupFeeResponse stripeRecoupFeeResponse = jsonObjectMapper.getObject(
+                    response, 
+                    StripeRecoupFeeResponse.class
+            );
+
+            return stripeRecoupFeeResponse.toRecoupFeeResponse();
+        } catch (GatewayClientException | GatewayException | DownstreamException  e) {
+            return RecoupFeeResponse.fromException(e);
+        } 
+    }
+    
+    private String recoupFeePayload(RecoupFeeRequest recoupFeeRequest) {
+        List<BasicNameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("amount", recoupFeeRequest.getFee().getAmountDue().toString()));
+        params.add(new BasicNameValuePair("currency", "GBP"));
+        //@TODO get this from config
+        params.add(new BasicNameValuePair("destination", "StripePlatformAccountId"));
+        
+        return URLEncodedUtils.format(params, UTF_8);
+    }
+    
+    private Map<String, String> recoupFeeHeaders(RecoupFeeRequest recoupFeeRequest) {
+        Map<String, String> headers = new HashMap<>();
+        headers.putAll(AuthUtil.getStripeAuthHeader(
+                stripeGatewayConfig,
+                recoupFeeRequest.getCharge().getGatewayAccount().isLive()
+        ));
+        headers.put("Stripe-Account", recoupFeeRequest.getCharge().getGatewayAccount().getCredentials().get("stripe_account_id"));
+        
+        return headers;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeRecoupFeeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripeRecoupFeeResponse.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.gateway.model.response.RecoupFeeResponse;
+
+public class StripeRecoupFeeResponse {
+    @JsonProperty("amount")
+    private Long amount;
+
+    public RecoupFeeResponse toRecoupFeeResponse() {
+        return new RecoupFeeResponse(true, amount, null);
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -82,6 +82,7 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET}
+  feePercentage: ${STRIPE_FEE_PERCENTAGE:-0.08}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/fee/StripeFeeProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/fee/StripeFeeProcessorTest.java
@@ -1,0 +1,189 @@
+package uk.gov.pay.connector.gateway.stripe.fee;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.dropwizard.setup.Environment;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.model.request.RecoupFeeRequest;
+import uk.gov.pay.connector.gateway.model.response.RecoupFeeResponse;
+import uk.gov.pay.connector.gateway.stripe.DownstreamException;
+import uk.gov.pay.connector.gateway.stripe.GatewayClientException;
+import uk.gov.pay.connector.gateway.stripe.GatewayException;
+import uk.gov.pay.connector.gateway.stripe.StripeGatewayClient;
+import uk.gov.pay.connector.gateway.stripe.StripeGatewayClientResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+import java.util.Map;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeFeeProcessorTest {
+    @Mock
+    private ConnectorConfiguration connectorConfiguration;
+    @Mock
+    private GatewayClientFactory gatewayClientFactory;
+    @Mock
+    private StripeGatewayClient stripeGatewayClient;
+    @Mock
+    private StripeGatewayConfig stripeGatewayConfig;
+    @Mock
+    private StripeGatewayClientResponse response;
+    
+    private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
+    @Mock
+    protected Environment environment;
+    
+    @Mock
+    protected MetricRegistry metrics;
+    
+    private StripeFeeProcessor stripeFeeProcessor;
+    
+    private double feePercentage = 0.08;
+    private URI feeUri;
+    private ChargeEntity charge;
+    
+    @Before
+    public void setUp() {
+        when(stripeGatewayConfig.getFeePercentage()).thenReturn(feePercentage);
+        when(stripeGatewayConfig.getUrl()).thenReturn("stripeUrl");
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
+        when(connectorConfiguration.getStripeConfig()).thenReturn(stripeGatewayConfig);
+        
+        when(environment.metrics()).thenReturn(metrics);
+        
+        when(gatewayClientFactory.createStripeGatewayClient(
+                eq(PaymentGatewayName.STRIPE),
+                eq(GatewayOperation.RECOUP_FEE),
+                eq(metrics))).thenReturn(stripeGatewayClient);
+        
+        stripeFeeProcessor = new StripeFeeProcessor(gatewayClientFactory, connectorConfiguration, objectMapper, environment);
+        feeUri = URI.create(stripeGatewayConfig.getUrl() + "/v1/transfers");
+        GatewayAccountEntity gatewayAccount = buildGatewayAccountEntity();
+
+        charge = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withAmount(10000L)
+                .build();
+
+    }
+    
+    @Test
+    public void calculateFee_PercentageOfChargeAmountIsWhole() throws Exception {
+        assertThat(stripeFeeProcessor.calculateFee(10000L, 10L), is(18L));
+    }
+
+    @Test
+    public void calculateFee_PercentageOfChargeAmountIsNotWhole() throws Exception {
+        assertThat(stripeFeeProcessor.calculateFee(10001L, 10L), is(19L));
+    }
+
+    @Test
+    public void calculateFee_PercentageOfChargeAmountIsLessThan1() throws Exception {
+        assertThat(stripeFeeProcessor.calculateFee(1000L, 10L), is(11L));
+    }
+
+    @Test
+    public void calculateFee_PercentageOfChargeAmountIs0() throws Exception {
+        assertThat(stripeFeeProcessor.calculateFee(0L, 10L), is(10L));
+    }
+    
+    @Test
+    public void recoupFee_responseShouldRecordAmountCollected() throws  Exception{
+        long amountCollected = 50L;
+        final String jsonResponse = new Gson().toJson(ImmutableMap.of("amount", amountCollected));
+        when(stripeGatewayClient.postRequest(eq(feeUri), anyString(), any(Map.class), any(MediaType.class), anyString())).thenReturn(jsonResponse);
+        
+        RecoupFeeResponse response = stripeFeeProcessor.recoupFee(RecoupFeeRequest.of(charge, new FeeEntity(charge, amountCollected)));
+        
+        assertThat(response.getAmountCollected(), is(amountCollected));
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    public void recoupFee_responseShouldNotBeSuccessfulAndShouldRecordErrorIfGatewayExeption() throws  Exception{
+        long amountCollected = 50L;
+        when(stripeGatewayClient.postRequest(
+                eq(feeUri),
+                anyString(),
+                any(Map.class),
+                any(MediaType.class),
+                anyString())).thenThrow(new GatewayException("url", new Exception("message")));
+
+        RecoupFeeResponse response = stripeFeeProcessor.recoupFee(RecoupFeeRequest.of(charge, new FeeEntity(charge, amountCollected)));
+
+        assertFalse(response.isSuccessful());
+        assertThat(response.getErrorMessage(), is("java.lang.Exception: message"));
+    }
+
+    @Test
+    public void recoupFee_responseShouldNotBeSuccessfulAndShouldRecordErrorIfConnectionExeption() throws  Exception{
+        long amountCollected = 50L;
+        when(stripeGatewayClient.postRequest(
+                eq(feeUri),
+                anyString(),
+                any(Map.class),
+                any(MediaType.class),
+                anyString())).thenThrow(new DownstreamException(200, "message"));
+
+        RecoupFeeResponse response = stripeFeeProcessor.recoupFee(RecoupFeeRequest.of(charge, new FeeEntity(charge, amountCollected)));
+
+        assertFalse(response.isSuccessful());
+        assertThat(response.getErrorMessage(), is("message"));
+    }
+
+    @Test
+    public void recoupFee_responseShouldNotBeSuccessfulAndShouldRecordErrorIfGatewayClientExeption() throws  Exception{
+        long amountCollected = 50L;
+        when(stripeGatewayClient.postRequest(
+                eq(feeUri),
+                anyString(),
+                any(Map.class),
+                any(MediaType.class),
+                anyString())).thenThrow(new GatewayClientException("message", response));
+
+
+        RecoupFeeResponse response = stripeFeeProcessor.recoupFee(RecoupFeeRequest.of(charge, new FeeEntity(charge, amountCollected)));
+
+        assertFalse(response.isSuccessful());
+        assertThat(response.getErrorMessage(), is("message"));
+    }
+
+
+    private GatewayAccountEntity buildGatewayAccountEntity() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("stripe");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
+    }
+}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -66,6 +66,8 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_FEE_PERCENTAGE:-0.08}
+
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -65,6 +65,8 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_FEE_PERCENTAGE:-0.08}
+
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -55,6 +55,7 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_FEE_PERCENTAGE:-0.08}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -61,6 +61,7 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_FEE_PERCENTAGE:-0.08}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -58,6 +58,7 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_FEE_PERCENTAGE:-0.08}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}


### PR DESCRIPTION
Adds fee processor interface, and implementation for Stripe.

The fee processor does 2 things:
given a total amount and a baseFee, it calculates a total fee due for a charge.
I haven't tried to make this very clever or generic. If we need to extend in 
future it is likely to be in ways we cannot foresee.

recoups a fee: it can talk to a gateway to recoup a fee for a charge.