### PR TITLE
PP-4992 Add `gateway_transaction_id` to refunds_history

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1121,4 +1121,12 @@
         </update>
     </changeSet>
 
+    <changeSet id="add gateway_transaction_id column to refunds_history table" author="">
+        <addColumn tableName="refunds_history">
+            <column name="gateway_transaction_id" type="text">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- Adds new field `gateway_transaction_id` to refunds_history to record gateway transaction ID related to the refund state.
