### PR TITLE
PP-4884 Add externalMetadata to the ChargeEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/exception/JsonNodeDatabaseConversionException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/JsonNodeDatabaseConversionException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.charge.exception;
+
+public class JsonNodeDatabaseConversionException extends RuntimeException {
+
+    public JsonNodeDatabaseConversionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import org.slf4j.Logger;
@@ -9,6 +10,7 @@ import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.SupportedLanguageJpaConverter;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.util.JsonNodeConverter;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
@@ -132,21 +134,25 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Column(name = "wallet")
     @Enumerated(EnumType.STRING)
     private WalletType walletType;
-    
+
+    @Column(name = "external_metadata", columnDefinition = "jsonb")
+    @Convert(converter = JsonNodeConverter.class)
+    private JsonNode externalMetadata;
+
     public ChargeEntity() {
         //for jpa
     }
 
     public ChargeEntity(Long amount, String returnUrl, String description, ServicePaymentReference reference,
                         GatewayAccountEntity gatewayAccount, String email, SupportedLanguage language,
-                        boolean delayedCapture) {
-        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture);
+                        boolean delayedCapture, JsonNode externalMetadata) {
+        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture, externalMetadata);
     }
 
     // Only the ChargeEntityFixture should directly call this constructor
     public ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, ServicePaymentReference reference,
                         GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate, SupportedLanguage language,
-                        boolean delayedCapture) {
+                        boolean delayedCapture, JsonNode externalMetadata) {
         this.amount = amount;
         this.status = status.getValue();
         this.returnUrl = returnUrl;
@@ -158,6 +164,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.email = email;
         this.language = language;
         this.delayedCapture = delayedCapture;
+        this.externalMetadata = externalMetadata;
     }
 
     public Long getId() {
@@ -218,6 +225,10 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public String getProviderSessionId() {
         return providerSessionId;
+    }
+
+    public JsonNode getExternalMetadata() {
+        return externalMetadata;
     }
 
     public void setExternalId(String externalId) {

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -127,7 +127,8 @@ public class ChargeService {
                     gatewayAccount,
                     chargeRequest.getEmail(),
                     language,
-                    chargeRequest.isDelayedCapture());
+                    chargeRequest.isDelayedCapture(),
+                    null);
             chargeDao.persist(chargeEntity);
 
             chargeEventDao.persistChargeEventOf(chargeEntity);

--- a/src/main/java/uk/gov/pay/connector/charge/util/JsonNodeConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/JsonNodeConverter.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.charge.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.postgresql.util.PGobject;
+import uk.gov.pay.connector.charge.exception.JsonNodeDatabaseConversionException;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.io.IOException;
+import java.sql.SQLException;
+
+@Converter
+public class JsonNodeConverter implements AttributeConverter<JsonNode, PGobject> {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Override
+    public PGobject convertToDatabaseColumn(JsonNode jsonNode) {
+        PGobject pgJson = new PGobject();
+        pgJson.setType("jsonb");
+        try {
+            pgJson.setValue(mapper.writeValueAsString(jsonNode));
+            mapper.writeValueAsString(jsonNode);
+        } catch (SQLException | JsonProcessingException e) {
+            throw new JsonNodeDatabaseConversionException("Cannot serialise JsonNode to PGObject");
+        }
+        return pgJson;
+    }
+
+    @Override
+    public JsonNode convertToEntityAttribute(PGobject dbData) {
+        if (dbData == null) {
+            return null;
+        }
+
+        try {
+            return mapper.readValue(dbData.toString(), JsonNode.class);
+        } catch (IOException e) {
+            throw new JsonNodeDatabaseConversionException("Cannot deserialize database value to JsonNode");
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.model.domain;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.wallets.WalletType;
@@ -45,6 +46,7 @@ public class ChargeEntityFixture {
     private boolean delayedCapture = false;
     private Long corporateSurcharge = null;
     private WalletType walletType = null;
+    private JsonNode externalMetadata = null;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -52,7 +54,7 @@ public class ChargeEntityFixture {
 
     public ChargeEntity build() {
         ChargeEntity chargeEntity = new ChargeEntity(amount, status, returnUrl, description, reference,
-                gatewayAccountEntity, email, createdDate, language, delayedCapture);
+                gatewayAccountEntity, email, createdDate, language, delayedCapture, externalMetadata);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setGatewayTransactionId(transactionId);
@@ -158,6 +160,11 @@ public class ChargeEntityFixture {
     
     public ChargeEntityFixture withWalletType(WalletType walletType) {
         this.walletType = walletType;
+        return this;
+    }
+
+    public ChargeEntityFixture withExternalMetadata(JsonNode externalMetadata) {
+        this.externalMetadata = externalMetadata;
         return this;
     }
 


### PR DESCRIPTION

- add externalMetadata to `ChargeEntity` and `ChargeEntityFixture`.
- add tests in `ChargeDaoITest` to confirm persistance and retrieval of
externalMetadata.

## WHAT YOU DID
Splitting this work up into a few PRs after it snow balled. This is to add the persistence layer. Subsequent PRs to follow to add to service and Api layer.