### PR TITLE
PP-4993 Refactor stripe capture and refund

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.ws.rs.ProcessingException;
@@ -39,6 +40,11 @@ public class GatewayClient {
     public GatewayClient.Response postRequestFor(URI url, GatewayAccountEntity account, GatewayOrder request, Map<String, String> headers) 
             throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayConnectionTimeoutException {
         return postRequestFor(url, account, request, emptyList(), headers);
+    }
+    
+    public GatewayClient.Response postRequestFor(GatewayClientRequest request)
+            throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayConnectionTimeoutException {
+        return postRequestFor(request.getUrl(), request.getGatewayAccount(), request.getGatewayOrder(), request.getHeaders());
     }
 
     public GatewayClient.Response postRequestFor(URI url, 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayClientRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayClientRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.model.request;
+
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+import java.util.Map;
+
+public interface GatewayClientRequest {
+    URI getUrl();
+    GatewayOrder getGatewayOrder();
+    Map<String, String> getHeaders();
+    GatewayAccountEntity getGatewayAccount();
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -1,35 +1,25 @@
 package uk.gov.pay.connector.gateway.stripe.handler;
 
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
 import uk.gov.pay.connector.gateway.stripe.response.StripeRefundResponse;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
 import static uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse.fromBaseRefundResponse;
-import static uk.gov.pay.connector.gateway.util.AuthUtil.getStripeAuthHeader;
 
 public class StripeRefundHandler {
     private static final Logger logger = LoggerFactory.getLogger(StripeRefundHandler.class);
@@ -37,25 +27,20 @@ public class StripeRefundHandler {
     private final StripeGatewayConfig stripeGatewayConfig;
     private JsonObjectMapper jsonObjectMapper;
 
-    public StripeRefundHandler(GatewayClient client, StripeGatewayConfig stripeGatewayConfig, JsonObjectMapper jsonObjectMapper) {
+    public StripeRefundHandler(
+            GatewayClient client,
+            StripeGatewayConfig stripeGatewayConfig,
+            JsonObjectMapper jsonObjectMapper
+    ) {
         this.client = client;
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.jsonObjectMapper = jsonObjectMapper;
     }
 
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
-        String url = stripeGatewayConfig.getUrl() + "/v1/refunds";
-        GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
-
         try {
-            String payload = URLEncodedUtils.format(buildPayload(request.getTransactionId(), request.getAmount()), UTF_8);
-            final String response = client.postRequestFor(URI.create(url),
-                    gatewayAccount,
-                    new GatewayOrder(OrderRequestType.REFUND, payload, APPLICATION_FORM_URLENCODED_TYPE),
-                    getStripeAuthHeader(stripeGatewayConfig, gatewayAccount.isLive())).getEntity();
-            String reference = jsonObjectMapper.getObject(response, Map.class).get("id").toString();
+            String reference = refundCharge(request);
             return fromBaseRefundResponse(StripeRefundResponse.of(reference), GatewayRefundResponse.RefundState.COMPLETE);
-
         } catch (GatewayErrorException e) {
 
             if (e.getFamily() == CLIENT_ERROR) {
@@ -67,7 +52,7 @@ public class StripeRefundHandler {
                         StripeRefundResponse.of(error.getCode(), error.getMessage()),
                         GatewayRefundResponse.RefundState.ERROR);
             }
-            
+
             if (e.getFamily() == SERVER_ERROR) {
                 logger.error("Refund failed for refund gateway request {}. Reason: {}. Status code from Stripe: {}.", request, e.getMessage(), e.getStatus());
                 GatewayError gatewayError = gatewayConnectionError("An internal server error occurred while refunding Transaction id: " + request.getTransactionId());
@@ -77,20 +62,27 @@ public class StripeRefundHandler {
             logger.info("Unrecognised response status when refunding. refund_external_id={}, status={}, response={}",
                     request.getRefundExternalId(), e.getStatus(), e.getResponseFromGateway());
             throw new RuntimeException("Unrecognised response status when refunding.");
-            
+
         } catch (GatewayException e) {
             logger.error("Refund failed for refund gateway request {}. GatewayException: {}.", request, e);
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());
-        } 
+        }
     }
 
-    private List<BasicNameValuePair> buildPayload(String chargeGatewayId, String amount) {
-        List<BasicNameValuePair> payload = new ArrayList<>();
-        payload.add(new BasicNameValuePair("charge", chargeGatewayId));
-        payload.add(new BasicNameValuePair("amount", amount));
-        payload.add(new BasicNameValuePair("refund_application_fee", "true"));
-        payload.add(new BasicNameValuePair("reverse_transfer", "true"));
+    private String refundCharge(RefundGatewayRequest request)
+            throws
+            GatewayException.GenericGatewayException,
+            GatewayErrorException,
+            GatewayException.GatewayConnectionTimeoutException {
+        final GatewayClient.Response refundResponse = client.postRequestFor(
+                StripeRefundRequest.of(request, stripeGatewayConfig)
+        );
+        String reference = jsonObjectMapper.getObject(refundResponse.getEntity(), Map.class).get("id").toString();
+        logger.info("As part of refund {} refunded stripe charge id {}",
+                request.getTransactionId(),
+                request.getRefundExternalId()
+        );
 
-        return payload;
+        return reference;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+public class StripeCaptureRequest extends StripeRequest {
+
+    private String stripeChargeId;
+
+    private StripeCaptureRequest(
+            GatewayAccountEntity gatewayAccount,
+            String stripeChargeId,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeChargeId = stripeChargeId;
+    }
+    
+    public static StripeCaptureRequest of(CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeCaptureRequest(
+                request.getGatewayAccount(),
+                request.getTransactionId(),
+                request.getExternalId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    public URI getUrl() {
+        return URI.create(stripeGatewayConfig.getUrl() + "/v1/charges/" + stripeChargeId + "/capture");
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        List<BasicNameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("expand[]", "balance_transaction"));
+        String payload = URLEncodedUtils.format(params, UTF_8);
+
+        return new GatewayOrder(
+                OrderRequestType.CAPTURE,
+                payload,
+                APPLICATION_FORM_URLENCODED_TYPE
+        );    
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+
+public class StripeRefundRequest extends StripeRequest {
+    private final String stripeChargeId;
+    private final String amount;
+    
+    private StripeRefundRequest(
+            String amount,
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            String stripeChargeId,
+            StripeGatewayConfig stripeGatewayConfig
+            ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeChargeId = stripeChargeId;
+        this.amount = amount;
+    }
+    
+    public static StripeRefundRequest of(RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeRefundRequest(              
+                request.getAmount(),
+                request.getGatewayAccount(),
+                request.getRefundExternalId(),
+                request.getTransactionId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    public URI getUrl() {
+        return URI.create(stripeGatewayConfig.getUrl() + "/v1/refunds");
+    }
+
+    @Override
+    public GatewayOrder getGatewayOrder() {
+        List<BasicNameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("charge", stripeChargeId));
+        params.add(new BasicNameValuePair("amount", amount));
+        params.add(new BasicNameValuePair("refund_application_fee", "true"));
+        params.add(new BasicNameValuePair("reverse_transfer", "true"));
+        String payload = URLEncodedUtils.format(params, UTF_8);
+
+        return new GatewayOrder(
+                OrderRequestType.REFUND,
+                payload,
+                APPLICATION_FORM_URLENCODED_TYPE
+        );    
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
@@ -1,0 +1,46 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
+import uk.gov.pay.connector.gateway.util.AuthUtil;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class StripeRequest implements GatewayClientRequest {
+
+    protected GatewayAccountEntity gatewayAccount;
+    private String idempotencyKey;
+    protected StripeGatewayConfig stripeGatewayConfig;
+    protected String stripeConnectAccountId;
+
+    protected StripeRequest(GatewayAccountEntity gatewayAccount, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig) {
+        if (gatewayAccount == null) {
+            throw new IllegalArgumentException("Cannot create StripeRequest without a gateway account");
+        }
+
+        String stripeAccountId = gatewayAccount.getCredentials().get("stripe_account_id");
+        if (stripeAccountId == null) {
+            throw new IllegalArgumentException("Cannot create StripeRequest with a gateway account with out a stripe account id set");
+        }
+        
+        this.gatewayAccount = gatewayAccount;
+        this.idempotencyKey = idempotencyKey;
+        this.stripeGatewayConfig = stripeGatewayConfig;
+        this.stripeConnectAccountId = stripeAccountId;
+    }
+
+    public GatewayAccountEntity getGatewayAccount() {
+        return gatewayAccount;
+    }
+
+    public Map<String, String> getHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        Optional.ofNullable(idempotencyKey).ifPresent(key -> headers.put("Idempotency-Key", key));
+        headers.putAll(AuthUtil.getStripeAuthHeader(stripeGatewayConfig, gatewayAccount.isLive()));
+
+        return headers;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -1,27 +1,24 @@
 package uk.gov.pay.connector.gateway.stripe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
+import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
-
-import java.net.URI;
-import java.util.Map;
 
 import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -30,7 +27,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
@@ -45,7 +41,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 public class StripeRefundHandlerTest {
     private StripeRefundHandler refundHandler;
     private RefundGatewayRequest refundRequest;
-    private URI refundsUri;
     private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
 
     @Mock
@@ -56,18 +51,27 @@ public class StripeRefundHandlerTest {
     @Before
     public void setup() {
         refundHandler = new StripeRefundHandler(gatewayClient, gatewayConfig, objectMapper);
-        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity().withAmount(100L).build();
+
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(123L);
+        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        gatewayAccount.setType(GatewayAccountEntity.Type.LIVE);
+        gatewayAccount.setGatewayName("stripe");
+        
+        RefundEntity refundEntity = RefundEntityFixture
+                .aValidRefundEntity()
+                .withAmount(100L)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        
         refundRequest = RefundGatewayRequest.valueOf(refundEntity);
-        when(gatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
-        refundsUri = URI.create(gatewayConfig.getUrl() + "/v1/refunds");
     }
 
     @Test
     public void shouldRefundInFull() throws Exception {
-        final String jsonResponse = load(STRIPE_REFUND_FULL_CHARGE_RESPONSE);
         GatewayClient.Response response = mock(GatewayClient.Response.class);
-        when(response.getEntity()).thenReturn(jsonResponse);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenReturn(response);
+        when(response.getEntity()).thenReturn(load(STRIPE_REFUND_FULL_CHARGE_RESPONSE));
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenReturn(response);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
@@ -80,7 +84,7 @@ public class StripeRefundHandlerTest {
     public void shouldNotRefund_whenAmountIsMoreThanChargeAmount() throws Exception {
         GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", 
                 load(STRIPE_REFUND_ERROR_GREATER_AMOUNT_RESPONSE), 402);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(gatewayClientException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(gatewayClientException);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
@@ -94,7 +98,7 @@ public class StripeRefundHandlerTest {
     public void shouldNotRefund_anAlreadyRefundedCharge() throws Exception {
         GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", 
                 load(STRIPE_REFUND_ERROR_ALREADY_REFUNDED_RESPONSE), 402);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(gatewayClientException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(gatewayClientException);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
 
@@ -108,7 +112,7 @@ public class StripeRefundHandlerTest {
     @Test
     public void shouldNotRefund_whenStatusCode4xx() throws Exception {
         GatewayErrorException gatewayClientException = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", load(STRIPE_ERROR_RESPONSE), 402);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(gatewayClientException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(gatewayClientException);
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
         assertNotNull(refund);
@@ -121,7 +125,7 @@ public class StripeRefundHandlerTest {
     @Test
     public void shouldNotRefund_whenStatusCode5xx() throws Exception {
         GatewayErrorException downstreamException = new GatewayErrorException("Problem with Stripe servers", "nginx problem", INTERNAL_SERVER_ERROR_500);
-        when(gatewayClient.postRequestFor(eq(refundsUri), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(downstreamException);
+        when(gatewayClient.postRequestFor(any(StripeRefundRequest.class))).thenThrow(downstreamException);
 
         GatewayRefundResponse response = refundHandler.refund(refundRequest);
         assertThat(response.getError().isPresent(), Is.is(true));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
@@ -1,0 +1,106 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeCaptureRequestTest {
+    private final String chargeExternalId = "payChargeExternalId";
+    private final String stripeChargeId = "stripeChargeId";
+    private final String stripeBaseUrl = "stripeUrl";
+    private final String stripeLiveApiToken = "stripe_live_api_token";
+    private final long gatewayAccountId = 123L;
+
+    private CaptureGatewayRequest captureGatewayRequest;
+    private StripeCaptureRequest stripeCaptureRequest;
+
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        when(gatewayAccount.getId()).thenReturn(gatewayAccountId);
+        when(gatewayAccount.isLive()).thenReturn(true);
+
+        when(charge.getGatewayTransactionId()).thenReturn(stripeChargeId);
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+        when(charge.getExternalId()).thenReturn(chargeExternalId);
+
+        captureGatewayRequest = CaptureGatewayRequest.valueOf(charge);
+
+        when(stripeAuthTokens.getLive()).thenReturn(stripeLiveApiToken);
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+
+        stripeCaptureRequest = StripeCaptureRequest.of(captureGatewayRequest, stripeGatewayConfig);
+    }
+
+    @Test
+    public void shouldCreateCorrectCaptureUrl() {
+        assertThat(
+                stripeCaptureRequest.getUrl(),
+                is(URI.create(stripeBaseUrl + "/v1/charges/" + stripeChargeId + "/capture"))
+        );
+    }
+
+    @Test
+    public void shouldCreateCorrectCapturePayload() {
+        assertThat(
+                stripeCaptureRequest.getGatewayOrder().getPayload(),
+                containsString("expand%5B%5D=balance_transaction")
+        );
+    }
+
+    @Test
+    public void shouldSetGatewayOrderToBeOfTypeCapture() {
+        assertThat(
+                stripeCaptureRequest.getGatewayOrder().getOrderRequestType(),
+                is(OrderRequestType.CAPTURE)
+        );
+    }
+
+    @Test
+    public void shouldCreateCorrectCaptureHeaders() {
+        assertThat(
+                stripeCaptureRequest.getHeaders().get("Idempotency-Key"),
+                is(chargeExternalId)
+        );
+
+        assertThat(
+                stripeCaptureRequest.getHeaders().get("Authorization"),
+                is("Bearer " + stripeLiveApiToken)
+        );
+    }
+    
+    @Test
+    public void shouldContainCorrectGatewayAccount() {
+        assertThat(
+                stripeCaptureRequest.getGatewayAccount().getId(),
+                is(gatewayAccountId)
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -1,0 +1,82 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeRefundRequestTest {
+    private final String refundExternalId = "payRefundExternalId";
+    private final long refundAmount = 100L;
+    private final String stripeChargeId = "stripeChargeId";
+    private final String stripeBaseUrl = "stripeUrl";
+
+    private StripeRefundRequest stripeRefundRequest;
+
+    @Mock
+    RefundEntity refund;
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+    
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+
+        when(charge.getGatewayTransactionId()).thenReturn(stripeChargeId);
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+
+        when(refund.getAmount()).thenReturn(refundAmount);
+        when(refund.getExternalId()).thenReturn(refundExternalId);
+        when(refund.getChargeEntity()).thenReturn(charge);
+
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
+
+        stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, stripeGatewayConfig);
+    }
+    @Test
+    public void createsCorrectRefundUrl() {
+        assertThat(stripeRefundRequest.getUrl(), is(URI.create(stripeBaseUrl + "/v1/refunds")));
+    }
+
+    @Test
+    public void createsCorrectRefundPayload() {
+        String payload = stripeRefundRequest.getGatewayOrder().getPayload();
+        
+        assertThat(payload, containsString("charge=" + stripeChargeId));
+        assertThat(payload, containsString("amount=" + refundAmount));
+        assertThat(payload, containsString("refund_application_fee=true"));
+        assertThat(payload, containsString("reverse_transfer=true"));
+    }
+    
+    @Test
+    public void createsCorrectIdempotencyKey() {
+        assertThat(
+                stripeRefundRequest.getHeaders().get("Idempotency-Key"), 
+                is(refundExternalId));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
@@ -34,7 +34,7 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        assertLastGatewayClientLoggingEventContains("Exception for gateway url=http://gobbledygook.invalid.url, error message: java.net.UnknownHostException");
+        assertLastGatewayClientLoggingEventContains("Exception for gateway url=http://gobbledygook.invalid.url");
         Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundITest.java
@@ -1,0 +1,104 @@
+package uk.gov.pay.connector.it.resources.stripe;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.rules.StripeMockClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static io.restassured.RestAssured.given;
+import static org.eclipse.jetty.http.HttpStatus.ACCEPTED_202;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class StripeRefundITest extends ChargingITestBase {
+    private String stripeAccountId = "stripe_account_id";
+    private String accountId = "555";
+
+    private StripeMockClient stripeMockClient = new StripeMockClient();
+    private DatabaseFixtures.TestAccount defaultTestAccount;
+    private DatabaseFixtures.TestCharge defaultTestCharge;
+
+    public StripeRefundITest() {
+        super("stripe");
+    }
+
+    @Before
+    public void setup() {
+        super.setup();
+        defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withPaymentProvider("stripe")
+                .withCredentials(ImmutableMap.of("stripe_account_id", stripeAccountId))
+                .withAccountId(Long.valueOf(accountId))
+                .insert();
+
+        defaultTestCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withAmount(100L)
+                .withTransactionId("charge_transaction_id")
+                .withTestAccount(defaultTestAccount)
+                .withChargeStatus(CAPTURED)
+                .insert();
+
+
+    }
+
+    @Test
+    public void stripeRefund() {
+        String externalChargeId = defaultTestCharge.getExternalChargeId();
+        long amount = 10L;
+        
+        stripeMockClient.mockCancelCharge();
+
+        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
+        String refundPayload = new Gson().toJson(refundData);
+
+        ValidatableResponse response = given().port(testContext.getPort())
+                .body(refundPayload)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                        .replace("{accountId}", accountId)
+                        .replace("{chargeId}", externalChargeId))
+                .then()
+                .statusCode(ACCEPTED_202);
+
+        List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
+        assertThat(refundsFoundByChargeId.size(), is(1));
+
+        Long chargeId = databaseTestHelper.getChargeIdByExternalId(externalChargeId);
+        assertEquals(databaseTestHelper.getChargeStatus(chargeId), CAPTURED.getValue());
+
+        String refundId = response.extract().path("refund_id");
+
+        verify(postRequestedFor(urlEqualTo("/v1/refunds"))
+                .withHeader("Idempotency-Key", equalTo(refundId))
+                .withRequestBody(containing("charge=" + defaultTestCharge.getTransactionId()))
+                .withRequestBody(containing("amount=" + amount))
+                .withRequestBody(containing("reverse_transfer=true"))
+                .withRequestBody(containing("refund_application_fee=true")));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/CardCaptureProcessBaseITest.java
@@ -26,7 +26,8 @@ abstract public class CardCaptureProcessBaseITest {
                     CREDENTIALS_MERCHANT_ID, "merchant-id",
                     CREDENTIALS_USERNAME, "test-user",
                     CREDENTIALS_PASSWORD, "test-password",
-                CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphraser"
+                CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphraser",
+                    "stripe_account_id", "stripe_account_id"
             );
 
     protected int port = PortFactory.findFreePort();


### PR DESCRIPTION
In order to be able to change these easily in next PR, I have moved the
details of constructing a stripe capture and stripe refund request into
their own objects, with tests. Th functionality should be unchanged. 