### PR TITLE
PP-4758: Add status code to GatewayErrorException

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -11,7 +11,7 @@ import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
@@ -92,7 +92,7 @@ public class ChargeCancelService {
             
             chargeStatus = determineTerminalState(gatewayResponse.getBaseResponse().get(), statusFlow);
             stringifiedResponse = gatewayResponse.getBaseResponse().get().toString();
-        } catch (GatewayErrorException e) {
+        } catch (GatewayException e) {
             logger.error(e.getMessage());
             chargeStatus = statusFlow.getFailureTerminalState();
             stringifiedResponse = e.getMessage();
@@ -107,7 +107,7 @@ public class ChargeCancelService {
         chargeEventDao.persistChargeEventOf(chargeEntity);
     }
 
-    private GatewayResponse<BaseCancelResponse> doGatewayCancel(ChargeEntity chargeEntity) throws GatewayErrorException {
+    private GatewayResponse<BaseCancelResponse> doGatewayCancel(ChargeEntity chargeEntity) throws GatewayException {
         return providers.byName(chargeEntity.getPaymentGatewayName()).cancel(CancelGatewayRequest.valueOf(chargeEntity));
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayException.java
@@ -3,17 +3,19 @@ package uk.gov.pay.connector.gateway;
 import uk.gov.pay.connector.gateway.model.ErrorType;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 
-public abstract class GatewayErrorException extends Exception {
+import java.util.Optional;
 
-    private GatewayErrorException(String message) {
+public abstract class GatewayException extends Exception {
+
+    private GatewayException(String message) {
         super(message);
     }
 
     public abstract GatewayError toGatewayError();
 
-    public static class GenericGatewayErrorException extends GatewayErrorException {
+    public static class GenericGatewayException extends GatewayException {
 
-        public GenericGatewayErrorException(String message) {
+        public GenericGatewayException(String message) {
             super(message);
         }
 
@@ -22,9 +24,9 @@ public abstract class GatewayErrorException extends Exception {
         }
     }
 
-    public static class GatewayConnectionTimeoutErrorException extends GatewayErrorException {
+    public static class GatewayConnectionTimeoutException extends GatewayException {
 
-        public GatewayConnectionTimeoutErrorException(String message) {
+        public GatewayConnectionTimeoutException(String message) {
             super(message);
         }
 
@@ -33,18 +35,25 @@ public abstract class GatewayErrorException extends Exception {
         }
     }
 
-    public static class GatewayConnectionErrorException extends GatewayErrorException {
+    public static class GatewayErrorException extends GatewayException {
 
         private final String responseFromGateway;
+        private final Integer status;
 
-        public GatewayConnectionErrorException(String message, String responseFromGateway) {
+        public GatewayErrorException(String message, String responseFromGateway, int status) {
             super(message);
             this.responseFromGateway = responseFromGateway;
+            this.status = status;
         }
 
-        public GatewayConnectionErrorException(String message) {
+        public GatewayErrorException(String message) {
             super(message);
             this.responseFromGateway = "null";
+            this.status = null;
+        }
+
+        public Optional<Integer> getStatus() {
+            return Optional.ofNullable(status);
         }
 
         public String getResponseFromGateway() {

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayResponseUnmarshaller.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayResponseUnmarshaller.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gateway;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshallerException;
 
@@ -12,7 +11,7 @@ public class GatewayResponseUnmarshaller {
 
     private static final Logger logger = LoggerFactory.getLogger(GatewayResponseUnmarshaller.class);
     
-    public static <T> T unmarshallResponse(GatewayClient.Response response, Class<T> unmarshallingTarget) throws GatewayConnectionErrorException {
+    public static <T> T unmarshallResponse(GatewayClient.Response response, Class<T> unmarshallingTarget) throws GatewayException.GatewayErrorException {
         String payload = response.getEntity();
         logger.debug("response payload={}", payload);
         try {
@@ -20,7 +19,7 @@ public class GatewayResponseUnmarshaller {
         } catch (XMLUnmarshallerException e) {
             String error = format("Could not unmarshall response %s.", payload);
             logger.error(error, e);
-            throw new GatewayConnectionErrorException("Invalid Response Received From Gateway");
+            throw new GatewayException.GatewayErrorException("Invalid Response Received From Gateway");
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -22,19 +22,19 @@ public interface PaymentProvider {
 
     Optional<String> generateTransactionId();
 
-    GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws GatewayErrorException;
+    GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws GatewayException;
 
-    ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) throws GatewayErrorException;
+    ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) throws GatewayException;
 
     Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 
-    GatewayResponse<BaseAuthoriseResponse> authoriseWallet(WalletAuthorisationGatewayRequest request) throws GatewayErrorException;
+    GatewayResponse<BaseAuthoriseResponse> authoriseWallet(WalletAuthorisationGatewayRequest request) throws GatewayException;
 
     CaptureResponse capture(CaptureGatewayRequest request);
 
     GatewayRefundResponse refund(RefundGatewayRequest request);
 
-    GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayErrorException;
+    GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayException;
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity);
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.epdq;
 import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -41,7 +41,7 @@ public class EpdqCaptureHandler implements CaptureHandler {
                     buildCaptureOrder(request),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, EpdqCaptureResponse.class), PENDING);
-        } catch (GatewayErrorException e) {
+        } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.gateway.epdq;
 
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionTimeoutErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.RefundHandler;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqRefundResponse;
@@ -43,7 +43,7 @@ public class EpdqRefundHandler implements RefundHandler {
                     buildRefundOrder(request),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, EpdqRefundResponse.class), PENDING);
-        } catch (GenericGatewayErrorException | GatewayConnectionTimeoutErrorException | GatewayConnectionErrorException e) {
+        } catch (GenericGatewayException | GatewayException.GatewayConnectionTimeoutException | GatewayErrorException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -3,10 +3,8 @@ package uk.gov.pay.connector.gateway.model.response;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionTimeoutErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 
 import java.util.Optional;
@@ -53,11 +51,11 @@ public class GatewayResponse<T extends BaseResponse> {
         return Optional.ofNullable(gatewayError);
     }
     
-    public void throwGatewayError() throws GatewayErrorException {
+    public void throwGatewayError() throws GatewayException {
         switch (gatewayError.getErrorType()) {
-            case GENERIC_GATEWAY_ERROR: throw new GenericGatewayErrorException(gatewayError.getMessage());
-            case GATEWAY_CONNECTION_ERROR: throw new GatewayConnectionErrorException(gatewayError.getMessage());
-            case GATEWAY_CONNECTION_TIMEOUT_ERROR: throw new GatewayConnectionTimeoutErrorException(gatewayError.getMessage());
+            case GENERIC_GATEWAY_ERROR: throw new GatewayException.GenericGatewayException(gatewayError.getMessage());
+            case GATEWAY_CONNECTION_ERROR: throw new GatewayException.GatewayErrorException(gatewayError.getMessage());
+            case GATEWAY_CONNECTION_TIMEOUT_ERROR: throw new GatewayConnectionTimeoutException(gatewayError.getMessage());
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.smartpay;
 import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 
@@ -34,7 +34,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
                     buildCaptureOrderFor(request),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, SmartpayCaptureResponse.class), PENDING);
-        } catch (GatewayErrorException e) {
+        } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.RefundHandler;
 import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
@@ -35,7 +35,7 @@ public class SmartpayRefundHandler implements RefundHandler {
                     buildRefundOrderFor(request),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, SmartpayRefundResponse.class), PENDING);
-        } catch (GatewayErrorException e) {
+        } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -2,11 +2,8 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import uk.gov.pay.connector.gateway.CaptureHandler;
-import uk.gov.pay.connector.gateway.CaptureResponse;
-import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.*;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 
 import java.net.URI;
@@ -37,7 +34,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
                     buildCaptureOrder(request),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, WorldpayCaptureResponse.class), PENDING);
-        } catch (GatewayErrorException e) {
+        } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());
         }
      }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.gateway.worldpay;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
@@ -16,11 +16,11 @@ public interface WorldpayGatewayResponseGenerator {
 
     Logger logger = LoggerFactory.getLogger(WorldpayGatewayResponseGenerator.class);
 
-    default GatewayResponse getWorldpayGatewayResponse(GatewayClient.Response response) throws GatewayConnectionErrorException {
+    default GatewayResponse getWorldpayGatewayResponse(GatewayClient.Response response) throws GatewayErrorException {
         return getWorldpayGatewayResponse(response, WorldpayOrderStatusResponse.class);
     }
 
-    default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GatewayConnectionErrorException {
+    default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<T> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, target));
         Optional.ofNullable(response.getResponseCookies().get(WORLDPAY_MACHINE_COOKIE_NAME))

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.RefundHandler;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
@@ -35,7 +35,7 @@ public class WorldpayRefundHandler implements RefundHandler {
                     buildRefundOrder(request), 
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, WorldpayRefundResponse.class), PENDING);
-        } catch (GatewayErrorException e) {
+        } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.worldpay.applepay;
 
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -27,7 +27,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
     }
 
     @Override
-    public GatewayResponse<BaseAuthoriseResponse> authorise(WalletAuthorisationGatewayRequest request) throws GatewayErrorException {
+    public GatewayResponse<BaseAuthoriseResponse> authorise(WalletAuthorisationGatewayRequest request) throws GatewayException {
         
         GatewayClient.Response response = authoriseClient.postRequestFor(
                 gatewayUrlMap.get(request.getGatewayAccount().getType()), 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseBaseService.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.exception.GenericGatewayRuntimeException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -72,10 +72,10 @@ public class CardAuthoriseBaseService {
         ).inc();
     }
     
-    public static ChargeStatus mapFromGatewayErrorException(GatewayErrorException e) {
-        if (e instanceof GatewayErrorException.GenericGatewayErrorException) return AUTHORISATION_ERROR;
-        if (e instanceof GatewayErrorException.GatewayConnectionTimeoutErrorException) return AUTHORISATION_TIMEOUT;
-        if (e instanceof GatewayErrorException.GatewayConnectionErrorException) return AUTHORISATION_UNEXPECTED_ERROR;
-        throw new RuntimeException("Unrecognised GatewayErrorException instance " + e.getClass());
+    public static ChargeStatus mapFromGatewayErrorException(GatewayException e) {
+        if (e instanceof GatewayException.GenericGatewayException) return AUTHORISATION_ERROR;
+        if (e instanceof GatewayException.GatewayConnectionTimeoutException) return AUTHORISATION_TIMEOUT;
+        if (e instanceof GatewayException.GatewayErrorException) return AUTHORISATION_UNEXPECTED_ERROR;
+        throw new RuntimeException("Unrecognised GatewayException instance " + e.getClass());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -72,7 +72,7 @@ public class CardAuthoriseService {
                 auth3dsDetailsEntity = extractAuth3dsDetails(operationResponse);
                 sessionIdentifier = operationResponse.getSessionIdentifier();
                 
-            } catch (GatewayErrorException e) {
+            } catch (GatewayException e) {
                 newStatus = CardAuthoriseBaseService.mapFromGatewayErrorException(e);
                 operationResponse = GatewayResponse.GatewayResponseBuilder.responseBuilder().withGatewayError(e.toGatewayError()).build();
             }
@@ -139,7 +139,7 @@ public class CardAuthoriseService {
         return cardTypes.stream().anyMatch(CardTypeEntity::isRequires3ds);
     }
 
-    private GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, AuthCardDetails authCardDetails) throws GatewayErrorException {
+    private GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, AuthCardDetails authCardDetails) throws GatewayException {
         return getPaymentProviderFor(charge).authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails));
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
@@ -4,7 +4,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeExpiryService;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.report.model.GatewayStatusComparison;
 
 import javax.inject.Inject;
@@ -44,7 +44,7 @@ public class DiscrepancyService {
                 .map(charge -> {
                     try {
                         return GatewayStatusComparison.from(charge, queryService.getChargeGatewayStatus(charge));
-                    } catch(GatewayErrorException e) {
+                    } catch(GatewayException e) {
                         return GatewayStatusComparison.getEmpty(charge);
                     }
                 });

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 
@@ -15,7 +15,7 @@ public class QueryService {
         this.providers = providers;
     }
     
-    public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) throws GatewayErrorException {
+    public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) throws GatewayException {
         return providers.byName(charge.getPaymentGatewayName()).queryPaymentStatus(charge);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationHandler.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.wallets;
 
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
 public interface WalletAuthorisationHandler {
-    GatewayResponse<BaseAuthoriseResponse> authorise(WalletAuthorisationGatewayRequest request) throws GatewayErrorException;
+    GatewayResponse<BaseAuthoriseResponse> authorise(WalletAuthorisationGatewayRequest request) throws GatewayException;
 }

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -9,8 +9,8 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -68,12 +68,12 @@ public class WalletAuthoriseService {
                     operationResponse.throwGatewayError();
                 }
 
-            } catch (GatewayErrorException e) {
+            } catch (GatewayException e) {
                 
                 logger.error("Error occurred authorising charge. Charge external id: {}; message: {}", charge.getExternalId(), e.getMessage());
                 
-                if (e instanceof GatewayConnectionErrorException) {
-                    logger.error("Response from gateway: {}", ((GatewayConnectionErrorException) e).getResponseFromGateway());
+                if (e instanceof GatewayErrorException) {
+                    logger.error("Response from gateway: {}", ((GatewayErrorException) e).getResponseFromGateway());
                 }
                 
                 chargeStatus = CardAuthoriseBaseService.mapFromGatewayErrorException(e);
@@ -163,7 +163,7 @@ public class WalletAuthoriseService {
     }
 
     private GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity chargeEntity, WalletAuthorisationData walletAuthorisationData)
-            throws GatewayErrorException {
+            throws GatewayException {
 
         logger.info("Authorising charge for {}", walletAuthorisationData.getWalletType().toString());
         WalletAuthorisationGatewayRequest authorisationGatewayRequest =

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -14,8 +14,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GenericGatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -182,7 +181,7 @@ public class ChargeExpiryServiceTest {
 
                     try {
                         verify(mockPaymentProvider, never()).cancel(any());
-                    } catch (GatewayErrorException ignored) {}
+                    } catch (GatewayException ignored) {}
                     
                     assertThat(chargeEntity.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
                 });
@@ -198,7 +197,7 @@ public class ChargeExpiryServiceTest {
                 .build();
 
         when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
-        when(mockPaymentProvider.cancel(any())).thenThrow(new GenericGatewayErrorException("something went wrong"));
+        when(mockPaymentProvider.cancel(any())).thenThrow(new GatewayException.GenericGatewayException("something went wrong"));
         ArgumentCaptor<ChargeEntity> captor = ArgumentCaptor.forClass(ChargeEntity.class);
         doNothing().when(mockChargeEventDao).persistChargeEventOf(captor.capture());
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -86,7 +86,7 @@ public class EpdqCaptureHandlerTest {
     @Test
     public void shouldNotCaptureIfPaymentProviderReturnsNon200HttpStatusCode() throws Exception {
         when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
         
         CaptureResponse gatewayResponse = epdqCaptureHandler.capture(buildTestCaptureRequest());
         assertThat(gatewayResponse.isSuccessful(), is(false));

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -4,7 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.ErrorType;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -58,7 +58,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         try {
             mockPaymentProviderResponse(400, errorAuthResponse());
             provider.authorise(buildTestAuthorisationRequest());
-        } catch (GatewayErrorException.GatewayConnectionErrorException e) {
+        } catch (GatewayException.GatewayErrorException e) {
             assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_CONNECTION_ERROR));
         }
     }
@@ -85,7 +85,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
         try {
             mockPaymentProviderResponse(400, errorCancelResponse());
             provider.cancel(buildTestCancelRequest());
-        } catch (GatewayErrorException.GatewayConnectionErrorException e) {
+        } catch (GatewayException.GatewayErrorException e) {
             assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_CONNECTION_ERROR));
         }
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -85,7 +85,7 @@ public class WorldpayCaptureHandlerTest {
     @Test
     public void shouldErrorIfWorldpayResponseIsNot200() throws Exception {
         when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayErrorException.GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
         
         CaptureResponse gatewayResponse = worldpayCaptureHandler.capture(getCaptureRequest());
         assertThat(gatewayResponse.isSuccessful(), is(false));

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -8,11 +8,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.GatewayClientFactory;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
-import uk.gov.pay.connector.gateway.GatewayOperation;
-import uk.gov.pay.connector.gateway.GatewayOrder;
-import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.*;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ErrorType;
@@ -84,7 +80,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         chargeEntity.setGatewayAccount(gatewayAccountEntity);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -122,7 +118,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         chargeEntity.setGatewayAccount(gatewayAccountEntity);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any())).thenReturn(mockGatewayClient);
@@ -130,7 +126,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         try {
             WorldpayPaymentProvider worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
             worldpayPaymentProvider.authorise(getCardAuthorisationRequest(chargeEntity));
-        } catch (GatewayConnectionErrorException e) {
+        } catch (GatewayException.GatewayErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), anyMap());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS), gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -152,7 +148,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
 
         gatewayAccountEntity.setRequires3ds(true);
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -162,7 +158,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
 
         try {
             worldpayPaymentProvider.authorise(getCardAuthorisationRequest(mockChargeEntity));
-        } catch (GatewayConnectionErrorException e) {
+        } catch (GatewayException.GatewayErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), anyMap());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS), gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -178,7 +174,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         when(mockChargeEntity.getGatewayTransactionId()).thenReturn("MyUniqueTransactionId!");
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 401 from gateway"));
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 401 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any())).thenReturn(mockGatewayClient);
@@ -212,7 +208,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         when(mockChargeEntity.getProviderSessionId()).thenReturn(providerSessionId);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -247,7 +243,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         when(mockChargeEntity.getProviderSessionId()).thenReturn(providerSessionId);
 
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(GatewayOperation.class), any()))
@@ -284,7 +280,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
         mockWorldpayErrorResponse(401);
         try {
             provider.authorise(getCardAuthorisationRequest());
-        } catch (GatewayConnectionErrorException e) {
+        } catch (GatewayException.GatewayErrorException e) {
             assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 401 from gateway", ErrorType.GATEWAY_CONNECTION_ERROR));
         }
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
@@ -61,14 +61,14 @@ public class WorldpayWalletAuthorisationHandlerTest {
         chargeEntity.setGatewayAccount(gatewayAccountEntity);
         gatewayAccountEntity.setCredentials(ImmutableMap.of("merchant_id", "MERCHANTCODE"));
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
-                .thenThrow(new GatewayConnectionErrorException("Unexpected HTTP status code 400 from gateway"));
+                .thenThrow(new GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
     }
 
     @Test
     public void shouldSendApplePayRequestWhenApplePayDetailsArePresent() throws Exception {
         try {
             worldpayApplePayAuthorisationHandler.authorise(getApplePayAuthorisationRequest());
-        } catch (GatewayConnectionErrorException e) {
+        } catch (GatewayErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
@@ -82,7 +82,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
     public void shouldSendGooglePayRequestWhenGooglePayDetailsArePresent() throws Exception {
         try {
             worldpayApplePayAuthorisationHandler.authorise(getGooglePayAuthorisationRequest());
-        } catch (GatewayConnectionErrorException e) {
+        } catch (GatewayErrorException e) {
             ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
             ArgumentCaptor<Map<String, String>> headers = ArgumentCaptor.forClass(Map.class);
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -19,7 +19,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
@@ -601,7 +601,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Test
     public void doAuthorise_shouldReportAuthorisationTimeout_whenProviderTimeout() throws Exception {
         
-        providerWillRespondWithError(new GatewayErrorException.GatewayConnectionTimeoutErrorException("Connection timed out"));
+        providerWillRespondWithError(new GatewayException.GatewayConnectionTimeoutException("Connection timed out"));
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
@@ -615,7 +615,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Test
     public void doAuthorise_shouldReportUnexpectedError_whenProviderError() throws Exception {
 
-        providerWillRespondWithError(new GatewayErrorException.GatewayConnectionErrorException("Malformed response received"));
+        providerWillRespondWithError(new GatewayException.GatewayErrorException("Malformed response received"));
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
@@ -8,7 +8,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.service.ChargeExpiryService;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 
@@ -42,7 +42,7 @@ public class DiscrepancyServiceTest {
     }
     
     @Test
-    public void aChargeShouldBeCancellable_whenPayAndGatewayStatusesAllowItAndIsOlderThan7Days() throws GatewayErrorException {
+    public void aChargeShouldBeCancellable_whenPayAndGatewayStatusesAllowItAndIsOlderThan7Days() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.now().minusDays(8))
                 .withStatus(EXPIRED)
@@ -57,7 +57,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenPayAndGatewayStatusesMatch() throws GatewayErrorException{
+    public void aChargeShouldNotBeCancellable_whenPayAndGatewayStatusesMatch() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.now().minusDays(8))
                 .withStatus(AUTHORISATION_SUCCESS)
@@ -68,7 +68,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenPayStatusIsSuccess() throws GatewayErrorException{
+    public void aChargeShouldNotBeCancellable_whenPayStatusIsSuccess() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.now().minusDays(8))
                 .withStatus(CAPTURED)
@@ -79,7 +79,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenPayStatusIsUnfinished() throws GatewayErrorException{
+    public void aChargeShouldNotBeCancellable_whenPayStatusIsUnfinished() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.now().minusDays(8))
                 .withStatus(AUTHORISATION_3DS_READY)
@@ -90,7 +90,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenGatewayStatusIsFinished() throws GatewayErrorException {
+    public void aChargeShouldNotBeCancellable_whenGatewayStatusIsFinished() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.now().minusDays(8))
                 .withStatus(EXPIRED)
@@ -101,7 +101,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenChargeIsLessThan7DaysOld() throws GatewayErrorException{
+    public void aChargeShouldNotBeCancellable_whenChargeIsLessThan7DaysOld() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.now().minusDays(6))
                 .withStatus(EXPIRED)
@@ -111,7 +111,7 @@ public class DiscrepancyServiceTest {
         assertChargeIsNotCancelled(charge, chargeQueryResponse);
     }
 
-    private void assertChargeIsNotCancelled(ChargeEntity charge, ChargeQueryResponse chargeQueryResponse) throws GatewayErrorException {
+    private void assertChargeIsNotCancelled(ChargeEntity charge, ChargeQueryResponse chargeQueryResponse) throws GatewayException {
         when(chargeService.findChargeById(charge.getExternalId())).thenReturn(charge);
         when(queryService.getChargeGatewayStatus(charge)).thenReturn(chargeQueryResponse);
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -12,7 +12,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -27,8 +27,6 @@ import javax.ws.rs.core.Response;
 import java.net.HttpCookie;
 import java.net.SocketException;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 import static java.util.Collections.emptyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,8 +34,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GatewayClientTest {
@@ -91,14 +87,14 @@ public class GatewayClientTest {
         when(mockGatewayOrder.getMediaType()).thenReturn(mediaType);
     }
 
-    @Test(expected = GatewayErrorException.GatewayConnectionErrorException.class)
+    @Test(expected = GatewayException.GatewayErrorException.class)
     public void shouldReturnGatewayErrorWhenProviderFails() throws Exception {
         when(mockResponse.getStatus()).thenReturn(500);
         gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, mockGatewayAccountEntity, mockGatewayOrder, emptyMap());
         verify(mockResponse).close();
     }
 
-    @Test(expected = GatewayErrorException.GenericGatewayErrorException.class)
+    @Test(expected = GatewayException.GenericGatewayException.class)
     public void shouldReturnGatewayErrorWhenProviderFailsWithAProcessingException() throws Exception {
         when(mockBuilder.post(Entity.entity(orderPayload, mediaType))).thenThrow(new ProcessingException(new SocketException("socket failed")));
         gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, mockGatewayAccountEntity, mockGatewayOrder, emptyMap());

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -25,8 +25,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionErrorException;
-import uk.gov.pay.connector.gateway.GatewayErrorException.GatewayConnectionTimeoutErrorException;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -321,7 +321,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldReportAuthorisationTimeout_whenProviderTimeout() throws Exception {
-        providerWillRespondWithError(new GatewayConnectionTimeoutErrorException("Connection timed out"));
+        providerWillRespondWithError(new GatewayConnectionTimeoutException("Connection timed out"));
 
         GatewayResponse response = walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
@@ -331,7 +331,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Test
     public void doAuthorise_shouldReportUnexpectedError_whenProviderError() throws Exception {
-        providerWillRespondWithError(new GatewayConnectionErrorException("Malformed response received"));
+        providerWillRespondWithError(new GatewayException.GatewayErrorException("Malformed response received"));
 
         GatewayResponse response = walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 


### PR DESCRIPTION
The end goal is to delete StripeGatewayClient. Classes that use
StripeGatwayClient rely on the status code field of the
`uk.gov.pay.connector.gateway.stripe.GatewayClientException` thrown to
determine how to respond to the original API call. This commit therefore adds
status code to the now-renamed GatewayErrorException so we can deprecate
StripeGatewayClient while preserving functionality. Note that
`uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException` will
represent 4xx and 5xx errors and there is no need to have separate classes
representing either like it's being done with StripeGatewayClient.

I also took the opportunity to rename the
`uk.gov.pay.connector.gateway.GatewayException` class and subclasses to
something more succint. I really disliked the old naming of
'GatewayConnectionErrorException' as it was never about an issue with
connecting to the PSP.
