### PR TITLE
Pp 4993 fees and refunds using net transfer

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -4,6 +4,7 @@ import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 public class StripeGatewayConfig extends Configuration {
 
@@ -18,9 +19,16 @@ public class StripeGatewayConfig extends Configuration {
     @Valid
     @NotNull
     private StripeWebhookSigningSecrets webhookSigningSecrets;
+    
+    @Valid
+    private Double feePercentage;
 
     @Valid
     private String platformAccountId;
+
+    @Valid
+    @NotNull
+    private Boolean collectFee;
 
     public String getUrl() {
         return url;
@@ -32,6 +40,16 @@ public class StripeGatewayConfig extends Configuration {
 
     public StripeWebhookSigningSecrets getWebhookSigningSecrets() {
         return webhookSigningSecrets;
+    }
+
+
+    public Double getFeePercentage() {
+        return Optional.ofNullable(feePercentage).orElse(0.0);
+    }
+
+
+    public Boolean isCollectFee() {
+        return collectFee;
     }
 
     public String getPlatformAccountId() {

--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -19,6 +19,9 @@ public class StripeGatewayConfig extends Configuration {
     @NotNull
     private StripeWebhookSigningSecrets webhookSigningSecrets;
 
+    @Valid
+    private String platformAccountId;
+
     public String getUrl() {
         return url;
     }
@@ -29,5 +32,9 @@ public class StripeGatewayConfig extends Configuration {
 
     public StripeWebhookSigningSecrets getWebhookSigningSecrets() {
         return webhookSigningSecrets;
+    }
+
+    public String getPlatformAccountId() {
+        return platformAccountId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.charge.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -15,6 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @Entity
@@ -23,6 +25,17 @@ import java.time.ZonedDateTime;
 @SequenceGenerator(name = "charges_charge_id_seq",
         sequenceName = "charges_charge_id_seq", allocationSize = 1)
 public class FeeEntity {
+    public FeeEntity() {
+        
+    }
+    
+    public FeeEntity(ChargeEntity chargeEntity, Long amount) {
+        this.externalId = RandomIdGenerator.newId();
+        this.chargeEntity = chargeEntity;
+        this.amountDue = amount;
+        this.amountCollected = amount;
+        this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "charges_charge_id_seq")

--- a/src/main/java/uk/gov/pay/connector/fee/dao/FeeDao.java
+++ b/src/main/java/uk/gov/pay/connector/fee/dao/FeeDao.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.fee.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+import uk.gov.pay.connector.common.dao.JpaDao;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+@Transactional
+public class FeeDao extends JpaDao<FeeEntity> {
+    @Inject
+    public FeeDao(final Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
@@ -14,6 +14,7 @@ public class CaptureResponse {
     private final ChargeState chargeState;
     private final GatewayError gatewayError;
     private final String stringified;
+    private Long feeAmount;
 
     private CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError, String stringified) {
         this.transactionId = transactionId;
@@ -21,9 +22,21 @@ public class CaptureResponse {
         this.gatewayError = gatewayError;
         this.stringified = stringified;
     }
-    
-    public static CaptureResponse of(String transactionId, ChargeState chargeState) {
-        return new CaptureResponse(transactionId, chargeState, null, null);
+
+    public CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError, String stringified, Long feeAmount) {
+        this.transactionId = transactionId;
+        this.chargeState = chargeState;
+        this.gatewayError = gatewayError;
+        this.stringified = stringified;
+        this.feeAmount = feeAmount;
+    }
+
+    public CaptureResponse(String transactionId, ChargeState chargeState, Long feeAmount) {
+        this(transactionId, chargeState, null, null, feeAmount);
+    }
+
+    public CaptureResponse(GatewayError gatewayError, String stringified) {
+        this(null, null, gatewayError, stringified, null);
     }
 
     public static CaptureResponse fromGatewayError(GatewayError gatewayError) {
@@ -54,6 +67,10 @@ public class CaptureResponse {
 
     public boolean isSuccessful() {
         return gatewayError == null;
+    }
+
+    public Optional<Long> getFee() {
+        return Optional.ofNullable(feeAmount);
     }
 
     public enum ChargeState {

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
@@ -21,6 +21,10 @@ public class CaptureResponse {
         this.gatewayError = gatewayError;
         this.stringified = stringified;
     }
+    
+    public static CaptureResponse of(String transactionId, ChargeState chargeState) {
+        return new CaptureResponse(transactionId, chargeState, null, null);
+    }
 
     public static CaptureResponse fromGatewayError(GatewayError gatewayError) {
         return new CaptureResponse(null, null, gatewayError, gatewayError.toString());

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -4,8 +4,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -127,6 +127,5 @@ public class GatewayClient {
         public Map<String, String> getResponseCookies() {
             return responseCookies;
         }
-
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.ws.rs.ProcessingException;
@@ -39,6 +40,11 @@ public class GatewayClient {
     public GatewayClient.Response postRequestFor(URI url, GatewayAccountEntity account, GatewayOrder request, Map<String, String> headers) 
             throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayConnectionTimeoutException {
         return postRequestFor(url, account, request, emptyList(), headers);
+    }
+    
+    public GatewayClient.Response postRequestFor(GatewayClientRequest request)
+            throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayConnectionTimeoutException {
+        return postRequestFor(request.getUrl(), request.getGatewayAccount(), request.getGatewayOrder(), request.getHeaders());
     }
 
     public GatewayClient.Response postRequestFor(URI url, 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -56,7 +56,7 @@ public class EpdqRefundHandler implements RefundHandler {
                         CREDENTIALS_SHA_IN_PASSPHRASE))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withTransactionId(request.getTransactionId())
-                .withAmount(request.getAmount())
+                .withAmount(request.getAmountAsString())
                 .build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
@@ -12,10 +12,14 @@ public class CaptureGatewayRequest implements GatewayRequest {
         this.charge = charge;
     }
 
-    public String getAmount() {
+    public String getAmountAsString() {
         return String.valueOf(charge.getAmount());
     }
-
+    
+    public Long getAmount() {
+        return charge.getAmount();
+    }
+    
     public String getTransactionId() {
         return charge.getGatewayTransactionId();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayClientRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayClientRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.model.request;
+
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+import java.util.Map;
+
+public interface GatewayClientRequest {
+    URI getUrl();
+    GatewayOrder getGatewayOrder();
+    Map<String, String> getHeaders();
+    GatewayAccountEntity getGatewayAccount();
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -7,12 +7,12 @@ import uk.gov.pay.connector.gateway.GatewayOperation;
 public class RefundGatewayRequest implements GatewayRequest {
 
     private final GatewayAccountEntity gatewayAccountEntity;
-    private final String amount;
+    private final Long amount;
     private final String transactionId;
     private final String refundExternalId;
     private final String chargeExternalId;
 
-    private RefundGatewayRequest(String transactionId, GatewayAccountEntity gatewayAccount, String amount, String refundExternalId, String chargeExternalId) {
+    private RefundGatewayRequest(String transactionId, GatewayAccountEntity gatewayAccount, Long amount, String refundExternalId, String chargeExternalId) {
         this.transactionId = transactionId;
         this.gatewayAccountEntity = gatewayAccount;
         this.amount = amount;
@@ -20,7 +20,11 @@ public class RefundGatewayRequest implements GatewayRequest {
         this.chargeExternalId = chargeExternalId;
     }
 
-    public String getAmount() {
+    public String getAmountAsString() {
+        return String.valueOf(amount);
+    }
+
+    public Long getAmount() {
         return amount;
     }
 
@@ -68,7 +72,7 @@ public class RefundGatewayRequest implements GatewayRequest {
         return new RefundGatewayRequest(
                 refundEntity.getChargeEntity().getGatewayTransactionId(),
                 refundEntity.getChargeEntity().getGatewayAccount(),
-                String.valueOf(refundEntity.getAmount()),
+                refundEntity.getAmount(),
                 refundEntity.getExternalId(),
                 refundEntity.getChargeEntity().getExternalId()
         );

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -10,12 +10,14 @@ public class RefundGatewayRequest implements GatewayRequest {
     private final String amount;
     private final String transactionId;
     private final String refundExternalId;
+    private final String chargeExternalId;
 
-    private RefundGatewayRequest(String transactionId, GatewayAccountEntity gatewayAccount, String amount, String refundExternalId) {
+    private RefundGatewayRequest(String transactionId, GatewayAccountEntity gatewayAccount, String amount, String refundExternalId, String chargeExternalId) {
         this.transactionId = transactionId;
         this.gatewayAccountEntity = gatewayAccount;
         this.amount = amount;
         this.refundExternalId = refundExternalId;
+        this.chargeExternalId = chargeExternalId;
     }
 
     public String getAmount() {
@@ -24,6 +26,10 @@ public class RefundGatewayRequest implements GatewayRequest {
 
     public String getTransactionId() {
         return transactionId;
+    }
+
+    public String getChargeExternalId() {
+        return chargeExternalId;
     }
 
     @Override
@@ -63,7 +69,9 @@ public class RefundGatewayRequest implements GatewayRequest {
                 refundEntity.getChargeEntity().getGatewayTransactionId(),
                 refundEntity.getChargeEntity().getGatewayAccount(),
                 String.valueOf(refundEntity.getAmount()),
-                refundEntity.getExternalId());
+                refundEntity.getExternalId(),
+                refundEntity.getChargeEntity().getExternalId()
+        );
     }
     
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -43,7 +43,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
         return SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withAmount(request.getAmount())
+                .withAmount(request.getAmountAsString())
                 .build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -45,7 +45,7 @@ public class SmartpayRefundHandler implements RefundHandler {
                 .withReference(request.getRefundExternalId())
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(getMerchantCode(request))
-                .withAmount(request.getAmount())
+                .withAmount(request.getAmountAsString())
                 .build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -361,10 +361,9 @@ public class StripePaymentProvider implements PaymentProvider {
         params.add(new BasicNameValuePair("description", description));
         params.add(new BasicNameValuePair("source", sourceId));
         params.add(new BasicNameValuePair("capture", "false"));
+        params.add(new BasicNameValuePair("transfer_group", externalId));
         String stripeAccountId = getStripeAccountId(externalId, gatewayAccount);
-
         params.add(new BasicNameValuePair("on_behalf_of", stripeAccountId));
-        params.add(new BasicNameValuePair("transfer_data[destination]", stripeAccountId));
         return URLEncodedUtils.format(params, UTF_8);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.request.StripeCaptureRequest;
 import uk.gov.pay.connector.gateway.stripe.response.StripeCaptureResponse;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -47,17 +48,10 @@ public class StripeCaptureHandler implements CaptureHandler {
 
     @Override
     public CaptureResponse capture(CaptureGatewayRequest request) {
-
         String transactionId = request.getTransactionId();
-        String url = stripeGatewayConfig.getUrl() + "/v1/charges/" + transactionId + "/capture";
-        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
 
         try {
-            String captureResponse = client.postRequestFor(
-                    URI.create(url),
-                    gatewayAccount, 
-                    new GatewayOrder(OrderRequestType.CAPTURE, StringUtils.EMPTY, APPLICATION_FORM_URLENCODED_TYPE),
-                    AuthUtil.getStripeAuthHeader(stripeGatewayConfig, gatewayAccount.isLive())).getEntity();
+            String captureResponse = client.postRequestFor(StripeCaptureRequest.of(request, stripeGatewayConfig)).getEntity();
             String stripeTransactionId = jsonObjectMapper.getObject(captureResponse, Map.class).get("id").toString();
             return fromBaseCaptureResponse(new StripeCaptureResponse(stripeTransactionId), COMPLETE);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -1,35 +1,25 @@
 package uk.gov.pay.connector.gateway.stripe.handler;
 
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
 import uk.gov.pay.connector.gateway.stripe.response.StripeRefundResponse;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
 import static uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse.fromBaseRefundResponse;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getStripeAuthHeader;
 
 public class StripeRefundHandler {
     private static final Logger logger = LoggerFactory.getLogger(StripeRefundHandler.class);
@@ -37,25 +27,20 @@ public class StripeRefundHandler {
     private final StripeGatewayConfig stripeGatewayConfig;
     private JsonObjectMapper jsonObjectMapper;
 
-    public StripeRefundHandler(GatewayClient client, StripeGatewayConfig stripeGatewayConfig, JsonObjectMapper jsonObjectMapper) {
+    public StripeRefundHandler(
+            GatewayClient client,
+            StripeGatewayConfig stripeGatewayConfig,
+            JsonObjectMapper jsonObjectMapper
+    ) {
         this.client = client;
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.jsonObjectMapper = jsonObjectMapper;
     }
 
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
-        String url = stripeGatewayConfig.getUrl() + "/v1/refunds";
-        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
-
         try {
-            String payload = URLEncodedUtils.format(buildPayload(request.getTransactionId(), request.getAmount()), UTF_8);
-            final String response = client.postRequestFor(URI.create(url),
-                    gatewayAccount,
-                    new GatewayOrder(OrderRequestType.REFUND, payload, APPLICATION_FORM_URLENCODED_TYPE),
-                    getStripeAuthHeader(stripeGatewayConfig, gatewayAccount.isLive())).getEntity();
-            String reference = jsonObjectMapper.getObject(response, Map.class).get("id").toString();
+            String reference = refundCharge(request);
             return fromBaseRefundResponse(StripeRefundResponse.of(reference), GatewayRefundResponse.RefundState.COMPLETE);
-
         } catch (GatewayErrorException e) {
 
             if (e.getFamily() == CLIENT_ERROR) {
@@ -67,7 +52,7 @@ public class StripeRefundHandler {
                         StripeRefundResponse.of(error.getCode(), error.getMessage()),
                         GatewayRefundResponse.RefundState.ERROR);
             }
-            
+
             if (e.getFamily() == SERVER_ERROR) {
                 logger.error("Refund failed for refund gateway request {}. Reason: {}. Status code from Stripe: {}.", request, e.getMessage(), e.getStatus());
                 GatewayError gatewayError = gatewayConnectionError("An internal server error occurred while refunding Transaction id: " + request.getTransactionId());
@@ -77,20 +62,27 @@ public class StripeRefundHandler {
             logger.info("Unrecognised response status when refunding. refund_external_id={}, status={}, response={}",
                     request.getRefundExternalId(), e.getStatus(), e.getResponseFromGateway());
             throw new RuntimeException("Unrecognised response status when refunding.");
-            
+
         } catch (GatewayException e) {
             logger.error("Refund failed for refund gateway request {}. GatewayException: {}.", request, e);
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
-        } 
+        }
     }
 
-    private List<BasicNameValuePair> buildPayload(String chargeGatewayId, String amount) {
-        List<BasicNameValuePair> payload = new ArrayList<>();
-        payload.add(new BasicNameValuePair("charge", chargeGatewayId));
-        payload.add(new BasicNameValuePair("amount", amount));
-        payload.add(new BasicNameValuePair("refund_application_fee", "true"));
-        payload.add(new BasicNameValuePair("reverse_transfer", "true"));
+    private String refundCharge(RefundGatewayRequest request)
+            throws
+            GatewayException.GenericGatewayException,
+            GatewayErrorException,
+            GatewayException.GatewayConnectionTimeoutException {
+        final GatewayClient.Response refundResponse = client.postRequestFor(
+                StripeRefundRequest.of(request, stripeGatewayConfig)
+        );
+        String reference = jsonObjectMapper.getObject(refundResponse.getEntity(), Map.class).get("id").toString();
+        logger.info("As part of refund {} refunded stripe charge id {}",
+                request.getTransactionId(),
+                request.getRefundExternalId()
+        );
 
-        return payload;
+        return reference;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -10,7 +10,9 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeTransferResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
 import uk.gov.pay.connector.gateway.stripe.response.StripeRefundResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
@@ -40,6 +42,8 @@ public class StripeRefundHandler {
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
         try {
             String reference = refundCharge(request);
+            transferFromConnectAccount(request);
+
             return fromBaseRefundResponse(StripeRefundResponse.of(reference), GatewayRefundResponse.RefundState.COMPLETE);
         } catch (GatewayErrorException e) {
 
@@ -69,20 +73,29 @@ public class StripeRefundHandler {
         }
     }
 
-    private String refundCharge(RefundGatewayRequest request)
-            throws
-            GatewayException.GenericGatewayException,
-            GatewayErrorException,
-            GatewayException.GatewayConnectionTimeoutException {
-        final GatewayClient.Response refundResponse = client.postRequestFor(
-                StripeRefundRequest.of(request, stripeGatewayConfig)
+
+    private void transferFromConnectAccount(RefundGatewayRequest request) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
+        String transferResponse = client.postRequestFor(StripeTransferInRequest.of(request, stripeGatewayConfig)).getEntity();
+        StripeTransferResponse stripeTransferResponse = jsonObjectMapper.getObject(transferResponse, StripeTransferResponse.class);
+        logger.info("As part of refund {} refunding charge id {}, transferred net amount {} - transfer id {} -  from Stripe Connect account id {} in transfer group {}",
+                request.getRefundExternalId(),
+                request.getChargeExternalId(),
+                stripeTransferResponse.getAmount(),
+                stripeTransferResponse.getId(),
+                stripeTransferResponse.getDestinationStripeAccountId(),
+                stripeTransferResponse.getStripeTransferGroup()
         );
-        String reference = jsonObjectMapper.getObject(refundResponse.getEntity(), Map.class).get("id").toString();
-        logger.info("As part of refund {} refunded stripe charge id {}",
+    }
+    
+    private String refundCharge(RefundGatewayRequest request) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
+        final String refundResponse = client.postRequestFor(StripeRefundRequest.of(request, stripeGatewayConfig)).getEntity();
+        String reference = jsonObjectMapper.getObject(refundResponse, Map.class).get("id").toString();
+        logger.info("As part of refund {} to refund charge id {} refunded stripe charge id {}",
                 request.getTransactionId(),
+                request.getChargeExternalId(),
                 request.getRefundExternalId()
         );
-
+        
         return reference;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCaptureResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeCaptureResponse {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("balance_transaction")
+    private BalanceTransaction balanceTransaction;
+
+
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class BalanceTransaction {
+
+        @JsonProperty("fee")
+        private Long fee;
+
+        public Long getFee() {
+            return fee;
+        }
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Long getFee() {
+        return balanceTransaction.getFee();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -2,6 +2,9 @@ package uk.gov.pay.connector.gateway.stripe.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.StringJoiner;
 
 /** Example response from Stripe:
 {
@@ -42,6 +45,13 @@ public class StripeErrorResponse {
     
     @Override
     public String toString() {
-        return "error code: " + error.code + " error message: " + error.message;
+        StringJoiner joiner = new StringJoiner(", ", "Stripe capture response (", ")");
+        if (StringUtils.isNotBlank(error.getCode())) {
+            joiner.add("error code: " + error.getCode());
+        }
+        if (StringUtils.isNotBlank(error.getMessage())) {
+            joiner.add("error: " + error.getMessage());
+        }
+        return joiner.toString();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -39,4 +39,9 @@ public class StripeErrorResponse {
             return message;
         }
     }
+    
+    @Override
+    public String toString() {
+        return "error code: " + error.code + " error message: " + error.message;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeTransferResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeTransferResponse.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeTransferResponse {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("amount")
+    private String amount;
+
+    @JsonProperty("destination")
+    private String destinationStripeAccountId;
+
+    @JsonProperty("transfer_group")
+    private String stripeTransferGroup;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public String getDestinationStripeAccountId() {
+        return destinationStripeAccountId;
+    }
+
+    public String getStripeTransferGroup() {
+        return stripeTransferGroup;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+public class StripeCaptureRequest extends StripeRequest {
+
+    private String stripeChargeId;
+
+    private StripeCaptureRequest(
+            GatewayAccountEntity gatewayAccount,
+            String stripeChargeId,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeChargeId = stripeChargeId;
+    }
+    
+    public static StripeCaptureRequest of(CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeCaptureRequest(
+                request.getGatewayAccount(),
+                request.getTransactionId(),
+                request.getExternalId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    public URI getUrl() {
+        return URI.create(stripeGatewayConfig.getUrl() + "/v1/charges/" + stripeChargeId + "/capture");
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        List<BasicNameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("expand[]", "balance_transaction"));
+        String payload = URLEncodedUtils.format(params, UTF_8);
+
+        return new GatewayOrder(
+                OrderRequestType.CAPTURE,
+                payload,
+                APPLICATION_FORM_URLENCODED_TYPE
+        );    
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+public class StripeRefundRequest extends StripeRequest {
+    private final String stripeChargeId;
+    private final String amount;
+    
+    private StripeRefundRequest(
+            String amount,
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            String stripeChargeId,
+            StripeGatewayConfig stripeGatewayConfig
+            ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeChargeId = stripeChargeId;
+        this.amount = amount;
+    }
+    
+    public static StripeRefundRequest of(RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeRefundRequest(              
+                request.getAmount(),
+                request.getGatewayAccount(),
+                request.getRefundExternalId(),
+                request.getTransactionId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    public URI getUrl() {
+        return URI.create(stripeGatewayConfig.getUrl() + "/v1/refunds");
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        List<BasicNameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("charge", stripeChargeId));
+        params.add(new BasicNameValuePair("amount", amount));
+        params.add(new BasicNameValuePair("refund_application_fee", "true"));
+        String payload = URLEncodedUtils.format(params, UTF_8);
+
+        return new GatewayOrder(
+                OrderRequestType.REFUND,
+                payload,
+                APPLICATION_FORM_URLENCODED_TYPE
+        );    
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -17,10 +17,10 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 
 public class StripeRefundRequest extends StripeRequest {
     private final String stripeChargeId;
-    private final String amount;
+    private final Long amount;
     
     private StripeRefundRequest(
-            String amount,
+            Long amount,
             GatewayAccountEntity gatewayAccount,
             String idempotencyKey,
             String stripeChargeId,
@@ -50,7 +50,7 @@ public class StripeRefundRequest extends StripeRequest {
     public GatewayOrder getGatewayOrder() {
         List<BasicNameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("charge", stripeChargeId));
-        params.add(new BasicNameValuePair("amount", amount));
+        params.add(new BasicNameValuePair("amount", String.valueOf(amount)));
         params.add(new BasicNameValuePair("refund_application_fee", "true"));
         String payload = URLEncodedUtils.format(params, UTF_8);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
+import uk.gov.pay.connector.gateway.util.AuthUtil;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class StripeRequest implements GatewayClientRequest {
+
+    protected GatewayAccountEntity gatewayAccount;
+    private String idempotencyKey;
+    protected StripeGatewayConfig stripeGatewayConfig;
+    protected String stripeConnectAccountId;
+
+    protected StripeRequest(GatewayAccountEntity gatewayAccount, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig) {
+        if (gatewayAccount == null) {
+            throw new IllegalArgumentException("Cannot create StripeRequest without a gateway account");
+        }
+
+        String stripeConnectAccountId = gatewayAccount.getCredentials().get("stripe_account_id");
+        if (stripeConnectAccountId == null) {
+            throw new IllegalArgumentException("Cannot create StripeRequest with a gateway account with out a stripe account id set");
+        }
+        
+        this.gatewayAccount = gatewayAccount;
+        this.idempotencyKey = idempotencyKey;
+        this.stripeGatewayConfig = stripeGatewayConfig;
+        this.stripeConnectAccountId = stripeConnectAccountId;
+    }
+
+    public GatewayAccountEntity getGatewayAccount() {
+        return gatewayAccount;
+    }
+
+    public Map<String, String> getHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        Optional.ofNullable(idempotencyKey).ifPresent(idempotencyKey -> headers.put("Idempotency-Key", idempotencyKey));
+        headers.putAll(AuthUtil.getStripeAuthHeader(stripeGatewayConfig, gatewayAccount.isLive()));
+
+        return headers;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -22,7 +22,7 @@ public class StripeTransferInRequest extends StripeTransferRequest {
     private final String transferGroup;
 
     private StripeTransferInRequest(
-            String amount,
+            Long amount,
             GatewayAccountEntity gatewayAccount,
             String stripeChargeId,
             String idempotencyKey,

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+/***
+ * Represents a request to transfer an amount from a Stripe Connect account to 
+ * Pay's Stripe Platform account
+ */
+public class StripeTransferInRequest extends StripeTransferRequest {
+    private final String transferGroup;
+
+    private StripeTransferInRequest(
+            String amount,
+            GatewayAccountEntity gatewayAccount,
+            String stripeChargeId,
+            String idempotencyKey,
+            String transferGroup,
+            StripeGatewayConfig stripeGatewayConfig
+    ) {
+        super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig);
+        this.transferGroup = transferGroup;
+    }
+
+    public static StripeTransferInRequest of(RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeTransferInRequest(
+                request.getAmount(),
+                request.getGatewayAccount(),
+                request.getTransactionId(),
+                request.getRefundExternalId(),
+                request.getChargeExternalId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        List<BasicNameValuePair> params = getCommonPayloadParameters();
+        params.add(new BasicNameValuePair("destination", stripeGatewayConfig.getPlatformAccountId()));
+        params.add(new BasicNameValuePair("transfer_group", transferGroup));
+        String payload = URLEncodedUtils.format(params, UTF_8);
+
+        return new GatewayOrder(
+                OrderRequestType.REFUND,
+                payload,
+                APPLICATION_FORM_URLENCODED_TYPE
+        );
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        Map<String, String> headers = super.getHeaders();
+        headers.put("Stripe-Account", stripeConnectAccountId);
+
+        return headers;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+public class StripeTransferOutRequest extends StripeTransferRequest {
+
+    public StripeTransferOutRequest(String amount,
+                                    GatewayAccountEntity gatewayAccount,
+                                    String sourceTransactionId,
+                                    String idempotencyKey,
+                                    StripeGatewayConfig stripeGatewayConfig
+    ) {
+        super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig);
+    }
+    
+    public static StripeTransferOutRequest of(String amount, CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeTransferOutRequest(
+                amount,
+                request.getGatewayAccount(),
+                request.getTransactionId(),
+                request.getExternalId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        List<BasicNameValuePair> params = getCommonPayloadParameters();
+        params.add(new BasicNameValuePair("destination", stripeConnectAccountId));
+        params.add(new BasicNameValuePair("source_transaction", stripeChargeId));
+        String payload = URLEncodedUtils.format(params, UTF_8);
+
+        return new GatewayOrder(
+                OrderRequestType.CAPTURE,
+                payload,
+                APPLICATION_FORM_URLENCODED_TYPE
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -15,7 +15,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 
 public class StripeTransferOutRequest extends StripeTransferRequest {
 
-    public StripeTransferOutRequest(String amount,
+    private StripeTransferOutRequest(Long amount,
                                     GatewayAccountEntity gatewayAccount,
                                     String sourceTransactionId,
                                     String idempotencyKey,
@@ -24,7 +24,7 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
         super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig);
     }
     
-    public static StripeTransferOutRequest of(String amount, CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+    public static StripeTransferOutRequest of(Long amount, CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
         return new StripeTransferOutRequest(
                 amount,
                 request.getGatewayAccount(),

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -10,11 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class StripeTransferRequest extends StripeRequest {
-    protected String amount;
+    protected Long amount;
     protected String stripeChargeId;
 
     protected StripeTransferRequest(
-            String amount,
+            Long amount,
             GatewayAccountEntity gatewayAccount,
             String stripeChargeId,
             String idempotencyKey,
@@ -34,7 +34,7 @@ public abstract class StripeTransferRequest extends StripeRequest {
 
     protected List<BasicNameValuePair> getCommonPayloadParameters() {
         List<BasicNameValuePair> params = new ArrayList<>();
-        params.add(new BasicNameValuePair("amount", amount));
+        params.add(new BasicNameValuePair("amount", String.valueOf(amount)));
         params.add(new BasicNameValuePair("currency", "GBP"));
         params.add(new BasicNameValuePair("expand[]", "balance_transaction"));
         params.add(new BasicNameValuePair("expand[]", "destination_payment"));

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class StripeTransferRequest extends StripeRequest {
+    protected String amount;
+    protected String stripeChargeId;
+
+    protected StripeTransferRequest(
+            String amount,
+            GatewayAccountEntity gatewayAccount,
+            String stripeChargeId,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeChargeId = stripeChargeId;
+        this.amount = amount;
+    }
+
+    public abstract GatewayOrder getGatewayOrder();
+
+    @Override
+    public URI getUrl() {
+        return URI.create(stripeGatewayConfig.getUrl() + "/v1/transfers");
+    }
+
+    protected List<BasicNameValuePair> getCommonPayloadParameters() {
+        List<BasicNameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("amount", amount));
+        params.add(new BasicNameValuePair("currency", "GBP"));
+        params.add(new BasicNameValuePair("expand[]", "balance_transaction"));
+        params.add(new BasicNameValuePair("expand[]", "destination_payment"));
+
+        return params;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -43,7 +43,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
         return aWorldpayCaptureOrderRequestBuilder()
                 .withDate(DateTime.now(DateTimeZone.UTC))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withAmount(request.getAmount())
+                .withAmount(request.getAmountAsString())
                 .withTransactionId(request.getTransactionId())
                 .build();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -44,7 +44,7 @@ public class WorldpayRefundHandler implements RefundHandler {
         return aWorldpayRefundOrderRequestBuilder()
                 .withReference(request.getRefundExternalId())
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withAmount(request.getAmount())
+                .withAmount(request.getAmountAsString())
                 .withTransactionId(request.getTransactionId())
                 .build();
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -7,8 +7,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
+import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -31,6 +33,7 @@ public class CardCaptureService {
     private static final Logger LOG = LoggerFactory.getLogger(CardCaptureService.class);
 
     private final UserNotificationService userNotificationService;
+    private final FeeDao feeDao;
     private final ChargeService chargeService;
     private final PaymentProviders providers;
     protected final Logger logger = LoggerFactory.getLogger(getClass());
@@ -38,10 +41,12 @@ public class CardCaptureService {
 
     @Inject
     public CardCaptureService(ChargeService chargeService,
+                              FeeDao feeDao,
                               PaymentProviders providers,
                               UserNotificationService userNotificationService,
                               Environment environment) {
         this.chargeService = chargeService;
+        this.feeDao = feeDao;
         this.providers = providers;
         this.metricRegistry = environment.metrics();
         this.userNotificationService = userNotificationService;
@@ -88,27 +93,35 @@ public class CardCaptureService {
     }
 
     @Transactional
-    public void processGatewayCaptureResponse(String chargeId, String oldStatus, CaptureResponse operationResponse) {
+    public void processGatewayCaptureResponse(String chargeId, String oldStatus, CaptureResponse captureResponse) {
 
-        ChargeStatus nextStatus = determineNextStatus(operationResponse);
-        checkTransactionId(chargeId, operationResponse);
+        ChargeStatus nextStatus = determineNextStatus(captureResponse);
+        checkTransactionId(chargeId, captureResponse);
+
 
         ChargeEntity charge = chargeService.updateChargePostCapture(chargeId, nextStatus);
+        captureResponse.getFee().ifPresent(fee -> persistFee(charge, fee));
 
         // Used by Sumo Logic saved search
         LOG.info("Capture for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                 charge.getExternalId(), charge.getPaymentGatewayName().getName(), charge.getGatewayTransactionId(),
                 charge.getGatewayAccount().getAnalyticsId(), charge.getGatewayAccount().getId(),
-                operationResponse, oldStatus, nextStatus);
+                captureResponse, oldStatus, nextStatus);
 
         metricRegistry.counter(format("gateway-operations.%s.%s.%s.capture.result.%s",
                 charge.getGatewayAccount().getGatewayName(),
                 charge.getGatewayAccount().getType(),
                 charge.getGatewayAccount().getId(), nextStatus.toString())).inc();
 
-        if (operationResponse.isSuccessful()) {
+        if (captureResponse.isSuccessful()) {
             userNotificationService.sendPaymentConfirmedEmail(charge);
         }
+    }
+
+    @Transactional
+    private void persistFee(ChargeEntity charge, Long feeAmount) {
+        FeeEntity fee = new FeeEntity(charge, feeAmount);
+        feeDao.persist(fee);
     }
 
     private void checkTransactionId(String chargeId, CaptureResponse operationResponse) {
@@ -119,7 +132,12 @@ public class CardCaptureService {
     }
 
     private ChargeStatus determineNextStatus(CaptureResponse operationResponse) {
-        if (operationResponse.getError().isPresent()) return CAPTURE_APPROVED_RETRY;
-        if (operationResponse.state().equals(PENDING)) return CAPTURE_SUBMITTED; else return CAPTURED;
+        if (operationResponse.getError().isPresent()) {
+            return CAPTURE_APPROVED_RETRY;
+        } else if (PENDING.equals(operationResponse.state())) {
+            return CAPTURE_SUBMITTED;
+        } else {
+            return CAPTURED;
+        }
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -82,6 +82,9 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-false}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -1,27 +1,24 @@
 package uk.gov.pay.connector.gateway.stripe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
+import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
-
-import java.net.URI;
-import java.util.Map;
 
 import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -30,7 +27,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
@@ -45,7 +41,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 public class StripeRefundHandlerTest {
     private StripeRefundHandler refundHandler;
     private RefundGatewayRequest refundRequest;
-    private URI refundsUri;
     private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
 
     @Mock
@@ -56,18 +51,27 @@ public class StripeRefundHandlerTest {
     @Before
     public void setup() {
         refundHandler = new StripeRefundHandler(gatewayClient, gatewayConfig, objectMapper);
-        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity().withAmount(100L).build();
+
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(123L);
+        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        gatewayAccount.setType(GatewayAccountEntity.Type.LIVE);
+        gatewayAccount.setGatewayName("stripe");
+        
+        RefundEntity refundEntity = RefundEntityFixture
+                .aValidRefundEntity()
+                .withAmount(100L)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        
         refundRequest = RefundGatewayRequest.valueOf(refundEntity);
-        when(gatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
-        refundsUri = URI.create(gatewayConfig.getUrl() + "/v1/refunds");
     }
 
     @Test
     public void shouldRefundInFull() throws Exception {
-        final String jsonResponse = load(STRIPE_REFUND_FULL_CHARGE_RESPONSE);
         GatewayClient.Response response = mock(GatewayClient.Response.class);
-        when(response.getEntity()).thenReturn(jsonResponse);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenReturn(response);
+        when(response.getEntity()).thenReturn(load(STRIPE_REFUND_FULL_CHARGE_RESPONSE));
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenReturn(response);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
@@ -80,7 +84,7 @@ public class StripeRefundHandlerTest {
     public void shouldNotRefund_whenAmountIsMoreThanChargeAmount() throws Exception {
         GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", 
                 load(STRIPE_REFUND_ERROR_GREATER_AMOUNT_RESPONSE), 402);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(gatewayClientException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(gatewayClientException);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
@@ -94,7 +98,7 @@ public class StripeRefundHandlerTest {
     public void shouldNotRefund_anAlreadyRefundedCharge() throws Exception {
         GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", 
                 load(STRIPE_REFUND_ERROR_ALREADY_REFUNDED_RESPONSE), 402);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(gatewayClientException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(gatewayClientException);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
 
@@ -108,7 +112,7 @@ public class StripeRefundHandlerTest {
     @Test
     public void shouldNotRefund_whenStatusCode4xx() throws Exception {
         GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", load(STRIPE_ERROR_RESPONSE), 402);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(gatewayClientException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(gatewayClientException);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
@@ -121,7 +125,7 @@ public class StripeRefundHandlerTest {
     @Test
     public void shouldNotRefund_whenStatusCode5xx() throws Exception {
         GatewayErrorException downstreamException = new GatewayErrorException("Problem with Stripe servers", "nginx problem", INTERNAL_SERVER_ERROR_500);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(downstreamException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(downstreamException);
 
         GatewayRefundResponse response = refundHandler.refund(refundRequest);
         assertThat(response.getError().isPresent(), Is.is(true));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
 import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
@@ -35,6 +36,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_ERROR_ALREADY_REFUNDED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_ERROR_GREATER_AMOUNT_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_FULL_CHARGE_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TRANSFER_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -73,6 +75,11 @@ public class StripeRefundHandlerTest {
         when(response.getEntity()).thenReturn(load(STRIPE_REFUND_FULL_CHARGE_RESPONSE));
         when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenReturn(response);
 
+
+        GatewayClient.Response gatewayTransferResponse = mock(GatewayClient.Response.class);
+        when(gatewayTransferResponse.getEntity()).thenReturn(load(STRIPE_TRANSFER_RESPONSE));
+        when(gatewayClient.postRequestFor(any(StripeTransferInRequest.class))).thenReturn(gatewayTransferResponse);
+        
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
         assertTrue(refund.isSuccessful());

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
@@ -1,0 +1,106 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeCaptureRequestTest {
+    private final String chargeExternalId = "payChargeExternalId";
+    private final String stripeChargeId = "stripeChargeId";
+    private final String stripeBaseUrl = "stripeUrl";
+    private final String stripeLiveApiToken = "stripe_live_api_token";
+    private final long gatewayAccountId = 123L;
+
+    private CaptureGatewayRequest captureGatewayRequest;
+    private StripeCaptureRequest stripeCaptureRequest;
+
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        when(gatewayAccount.getId()).thenReturn(gatewayAccountId);
+        when(gatewayAccount.isLive()).thenReturn(true);
+
+        when(charge.getGatewayTransactionId()).thenReturn(stripeChargeId);
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+        when(charge.getExternalId()).thenReturn(chargeExternalId);
+
+        captureGatewayRequest = CaptureGatewayRequest.valueOf(charge);
+
+        when(stripeAuthTokens.getLive()).thenReturn(stripeLiveApiToken);
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+
+        stripeCaptureRequest = StripeCaptureRequest.of(captureGatewayRequest, stripeGatewayConfig);
+    }
+
+    @Test
+    public void shouldCreateCorrectCaptureUrl() {
+        assertThat(
+                stripeCaptureRequest.getUrl(),
+                is(URI.create(stripeBaseUrl + "/v1/charges/" + stripeChargeId + "/capture"))
+        );
+    }
+
+    @Test
+    public void shouldCreateCorrectCapturePayload() {
+        assertThat(
+                stripeCaptureRequest.getGatewayOrder().getPayload(),
+                containsString("expand%5B%5D=balance_transaction")
+        );
+    }
+
+    @Test
+    public void shouldSetGatewayOrderToBeOfTypeCapture() {
+        assertThat(
+                stripeCaptureRequest.getGatewayOrder().getOrderRequestType(),
+                is(OrderRequestType.CAPTURE)
+        );
+    }
+
+    @Test
+    public void shouldCreateCorrectCaptureHeaders() {
+        assertThat(
+                stripeCaptureRequest.getHeaders().get("Idempotency-Key"),
+                is(chargeExternalId)
+        );
+
+        assertThat(
+                stripeCaptureRequest.getHeaders().get("Authorization"),
+                is("Bearer " + stripeLiveApiToken)
+        );
+    }
+    
+    @Test
+    public void shouldContainCorrectGatewayAccount() {
+        assertThat(
+                stripeCaptureRequest.getGatewayAccount().getId(),
+                is(gatewayAccountId)
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -1,0 +1,81 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeRefundRequestTest {
+    private final String refundExternalId = "payRefundExternalId";
+    private final long refundAmount = 100L;
+    private final String stripeChargeId = "stripeChargeId";
+    private final String stripeBaseUrl = "stripeUrl";
+
+    private StripeRefundRequest stripeRefundRequest;
+
+    @Mock
+    RefundEntity refund;
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+    
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+
+        when(charge.getGatewayTransactionId()).thenReturn(stripeChargeId);
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+
+        when(refund.getAmount()).thenReturn(refundAmount);
+        when(refund.getExternalId()).thenReturn(refundExternalId);
+        when(refund.getChargeEntity()).thenReturn(charge);
+
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
+
+        stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, stripeGatewayConfig);
+    }
+    @Test
+    public void createsCorrectRefundUrl() {
+        assertThat(stripeRefundRequest.getUrl(), is(URI.create(stripeBaseUrl + "/v1/refunds")));
+    }
+
+    @Test
+    public void createsCorrectRefundPayload() {
+        String payload = stripeRefundRequest.getGatewayOrder().getPayload();
+        
+        assertThat(payload, containsString("charge=" + stripeChargeId));
+        assertThat(payload, containsString("amount=" + refundAmount));
+        assertThat(payload, containsString("refund_application_fee=true"));
+    }
+    
+    @Test
+    public void createsCorrectIdempotencyKey() {
+        assertThat(
+                stripeRefundRequest.getHeaders().get("Idempotency-Key"), 
+                is(refundExternalId));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -1,0 +1,96 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeTransferInRequestTest {
+    private final String refundExternalId = "payRefundExternalId";
+    private final String chargeExternalId = "payChargeExternalId";
+    private final long refundAmount = 100L;
+    private final String stripeBaseUrl = "stripeUrl";
+    private final String stripePlatformAccountId = "stripePlatformAccountId";
+    private final String stripeConnectAccountId = "stripe_account_id"; 
+
+    private StripeTransferInRequest stripeTransferInRequest;
+    
+    @Mock
+    RefundEntity refund;
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+
+
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+        when(charge.getExternalId()).thenReturn(chargeExternalId);
+
+        when(refund.getAmount()).thenReturn(refundAmount);
+        when(refund.getExternalId()).thenReturn(refundExternalId);
+        when(refund.getChargeEntity()).thenReturn(charge);
+
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+        when(stripeGatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
+
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
+
+        stripeTransferInRequest = StripeTransferInRequest.of(refundGatewayRequest, stripeGatewayConfig);
+    }
+
+    @Test
+    public void shouldCreateCorrectUrl() {
+        assertThat(stripeTransferInRequest.getUrl(), is(URI.create(stripeBaseUrl + "/v1/transfers")));
+    }
+
+    @Test
+    public void shouldCreateCorrectPayload() {
+        String payload = stripeTransferInRequest.getGatewayOrder().getPayload();
+        
+        assertThat(payload, containsString("destination=" + stripePlatformAccountId));
+        assertThat(payload, containsString("amount=" + refundAmount));
+        assertThat(payload, containsString("transfer_group=" + chargeExternalId));
+    }
+    
+    @Test
+    public void shouldHaveStripeAccountHeaderSetToStripeConnectAccountId() {
+        assertThat(
+                stripeTransferInRequest.getHeaders().get("Stripe-Account"),
+                is(stripeConnectAccountId)
+        );
+    }
+
+    @Test
+    public void shouldHaveIdempotencyKeySetToRefundExternalId() {
+        assertThat(
+                stripeTransferInRequest.getHeaders().get("Idempotency-Key"),
+                is(refundExternalId)
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
@@ -18,7 +17,7 @@ import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class StripeTransferOutRequestTest {
     
-    private final String netTransferAmount = "200";
+    private final Long netTransferAmount = 200L;
     private final String chargeExternalId = "payChargeExternalId";
     private final String stripeBaseUrl = "stripeUrl";
     private final String stripeConnectAccountId = "stripe_account_id";

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
@@ -1,0 +1,77 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeTransferOutRequestTest {
+    
+    private final String netTransferAmount = "200";
+    private final String chargeExternalId = "payChargeExternalId";
+    private final String stripeBaseUrl = "stripeUrl";
+    private final String stripeConnectAccountId = "stripe_account_id";
+
+    private StripeTransferOutRequest stripeTransferOutRequest;
+
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+
+
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+        when(charge.getExternalId()).thenReturn(chargeExternalId);
+
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+
+        final CaptureGatewayRequest captureGatewayRequest = CaptureGatewayRequest.valueOf(charge);
+
+        stripeTransferOutRequest = StripeTransferOutRequest.of(netTransferAmount, captureGatewayRequest, stripeGatewayConfig);
+    }
+
+    @Test
+    public void shouldCreateCorrectUrl() {
+        assertThat(stripeTransferOutRequest.getUrl(), is(URI.create(stripeBaseUrl + "/v1/transfers")));
+    }
+
+    @Test
+    public void shouldCreateCorrectPayload() {
+        String payload = stripeTransferOutRequest.getGatewayOrder().getPayload();
+
+        assertThat(payload, containsString("destination=" + stripeConnectAccountId));
+        assertThat(payload, containsString("amount=" + netTransferAmount));
+    }
+
+    @Test
+    public void shouldHaveIdempotencyKeySetToChargeExternalId() {
+        assertThat(
+                stripeTransferOutRequest.getHeaders().get("Idempotency-Key"),
+                is(chargeExternalId)
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
@@ -34,7 +34,7 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        assertLastGatewayClientLoggingEventContains("Exception for gateway url=http://gobbledygook.invalid.url, error message: java.net.UnknownHostException");
+        assertLastGatewayClientLoggingEventContains("Exception for gateway url=http://gobbledygook.invalid.url");
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundITest.java
@@ -1,0 +1,102 @@
+package uk.gov.pay.connector.it.resources.stripe;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.rules.StripeMockClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static io.restassured.RestAssured.given;
+import static org.eclipse.jetty.http.HttpStatus.ACCEPTED_202;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class StripeRefundITest extends ChargingITestBase {
+    private String stripeAccountId = "stripe_account_id";
+    private String accountId = "555";
+
+    private StripeMockClient stripeMockClient = new StripeMockClient();
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+    private DatabaseFixtures.TestCharge defaultTestCharge;
+
+    public StripeRefundITest() {
+        super("stripe");
+    }
+
+    @Before
+    public void setup() {
+        super.setup();
+        defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withPaymentProvider("stripe")
+                .withCredentials(ImmutableMap.of("stripe_account_id", stripeAccountId))
+                .withAccountId(Long.valueOf(accountId))
+                .insert();
+
+        defaultTestCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withAmount(100L)
+                .withTransactionId("charge_transaction_id")
+                .withTestAccount(defaultTestAccount)
+                .withChargeStatus(CAPTURED)
+                .insert();
+
+
+    }
+
+    @Test
+    public void stripeRefund() {
+        String externalChargeId = defaultTestCharge.getExternalChargeId();
+        long amount = 10L;
+        
+        stripeMockClient.mockCancelCharge();
+
+        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
+        String refundPayload = new Gson().toJson(refundData);
+
+        ValidatableResponse response = given().port(testContext.getPort())
+                .body(refundPayload)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                        .replace("{accountId}", accountId)
+                        .replace("{chargeId}", externalChargeId))
+                .then()
+                .statusCode(ACCEPTED_202);
+
+        List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
+        assertThat(refundsFoundByChargeId.size(), is(1));
+
+        Long chargeId = databaseTestHelper.getChargeIdByExternalId(externalChargeId);
+        assertEquals(databaseTestHelper.getChargeStatus(chargeId), CAPTURED.getValue());
+
+        String refundId = response.extract().path("refund_id");
+
+        verify(postRequestedFor(urlEqualTo("/v1/refunds"))
+                .withHeader("Idempotency-Key", equalTo(refundId))
+                .withRequestBody(containing("charge=" + defaultTestCharge.getTransactionId()))
+                .withRequestBody(containing("amount=" + amount)));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -158,7 +158,7 @@ public class StripeResourceAuthorizeITest {
 
         List<LoggedRequest> requests = findAll(postRequestedFor(urlMatching("/v1/charges")));
         assertThat(requests).hasSize(1);
-        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody());
+        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody(externalChargeId));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class StripeResourceAuthorizeITest {
 
         List<LoggedRequest> requests = findAll(postRequestedFor(urlMatching("/v1/charges")));
         assertThat(requests).hasSize(1);
-        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody());
+        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody(externalChargeId));
     }
 
     @Test
@@ -331,15 +331,15 @@ public class StripeResourceAuthorizeITest {
         return "/v1/frontend/charges/{chargeId}/capture".replace("{chargeId}", chargeId);
     }
 
-    private String constructExpectedAuthoriseRequestBody() {
+    private String constructExpectedAuthoriseRequestBody(String chargeExternalId) {
         List<BasicNameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("amount", AMOUNT));
         params.add(new BasicNameValuePair("currency", "GBP"));
         params.add(new BasicNameValuePair("description", DESCRIPTION));
         params.add(new BasicNameValuePair("source", "src_1DT9bn2eZvKYlo2Cg5okt8WC")); //This comes from resources/stripe/create_sources_response.json
         params.add(new BasicNameValuePair("capture", "false"));
+        params.add(new BasicNameValuePair("transfer_group", chargeExternalId));
         params.add(new BasicNameValuePair("on_behalf_of", stripeAccountId));
-        params.add(new BasicNameValuePair("transfer_data[destination]", stripeAccountId));
         return URLEncodedUtils.format(params, UTF_8);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
@@ -26,7 +26,8 @@ abstract public class CardCaptureProcessBaseITest {
                     CREDENTIALS_MERCHANT_ID, "merchant-id",
                     CREDENTIALS_USERNAME, "test-user",
                     CREDENTIALS_PASSWORD, "test-password",
-                CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphraser"
+                CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphraser",
+                    "stripe_account_id", "stripe_account_id"
             );
 
     protected int port = PortFactory.findFreePort();

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -10,6 +10,11 @@ import uk.gov.pay.connector.it.service.CardCaptureProcessBaseITest;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.StripeMockClient;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
@@ -26,8 +31,18 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
+        new StripeMockClient().mockTransferSuccess(testCharge.getExternalChargeId());
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
+        
+        verify(postRequestedFor(urlEqualTo("/v1/charges/" + testCharge.getTransactionId() + "/capture"))
+                .withHeader("Idempotency-Key", equalTo(testCharge.getExternalChargeId())));
+        
+        verify(postRequestedFor(urlEqualTo("/v1/transfers"))
+                .withHeader("Idempotency-Key", equalTo(testCharge.getExternalChargeId()))
+                .withRequestBody(containing("destination=stripe_account_id"))
+                .withRequestBody(containing("source_transaction=" + testCharge.getTransactionId()))
+                .withRequestBody(containing("amount=" + (testCharge.getAmount()))));
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
     }
@@ -47,6 +62,18 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
 
         new StripeMockClient().mockCaptureError(testCharge.getTransactionId());
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
+        app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
+
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+    }
+
+    @Test
+    public void shouldGoToCaptureRetry_whenNetTransferFails() {
+        DatabaseFixtures.TestCharge testCharge = createTestCharge(PAYMENT_PROVIDER, CAPTURE_APPROVED);
+
+        new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
+        new StripeMockClient().mockTransferFailure();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -15,6 +15,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.hamcrest.CoreMatchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
@@ -42,9 +43,10 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
                 .withHeader("Idempotency-Key", equalTo(testCharge.getExternalChargeId()))
                 .withRequestBody(containing("destination=stripe_account_id"))
                 .withRequestBody(containing("source_transaction=" + testCharge.getTransactionId()))
-                .withRequestBody(containing("amount=" + (testCharge.getAmount()))));
+                .withRequestBody(containing("amount=" + (testCharge.getAmount() - 51))));
 
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getFeeByChargeId(testCharge.getChargeId()).get("amount_collected"), is(51L));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -6,7 +6,6 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -32,6 +31,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
@@ -84,7 +84,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     @Mock
     private UserNotificationService mockUserNotificationService;
     private CardCaptureService cardCaptureService;
-
+    @Mock
+    private FeeDao feeDao;
     @Mock
     private Appender<ILoggingEvent> mockAppender;
 
@@ -102,7 +103,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         
-        cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment);
+        cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment);
 
         Logger root = (Logger) LoggerFactory.getLogger(CardCaptureService.class);
         root.setLevel(Level.INFO);

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -514,7 +514,7 @@ public class ChargeRefundServiceTest {
             RefundGatewayRequest refundGatewayRequest = ((RefundGatewayRequest) object);
             return refundGatewayRequest.getGatewayAccount().equals(capturedCharge.getGatewayAccount()) &&
                     refundGatewayRequest.getTransactionId().equals(capturedCharge.getGatewayTransactionId()) &&
-                    refundGatewayRequest.getAmount().equals(String.valueOf(amountInPence));
+                    refundGatewayRequest.getAmountAsString().equals(String.valueOf(amountInPence));
         };
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -757,4 +757,12 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
+
+    public Map<String, Object> getFeeByChargeId(Long chargeId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("SELECT * from fees WHERE charge_id = :charge_id")
+                        .bind("charge_id", chargeId)
+                        .first()
+        );
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -133,6 +133,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_REFUND_FULL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_charge.json";
     public static final String STRIPE_REFUND_ERROR_GREATER_AMOUNT_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_error_greater_amount.json";
     public static final String STRIPE_REFUND_ERROR_ALREADY_REFUNDED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_error_charge_already_refunded.json";
+    public static final String STRIPE_TRANSFER_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/transfer_success_response.json";
 
     public static final String STRIPE_NOTIFICATION_3DS_SOURCE = TEMPLATE_BASE_NAME + "/stripe/notification_3ds_source.json";
 

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -66,6 +66,9 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
+
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -65,6 +65,9 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
+
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -55,6 +55,8 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -61,6 +61,8 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -58,6 +58,8 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID:-stripe_platform_account_id}
 
 executorServiceConfig:

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -58,6 +58,7 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID:-stripe_platform_account_id}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}

--- a/src/test/resources/templates/stripe/capture_success_response.json
+++ b/src/test/resources/templates/stripe/capture_success_response.json
@@ -1,6 +1,8 @@
 {
   "id": "ch_123456",
   "object": "charge",
-  "balance_transaction": "txn_1DUA6xHj08j2jFuBh4p9vEXz",
-  "captured": true
+  "captured": true,
+  "balance_transaction": {
+    "fee": 50
+  }
 }

--- a/src/test/resources/templates/stripe/transfer_success_response.json
+++ b/src/test/resources/templates/stripe/transfer_success_response.json
@@ -1,0 +1,5 @@
+{
+  "id": "tr_1EID0pFijUALR7rqVvcSKggr",
+  "object": "transfer",
+  "amount": 50
+}


### PR DESCRIPTION
This is a draft PR with everything I have done to start taking fees. I don't suggest that this is all merged as one. It can be split up into 4 parts, corresponding to the 4 commits:

074d662 Refactoring current Stripe capture and refund process
This should not change any functionality at all. You can satisfy yourself of this by checking that I haven't changed any of the integration tests.

a0e0e31 New code to support transfers between Connect and Platform accounts
This is entirely new code, and is safe to merge. I have written tests for the new components I have introduced.

6be2287 Change Stripe capture and refund 
This is the commit that changes how we do  captures and refunds with Stripe. Captures are now done by initially capturing on the platform account, then transferring to the Connect account. Likewise on the refund, we first refund the charge to the platform account, then transfer back the correct amount from the Connect account to the Platform account.

Environment variables necessary for this to work: `STRIPE_PLATFORM_ACCOUNT_ID`

NB: This commit may not be good as is - if a charge made in the 'old' way is refunded in the new way, bad things will happen.

670e335 Introduce fees
This commit uses the net transfer method to start deducting fees from each transaction.

Environment variables necessary for this to work: `STRIPE_TRANSACTION_FEE_PERCENTAGE`
(there is also `COLLECT_FEE_FEATURE_FLAG`, but this defaults to false, and can be turned on afer release)
