### PR TITLE
Pp 4884 handle non object metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <eclipselink.version>2.7.4</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <jackson.version>2.9.8</jackson.version>
-        <pay-java-commons.version>1.0.20190424113839</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190425085329</pay-java-commons.version>
         <surefire.version>2.22.1</surefire.version>
         <javax.persistence.version>2.2.1</javax.persistence.version>
         <jooq.version>3.11.11</jooq.version>

--- a/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
@@ -19,7 +19,15 @@ public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingEx
     @Override
     public Response toResponse(JsonMappingException exception) {
         LOGGER.error(exception.getMessage());
-        Map<String, String> entity = Map.of("message", exception.getMessage());
+        Map<String, String> entity = Map.of("message", sanitiseExceptionMessage(exception.getMessage()));
         return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
+    }
+
+    private String sanitiseExceptionMessage(String message) {
+        if (message.contains("Field [metadata] must be an object of JSON key-value pairs")) {
+            return "Field [metadata] must be an object of JSON key-value pairs";
+        }
+
+        return message;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -621,6 +621,50 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .contentType(JSON);
     }
 
+    @Test
+    public void shouldFailValidationWhenMetadataIsAString() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put(JSON_AMOUNT_KEY, AMOUNT);
+        payload.put(JSON_REFERENCE_KEY, "Test reference");
+        payload.put(JSON_DESCRIPTION_KEY, "Test description");
+        payload.put(JSON_GATEWAY_ACC_KEY, accountId);
+        payload.put(JSON_RETURN_URL_KEY, RETURN_URL);
+        payload.put(JSON_EMAIL_KEY, EMAIL);
+        payload.put(JSON_METADATA_KEY, "metadata cannot be a string");
+
+        String postBody = toJsonWithNulls(payload);
+
+        connectorRestApiClient
+                .postCreateCharge(postBody)
+                .log().body()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Field [metadata] must be an object of JSON key-value pairs"));
+    }
+
+    @Test
+    public void shouldFailValidationWhenMetadataIsAnArray() {
+        Object[] arrayMetadata = new Object[1];
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put(JSON_AMOUNT_KEY, AMOUNT);
+        payload.put(JSON_REFERENCE_KEY, "Test reference");
+        payload.put(JSON_DESCRIPTION_KEY, "Test description");
+        payload.put(JSON_GATEWAY_ACC_KEY, accountId);
+        payload.put(JSON_RETURN_URL_KEY, RETURN_URL);
+        payload.put(JSON_EMAIL_KEY, EMAIL);
+        payload.put(JSON_METADATA_KEY, arrayMetadata);
+
+        String postBody = toJsonWithNulls(payload);
+
+        connectorRestApiClient
+                .postCreateCharge(postBody)
+                .log().body()
+                .statusCode(400)
+                .contentType(JSON)
+                .body("message", is("Field [metadata] must be an object of JSON key-value pairs"));
+    }
+
     private String expectedChargeLocationFor(String accountId, String chargeId) {
         return "https://localhost:" + testContext.getPort() + "/v1/api/accounts/{accountId}/charges/{chargeId}"
                 .replace("{accountId}", accountId)


### PR DESCRIPTION
## WHAT YOU DID
If `metadata` isn't an object then return a status of 400 and a helpful exception message.

The exception that is thrown from `ExternalMetadataDeserilizer` (in `pay-java-commons`) is always caught within a Jackson library and the message is appended with some path information. This isn't useful to the client so the `JsonMappingExceptionMapper` removes it to return a cleaner message.

The first commit bumps `pay-java-commons` to include the necessary change to the `ExternalMetadataDeserializer`.