### PR TITLE
PP-5108 Include allow_zero_amount in get gateway account response

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -110,24 +110,47 @@ Content-Type: application/json
     "corporate_credit_card_surcharge_amount": 250,
     "corporate_debit_card_surcharge_amount": 50
     "corporate_prepaid_credit_card_surcharge_amount": 250,
-    "corporate_prepaid_debit_card_surcharge_amount": 50
+    "corporate_prepaid_debit_card_surcharge_amount": 50,
+    "allow_apple_pay": false,
+    "allow_google_pay": false,
+    "allow_zero_amount": false,
+    "email_collection_mode": "MANDATORY",
+    "toggle_3ds": false,
+    "email_notifications": {
+        "REFUND_ISSUED": {
+            "version": 1,
+            "enabled": true,
+            "template_body": null
+        },
+        "PAYMENT_CONFIRMED": {
+            "version": 1,
+            "enabled": true,
+            "template_body": null
+        }
+    }
 }
 ```
 
 #### Response field description
 
-| Field                                              | always present   | Description                                                                                       |
-| -------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------- |
-| `gateway_account_id`                               | X                | The account Id                                                                                    |
-| `type`                                             | X                | Account type for this provider (test/live)                                                        |
-| `payment_provider`                                 | X                | The payment provider for which this account is created.                                           |
-| `description`                                      | X                | An internal description to identify the gateway account. The default value is `null`.             |
-| `analytics_id`                                     | X                | An identifier used to identify the service in Google Analytics. The default value is `null`.      |
-| `service_name`                                     |                  | The service name that is saved for this account, present if not empty.                            |
-| `corporate_credit_card_surcharge_amount`           | X                | A corporate credit card surcharge amount in pence. The default value is `0`.                      |
-| `corporate_debit_card_surcharge_amount`            | X                | A corporate debit card surcharge amount in pence. The default value is `0`.                       |
-| `corporate_prepaid_credit_card_surcharge_amount`   | X                | A corporate prepaid credit card surcharge amount in pence. The default value is `0`.              |
-| `corporate_prepaid_debit_card_surcharge_amount`    | X                | A corporate prepaid debit card surcharge amount in pence. The default value is `0`.               |
+| Field                                            | always present | Description                                                                                  |
+|--------------------------------------------------|----------------|----------------------------------------------------------------------------------------------|
+| `gateway_account_id`                             | X              | The account Id                                                                               |
+| `type`                                           | X              | Account type for this provider (test/live)                                                   |
+| `payment_provider`                               | X              | The payment provider for which this account is created.                                      |
+| `description`                                    | X              | An internal description to identify the gateway account. The default value is `null`.        |
+| `analytics_id`                                   | X              | An identifier used to identify the service in Google Analytics. The default value is `null`. |
+| `service_name`                                   |                | The service name that is saved for this account, present if not empty.                       |
+| `corporate_credit_card_surcharge_amount`         | X              | A corporate credit card surcharge amount in pence. The default value is `0`.                 |
+| `corporate_debit_card_surcharge_amount`          | X              | A corporate debit card surcharge amount in pence. The default value is `0`.                  |
+| `corporate_prepaid_credit_card_surcharge_amount` | X              | A corporate prepaid credit card surcharge amount in pence. The default value is `0`.         |
+| `corporate_prepaid_debit_card_surcharge_amount`  | X              | A corporate prepaid debit card surcharge amount in pence. The default value is `0`.          |
+| `allow_apple_pay`                                | X              | Whether apple pay is enabled. The default value is `false`.                                  |
+| `allow_google_pay`                               | X              | Whether google pay is enabled. The default value is `false`.                                 |
+| `allow_zero_amount`                              | X              | Whether the account supports charges with a zero amount. The default value is `false`.       |
+| `email_collection_mode`                          | X              | Whether email address is required from paying users. Can be `MANDATORY`, `OPTIONAL` or `OFF` |
+| `toggle_3ds`                                     | X              | Whether 3DS is enabled. The default value is `false`.                                        |
+| `email_notifications`                            | X              | The settings for the different emails that are sent out                                      |
 
 ---------------------------------------------------------------------------------------------------------------
 ## GET /v1/api/accounts
@@ -158,6 +181,23 @@ Content-Type: application/json
       "corporate_debit_card_surcharge_amount": 0,
       "corporate_prepaid_credit_card_surcharge_amount": 0,
       "corporate_prepaid_debit_card_surcharge_amount": 0,
+      "allow_apple_pay": false,
+      "allow_google_pay": false,
+      "allow_zero_amount": false,
+      "email_collection_mode": "MANDATORY",
+      "toggle_3ds": false,
+      "email_notifications": {
+          "REFUND_ISSUED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          },
+          "PAYMENT_CONFIRMED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          }
+      },
       "_links": {
         "self": {
           "href": "https://connector.example.com/v1/api/accounts/100"
@@ -175,6 +215,23 @@ Content-Type: application/json
       "corporate_debit_card_surcharge_amount": 0,
       "corporate_prepaid_credit_card_surcharge_amount": 250,
       "corporate_prepaid_debit_card_surcharge_amount": 0,
+      "allow_apple_pay": false,
+      "allow_google_pay": false,
+      "allow_zero_amount": false,
+      "email_collection_mode": "MANDATORY",
+      "toggle_3ds": false,
+      "email_notifications": {
+          "REFUND_ISSUED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          },
+          "PAYMENT_CONFIRMED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          }
+      },
       "_links": {
         "self": {
           "href": "https://connector.example.com/v1/api/accounts/200"
@@ -191,6 +248,23 @@ Content-Type: application/json
       "corporate_debit_card_surcharge_amount": 0,
       "corporate_prepaid_credit_card_surcharge_amount": 0,
       "corporate_prepaid_debit_card_surcharge_amount": 0,
+      "allow_apple_pay": false,
+      "allow_google_pay": false,
+      "allow_zero_amount": false,
+      "email_collection_mode": "MANDATORY",
+      "toggle_3ds": false,
+      "email_notifications": {
+          "REFUND_ISSUED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          },
+          "PAYMENT_CONFIRMED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          }
+      },
       "_links": {
         "self": {
           "href": "https://connector.example.com/v1/api/accounts/400"
@@ -203,20 +277,27 @@ Content-Type: application/json
 
 #### Response field description
 
-| Field                                              | always present     | Description                                                                                       |
-| -------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------- |
-| `accounts`                                         | X                  | The collection of accounts.                                                                       |
-| `gateway_account_id`                               | X                  | The account Id.                                                                                   |
-| `type`                                             | X                  | Account type for this provider (test/live).                                                       |
-| `payment_provider`                                 | X                  | The payment provider for which this account is created.                                           |
-| `description`                                      | X                  | An internal description to identify the gateway account. The default value is `null`.             |
-| `analytics_id`                                     | X                  | An identifier used to identify the service in Google Analytics. The default value is `null`.      |
-| `service_name`                                     |                    | The service name that is saved for this account, present if not empty.                            |
-| `corporate_credit_card_surcharge_amount`           | X                  | A corporate credit card surcharge amount in pence. The default value is `0`.                      |
-| `corporate_debit_card_surcharge_amount`            | X                  | A corporate debit card surcharge amount in pence. The default value is `0`.                       |
-| `corporate_prepaid_credit_card_surcharge_amount`   | X                  | A corporate prepaid credit card surcharge amount in pence. The default value is `0`.              |
-| `corporate_prepaid_debit_card_surcharge_amount`    | X                  | A corporate prepaid debit card surcharge amount in pence. The default value is `0`.               |
-| `_links.self`                                      | X                  | A self link to get this account resource by account-id.                                           |
+| Field                                            | always present | Description                                                                                  |
+|--------------------------------------------------|----------------|----------------------------------------------------------------------------------------------|
+| `accounts`                                       | X              | The collection of accounts.                                                                  |
+| `gateway_account_id`                             | X              | The account Id.                                                                              |
+| `type`                                           | X              | Account type for this provider (test/live).                                                  |
+| `payment_provider`                               | X              | The payment provider for which this account is created.                                      |
+| `description`                                    | X              | An internal description to identify the gateway account. The default value is `null`.        |
+| `analytics_id`                                   | X              | An identifier used to identify the service in Google Analytics. The default value is `null`. |
+| `service_name`                                   |                | The service name that is saved for this account, present if not empty.                       |
+| `corporate_credit_card_surcharge_amount`         | X              | A corporate credit card surcharge amount in pence. The default value is `0`.                 |
+| `corporate_debit_card_surcharge_amount`          | X              | A corporate debit card surcharge amount in pence. The default value is `0`.                  |
+| `corporate_prepaid_credit_card_surcharge_amount` | X              | A corporate prepaid credit card surcharge amount in pence. The default value is `0`.         |
+| `corporate_prepaid_debit_card_surcharge_amount`  | X              | A corporate prepaid debit card surcharge amount in pence. The default value is `0`.          |
+| `allow_apple_pay`                                | X              | Whether apple pay is enabled. The default value is `false`.                                  |
+| `allow_google_pay`                               | X              | Whether google pay is enabled. The default value is `false`.                                 |
+| `allow_zero_amount`                              | X              | Whether the account supports charges with a zero amount. The default value is `false`.       |
+| `email_collection_mode`                          | X              | Whether email address is required from paying users. Can be `MANDATORY`, `OPTIONAL` or `OFF` |
+| `toggle_3ds`                                     | X              | Whether 3DS is enabled. The default value is `false`.                                        |
+| `email_notifications`                            | X              | The settings for the different emails that are sent out                                      |
+| `_links.self`                                    | X              | A self link to get this account resource by account-id.                                      |
+
 
 ---------------------------------------------------------------------------------------------------------------
 ## GET /v1/api/accounts/{accountId}/charges/{chargeId}
@@ -993,29 +1074,60 @@ Content-Type: application/json
     "gateway_account_id": "111222333",
     "description": "Sample Service",
     "analytics_id": "some identifier",
+    "requires3ds": false,
+    "notifySettings": null,
+    "notificationCredentials": null,
+    "live": false,
+    "type": "test",
     "corporate_credit_card_surcharge_amount": 0,
     "corporate_debit_card_surcharge_amount": 0,
     "corporate_prepaid_credit_card_surcharge_amount": 0,
     "corporate_prepaid_debit_card_surcharge_amount": 0,
     "credentials: {
       "username:" "Username"
+    },
+    "allow_apple_pay": false,
+    "allow_google_pay": false,
+    "allow_zero_amount": false,
+    "email_collection_mode": "MANDATORY",
+    "email_notifications": {
+      "REFUND_ISSUED": {
+          "version": 1,
+          "enabled": true,
+          "template_body": null
+      },
+      "PAYMENT_CONFIRMED": {
+          "version": 1,
+          "enabled": true,
+          "template_body": null
+      }
     }
 }
 ```
 
 #### Response field description
 
