### PR TITLE
PP-5142 Unify error responses produced by exception mappers

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/ConstraintViolationExceptionMapper.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.connector.common.exception;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -25,8 +26,9 @@ public class ConstraintViolationExceptionMapper implements ExceptionMapper<Const
                 .map(ConstraintViolation::getMessage)
                 .collect(Collectors.toList());
 
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, constraintViolationMessages);
         return Response.status(422)
-                .entity(ImmutableMap.of("message", constraintViolationMessages))
+                .entity(errorResponse)
                 .type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/common/exception/UnsupportedOperationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/UnsupportedOperationExceptionMapper.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.connector.common.exception;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -16,8 +18,9 @@ public class UnsupportedOperationExceptionMapper implements ExceptionMapper<Unsu
     @Override
     public Response toResponse(UnsupportedOperationException exception) {
         LOGGER.error(exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, List.of(exception.getMessage()));
         return Response.status(Response.Status.BAD_REQUEST)
-                .entity(ImmutableMap.of("message", exception.getMessage()))
+                .entity(errorResponse)
                 .type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/common/exception/ValidationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/ValidationExceptionMapper.java
@@ -1,13 +1,12 @@
 package uk.gov.pay.connector.common.exception;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
-import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -19,7 +18,7 @@ public class ValidationExceptionMapper implements ExceptionMapper<ValidationExce
     @Override
     public Response toResponse(ValidationException exception) {
         LOGGER.error(exception.getErrors().stream().collect(Collectors.joining("\n")));
-        Map<String, List<String>> entity = ImmutableMap.of("errors", exception.getErrors());
-        return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getErrors());
+        return Response.status(400).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ErrorIdentifier.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ErrorIdentifier.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.connector.common.model.api;
+
+public enum ErrorIdentifier {
+    GENERIC
+}

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.common.model.api;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public class ErrorResponse {
+    
+    @JsonProperty("error_identifier")
+    private final ErrorIdentifier identifier;
+    
+    @JsonProperty("message")
+    private final List<String> messages;
+    
+    @JsonProperty("reason")
+    private final String reason;
+    
+    public ErrorResponse(ErrorIdentifier identifier, List<String> messages, String reason) {
+        this.identifier = identifier;
+        this.messages = messages;
+        this.reason = reason;
+    }
+    
+    public ErrorResponse(ErrorIdentifier identifier, List<String> messages) {
+        this(identifier, messages, null);
+    }
+
+    public ErrorIdentifier getIdentifier() {
+        return identifier;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
@@ -3,11 +3,13 @@ package uk.gov.pay.connector.util;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 
 import javax.annotation.Priority;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
-import java.util.Map;
+import java.util.List;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -19,8 +21,8 @@ public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingEx
     @Override
     public Response toResponse(JsonMappingException exception) {
         LOGGER.error(exception.getMessage());
-        Map<String, String> entity = Map.of("message", sanitiseExceptionMessage(exception.getMessage()));
-        return Response.status(400).entity(entity).type(APPLICATION_JSON).build();
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, List.of(sanitiseExceptionMessage(exception.getMessage())));
+        return Response.status(400).entity(errorResponse).type(APPLICATION_JSON).build();
     }
 
     private String sanitiseExceptionMessage(String message) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -99,7 +99,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, 
                 is("Operation [add] is not valid for path [corporate_debit_card_surcharge_amount]"));
     }
@@ -115,7 +115,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Field [op] is required"));
     }
     
@@ -130,7 +130,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, 
                 is("Value [-100] is not valid for path [corporate_credit_card_surcharge_amount]"));
     }
@@ -146,7 +146,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, 
                 is("Value [not zero or a positive number that can be represented as a long] is not valid for path [corporate_debit_card_surcharge_amount]"));
     }
@@ -161,7 +161,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Field [value] is required"));
     }
 
@@ -176,7 +176,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Value [] is not valid for path [corporate_credit_card_surcharge_amount]"));
     }
 
@@ -192,7 +192,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Field [value] is required"));
     }
 
@@ -208,7 +208,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Field [value] is required"));
     }
 
