### PR TITLE
PP-4884 Add externalMetadata to ChargeEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/exception/ExternalMetadataConverterException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/ExternalMetadataConverterException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.charge.exception;
+
+public class ExternalMetadataConverterException extends RuntimeException {
+
+    public ExternalMetadataConverterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/ExternalMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ExternalMetadata.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.charge.model;
+
+import java.util.Map;
+
+public class ExternalMetadata {
+
+    private final Map<String, Object> metadata;
+
+    public ExternalMetadata(Map<String, Object> metadata) {
+        this.metadata = Map.copyOf(metadata);
+    }
+
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -8,7 +8,9 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.SupportedLanguageJpaConverter;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
+import uk.gov.pay.connector.charge.model.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.util.ExternalMetadataConverter;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
@@ -132,21 +134,25 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @Column(name = "wallet")
     @Enumerated(EnumType.STRING)
     private WalletType walletType;
-    
+
+    @Column(name = "external_metadata", columnDefinition = "jsonb")
+    @Convert(converter = ExternalMetadataConverter.class)
+    private ExternalMetadata externalMetadata;
+
     public ChargeEntity() {
         //for jpa
     }
 
     public ChargeEntity(Long amount, String returnUrl, String description, ServicePaymentReference reference,
                         GatewayAccountEntity gatewayAccount, String email, SupportedLanguage language,
-                        boolean delayedCapture) {
-        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture);
+                        boolean delayedCapture, ExternalMetadata externalMetadata) {
+        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture, externalMetadata);
     }
 
     // Only the ChargeEntityFixture should directly call this constructor
     public ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, ServicePaymentReference reference,
                         GatewayAccountEntity gatewayAccount, String email, ZonedDateTime createdDate, SupportedLanguage language,
-                        boolean delayedCapture) {
+                        boolean delayedCapture, ExternalMetadata externalMetadata) {
         this.amount = amount;
         this.status = status.getValue();
         this.returnUrl = returnUrl;
@@ -158,6 +164,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.email = email;
         this.language = language;
         this.delayedCapture = delayedCapture;
+        this.externalMetadata = externalMetadata;
     }
 
     public Long getId() {
@@ -218,6 +225,10 @@ public class ChargeEntity extends AbstractVersionedEntity {
 
     public String getProviderSessionId() {
         return providerSessionId;
+    }
+
+    public Optional<ExternalMetadata> getExternalMetadata() {
+        return Optional.ofNullable(externalMetadata);
     }
 
     public void setExternalId(String externalId) {

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -128,7 +128,8 @@ public class ChargeService {
                     gatewayAccount,
                     chargeRequest.getEmail(),
                     language,
-                    chargeRequest.isDelayedCapture());
+                    chargeRequest.isDelayedCapture(),
+                    null);
             
             if (chargeRequest.getPrefilledCardHolderDetails().isPresent()) {
                 PrefilledCardHolderDetails cardHolderDetails = chargeRequest.getPrefilledCardHolderDetails().get();

--- a/src/main/java/uk/gov/pay/connector/charge/util/ExternalMetadataConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/ExternalMetadataConverter.java
@@ -1,0 +1,51 @@
+package uk.gov.pay.connector.charge.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.postgresql.util.PGobject;
+import uk.gov.pay.connector.charge.exception.ExternalMetadataConverterException;
+import uk.gov.pay.connector.charge.model.ExternalMetadata;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Map;
+
+@Converter
+public class ExternalMetadataConverter implements AttributeConverter<ExternalMetadata, PGobject> {
+    
+    private final ObjectMapper mapper = new ObjectMapper();
+    
+    @Override
+    public PGobject convertToDatabaseColumn(ExternalMetadata externalMetadata) {
+        PGobject pgObject = new PGobject();
+        pgObject.setType("jsonb");
+
+        if (externalMetadata == null) {
+            return pgObject;
+        }
+
+        try {
+            pgObject.setValue(mapper.writeValueAsString(externalMetadata.getMetadata()));
+        } catch (JsonProcessingException | SQLException e) {
+            throw new ExternalMetadataConverterException("Failed to serialise externalMetadata");
+        }
+        return pgObject;
+    }
+
+    @Override
+    public ExternalMetadata convertToEntityAttribute(PGobject dbData) {
+        if (dbData == null) {
+            return null;
+        }
+
+        try {
+            Map<String, Object> metadata = mapper.readValue(dbData.toString(), new TypeReference<Map<String, Object>>() {});
+            return new ExternalMetadata(metadata);
+        } catch (IOException e) {
+            throw new ExternalMetadataConverterException("Failed to deserialise metadata to externalMetadata");
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/common/dao/JpaDao.java
+++ b/src/main/java/uk/gov/pay/connector/common/dao/JpaDao.java
@@ -30,4 +30,15 @@ public abstract class JpaDao<T> {
     public T merge(final T object) {
         return entityManager.get().merge(object);
     }
+
+    public void forceRefresh(final T object) {
+        EntityManager anEntityManager = entityManager.get();
+
+        if (anEntityManager.contains(object)) {
+            anEntityManager.refresh(object);
+        } else {
+            T mergedObject = anEntityManager.merge(object);
+            anEntityManager.refresh(mergedObject);
+        }
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.model.domain;
 
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.connector.charge.model.ExternalMetadata;
 import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
@@ -45,6 +46,7 @@ public class ChargeEntityFixture {
     private boolean delayedCapture = false;
     private Long corporateSurcharge = null;
     private WalletType walletType = null;
+    private ExternalMetadata externalMetadata = null;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -52,7 +54,7 @@ public class ChargeEntityFixture {
 
     public ChargeEntity build() {
         ChargeEntity chargeEntity = new ChargeEntity(amount, status, returnUrl, description, reference,
-                gatewayAccountEntity, email, createdDate, language, delayedCapture);
+                gatewayAccountEntity, email, createdDate, language, delayedCapture, externalMetadata);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setGatewayTransactionId(transactionId);
@@ -158,6 +160,11 @@ public class ChargeEntityFixture {
     
     public ChargeEntityFixture withWalletType(WalletType walletType) {
         this.walletType = walletType;
+        return this;
+    }
+
+    public ChargeEntityFixture withExternalMetadata(ExternalMetadata externalMetadata) {
+        this.externalMetadata = externalMetadata;
         return this;
     }
 


### PR DESCRIPTION
- Create `ExternalMetadata` type
- Add externalMetadata to `ChargeEntity` and `ChargeEntityFixture`
- Add test to `ChargeDaoITest` to confirm persistence and retrieval of externalMetadata.
- Add attributeConverter and custom exception for converting between `ExternalMetadata`
and `PGobject` as required by postgres for `json-b` column type.

## WHAT YOU DID
As discussed with @alexbishop1 we've decided to use a custom Type to store the external metadata rather than `JsonNode` for increased type safety. This introduces the type and uses it to add externalMetadata to the ChargeEntity (which I could see migrating to `pay-java-commons` if and when required to do so).

Validation logic of the meta data (e.g. the `Map` inside ExternalMetadata) will follow in the next step of adding it to the service and Api layer).