-| Field                                              | always present | Description                                                                                                       |
-| -------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `gateway_account_id`                               | X              | The account Id.                                                                                                   |
-| `payment_provider`                                 | X              | The payment provider for which this account is created.                                                           |
-| `credentials`                                      | X              | The payment provider credentials. Password is not returned. The default value is the empty JSON document {}.      |
-| `description`                                      | X              | An internal description to identify the gateway account. The default value is `null`.                             |
-| `analytics_id`                                     | X              | An identifier used to identify the service in Google Analytics. The default value is `null`.                      |
-| `corporate_credit_card_surcharge_amount`           | X              | A corporate credit card surcharge amount in pence. The default value is `0`.                                      |
-| `corporate_debit_card_surcharge_amount`            | X              | A corporate debit card surcharge amount in pence. The default value is `0`.                                       |
-| `corporate_prepaid_credit_card_surcharge_amount`   | X              | A corporate prepaid credit card surcharge amount in pence. The default value is `0`.                              |
-| `corporate_prepaid_debit_card_surcharge_amount`    | X              | A corporate prepaid debit card surcharge amount in pence. The default value is `0`.                               |
+| Field                                            | always present | Description                                                                                                             |
+|--------------------------------------------------|----------------|-------------------------------------------------------------------------------------------------------------------------|
+| `gateway_account_id`                             | X              | The account Id.                                                                                                         |
+| `payment_provider`                               | X              | The payment provider for which this account is created.                                                                 |
+| `credentials`                                    | X              | The payment provider credentials. Password is not returned. The default value is the empty JSON document {}.            |
+| `description`                                    | X              | An internal description to identify the gateway account. The default value is `null`.                                   |
+| `analytics_id`                                   | X              | An identifier used to identify the service in Google Analytics. The default value is `null`.                            |
+| `requires_3ds`                                   | X              | Whether 3DS is required. The default value is `false`.                                                                  |
+| `notify_settings`                                | X              | A JSON object containing the custom notify credentials for this account. The default value is `null`                    |
+| `notification_credentials`                       | X              | A JSON object containing credentials for receiving notifications from the payment provider. The default value is `null` |
+| `live`                                           | X              | Whether the gateway account is a live account or not.                                                                   |
+| `type`                                           | X              | The account type. Can be `live` or `test`                                                                               |
+| `corporate_credit_card_surcharge_amount`         | X              | A corporate credit card surcharge amount in pence. The default value is `0`.                                            |
+| `corporate_debit_card_surcharge_amount`          | X              | A corporate debit card surcharge amount in pence. The default value is `0`.                                             |
+| `corporate_prepaid_credit_card_surcharge_amount` | X              | A corporate prepaid credit card surcharge amount in pence. The default value is `0`.                                    |
+| `corporate_prepaid_debit_card_surcharge_amount`  | X              | A corporate prepaid debit card surcharge amount in pence. The default value is `0`.                                     |
+| `allow_apple_pay`                                | X              | Whether apple pay is enabled. The default value is `false`.                                                             |
+| `allow_google_pay`                               | X              | Whether google pay is enabled. The default value is `false`.                                                            |
+| `allow_zero_amount`                              | X              | Whether the account supports charges with a zero amount. The default value is `false`.                                  |
+| `email_collection_mode`                          | X              | Whether email address is required from paying users. Can be `MANDATORY`, `OPTIONAL` or `OFF`                            |
+| `email_notifications`                            | X              | The settings for the different emails that are sent out                                                                 |
 
 -----------------------------------------------------------------------------------------------------------
 ## PUT /v1/frontend/accounts/{accountId}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -42,41 +42,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 @SequenceGenerator(name = "gateway_accounts_gateway_account_id_seq",
         sequenceName = "gateway_accounts_gateway_account_id_seq", allocationSize = 1)
 public class GatewayAccountEntity extends AbstractVersionedEntity {
-
-    public class Views {
-        public class ApiView {
-        }
-
-        public class FrontendView {
-        }
-    }
-
-    public enum Type {
-        TEST("test"), LIVE("live");
-
-        private final String value;
-
-        Type(String value) {
-            this.value = value;
-        }
-
-        public String toString() {
-            return value;
-        }
-
-        public static Type fromString(String type) {
-            for (Type typeEnum : Type.values()) {
-                if (typeEnum.toString().equalsIgnoreCase(type)) {
-                    return typeEnum;
-                }
-            }
-            throw new IllegalArgumentException("gateway account type has to be one of (test, live)");
-        }
-    }
-
-    public GatewayAccountEntity() {
-    }
-
+    
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_accounts_gateway_account_id_seq")
     @JsonIgnore
@@ -124,6 +90,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Column(name = "corporate_prepaid_debit_card_surcharge_amount")
     private long corporatePrepaidDebitCardSurchargeAmount;
 
+    @Column(name = "allow_zero_amount")
+    private boolean allowZeroAmount;
+
     @Column(name = "notify_settings", columnDefinition = "json")
     @Convert(converter = JsonToMapConverter.class)
     private Map<String, String> notifySettings;
@@ -149,6 +118,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     )
     private List<CardTypeEntity> cardTypes = newArrayList();
 
