### PR TITLE
Pp 4885 add metadata to ChargeResponse

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -7,8 +7,10 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
+import uk.gov.pay.connector.charge.util.ExternalMetadataSerialiser;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.wallets.WalletType;
@@ -97,7 +99,10 @@ public class ChargeResponse {
 
     @JsonProperty("wallet_type")
     private WalletType walletType;
-
+    
+    @JsonProperty("metadata")
+    @JsonSerialize(using = ExternalMetadataSerialiser.class)
+    private ExternalMetadata externalMetadata;
 
     ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
         this.dataLinks = builder.getLinks();
@@ -123,6 +128,7 @@ public class ChargeResponse {
         this.totalAmount = builder.getTotalAmount();
         this.netAmount = builder.getNetAmount();
         this.walletType = builder.getWalletType();
+        this.externalMetadata = builder.getExternalMetadata();
     }
 
     public List<Map<String, Object>> getDataLinks() {
@@ -210,6 +216,10 @@ public class ChargeResponse {
 
     public WalletType getWalletType() {
         return walletType;
+    }
+
+    public ExternalMetadata getExternalMetadata() {
+        return externalMetadata;
     }
 
     public URI getLink(String rel) {

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -26,6 +26,278 @@ import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public class ChargeResponse {
 
+    @JsonProperty("links")
+    private List<Map<String, Object>> dataLinks;
+
+    @JsonProperty("charge_id")
+    private String chargeId;
+
+    @JsonProperty
+    private Long amount;
+
+    @JsonProperty
+    private ExternalTransactionState state;
+
+    @JsonProperty("card_brand")
+    private String cardBrand;
+
+    @JsonProperty("gateway_transaction_id")
+    private String gatewayTransactionId;
+
+    @JsonProperty("return_url")
+    private String returnUrl;
+
+    @JsonProperty("email")
+    private String email;
+
+    @JsonProperty
+    private String description;
+
+    @JsonProperty
+    @JsonSerialize(using = ToStringSerializer.class)
+    private ServicePaymentReference reference;
+
+    @JsonProperty("payment_provider")
+    private String providerName;
+
+    @JsonProperty("created_date")
+    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
+    private ZonedDateTime createdDate;
+
+    @JsonProperty("refund_summary")
+    private RefundSummary refundSummary;
+
+    @JsonProperty("settlement_summary")
+    private SettlementSummary settlementSummary;
+
+    @JsonProperty("auth_3ds_data")
+    private Auth3dsData auth3dsData;
+
+    @JsonProperty("card_details")
+    protected PersistedCard cardDetails;
+
+    @JsonProperty
+    @JsonSerialize(using = ToStringSerializer.class)
+    private SupportedLanguage language;
+
+    @JsonProperty("delayed_capture")
+    private boolean delayedCapture;
+
+    @JsonProperty("corporate_card_surcharge")
+    private Long corporateCardSurcharge;
+
+    @JsonProperty("fee")
+    private Long fee;
+
+    @JsonProperty("total_amount")
+    private Long totalAmount;
+
+    @JsonProperty("net_amount")
+    private Long netAmount;
+
+    @JsonProperty("wallet_type")
+    private WalletType walletType;
+
+
+    ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
+        this.dataLinks = builder.getLinks();
+        this.chargeId = builder.getChargeId();
+        this.amount = builder.getAmount();
+        this.state = builder.getState();
+        this.cardBrand = builder.getCardBrand();
+        this.gatewayTransactionId = builder.getGatewayTransactionId();
+        this.returnUrl = builder.getReturnUrl();
+        this.description = builder.getDescription();
+        this.reference = builder.getReference();
+        this.providerName = builder.getProviderName();
+        this.createdDate = builder.getCreatedDate();
+        this.email = builder.getEmail();
+        this.refundSummary = builder.getRefundSummary();
+        this.settlementSummary = builder.getSettlementSummary();
+        this.cardDetails = builder.getCardDetails();
+        this.auth3dsData = builder.getAuth3dsData();
+        this.language = builder.getLanguage();
+        this.delayedCapture = builder.isDelayedCapture();
+        this.corporateCardSurcharge = builder.getCorporateCardSurcharge();
+        this.fee = builder.getFee();
+        this.totalAmount = builder.getTotalAmount();
+        this.netAmount = builder.getNetAmount();
+        this.walletType = builder.getWalletType();
+    }
+
+    public List<Map<String, Object>> getDataLinks() {
+        return dataLinks;
+    }
+
+    public String getChargeId() {
+        return chargeId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public ExternalTransactionState getState() {
+        return state;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ServicePaymentReference getReference() {
+        return reference;
+    }
+
+    public String getProviderName() {
+        return providerName;
+    }
+
+    public RefundSummary getRefundSummary() {
+        return refundSummary;
+    }
+
+    public SettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
+    public Auth3dsData getAuth3dsData() {
+        return auth3dsData;
+    }
+
+    public PersistedCard getCardDetails() {
+        return cardDetails;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public boolean getDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public Long getCorporateCardSurcharge() {
+        return corporateCardSurcharge;
+    }
+    public Long getFee() {
+        return fee;
+    }
+
+    public Long getTotalAmount() {
+        return totalAmount;
+    }
+
+    public Long getNetAmount() {
+        return netAmount;
+    }
+
+    public WalletType getWalletType() {
+        return walletType;
+    }
+
+    public URI getLink(String rel) {
+        return dataLinks.stream()
+                .filter(map -> rel.equals(map.get("rel")))
+                .findFirst()
+                .map(link -> (URI) link.get("href"))
+                .get();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChargeResponse that = (ChargeResponse) o;
+        return delayedCapture == that.delayedCapture &&
+                Objects.equals(dataLinks, that.dataLinks) &&
+                Objects.equals(chargeId, that.chargeId) &&
+                Objects.equals(amount, that.amount) &&
+                Objects.equals(state, that.state) &&
+                Objects.equals(cardBrand, that.cardBrand) &&
+                Objects.equals(gatewayTransactionId, that.gatewayTransactionId) &&
+                Objects.equals(returnUrl, that.returnUrl) &&
+                Objects.equals(email, that.email) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(reference, that.reference) &&
+                Objects.equals(providerName, that.providerName) &&
+                Objects.equals(createdDate, that.createdDate) &&
+                Objects.equals(refundSummary, that.refundSummary) &&
+                Objects.equals(settlementSummary, that.settlementSummary) &&
+                Objects.equals(auth3dsData, that.auth3dsData) &&
+                Objects.equals(cardDetails, that.cardDetails) &&
+                language == that.language &&
+                Objects.equals(corporateCardSurcharge, that.corporateCardSurcharge) &&
+                Objects.equals(totalAmount, that.totalAmount) &&
+                walletType == that.walletType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dataLinks, chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
+                description, reference, providerName, createdDate, refundSummary, settlementSummary, auth3dsData,
+                cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, walletType);
+    }
+
+    @Override
+    public String toString() {
+        // Some services put PII in the description, so don’t include it in the stringification
+        return "ChargeResponse{" +
+                "dataLinks=" + dataLinks +
+                ", chargeId='" + chargeId + '\'' +
+                ", amount=" + amount +
+                ", state=" + state +
+                ", cardBrand='" + cardBrand + '\'' +
+                ", gatewayTransactionId='" + gatewayTransactionId + '\'' +
+                ", returnUrl='" + returnUrl + '\'' +
+                ", reference='" + reference + '\'' +
+                ", providerName='" + providerName + '\'' +
+                ", createdDate=" + createdDate +
+                ", refundSummary=" + refundSummary +
+                ", settlementSummary=" + settlementSummary +
+                ", auth3dsData=" + auth3dsData +
+                ", language=" + language +
+                ", delayedCapture=" + delayedCapture +
+                ", corporateCardSurcharge=" + corporateCardSurcharge +
+                ", totalAmount=" + totalAmount +
+                ", walletType=" + walletType.toString() +
+                '}';
+    }
+
+    public static class ChargeResponseBuilder extends AbstractChargeResponseBuilder<ChargeResponseBuilder, ChargeResponse> {
+        @Override
+        protected ChargeResponseBuilder thisObject() {
+            return this;
+        }
+
+        @Override
+        public ChargeResponse build() {
+            return new ChargeResponse(this);
+        }
+    }
+
+    public static ChargeResponseBuilder aChargeResponseBuilder() {
+        return new ChargeResponseBuilder();
+    }
+
+
+
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     public static class RefundSummary {
 
@@ -240,277 +512,6 @@ public class ChargeResponse {
                     '}';
         }
     }
-
-    public static class ChargeResponseBuilder extends AbstractChargeResponseBuilder<ChargeResponseBuilder, ChargeResponse> {
-        @Override
-        protected ChargeResponseBuilder thisObject() {
-            return this;
-        }
-
-        @Override
-        public ChargeResponse build() {
-            return new ChargeResponse(this);
-        }
-    }
-
-    public static ChargeResponseBuilder aChargeResponseBuilder() {
-        return new ChargeResponseBuilder();
-    }
-
-    @JsonProperty("links")
-    private List<Map<String, Object>> dataLinks;
-
-    @JsonProperty("charge_id")
-    private String chargeId;
-
-    @JsonProperty
-    private Long amount;
-
-    @JsonProperty
-    private ExternalTransactionState state;
-
-    @JsonProperty("card_brand")
-    private String cardBrand;
-
-    @JsonProperty("gateway_transaction_id")
-    private String gatewayTransactionId;
-
-    @JsonProperty("return_url")
-    private String returnUrl;
-
-    @JsonProperty("email")
-    private String email;
-
-    @JsonProperty
-    private String description;
-
-    @JsonProperty
-    @JsonSerialize(using = ToStringSerializer.class)
-    private ServicePaymentReference reference;
-
-    @JsonProperty("payment_provider")
-    private String providerName;
-
-    @JsonProperty("created_date")
-    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
-    private ZonedDateTime createdDate;
-
-    @JsonProperty("refund_summary")
-    private RefundSummary refundSummary;
-
-    @JsonProperty("settlement_summary")
-    private SettlementSummary settlementSummary;
-
-    @JsonProperty("auth_3ds_data")
-    private Auth3dsData auth3dsData;
-
-    @JsonProperty("card_details")
-    protected PersistedCard cardDetails;
-
-    @JsonProperty
-    @JsonSerialize(using = ToStringSerializer.class)
-    private SupportedLanguage language;
-
-    @JsonProperty("delayed_capture")
-    private boolean delayedCapture;
-
-    @JsonProperty("corporate_card_surcharge")
-    private Long corporateCardSurcharge;
-
-    @JsonProperty("fee")
-    private Long fee;
-
-    @JsonProperty("total_amount")
-    private Long totalAmount;
-   
-    @JsonProperty("net_amount")
-    private Long netAmount;
-    
-    @JsonProperty("wallet_type")
-    private WalletType walletType;
-
-
-    ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
-        this.dataLinks = builder.getLinks();
-        this.chargeId = builder.getChargeId();
-        this.amount = builder.getAmount();
-        this.state = builder.getState();
-        this.cardBrand = builder.getCardBrand();
-        this.gatewayTransactionId = builder.getGatewayTransactionId();
-        this.returnUrl = builder.getReturnUrl();
-        this.description = builder.getDescription();
-        this.reference = builder.getReference();
-        this.providerName = builder.getProviderName();
-        this.createdDate = builder.getCreatedDate();
-        this.email = builder.getEmail();
-        this.refundSummary = builder.getRefundSummary();
-        this.settlementSummary = builder.getSettlementSummary();
-        this.cardDetails = builder.getCardDetails();
-        this.auth3dsData = builder.getAuth3dsData();
-        this.language = builder.getLanguage();
-        this.delayedCapture = builder.isDelayedCapture();
-        this.corporateCardSurcharge = builder.getCorporateCardSurcharge();
-        this.fee = builder.getFee();
-        this.totalAmount = builder.getTotalAmount();
-        this.netAmount = builder.getNetAmount();
-        this.walletType = builder.getWalletType();
-    }
-
-    public List<Map<String, Object>> getDataLinks() {
-        return dataLinks;
-    }
-
-    public String getChargeId() {
-        return chargeId;
-    }
-
-    public Long getAmount() {
-        return amount;
-    }
-
-    public ExternalTransactionState getState() {
-        return state;
-    }
-
-    public String getCardBrand() {
-        return cardBrand;
-    }
-
-    public String getGatewayTransactionId() {
-        return gatewayTransactionId;
-    }
-
-    public String getReturnUrl() {
-        return returnUrl;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public ServicePaymentReference getReference() {
-        return reference;
-    }
-
-    public String getProviderName() {
-        return providerName;
-    }
-
-    public RefundSummary getRefundSummary() {
-        return refundSummary;
-    }
-
-    public SettlementSummary getSettlementSummary() {
-        return settlementSummary;
-    }
-
-    public Auth3dsData getAuth3dsData() {
-        return auth3dsData;
-    }
-
-    public PersistedCard getCardDetails() {
-        return cardDetails;
-    }
-
-    public SupportedLanguage getLanguage() {
-        return language;
-    }
-
-    public boolean getDelayedCapture() {
-        return delayedCapture;
-    }
-
-    public Long getCorporateCardSurcharge() {
-        return corporateCardSurcharge;
-    }
-    public Long getFee() {
-        return fee;
-    }
-
-    public Long getTotalAmount() {
-        return totalAmount;
-    }
-
-    public Long getNetAmount() {
-        return netAmount;
-    }
-    
-    public WalletType getWalletType() {
-        return walletType;
-    }
-
-    public URI getLink(String rel) {
-        return dataLinks.stream()
-                .filter(map -> rel.equals(map.get("rel")))
-                .findFirst()
-                .map(link -> (URI) link.get("href"))
-                .get();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ChargeResponse that = (ChargeResponse) o;
-        return delayedCapture == that.delayedCapture &&
-                Objects.equals(dataLinks, that.dataLinks) &&
-                Objects.equals(chargeId, that.chargeId) &&
-                Objects.equals(amount, that.amount) &&
-                Objects.equals(state, that.state) &&
-                Objects.equals(cardBrand, that.cardBrand) &&
-                Objects.equals(gatewayTransactionId, that.gatewayTransactionId) &&
-                Objects.equals(returnUrl, that.returnUrl) &&
-                Objects.equals(email, that.email) &&
-                Objects.equals(description, that.description) &&
-                Objects.equals(reference, that.reference) &&
-                Objects.equals(providerName, that.providerName) &&
-                Objects.equals(createdDate, that.createdDate) &&
-                Objects.equals(refundSummary, that.refundSummary) &&
-                Objects.equals(settlementSummary, that.settlementSummary) &&
-                Objects.equals(auth3dsData, that.auth3dsData) &&
-                Objects.equals(cardDetails, that.cardDetails) &&
-                language == that.language &&
-                Objects.equals(corporateCardSurcharge, that.corporateCardSurcharge) &&
-                Objects.equals(totalAmount, that.totalAmount) &&
-                walletType == that.walletType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(dataLinks, chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
-                description, reference, providerName, createdDate, refundSummary, settlementSummary, auth3dsData,
-                cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, walletType);
-    }
-
-    @Override
-    public String toString() {
-        // Some services put PII in the description, so don’t include it in the stringification
-        return "ChargeResponse{" +
-                "dataLinks=" + dataLinks +
-                ", chargeId='" + chargeId + '\'' +
-                ", amount=" + amount +
-                ", state=" + state +
-                ", cardBrand='" + cardBrand + '\'' +
-                ", gatewayTransactionId='" + gatewayTransactionId + '\'' +
-                ", returnUrl='" + returnUrl + '\'' +
-                ", reference='" + reference + '\'' +
-                ", providerName='" + providerName + '\'' +
-                ", createdDate=" + createdDate +
-                ", refundSummary=" + refundSummary +
-                ", settlementSummary=" + settlementSummary +
-                ", auth3dsData=" + auth3dsData +
-                ", language=" + language +
-                ", delayedCapture=" + delayedCapture +
-                ", corporateCardSurcharge=" + corporateCardSurcharge +
-                ", totalAmount=" + totalAmount +
-                ", walletType=" + walletType.toString() +
-                '}';
-    }
-
 }
 
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.charge.model.builder;
 
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
@@ -38,6 +39,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected Long totalAmount;
     protected Long netAmount;
     protected WalletType walletType;
+    protected ExternalMetadata externalMetadata;
 
     protected abstract T thisObject();
 
@@ -166,6 +168,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         this.walletType = walletType;
         return thisObject();
     }
+    
+    public T withExternalMetadata(ExternalMetadata externalMetadata) {
+        this.externalMetadata = externalMetadata;
+        return thisObject();
+    }
 
     public String getChargeId() {
         return chargeId;
@@ -259,5 +266,9 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public Long getFee() {
         return fee;
+    }
+
+    public ExternalMetadata getExternalMetadata() {
+        return externalMetadata;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -223,8 +223,10 @@ public class ChargeService {
                 .withAuth3dsData(auth3dsData)
                 .withLink("self", GET, selfUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeId))
                 .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()))
-                .withWalletType(chargeEntity.getWalletType())
-                .withFee(chargeEntity.getFeeAmount().orElse(null));
+                .withWalletType(chargeEntity.getWalletType());
+        
+        chargeEntity.getFeeAmount().ifPresent(builderOfResponse::withFee);
+        chargeEntity.getExternalMetadata().ifPresent(builderOfResponse::withExternalMetadata);
 
         if (ChargeStatus.AWAITING_CAPTURE_REQUEST.getValue().equals(chargeEntity.getStatus())) {
             builderOfResponse.withLink("capture", POST, captureUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()));

--- a/src/main/java/uk/gov/pay/connector/charge/util/ExternalMetadataSerialiser.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/ExternalMetadataSerialiser.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.charge.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
+
+import java.io.IOException;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class ExternalMetadataSerialiser extends StdSerializer<ExternalMetadata> {
+
+    public ExternalMetadataSerialiser() {
+        this(null);
+    }
+
+    private ExternalMetadataSerialiser(Class<ExternalMetadata> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(ExternalMetadata externalMetadata, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+        serializerProvider.defaultSerializeValue(externalMetadata.getMetadata(), jsonGenerator);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -402,7 +402,6 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
         connectorRestApiClient.postCreateCharge(postBody)
                 .statusCode(Status.CREATED.getStatusCode())
                 .contentType(JSON)
-                .log().body()
                 .body(JSON_CHARGE_KEY, is(notNullValue()))
                 .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
                 .body(JSON_REFERENCE_KEY, is("Reference"))
@@ -558,7 +557,11 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
         ValidatableResponse response = connectorRestApiClient
                 .postCreateCharge(postBody)
                 .statusCode(Status.CREATED.getStatusCode())
-                .contentType(JSON);
+                .contentType(JSON)
+                .log().body()
+                .body(JSON_METADATA_KEY + ".key1", is("string"))
+                .body(JSON_METADATA_KEY + ".key2", is(true))
+                .body(JSON_METADATA_KEY + ".key3", is(123));
 
         String externalChargeId = response.extract().path(JSON_CHARGE_KEY);
         Map<String, Object> charge = databaseTestHelper.getChargeByExternalId(externalChargeId);


### PR DESCRIPTION
## WHAT YOU DID
- First commit restructures `ChargeResponse` to keep members, constructor and methods of the parent class at the top, with static classes and builder beneath.
- Second commit add `metadata` to the `ChargeResponse` including tests. 