### PR TITLE
PP-5108 Allow update of allow_zero_amount flag

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -878,8 +878,8 @@ Content-Type: application/json
 ## PATCH /v1/api/accounts/{accountId}
 
 A generic endpoint that allows the patching of `allow_apple_pay`, `allow_google_pay`, `credentials/gateway_merchant_id`, `notify_settings`, `email_collection_mode`, 
-`corporate_credit_card_surcharge_amount`, `corporate_debit_card_surcharge_amount`, `corporate_prepaid_credit_card_surcharge_amount`
-or `corporate_prepaid_debit_card_surcharge_amount`.
+`corporate_credit_card_surcharge_amount`, `corporate_debit_card_surcharge_amount`, `corporate_prepaid_credit_card_surcharge_amount`, 
+`corporate_prepaid_debit_card_surcharge_amount` or `allow_zero_amount`
 
 ### Request example
 

--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
@@ -28,10 +28,7 @@ public class JsonPatchRequest {
     }
 
     public String valueAsString() {
-        if (value != null && value.isTextual()) {
-            return value.asText();
-        }
-        throw new JsonNodeNotCorrectTypeException("JSON node " + value + " is not of type string");
+        return value.asText();
     }
     
     public long valueAsLong() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -36,6 +36,8 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT = "corporate_debit_card_surcharge_amount";
     public static final String FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT = "corporate_prepaid_credit_card_surcharge_amount";
     public static final String FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT = "corporate_prepaid_debit_card_surcharge_amount";
+    public static final String FIELD_ALLOW_ZERO_AMOUNT = "allow_zero_amount";
+    
     private static final List<String> VALID_PATHS = asList(
             CREDENTIALS_GATEWAY_MERCHANT_ID,
             FIELD_NOTIFY_SETTINGS, 
@@ -45,7 +47,8 @@ public class GatewayAccountRequestValidator {
             FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT,
             FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT,
             FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT,
-            FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT);
+            FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT,
+            FIELD_ALLOW_ZERO_AMOUNT);
     
     private final RequestValidator requestValidator;
     
@@ -74,10 +77,13 @@ public class GatewayAccountRequestValidator {
                 validateEmailCollectionMode(payload);
                 break;
             case FIELD_ALLOW_GOOGLE_PAY:
-                validateAllowWebPayment(payload, FIELD_ALLOW_GOOGLE_PAY);
+                validateReplaceBooleanValue(payload, FIELD_ALLOW_GOOGLE_PAY);
                 break;
             case FIELD_ALLOW_APPLE_PAY:
-                validateAllowWebPayment(payload, FIELD_ALLOW_APPLE_PAY);
+                validateReplaceBooleanValue(payload, FIELD_ALLOW_APPLE_PAY);
+                break;
+            case FIELD_ALLOW_ZERO_AMOUNT:
+                validateReplaceBooleanValue(payload, FIELD_ALLOW_ZERO_AMOUNT);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT: 
             case FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT:
@@ -131,7 +137,7 @@ public class GatewayAccountRequestValidator {
         }
     }
 
