### PR TITLE
PP-4885 Add metadata to TransactionResponse

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/TransactionDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/TransactionDao.java
@@ -76,7 +76,8 @@ public class TransactionDao {
                         field("delayed_capture"),
                         field("corporate_surcharge"),
                         field("wallet"),
-                        field("fee_amount"))
+                        field("fee_amount"),
+                        field("external_metadata"))
                 .from(buildQueryFor(gatewayAccountId, QueryType.SELECT, params))
                 .orderBy(field("date_created").desc());
 
@@ -213,7 +214,8 @@ public class TransactionDao {
                 field("c.delayed_capture"),
                 field("c.corporate_surcharge"),
                 field("c.wallet"),
-                field("f.amount_collected").as("fee_amount"))
+                field("f.amount_collected").as("fee_amount"),
+                field("c.external_metadata"))
                 .from(table("charges").as("c")
                         .leftJoin(table("fees").asTable("f")).on("c.id = f.charge_id")
                         .leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))
@@ -248,7 +250,8 @@ public class TransactionDao {
                 field("c.delayed_capture"),
                 field("c.corporate_surcharge"),
                 field("c.wallet"),
-                field("f.amount_collected").as("fee_amount"))
+                field("f.amount_collected").as("fee_amount"),
+                field("c.external_metadata"))
                 .from(table("charges").as("c")
                         .leftJoin(table("fees").asTable("f")).on("c.id = f.charge_id")
                         .leftJoin(selectDistinct().on(field("label")).from("card_types").asTable("t")).on("c.card_brand=t.brand"))

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Transaction.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Transaction.java
@@ -1,12 +1,15 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 import org.eclipse.persistence.annotations.ReadOnly;
+import org.postgresql.util.PGobject;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumberConverter;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumberConverter;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.util.ExternalMetadataConverter;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import uk.gov.pay.connector.wallets.WalletType;
 
@@ -53,7 +56,9 @@ import java.util.Optional;
                         @ColumnResult(name = "delayed_capture", type = Boolean.class),
                         @ColumnResult(name = "corporate_surcharge", type = Long.class),
                         @ColumnResult(name = "wallet", type = String.class),
-                        @ColumnResult(name = "fee_amount", type = Long.class)}))
+                        @ColumnResult(name = "fee_amount", type = Long.class),
+                        @ColumnResult(name = "external_metadata", type = PGobject.class)
+                }))
 @Entity
 @ReadOnly
 public class Transaction implements Nettable {
@@ -92,6 +97,8 @@ public class Transaction implements Nettable {
     private Long corporateSurcharge;
     private WalletType walletType;
     private Long feeAmount;
+    @Convert(converter = ExternalMetadataConverter.class)
+    private ExternalMetadata externalMetadata;
 
     public Transaction() {
     }
@@ -124,7 +131,8 @@ public class Transaction implements Nettable {
                        boolean delayedCapture,
                        Long corporateSurcharge,
                        String walletType,
-                       Long feeAmount) {
+                       Long feeAmount,
+                       PGobject externalMetadata) {
         this.chargeId = chargeId;
         this.externalId = externalId;
         this.reference = reference;
@@ -154,6 +162,7 @@ public class Transaction implements Nettable {
         this.corporateSurcharge = corporateSurcharge;
         this.walletType = walletType == null ? null : WalletType.valueOf(walletType);
         this.feeAmount = feeAmount;
+        this.externalMetadata = new ExternalMetadataConverter().convertToEntityAttribute(externalMetadata);
     }
 
     public Long getChargeId() {
@@ -269,5 +278,9 @@ public class Transaction implements Nettable {
 
     public Optional<Long> getFeeAmount() {
         return Optional.ofNullable(feeAmount);
+    }
+
+    public Optional<ExternalMetadata> getExternalMetadata() {
+        return Optional.ofNullable(externalMetadata);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/TransactionSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/TransactionSearchStrategy.java
@@ -83,8 +83,10 @@ public class TransactionSearchStrategy extends AbstractSearchStrategy<Transactio
                 .withLink("refunds", GET, uriInfo.getBaseUriBuilder()
                         .path("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds")
                         .build(transaction.getGatewayAccountId(), transaction.getExternalId()))
-                .withWalletType(transaction.getWalletType())
-                .withFee(transaction.getFeeAmount().orElse(null));
+                .withWalletType(transaction.getWalletType());
+
+        transaction.getFeeAmount().ifPresent(transactionResponseBuilder::withFee);
+        transaction.getExternalMetadata().ifPresent(transactionResponseBuilder::withExternalMetadata);
 
         if (ChargeStatus.AWAITING_CAPTURE_REQUEST.getValue().equals(transaction.getStatus())) {
             transactionResponseBuilder

--- a/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TransactionDaoITest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.it.dao;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.dao.SearchParams;
 import uk.gov.pay.connector.charge.dao.TransactionDao;
 import uk.gov.pay.connector.charge.model.CardHolderName;
@@ -22,12 +23,14 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.time.ZonedDateTime.now;
 import static java.util.Collections.singletonList;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
@@ -195,6 +198,22 @@ public class TransactionDaoITest extends DaoITestBase {
         List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), new SearchParams());
         assertThat(transactions.get(0).getWalletType(), is(WalletType.APPLE_PAY));
         
+    }
+
+    @Test
+    public void shouldReturnExternalMetadata() {
+        Map<String, Object> metadata = Map.of("key1", true, "key2", 123, "key3", "string1");
+        ExternalMetadata externalMetadata = new ExternalMetadata(metadata);
+
+        TestCharge testCharge = withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .insert();
+
+        databaseTestHelper.addExternalMetadata(testCharge.getChargeId(), externalMetadata);
+
+        List<Transaction> transactions = transactionDao.findAllBy(defaultTestAccount.getAccountId(), new SearchParams());
+        assertThat(transactions.get(0).getExternalMetadata().get().getMetadata(), equalTo(metadata));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -651,6 +651,26 @@ public class DatabaseTestHelper {
         );
     }
 
+    public void addExternalMetadata(long chargeId, ExternalMetadata externalMetadata) {
+        PGobject jsonExternMetadata = new PGobject();
+        jsonExternMetadata.setType("json");
+
+        if (externalMetadata != null) {
+            try {
+                jsonExternMetadata.setValue(new Gson().toJson(externalMetadata.getMetadata()));
+            } catch (SQLException e) {
+                throw new ExternalMetadataConverterException("Failed to serialize metadata");
+            }
+        }
+
+        jdbi.withHandle(handle ->
+                handle.createStatement("UPDATE CHARGES set external_metadata=:metadata WHERE id=:chargeId")
+                        .bind("chargeId", chargeId)
+                        .bind("metadata", jsonExternMetadata)
+                        .execute()
+        );
+    }
+
     public void enable3dsForGatewayAccount(long accountId) {
         jdbi.withHandle(handle ->
                 handle.createStatement("UPDATE gateway_accounts set requires_3ds=true WHERE id=:gatewayAccountId")


### PR DESCRIPTION
- Added `ExternalMetadata` to Transaction (entity).
- Added test to `TransactionDaoITest` to confirm return of metadata.
- Added test to `ChargesApiV2ResourceITest` to assert return of metadata.

## WHAT YOU DID
This will add `metadata` to response from GET v2/api/account/{accountid}/charges