+    public GatewayAccountEntity() {
+    }
+    
     public GatewayAccountEntity(String gatewayName, Map<String, String> credentials, Type type) {
         this.gatewayName = gatewayName;
         this.credentials = credentials;
@@ -238,12 +210,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return allowApplePay;
     }
 
-    public void setAllowGooglePay(boolean allowGooglePay) {
-        this.allowGooglePay = allowGooglePay;
-    }
-
-    public void setAllowApplePay(boolean allowApplePay) {
-        this.allowApplePay = allowApplePay;
+    @JsonProperty("allow_zero_amount")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isAllowZeroAmount() {
+        return allowZeroAmount;
     }
 
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
@@ -353,5 +323,48 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setCorporatePrepaidDebitCardSurchargeAmount(long corporatePrepaidDebitCardSurchargeAmount) {
         this.corporatePrepaidDebitCardSurchargeAmount = corporatePrepaidDebitCardSurchargeAmount;
+    }
+
+    public void setAllowGooglePay(boolean allowGooglePay) {
+        this.allowGooglePay = allowGooglePay;
+    }
+
+    public void setAllowApplePay(boolean allowApplePay) {
+        this.allowApplePay = allowApplePay;
+    }
+
+    public void setAllowZeroAmount(boolean allowZeroAmount) {
+        this.allowZeroAmount = allowZeroAmount;
+    }
+
+    public class Views {
+        public class ApiView {
+        }
+
+        public class FrontendView {
+        }
+    }
+
+    public enum Type {
+        TEST("test"), LIVE("live");
+
+        private final String value;
+
+        Type(String value) {
+            this.value = value;
+        }
+
+        public String toString() {
+            return value;
+        }
+
+        public static Type fromString(String type) {
+            for (Type typeEnum : Type.values()) {
+                if (typeEnum.toString().equalsIgnoreCase(type)) {
+                    return typeEnum;
+                }
+            }
+            throw new IllegalArgumentException("gateway account type has to be one of (test, live)");
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -61,6 +61,9 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("toggle_3ds")
     private boolean requires3ds;
 
+    @JsonProperty("allow_zero_amount")
+    private boolean allowZeroAmount;
+    
     public GatewayAccountResourceDTO() {
     }
 
@@ -78,7 +81,8 @@ public class GatewayAccountResourceDTO {
                                      long corporatePrepaidDebitCardSurchargeAmount,
                                      Map<EmailNotificationType, EmailNotificationEntity> emailNotifications,
                                      EmailCollectionMode emailCollectionMode,
-                                     boolean requires3ds) {
+                                     boolean requires3ds,
+                                     boolean allowZeroAmount) {
         this.accountId = accountId;
         this.paymentProvider = paymentProvider;
         this.type = type;
@@ -94,6 +98,7 @@ public class GatewayAccountResourceDTO {
         this.emailNotifications = emailNotifications;
         this.emailCollectionMode = emailCollectionMode;
         this.requires3ds = requires3ds;
+        this.allowZeroAmount = allowZeroAmount;
     }
 
     public static GatewayAccountResourceDTO fromEntity(GatewayAccountEntity gatewayAccountEntity) {
@@ -112,7 +117,8 @@ public class GatewayAccountResourceDTO {
                 gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount(),
                 gatewayAccountEntity.getEmailNotifications(),
                 gatewayAccountEntity.getEmailCollectionMode(),
-                gatewayAccountEntity.isRequires3ds()
+                gatewayAccountEntity.isRequires3ds(),
+                gatewayAccountEntity.isAllowZeroAmount()
         );
     }
 
@@ -182,5 +188,9 @@ public class GatewayAccountResourceDTO {
 
     public boolean isRequires3ds() {
         return requires3ds;
+    }
+    
+    public boolean isAllowZeroAmount() {
+        return allowZeroAmount;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -32,6 +32,7 @@ public class GatewayAccountResourceDTOTest {
         entity.setCredentials(Collections.emptyMap());
         entity.setEmailCollectionMode(EmailCollectionMode.MANDATORY);
         entity.setRequires3ds(true);
+        entity.setAllowZeroAmount(true);
 
         Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
@@ -51,6 +52,7 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.isAllowApplePay(), is(entity.isAllowApplePay()));
         assertThat(dto.isAllowGooglePay(), is(entity.isAllowGooglePay()));
         assertThat(dto.isRequires3ds(), is(entity.isRequires3ds()));
+        assertThat(dto.isAllowZeroAmount(), is(entity.isAllowZeroAmount()));
         assertThat(dto.getEmailCollectionMode(), is(entity.getEmailCollectionMode()));
         assertThat(dto.getEmailNotifications().size(), is(1));
         assertThat(dto.getEmailNotifications().get(EmailNotificationType.PAYMENT_CONFIRMED).getTemplateBody(), is("testTemplate"));

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -52,6 +52,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         databaseTestHelper.updateCorporateCreditCardSurchargeAmountFor(Long.valueOf(accountId), 250);
         databaseTestHelper.updateCorporateDebitCardSurchargeAmountFor(Long.valueOf(accountId), 50);
         databaseTestHelper.allowApplePay(Long.valueOf(accountId));
+        databaseTestHelper.allowZeroAmount(Long.valueOf(accountId));
 
         givenSetup().accept(JSON)
                 .get(ACCOUNTS_FRONTEND_URL + accountId)
@@ -73,7 +74,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .body("corporate_credit_card_surcharge_amount", is(250))
                 .body("corporate_debit_card_surcharge_amount", is(50))
                 .body("allow_apple_pay", is(true))
-                .body("allow_google_pay", is(false));
+                .body("allow_google_pay", is(false))
+                .body("allow_zero_amount", is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -163,7 +163,8 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .body("service_name", is("service_name"))
                 .body("corporate_credit_card_surcharge_amount", is(0))
                 .body("allow_google_pay", is(false))
-                .body("allow_apple_pay", is(false));
+                .body("allow_apple_pay", is(false))
+                .body("allow_zero_amount", is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -608,6 +608,14 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
+    
+    public void allowZeroAmount(long accountId) {
+        jdbi.withHandle(handle ->
+                handle.createStatement("UPDATE gateway_accounts set allow_zero_amount=true WHERE id=:gatewayAccountId")
+                        .bind("gatewayAccountId", accountId)
+                        .execute()
+        );
+    }
 
     public void addWalletType(long chargeId, WalletType walletType) {
         jdbi.withHandle(handle ->


### PR DESCRIPTION
Co-Authored-By Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk>

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