-    private void validateAllowWebPayment(JsonNode payload, String field) {
+    private void validateReplaceBooleanValue(JsonNode payload, String field) {
         throwIfInvalidFieldOperation(payload, REPLACE);
         throwIfNullFieldValue(payload.get(FIELD_VALUE));
         String booleanString = payload.get(FIELD_VALUE).asText().toLowerCase();

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.CREDENTIALS_GATEWAY_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_GOOGLE_PAY;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_ZERO_AMOUNT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT;
@@ -124,6 +125,8 @@ public class GatewayAccountService {
                         (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setCorporatePrepaidCreditCardSurchargeAmount(gatewayAccountRequest.valueAsLong()));
                 put(FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT,
                         (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setCorporatePrepaidDebitCardSurchargeAmount(gatewayAccountRequest.valueAsLong()));
+                put(FIELD_ALLOW_ZERO_AMOUNT,
+                        (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setAllowZeroAmount(Boolean.valueOf(gatewayAccountRequest.valueAsString())));
             }};
 
     private void throwIfNotDigitalWalletSupportedGateway(GatewayAccountEntity gatewayAccountEntity) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -46,15 +46,22 @@ public class GatewayAccountRequestValidatorTest {
             "replace, allow_apple_pay, null, Field [value] is required",
             "replace, allow_google_pay, null, Field [value] is required",
             "replace, allow_apple_pay, unfalse, Value [unfalse] is not valid for [allow_apple_pay]",
-            "replace, allow_google_pay, unfalse, Value [unfalse] is not valid for [allow_google_pay]"
+            "replace, allow_google_pay, unfalse, Value [unfalse] is not valid for [allow_google_pay]",
+            "bad, allow_zero_amount, true, Operation [bad] is not valid for path [allow_zero_amount]",
+            "replace, allow_zero_amount, null, Field [value] is required",
+            "replace, allow_zero_amount, unfalse, Value [unfalse] is not valid for [allow_zero_amount]",
+            "remove, credentials/gateway_merchant_id, gatewayMerchantId, Operation [remove] is not valid for path [credentials/gateway_merchant_id]",
+            "add, credentials/gateway_merchant_id, , Field [value] cannot be empty",
+            "add, credentials/gateway_merchant_id, zzzzz, Field [credentials/gateway_merchant_id] value [zzzzz] does not match that expected for a Worldpay Merchant ID; should be 15 characters and within range [0-9a-f]",
+            "replace, credentials/gateway_merchant_id, null, Field [value] is required"
     })
-    public void shouldThrowWhenWebPaymentRequestsAreInvalid(String op, String path, @Nullable String flagValue, String expectedErrorMessage) {
+    public void shouldThrowWhenRequestsAreInvalid(String op, String path, @Nullable String value, String expectedErrorMessage) {
         Map<String, String> patch = new HashMap<String, String>(){{
             put(FIELD_OPERATION, op);
             put(FIELD_OPERATION_PATH, path);
         }};
         
-        if (flagValue != null) patch.put(FIELD_VALUE, flagValue);
+        if (value != null) patch.put(FIELD_VALUE, value);
         
         JsonNode jsonNode = new ObjectMapper().valueToTree(patch);
         try {
@@ -63,31 +70,6 @@ public class GatewayAccountRequestValidatorTest {
         } catch (ValidationException validationException) {
             assertThat(validationException.getErrors().size(), is(1));
             assertThat(validationException.getErrors(), hasItems(expectedErrorMessage));
-        }
-    }
-    
-    @Test
-    @Parameters({
-            "remove, gatewayMerchantId, Operation [remove] is not valid for path [credentials/gateway_merchant_id]", 
-            "add, , Field [value] cannot be empty",
-            "add, zzzzz, Field [credentials/gateway_merchant_id] value [zzzzz] does not match that expected for a Worldpay Merchant ID; should be 15 characters and within range [0-9a-f]",
-            "replace, null, Field [value] is required"
-    })
-    public void shouldThrowForInvalidMerchantGatewayIdPatchRequest(String op, @Nullable String gatewayMerchantId, String expectedErrorMessage) {
-        Map<String, String> patch = new HashMap<String, String>(){{
-            put(FIELD_OPERATION, op);
-            put(FIELD_OPERATION_PATH, "credentials/gateway_merchant_id");
-        }};
-        
-        if (gatewayMerchantId != null) patch.put(FIELD_VALUE, gatewayMerchantId);
-        
-        JsonNode jsonNode = new ObjectMapper().valueToTree(patch);   
-        try{
-            validator.validatePatchRequest(jsonNode);
-            fail( "Expected ValidationException" );
-        } catch (ValidationException e) {
-            assertThat(e.getErrors().size(), is(1));
-            assertThat(e.getErrors(), hasItems(expectedErrorMessage));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -101,9 +101,9 @@ public class GatewayAccountServiceTest {
 
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
 
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
 
-        assertThat(optionalGatewayAcc.isPresent(), is(true));
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(entity).setNotifySettings(settings);
         verify(mockGatewayAccountDao).merge(entity);
     }
@@ -117,9 +117,9 @@ public class GatewayAccountServiceTest {
 
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
 
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
 
-        assertThat(optionalGatewayAcc.isPresent(), is(true));
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(entity).setNotifySettings(null);
         verify(mockGatewayAccountDao).merge(entity);
     }
@@ -134,9 +134,9 @@ public class GatewayAccountServiceTest {
 
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
 
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
 
-        assertThat(optionalGatewayAcc.isPresent(), is(true));
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
         InOrder inOrder = Mockito.inOrder(entity, mockGatewayAccountDao);
         inOrder.verify(entity).setEmailCollectionMode(EmailCollectionMode.OFF);
         inOrder.verify(mockGatewayAccountDao).merge(entity);
@@ -151,8 +151,8 @@ public class GatewayAccountServiceTest {
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
-        assertThat(optionalGatewayAcc.isPresent(), is(true));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(entity).setCorporateCreditCardSurchargeAmount(100L);
         verify(mockGatewayAccountDao).merge(entity);
     }
@@ -166,8 +166,8 @@ public class GatewayAccountServiceTest {
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
-        assertThat(optionalGatewayAcc.isPresent(), is(true));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(entity).setCorporateDebitCardSurchargeAmount(100L);
         verify(mockGatewayAccountDao).merge(entity);
     }
@@ -181,8 +181,8 @@ public class GatewayAccountServiceTest {
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
-        assertThat(optionalGatewayAcc.isPresent(), is(true));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(entity).setCorporatePrepaidDebitCardSurchargeAmount(100L);
         verify(mockGatewayAccountDao).merge(entity);
     }
@@ -196,8 +196,8 @@ public class GatewayAccountServiceTest {
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
 
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
-        assertThat(optionalGatewayAcc.isPresent(), is(true));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
         verify(entity).setCorporatePrepaidCreditCardSurchargeAmount(100L);
         verify(mockGatewayAccountDao).merge(entity);
     }
@@ -211,7 +211,37 @@ public class GatewayAccountServiceTest {
         GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
         when(entity.getGatewayName()).thenReturn("epdq");
         when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
-        Optional<GatewayAccount> optionalGatewayAcc = gatewayAccountService.doPatch(gatewayAccountId, request);
-        assertThat(optionalGatewayAcc.isPresent(), is(false));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(false));
+    }
+
+    @Test
+    public void shouldUpdateAllowZeroAmountTrue() {
+        Long gatewayAccountId = 100L;
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+                "path", "allow_zero_amount",
+                "value", true)));
+        GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
+
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(entity).setAllowZeroAmount(true);
+        verify(mockGatewayAccountDao).merge(entity);
+    }
+
+    @Test
+    public void shouldUpdateAllowZeroAmountFalse() {
+        Long gatewayAccountId = 100L;
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(ImmutableMap.of("op", "replace",
+                "path", "allow_zero_amount",
+                "value", false)));
+        GatewayAccountEntity entity = mock(GatewayAccountEntity.class);
+
+        when(mockGatewayAccountDao.findById(gatewayAccountId)).thenReturn(Optional.of(entity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(gatewayAccountId, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(entity).setAllowZeroAmount(false);
+        verify(mockGatewayAccountDao).merge(entity);
     }
 }


### PR DESCRIPTION
Add valid path to gateway account patch request which updates the allow_zero_amount flag on a gateway account.

Co-Authored-By Yancoba Thompson <yancoba.thompson@digital.cabinet-office.gov.uk>

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
