### PR TITLE
PP-4884 Add ExernalMetadata to create charge request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -53,10 +53,10 @@ import uk.gov.pay.connector.report.resource.TransactionsSummaryResource;
 import uk.gov.pay.connector.token.resource.SecurityTokensResource;
 import uk.gov.pay.connector.usernotification.resource.EmailNotificationResource;
 import uk.gov.pay.connector.util.DependentResourceWaitCommand;
+import uk.gov.pay.connector.util.JsonMappingExceptionMapper;
 import uk.gov.pay.connector.util.XrayUtils;
 import uk.gov.pay.connector.webhook.resource.NotificationResource;
 
-import javax.net.ssl.HttpsURLConnection;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -104,6 +104,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         });
         environment.jersey().register(new JsonProcessingExceptionMapper());
         environment.jersey().register(new EarlyEofExceptionMapper());
+        environment.jersey().register(new JsonMappingExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.SupportedLanguageJsonDeserializer;
+import uk.gov.pay.connector.charge.util.ExternalMetadataDeserialiser;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Max;
@@ -51,6 +52,11 @@ public class ChargeCreateRequest {
     @Valid
     private PrefilledCardHolderDetails prefilledCardHolderDetails;
 
+    @JsonProperty("metadata")
+    @JsonDeserialize(using = ExternalMetadataDeserialiser.class)
+    @Valid
+    private ExternalMetadata externalMetadata;
+
     public ChargeCreateRequest() {
         // for Jackson
     }
@@ -62,7 +68,8 @@ public class ChargeCreateRequest {
                         String email,
                         boolean delayedCapture,
                         SupportedLanguage language,
-                        PrefilledCardHolderDetails prefilledCardHolderDetails) {
+                        PrefilledCardHolderDetails prefilledCardHolderDetails,
+                        ExternalMetadata externalMetadata) {
         this.amount = amount;
         this.description = description;
         this.reference = reference;
@@ -71,6 +78,7 @@ public class ChargeCreateRequest {
         this.delayedCapture = delayedCapture;
         this.language = language;
         this.prefilledCardHolderDetails = prefilledCardHolderDetails;
+        this.externalMetadata = externalMetadata;
     }
 
     public long getAmount() {
@@ -103,6 +111,10 @@ public class ChargeCreateRequest {
     
     public Optional<PrefilledCardHolderDetails> getPrefilledCardHolderDetails() {
         return Optional.ofNullable(prefilledCardHolderDetails);
+    }
+
+    public Optional<ExternalMetadata> getExternalMetadata() {
+        return Optional.ofNullable(externalMetadata);
     }
 
     public String toStringWithoutPersonalIdentifiableInformation() {

--- a/src/main/java/uk/gov/pay/connector/charge/model/ExternalMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ExternalMetadata.java
@@ -2,18 +2,20 @@ package uk.gov.pay.connector.charge.model;
 
 import uk.gov.pay.connector.util.ValidExternalMetadata;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ExternalMetadata {
-    
+
     @ValidExternalMetadata
     private final Map<String, Object> metadata;
 
     public ExternalMetadata(Map<String, Object> metadata) {
-        this.metadata = Map.copyOf(metadata);
+        this.metadata = new HashMap<>(metadata);
     }
 
     public Map<String, Object> getMetadata() {
-        return metadata;
+        return Collections.unmodifiableMap(metadata);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/util/ExternalMetadataDeserialiser.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/ExternalMetadataDeserialiser.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.charge.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import uk.gov.pay.connector.charge.model.ExternalMetadata;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ExternalMetadataDeserialiser extends JsonDeserializer<ExternalMetadata> {
+
+    @Override
+    public ExternalMetadata deserialize(final JsonParser jsonParser, final DeserializationContext ctxt) throws IOException {
+        Map<String, Object> metadata = jsonParser.getCodec().readValue(jsonParser, new TypeReference<Map<String, Object>>() {});
+        if (metadata != null) {
+            return new ExternalMetadata(metadata);
+        }
+
+        assert false : "This should never be invoked since we currently do no deserialize null values.";
+        throw new JsonMappingException(jsonParser, "metadata cannot be null");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
@@ -1,0 +1,25 @@
+package uk.gov.pay.connector.util;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.Map;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+@Priority(1)
+public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonMappingExceptionMapper.class);
+
+    @Override
+    public Response toResponse(JsonMappingException exception) {
+        LOGGER.error(exception.getMessage());
+        Map<String, String> entity = Map.of("message", exception.getMessage());
+        return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/MapValueNotNull.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapValueNotNull.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER, ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = MapValueNotNullValidator.class)
+public @interface MapValueNotNull {
+    String message() default "value must not be null";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+    @Target({ FIELD, PARAMETER})
+    @Retention(RUNTIME)
+    @interface List {
+        MapValueNotNull[] value();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/MapValueNotNullValidator.java
+++ b/src/main/java/uk/gov/pay/connector/util/MapValueNotNullValidator.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.connector.util;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.Map;
+import java.util.Objects;
+
+public class MapValueNotNullValidator implements ConstraintValidator<MapValueNotNull, Map<String, Object>> {
+
+    @Override
+    public boolean isValid(Map<String, Object> theMap, ConstraintValidatorContext context) {
+        if (theMap == null) {
+            return true;
+        }
+
+        return theMap.values().stream()
+                .noneMatch(Objects::isNull);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/ValidExternalMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/util/ValidExternalMetadata.java
@@ -14,11 +14,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({FIELD, PARAMETER})
 @Retention(RUNTIME)
 @Constraint(validatedBy = {})
-@NotNull(message = "metadata must not be null")
-@Size(max = 10, message = "metadata cannot have more than {max} key-value pairs")
-@MapKeyLength(max = 30, min = 1, message = "metadata keys must be between {min} and {max} characters long")
-@MapValueTypes(types = {String.class, Number.class, Boolean.class}, message = "metadata values must be of type String, Boolean or Number")
-@MapValueLength(max = 50, min = 0, message = "metadata values must be no greater than {max} characters long")
+@NotNull(message = "Field [metadata] must not be null")
+@Size(max = 10, message = "Field [metadata] cannot have more than {max} key-value pairs")
+@MapKeyLength(max = 30, min = 1, message = "Field [metadata] keys must be between {min} and {max} characters long")
+@MapValueTypes(types = {String.class, Number.class, Boolean.class}, message = "Field [metadata] values must be of type String, Boolean or Number")
+@MapValueLength(max = 50, message = "Field [metadata] values must be no greater than {max} characters long")
+@MapValueNotNull(message = "Field [metadata] must not have null values")
 public @interface ValidExternalMetadata {
     String message() default "Invalid metadata";
 

--- a/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
@@ -11,6 +11,7 @@ public final class ChargeCreateRequestBuilder {
     private boolean delayedCapture;
     private SupportedLanguage language;
     private PrefilledCardHolderDetails prefilledCardHolderDetails;
+    private ExternalMetadata externalMetadata;
 
     private ChargeCreateRequestBuilder() {
     }
@@ -59,7 +60,13 @@ public final class ChargeCreateRequestBuilder {
         return this;
     }
 
+    public ChargeCreateRequestBuilder withExternalMetadata(ExternalMetadata externalMetadata) {
+        this.externalMetadata = externalMetadata;
+        return this;
+    }
+
     public ChargeCreateRequest build() {
-        return new ChargeCreateRequest(amount, description, reference, returnUrl, email, delayedCapture, language, prefilledCardHolderDetails);
+        return new ChargeCreateRequest(amount, description, reference, returnUrl, email, delayedCapture, language,
+                prefilledCardHolderDetails, externalMetadata);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/model/ExternalMetadataTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ExternalMetadataTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,7 +50,7 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("metadata cannot have more than 10 key-value pairs"));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] cannot have more than 10 key-value pairs"));
     }
 
     @Test
@@ -60,7 +61,7 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("metadata keys must be between 1 and 30 characters long"));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] keys must be between 1 and 30 characters long"));
     }
 
     @Test
@@ -71,7 +72,7 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("metadata keys must be between 1 and 30 characters long"));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] keys must be between 1 and 30 characters long"));
     }
 
     @Test
@@ -82,7 +83,7 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("metadata values must be no greater than 50 characters long"));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] values must be no greater than 50 characters long"));
     }
 
     @Test
@@ -93,7 +94,7 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("metadata values must be of type String, Boolean or Number"));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] values must be of type String, Boolean or Number"));
     }
 
     @Test
@@ -104,7 +105,19 @@ public class ExternalMetadataTest {
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 
         assertThat(violations.size(), is(1));
-        assertThat(violations.iterator().next().getMessage(), is("metadata values must be of type String, Boolean or Number"));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] values must be of type String, Boolean or Number"));
+    }
+
+    @Test
+    public void shouldFailValidationWhenAValueIsNull() {
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("key1", null);
+        ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
+
+        Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
+
+        assertThat(violations.size(), is(1));
+        assertThat(violations.iterator().next().getMessage(), is("Field [metadata] must not have null values"));
     }
 
     @Test
