### PR TITLE
PP-4884 Add validation for ExternalMetadata

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ExternalMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ExternalMetadata.java
@@ -1,9 +1,12 @@
 package uk.gov.pay.connector.charge.model;
 
+import uk.gov.pay.connector.util.ValidExternalMetadata;
+
 import java.util.Map;
 
 public class ExternalMetadata {
-
+    
+    @ValidExternalMetadata
     private final Map<String, Object> metadata;
 
     public ExternalMetadata(Map<String, Object> metadata) {

--- a/src/main/java/uk/gov/pay/connector/util/MapKeyLength.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapKeyLength.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = MapKeyLengthValidator.class)
+public @interface MapKeyLength {
+    String message() default "keys must be between {min} and {max}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    int min() default 0;
+
+    int max() default Integer.MAX_VALUE;
+
+    @Target({ FIELD, PARAMETER})
+    @Retention(RUNTIME)
+    @interface List {
+        MapKeyLength[] value();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/MapKeyLengthValidator.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapKeyLengthValidator.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Map;
+
+public class MapKeyLengthValidator implements ConstraintValidator<MapKeyLength, Map<String, Object>> {
+
+    private int max;
+    private int min;
+
+    @Override
+    public void initialize(MapKeyLength constraintAnnotation) {
+        max = constraintAnnotation.max();
+        min = constraintAnnotation.min();
+    }
+
+    @Override
+    public boolean isValid(Map<String, Object> theMap, ConstraintValidatorContext context) {
+        if (theMap == null) {
+            return true;
+        }
+
+        return theMap.keySet().stream()
+                .noneMatch(key -> key.length() < min || key.length() > max);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/MapValueAsStringLengthValidator.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapValueAsStringLengthValidator.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Map;
+import java.util.Objects;
+
+public class MapValueAsStringLengthValidator implements ConstraintValidator<MapValueLength, Map<String, Object>> {
+
+    private int max;
+    private int min;
+
+    @Override
+    public void initialize(MapValueLength constraintAnnotation) {
+        max = constraintAnnotation.max();
+        min = constraintAnnotation.min();
+    }
+
+    @Override
+    public boolean isValid(Map<String, Object> theMap, ConstraintValidatorContext context) {
+        if (theMap == null) {
+            return true;
+        }
+
+        return theMap.values().stream()
+                .filter(Objects::nonNull)
+                .map(Object::toString)
+                .noneMatch(value -> value.length() < min || value.length() > max);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/MapValueLength.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapValueLength.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = MapValueAsStringLengthValidator.class)
+public @interface MapValueLength {
+    String message() default "values must be between {min} and {max}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    int min() default 0;
+
+    int max() default Integer.MAX_VALUE;
+
+    @Target({ FIELD, PARAMETER})
+    @Retention(RUNTIME)
+    @interface List {
+        MapValueLength[] value();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/MapValueTypes.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapValueTypes.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = MapValueTypesValidator.class)
+public @interface MapValueTypes {
+    String message() default "value must be of type {types}";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    Class[] types();
+
+    @Target({ FIELD, PARAMETER})
+    @Retention(RUNTIME)
+    @interface List {
+        MapValueTypes[] value();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/MapValueTypesValidator.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapValueTypesValidator.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class MapValueTypesValidator implements ConstraintValidator<MapValueTypes, Map<String, Object>> {
+
+    private Set<Class> allowedTypes;
+
+    @Override
+    public void initialize(MapValueTypes constraintAnnotation) {
+        allowedTypes = Set.of(constraintAnnotation.types());
+    }
+
+    @Override
+    public boolean isValid(Map<String, Object> theMap, ConstraintValidatorContext context) {
+        if (theMap == null) {
+            return true;
+        }
+
+        return theMap.values().stream()
+                .filter(Objects::nonNull)
+                .map(Object::getClass)
+                .allMatch(this::validType);
+    }
+
+    private boolean validType(Class clazz) {
+        return allowedTypes.stream().anyMatch(permittedClass -> permittedClass.isAssignableFrom(clazz));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/ValidExternalMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/util/ValidExternalMetadata.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Constraint(validatedBy = {})
+@NotNull(message = "metadata must not be null")
+@Size(max = 10, message = "metadata cannot have more than {max} key-value pairs")
+@MapKeyLength(max = 30, min = 1, message = "metadata keys must be between {min} and {max} characters long")
+@MapValueTypes(types = {String.class, Number.class, Boolean.class}, message = "metadata values must be of type String, Boolean or Number")
+@MapValueLength(max = 50, min = 0, message = "metadata values must be no greater than {max} characters long")
+public @interface ValidExternalMetadata {
+    String message() default "Invalid metadata";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    @Target({FIELD, PARAMETER})
+    @Retention(RUNTIME)
+    @interface List {
+        ValidExternalMetadata[] value();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/ExternalMetadataTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ExternalMetadataTest.java
@@ -1,0 +1,130 @@
+package uk.gov.pay.connector.charge.model;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+
+public class ExternalMetadataTest {
+
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final String TOO_LONG_VALUE = "This value is over fifty characters long and is invalid!";
+    private final String TOO_LONG_KEY = "This key is over thirty characters long and is invalid!";
+
+    @Test
+    public void shouldPassValidation() {
+        Map<String, Object> metadata = Map.of(
+                "key1", "string",
+                "key2", true,
+                "key3", 123,
+                "key4", 1.234,
+                "key5", ""
+        );
+        ExternalMetadata validExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(validExternalMetadata);
+
+        assertThat(violations.size(), is(0));
+    }
+
+    @Test
+    public void shouldFailValidationWithMoreThan10Keys() {
+        Map<String, Object> metadata = IntStream.rangeClosed(1, 11).boxed()
+                .collect(Collectors.toUnmodifiableMap(i -> "key" + i, i-> "value" + i));
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getMessage(), is("metadata cannot have more than 10 key-value pairs"));
+    }
+
+    @Test
+    public void shouldFailValidationForKeysToLong() {
+        Map<String, Object> metadata = Map.of(TOO_LONG_KEY, "string");
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getMessage(), is("metadata keys must be between 1 and 30 characters long"));
+    }
+
+    @Test
+    public void shouldFailValidationForEmptyKey() {
+        Map<String, Object> metadata = Map.of("", "string");
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getMessage(), is("metadata keys must be between 1 and 30 characters long"));
+    }
+
+    @Test
+    public void shouldFailValidationForValueToLong() {
+        Map<String, Object> metadata = Map.of("key1", TOO_LONG_VALUE);
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getMessage(), is("metadata values must be no greater than 50 characters long"));
+    }
+
+    @Test
+    public void shouldFailValidationWhenValueIsObject() {
+        Map<String, Object> metadata = Map.of("key1", mapper.createObjectNode());
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getMessage(), is("metadata values must be of type String, Boolean or Number"));
+    }
+
+    @Test
+    public void shouldFailValidationWhenValueIsArray() {
+        Map<String, Object> metadata = Map.of("key1", mapper.createArrayNode());
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getMessage(), is("metadata values must be of type String, Boolean or Number"));
+    }
+
+    @Test
+    public void shouldFailWithMultipleViolations() {
+        Map<String, Object> metadata = Map.of(
+                TOO_LONG_KEY, "string",
+                "key2", mapper.createArrayNode(),
+                "key3", TOO_LONG_VALUE
+        );
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+        Set<String> expectedErrorMessages = Set.of(
+                "metadata values must be of type String, Boolean or Number",
+                "metadata values must be no greater than 50 characters long",
+                "metadata keys must be between 1 and 30 characters long");
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(3));
+        assertThat(expectedErrorMessages.contains(violations.iterator().next().getMessage()), is(true));
+        assertThat(expectedErrorMessages.contains(violations.iterator().next().getMessage()), is(true));
+        assertThat(expectedErrorMessages.contains(violations.iterator().next().getMessage()), is(true));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Add validation to `ExternalMetadata` based on composing validations which gives us a fine grain control and flexibility of messages/ limits.
- Create custom validations for map key length, map value length and map value types.
- I would like to add this as-is (subject to review comments of course) to progress the story and unblock future work. I will revisit with a view of increasing the sophistication of the error messages to to reference the keys when a value is invalid.