### PR TITLE
PP-4884 Change ConstraintViolationMapper to return http status code 422

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/ConstraintViolationExceptionMapper.java
@@ -25,7 +25,7 @@ public class ConstraintViolationExceptionMapper implements ExceptionMapper<Const
                 .map(ConstraintViolation::getMessage)
                 .collect(Collectors.toList());
 
-        return Response.status(400)
+        return Response.status(422)
                 .entity(ImmutableMap.of("message", constraintViolationMessages))
                 .type(APPLICATION_JSON).build();
     }

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -43,7 +43,7 @@ public class ChargesFrontendResourceTest {
                 .request()
                 .put(Entity.json(""));
 
-        assertThat(response.getStatus(), is(400));
+        assertThat(response.getStatus(), is(422));
         
         List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
         assertThat(listOfErrors.size(), is(1));
@@ -51,13 +51,13 @@ public class ChargesFrontendResourceTest {
     }
 
     @Test
-    public void shouldReturn400_whenPutToChargeStatus_emptyNewStatus() {
+    public void shouldReturn422_whenPutToChargeStatus_emptyNewStatus() {
         Response response = resources.client()
                 .target("/v1/frontend/charges/irrelevant_charge_id/status")
                 .request()
                 .put(Entity.json(Collections.singletonMap("new_status", "")));
 
-        assertEquals( 400, response.getStatus());
+        assertEquals( 422, response.getStatus());
         
         List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
         assertThat(listOfErrors.size(), is(2));
@@ -67,13 +67,13 @@ public class ChargesFrontendResourceTest {
     }
 
     @Test
-    public void shouldReturn400_whenPutToChargeStatus_invalidNewStatus() {
+    public void shouldReturn422_whenPutToChargeStatus_invalidNewStatus() {
         Response response = resources.client()
                 .target("/v1/frontend/charges/irrelevant_charge_id/status")
                 .request()
                 .put(Entity.json(Collections.singletonMap("new_status", "invalid_status")));
 
-        assertEquals(400, response.getStatus());
+        assertEquals(422, response.getStatus());
 
         List<String> listOfErrors = (List) response.readEntity(Map.class).get("message");
         assertThat(listOfErrors.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -47,17 +47,17 @@ public class GatewayAccountResourceValidationTest {
             .build();
 
     @Test
-    public void shouldReturn400_whenEverythingMissing() {
+    public void shouldReturn422_whenEverythingMissing() {
         Response response = resources.client()
                 .target("/v1/api/accounts")
                 .request()
                 .post(Entity.json(""));
 
-        assertThat(response.getStatus(), is(400));
+        assertThat(response.getStatus(), is(422));
     }
 
     @Test
-    public void shouldReturn400_whenProviderAccountTypeIsInvalid() {
+    public void shouldReturn422_whenProviderAccountTypeIsInvalid() {
 
         Map<String, Object> payload = ImmutableMap.of("type", "invalid");
 
@@ -66,14 +66,14 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .post(Entity.json(payload));
 
-        assertThat(response.getStatus(), is(400));
+        assertThat(response.getStatus(), is(422));
 
         String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Unsupported payment provider account type, should be one of (test, live)"));
     }
 
     @Test
-    public void shouldReturn400_whenPaymentProviderIsInvalid() {
+    public void shouldReturn422_whenPaymentProviderIsInvalid() {
 
         Map<String, Object> payload = ImmutableMap.of("payment_provider", "blockchain");
 
@@ -82,7 +82,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .post(Entity.json(payload));
 
-        assertThat(response.getStatus(), is(400));
+        assertThat(response.getStatus(), is(422));
 
         String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Unsupported payment provider value."));

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayITest.java
@@ -89,7 +89,7 @@ public class CardResourceAuthoriseApplePayITest extends ChargingITestBase {
                 .body(payload)
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
-                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
                 .body("message", contains("Card holder name must be a maximum of 255 chars"));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
@@ -108,7 +108,7 @@ public class CardResourceAuthoriseApplePayITest extends ChargingITestBase {
                 .body(payload)
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
-                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
                 .body("message", contains("Email must be a maximum of 254 chars"));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayITest.java
@@ -14,7 +14,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -84,7 +83,7 @@ public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
                 .body(googlePayload)
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
-                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
                 .body("message", contains("Card holder name must be a maximum of 255 chars"));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
@@ -104,7 +103,7 @@ public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
                 .body(googlePayload)
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
-                .statusCode(HttpStatus.SC_BAD_REQUEST)
+                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
                 .body("message", contains("Email must be a maximum of 254 chars"));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
@@ -420,7 +420,7 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
                 .body(randomCardNumber)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
-                .statusCode(400)
+                .statusCode(422)
                 .contentType(JSON)
                 .body("message", containsInAnyOrder("Values do not match expected format/length."));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
@@ -247,7 +246,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturn400WhenAmountIsLessThanMinAmount() {
+    public void shouldReturn422WhenAmountIsLessThanMinAmount() {
 
         String expectedReference = "Test reference";
         String expectedDescription = "Test description";
@@ -261,7 +260,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
 
         connectorRestApiClient
                 .postCreateCharge(postBody)
-                .statusCode(Status.BAD_REQUEST.getStatusCode());
+                .statusCode(422);
     }
 
     @Test
@@ -314,7 +313,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .put(JSON_RETURN_URL_KEY, RETURN_URL).build());
 
         connectorRestApiClient.postCreateCharge(postBody)
-                .statusCode(BAD_REQUEST.getStatusCode())
+                .statusCode(422)
                 .contentType(JSON)
                 .header("Location", is(nullValue()))
                 .body(JSON_CHARGE_KEY, is(nullValue()))
@@ -328,7 +327,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
     @Test
     public void cannotMakeChargeForMissingFields() {
         connectorRestApiClient.postCreateCharge("{}")
-                .statusCode(BAD_REQUEST.getStatusCode())
+                .statusCode(422)
                 .contentType(JSON)
                 .header("Location", is(nullValue()))
                 .body(JSON_CHARGE_KEY, is(nullValue()))
@@ -341,7 +340,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturn400WhenPrefilledCardHolderDetailsFieldsAreLongerThanMaximum() {
+    public void shouldReturn422WhenPrefilledCardHolderDetailsFieldsAreLongerThanMaximum() {
         ImmutableMap preFilledBillingAddress = ImmutableMap.builder()
                 .put(JSON_CARDHOLDER_NAME_KEY, randomAlphanumeric(256))
                 .put(JSON_BILLING_ADDRESS_KEY, ImmutableMap.builder()
@@ -362,7 +361,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .build());
 
         connectorRestApiClient.postCreateCharge(postBody)
-                .statusCode(BAD_REQUEST.getStatusCode())
+                .statusCode(422)
                 .contentType(JSON)
                 .header("Location", is(nullValue()))
                 .body(JSON_CHARGE_KEY, is(nullValue()))
@@ -572,7 +571,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturn400ForInvalidMetadata() {
+    public void shouldReturn422ForInvalidMetadata() {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("key1", null);
         metadata.put("key2", new HashMap<>());
@@ -593,7 +592,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
 
         connectorRestApiClient
                 .postCreateCharge(postBody)
-                .statusCode(400)
+                .statusCode(422)
                 .contentType(JSON)
                 .body(JSON_MESSAGE_KEY, containsInAnyOrder(
                         "Field [metadata] values must be of type String, Boolean or Number",

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -138,7 +138,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .body(invalidPayload)
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
-                .statusCode(BAD_REQUEST.getStatusCode())
+                .statusCode(422)
                 .body("message", is(Collections.singletonList("Field [signature] must not be empty")));
     }
 


### PR DESCRIPTION
- 422 seems more appropriate for entities which fail validation but are otherwise
understood and the request syntax was correct.

## WHAT YOU DID
The acceptance criteria for story [PP-4884](https://payments-platform.atlassian.net/browse/PP-4884) requires validation errors to return http status [422](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422) which means the service has understood the request but it cannot be processed (as opposed to [400](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) which represents the request a broader bad request)