@@ -224,7 +224,7 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("errors").get(0).textValue();
+        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
         assertThat(errorMessage, is("Value [false] must be of type boolean for path [allow_zero_amount]"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.GatewayConfig;
 import uk.gov.pay.connector.app.WorldpayConfig;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.rules.ResourceTestRuleWithCustomExceptionMappersBuilder;
 
@@ -26,7 +27,7 @@ import static org.mockito.Mockito.when;
 public class GatewayAccountResourceValidationTest {
 
     private static ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
-    
+
     private static WorldpayConfig mockWorldpayConfig = mock(WorldpayConfig.class);
 
     private static GatewayConfig mockGatewayConfig = mock(GatewayConfig.class);
@@ -99,9 +100,8 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, 
-                is("Operation [add] is not valid for path [corporate_debit_card_surcharge_amount]"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Operation [add] is not valid for path [corporate_debit_card_surcharge_amount]", ErrorIdentifier.GENERIC);
     }
 
     @Test
@@ -115,10 +115,10 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, is("Field [op] is required"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Field [op] is required", ErrorIdentifier.GENERIC);
     }
-    
+
     @Test
     public void shouldReturn400_whenCorporateCreditCardSurchargeAmountIsNegativeValue() {
         JsonNode jsonNode = new ObjectMapper()
@@ -130,9 +130,9 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, 
-                is("Value [-100] is not valid for path [corporate_credit_card_surcharge_amount]"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Value [-100] is not valid for path [corporate_credit_card_surcharge_amount]",
+                ErrorIdentifier.GENERIC);
     }
 
     @Test
@@ -146,9 +146,9 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, 
-                is("Value [not zero or a positive number that can be represented as a long] is not valid for path [corporate_debit_card_surcharge_amount]"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Value [not zero or a positive number that can be represented as a long] is not valid for path [corporate_debit_card_surcharge_amount]",
+                ErrorIdentifier.GENERIC);
     }
 
     @Test
@@ -161,8 +161,8 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, is("Field [value] is required"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Field [value] is required", ErrorIdentifier.GENERIC);
     }
 
     @Test
@@ -176,8 +176,9 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, is("Value [] is not valid for path [corporate_credit_card_surcharge_amount]"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Value [] is not valid for path [corporate_credit_card_surcharge_amount]",
+                ErrorIdentifier.GENERIC);
     }
 
     @Test
@@ -192,8 +193,8 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, is("Field [value] is required"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Field [value] is required", ErrorIdentifier.GENERIC);
     }
 
     @Test
@@ -208,8 +209,8 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, is("Field [value] is required"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Field [value] is required", ErrorIdentifier.GENERIC);
     }
 
     @Test
@@ -224,7 +225,17 @@ public class GatewayAccountResourceValidationTest {
                 .request()
                 .method("PATCH", Entity.json(jsonNode));
         assertThat(response.getStatus(), is(400));
-        String errorMessage = response.readEntity(JsonNode.class).get("message").get(0).textValue();
-        assertThat(errorMessage, is("Value [false] must be of type boolean for path [allow_zero_amount]"));
+        JsonNode body = response.readEntity(JsonNode.class);
+        assertErrorBodyMatches(body, "Value [false] must be of type boolean for path [allow_zero_amount]",
+                ErrorIdentifier.GENERIC);
+    }
+
+    private void assertErrorBodyMatches(JsonNode body, String expectedMessage, ErrorIdentifier identifier) {
+        JsonNode message = body.get("message");
+        assertThat(message.isArray(), is(true));
+        assertThat(message.size(), is(1));
+        assertThat(message.get(0).textValue(),
+                is(expectedMessage));
+        assertThat(body.get("error_identifier").textValue(), is(identifier.toString()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -2,19 +2,20 @@ package uk.gov.pay.connector.it.resources;
 
 import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.postgresql.util.PGobject;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.util.ExternalMetadataConverter;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import javax.ws.rs.core.Response.Status;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
@@ -25,6 +26,7 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.notNullValue;
@@ -621,7 +623,8 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .log().body()
                 .statusCode(400)
                 .contentType(JSON)
-                .body("message", is(List.of("Field [metadata] must be an object of JSON key-value pairs")));
+                .body("message", contains("Field [metadata] must be an object of JSON key-value pairs"))
+                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -643,7 +646,8 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .log().body()
                 .statusCode(400)
                 .contentType(JSON)
-                .body("message", is(List.of("Field [metadata] must be an object of JSON key-value pairs")));
+                .body("message", contains("Field [metadata] must be an object of JSON key-value pairs"))
+                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private String expectedChargeLocationFor(String accountId, String chargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import javax.ws.rs.core.Response.Status;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
@@ -620,7 +621,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .log().body()
                 .statusCode(400)
                 .contentType(JSON)
-                .body("message", is("Field [metadata] must be an object of JSON key-value pairs"));
+                .body("message", is(List.of("Field [metadata] must be an object of JSON key-value pairs")));
     }
 
     @Test
@@ -642,7 +643,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .log().body()
                 .statusCode(400)
                 .contentType(JSON)
-                .body("message", is("Field [metadata] must be an object of JSON key-value pairs"));
+                .body("message", is(List.of("Field [metadata] must be an object of JSON key-value pairs")));
     }
 
     private String expectedChargeLocationFor(String accountId, String chargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
@@ -5,6 +5,7 @@ import io.restassured.specification.RequestSpecification;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -14,7 +15,7 @@ import java.util.Collections;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
@@ -136,8 +137,8 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
                 .then()
                 .statusCode(400)
-                .body("message", hasSize(1))
-                .body("message[0]", is("Operation [not_replace] not supported for path [bank_account]"));
+                .body("message", contains("Operation [not_replace] not supported for path [bank_account]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceITest.java
@@ -136,8 +136,8 @@ public class StripeAccountSetupResourceITest extends GatewayAccountResourceTestB
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
                 .then()
                 .statusCode(400)
-                .body("errors", hasSize(1))
-                .body("errors[0]", is("Operation [not_replace] not supported for path [bank_account]"));
+                .body("message", hasSize(1))
+                .body("message[0]", is("Operation [not_replace] not supported for path [bank_account]"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
@@ -112,7 +112,7 @@ public class EpdqCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", containsString("Wallets are not supported for ePDQ"));
+                .body("message", contains("Wallets are not supported for ePDQ"));
     }
 
     @Test
@@ -127,7 +127,7 @@ public class EpdqCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", containsString("Wallets are not supported for ePDQ"));
+                .body("message", contains("Wallets are not supported for ePDQ"));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceITest.java
@@ -8,6 +8,7 @@ import io.restassured.response.ValidatableResponse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -112,7 +113,8 @@ public class EpdqCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", contains("Wallets are not supported for ePDQ"));
+                .body("message", contains("Wallets are not supported for ePDQ"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -127,7 +129,8 @@ public class EpdqCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", contains("Wallets are not supported for ePDQ"));
+                .body("message", contains("Wallets are not supported for ePDQ"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceITest.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
@@ -162,7 +162,7 @@ public class SmartpayCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", containsString("Wallets are not supported for Smartpay"));
+                .body("message", contains("Wallets are not supported for Smartpay"));
     }
 
     @Test
@@ -177,7 +177,7 @@ public class SmartpayCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", containsString("Wallets are not supported for Smartpay"));
+                .body("message", contains("Wallets are not supported for Smartpay"));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceITest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -162,7 +163,8 @@ public class SmartpayCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", contains("Wallets are not supported for Smartpay"));
+                .body("message", contains("Wallets are not supported for Smartpay"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -177,7 +179,8 @@ public class SmartpayCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(400)
-                .body("message", contains("Wallets are not supported for Smartpay"));
+                .body("message", contains("Wallets are not supported for Smartpay"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -262,7 +263,8 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlForApplePay(externalChargeId))
                 .then()
                 .statusCode(400)
-                .body("message", contains("Wallets are not supported for Stripe"));
+                .body("message", contains("Wallets are not supported for Stripe"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -279,7 +281,8 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlForGooglePay(externalChargeId))
                 .then()
                 .statusCode(400)
-                .body("message", contains("Wallets are not supported for Stripe"));
+                .body("message", contains("Wallets are not supported for Stripe"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -48,6 +48,7 @@ import static org.eclipse.jetty.http.HttpStatus.BAD_REQUEST_400;
 import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 import static org.eclipse.jetty.http.HttpStatus.NO_CONTENT_204;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
@@ -261,7 +262,7 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlForApplePay(externalChargeId))
                 .then()
                 .statusCode(400)
-                .body("message", containsString("Wallets are not supported for Stripe"));
+                .body("message", contains("Wallets are not supported for Stripe"));
     }
 
     @Test
@@ -278,7 +279,7 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlForGooglePay(externalChargeId))
                 .then()
                 .statusCode(400)
-                .body("message", containsString("Wallets are not supported for Stripe"));
+                .body("message", contains("Wallets are not supported for Stripe"));
     }
 
     @Test


### PR DESCRIPTION
- Add ErrorResponse model to unify the contents of error responses. Include in this an ErrorIdentifier, which will always be "GENERIC" for now.
- All error responses created by exception mappers now include a "message" field which is an array of strings.
- Error responses produced by ResponseUtils.java will be modified in a later commit.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
