### PR TITLE
PP-5108 Add provider state for wallet payments

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -160,6 +160,17 @@ public class TransactionsApiContractTest {
                 .insert();
     }
 
+    @State("a gateway account supporting digital wallet with external id 666 exists in the database")
+    public void anAccountExists() {
+        String aDigitalWalletSupportedPaymentProvider = "worldpay";
+        DatabaseFixtures
+                .withDatabaseTestHelper(dbHelper)
+                .aTestAccount()
+                .withAccountId(666L)
+                .withPaymentProvider(aDigitalWalletSupportedPaymentProvider)
+                .insert();
+    }
+
     @State({"default", "Card types exist in the database"})
     public void defaultCase() {
     }


### PR DESCRIPTION
## WHAT YOU DID
 - wallet payments are currently only available with Worldpay
 so this state needed to be added for future pact testing.

Solo: @cobainc0 