@@ -116,9 +129,9 @@ public class ExternalMetadataTest {
         );
         ExternalMetadata invalidExternalMetadata = new ExternalMetadata(metadata);
         Set<String> expectedErrorMessages = Set.of(
-                "metadata values must be of type String, Boolean or Number",
-                "metadata values must be no greater than 50 characters long",
-                "metadata keys must be between 1 and 30 characters long");
+                "Field [metadata] values must be of type String, Boolean or Number",
+                "Field [metadata] values must be no greater than 50 characters long",
+                "Field [metadata] keys must be between 1 and 30 characters long");
 
         Set<ConstraintViolation<ExternalMetadata>> violations = validator.validate(invalidExternalMetadata);
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -18,6 +18,7 @@ import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.ChargeCreateRequest;
 import uk.gov.pay.connector.charge.model.ChargeCreateRequestBuilder;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
+import uk.gov.pay.connector.charge.model.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.PrefilledCardHolderDetails;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -43,6 +44,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
@@ -50,6 +52,7 @@ import static java.util.Collections.singletonList;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.UriBuilder.fromUri;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -188,6 +191,22 @@ public class ChargeServiceTest {
 
         ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+    }
+
+    @Test
+    public void shouldCreateAChargeWithExternalMetadata() {
+        Map<String, Object> metadata = Map.of(
+                "key1", "string",
+                "key2", true,
+                "key3", 123,
+                "key4", 1.23);
+        final ChargeCreateRequest request = requestBuilder.withExternalMetadata(new ExternalMetadata(metadata)).build();
+
+        service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+        assertThat(chargeEntityArgumentCaptor.getValue().getExternalMetadata().get().getMetadata(), equalTo(metadata));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/JsonEncoder.java
+++ b/src/test/java/uk/gov/pay/connector/util/JsonEncoder.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.util;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class JsonEncoder {
 
@@ -8,5 +9,12 @@ public class JsonEncoder {
 
     public static String toJson(Object obj) {
         return jsonEncoder.toJson(obj);
+    }
+
+    public static String toJsonWithNulls(Object obj) {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.serializeNulls();
+        Gson jsonEncoderWithNulls = gsonBuilder.create();
+        return jsonEncoderWithNulls.toJson(obj);
     }
 }


### PR DESCRIPTION
- Add `ExternalMetadata` to `ChargeCreateRequest`
- Add `ExternalMetadata` to `ChargeService`
- Add test to `ChargeServiceTest`
- Add `ChargesApiCreateResourceITest` tests for externalMetadata.
- Add `ExternalMetadataDeserialiser`
- Add validation for map values being null.

## WHAT YOU DID
This does not include returning the metadata in the response which is covered by PP-4885. The ITest therefore checks that is has been persisted to the database and stops short of checking it is present in the successful response.