### PR TITLE
PP-4993 Backwards compatible Stripe refund

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -361,6 +361,7 @@ public class StripePaymentProvider implements PaymentProvider {
         params.add(new BasicNameValuePair("description", description));
         params.add(new BasicNameValuePair("source", sourceId));
         params.add(new BasicNameValuePair("capture", "false"));
+        params.add(new BasicNameValuePair("transfer_group", externalId));
         String stripeAccountId = getStripeAccountId(externalId, gatewayAccount);
 
         params.add(new BasicNameValuePair("on_behalf_of", stripeAccountId));

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -10,11 +10,12 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
+import uk.gov.pay.connector.gateway.stripe.json.StripeRefund;
+import uk.gov.pay.connector.gateway.stripe.json.StripeTransferResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
 import uk.gov.pay.connector.gateway.stripe.response.StripeRefundResponse;
 import uk.gov.pay.connector.util.JsonObjectMapper;
-
-import java.util.Map;
 
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
@@ -39,8 +40,10 @@ public class StripeRefundHandler {
 
     public GatewayRefundResponse refund(RefundGatewayRequest request) {
         try {
-            String reference = refundCharge(request);
-            return fromBaseRefundResponse(StripeRefundResponse.of(reference), GatewayRefundResponse.RefundState.COMPLETE);
+            StripeRefund refundResponse = refundCharge(request);
+            transferFromConnectAccount(request);
+
+            return fromBaseRefundResponse(StripeRefundResponse.of(refundResponse.getId()), GatewayRefundResponse.RefundState.COMPLETE);
         } catch (GatewayErrorException e) {
 
             if (e.getFamily() == CLIENT_ERROR) {
@@ -69,20 +72,29 @@ public class StripeRefundHandler {
         }
     }
 
-    private String refundCharge(RefundGatewayRequest request)
-            throws
-            GatewayException.GenericGatewayException,
-            GatewayErrorException,
-            GatewayException.GatewayConnectionTimeoutException {
-        final GatewayClient.Response refundResponse = client.postRequestFor(
-                StripeRefundRequest.of(request, stripeGatewayConfig)
-        );
-        String reference = jsonObjectMapper.getObject(refundResponse.getEntity(), Map.class).get("id").toString();
-        logger.info("As part of refund {} refunded stripe charge id {}",
+    private StripeRefund refundCharge(RefundGatewayRequest request) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
+        StripeRefundRequest stripeRefundRequest = StripeRefundRequest.of(request, stripeGatewayConfig);
+        final String refundResponse = client.postRequestFor(stripeRefundRequest).getEntity();
+        StripeRefund refund = jsonObjectMapper.getObject(refundResponse, StripeRefund.class);
+        logger.info("As part of refund {} to refund charge id {} refunded stripe charge id {}",
                 request.getTransactionId(),
+                request.getChargeExternalId(),
                 request.getRefundExternalId()
         );
 
-        return reference;
+        return refund;
+    }
+    
+    private void transferFromConnectAccount(RefundGatewayRequest request) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
+        String transferResponse = client.postRequestFor(StripeTransferInRequest.of(request, stripeGatewayConfig)).getEntity();
+        StripeTransferResponse stripeTransferResponse = jsonObjectMapper.getObject(transferResponse, StripeTransferResponse.class);
+        logger.info("As part of refund {} refunding charge id {}, transferred net amount {} - transfer id {} -  from Stripe Connect account id {} in transfer group {}",
+                request.getRefundExternalId(),
+                request.getChargeExternalId(),
+                stripeTransferResponse.getAmount(),
+                stripeTransferResponse.getId(),
+                stripeTransferResponse.getDestinationStripeAccountId(),
+                stripeTransferResponse.getStripeTransferGroup()
+        );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeRefund.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeRefund.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripeRefund {
+    @JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -51,8 +51,6 @@ public class StripeRefundRequest extends StripeRequest {
         List<BasicNameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("charge", stripeChargeId));
         params.add(new BasicNameValuePair("amount", amount));
-        params.add(new BasicNameValuePair("refund_application_fee", "true"));
-        params.add(new BasicNameValuePair("reverse_transfer", "true"));
         String payload = URLEncodedUtils.format(params, UTF_8);
 
         return new GatewayOrder(

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -82,6 +82,7 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -69,8 +69,6 @@ public class StripeRefundRequestTest {
         
         assertThat(payload, containsString("charge=" + stripeChargeId));
         assertThat(payload, containsString("amount=" + refundAmount));
-        assertThat(payload, containsString("refund_application_fee=true"));
-        assertThat(payload, containsString("reverse_transfer=true"));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -158,7 +158,7 @@ public class StripeResourceAuthorizeITest {
 
         List<LoggedRequest> requests = findAll(postRequestedFor(urlMatching("/v1/charges")));
         assertThat(requests).hasSize(1);
-        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody());
+        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody(externalChargeId));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class StripeResourceAuthorizeITest {
 
         List<LoggedRequest> requests = findAll(postRequestedFor(urlMatching("/v1/charges")));
         assertThat(requests).hasSize(1);
-        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody());
+        assertThat(requests.get(0).getBodyAsString()).isEqualTo(constructExpectedAuthoriseRequestBody(externalChargeId));
     }
 
     @Test
@@ -331,13 +331,14 @@ public class StripeResourceAuthorizeITest {
         return "/v1/frontend/charges/{chargeId}/capture".replace("{chargeId}", chargeId);
     }
 
-    private String constructExpectedAuthoriseRequestBody() {
+    private String constructExpectedAuthoriseRequestBody(String chargeExternalId) {
         List<BasicNameValuePair> params = new ArrayList<>();
         params.add(new BasicNameValuePair("amount", AMOUNT));
         params.add(new BasicNameValuePair("currency", "GBP"));
         params.add(new BasicNameValuePair("description", DESCRIPTION));
         params.add(new BasicNameValuePair("source", "src_1DT9bn2eZvKYlo2Cg5okt8WC")); //This comes from resources/stripe/create_sources_response.json
         params.add(new BasicNameValuePair("capture", "false"));
+        params.add(new BasicNameValuePair("transfer_group", chargeExternalId));
         params.add(new BasicNameValuePair("on_behalf_of", stripeAccountId));
         params.add(new BasicNameValuePair("transfer_data[destination]", stripeAccountId));
         return URLEncodedUtils.format(params, UTF_8);

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -61,6 +61,11 @@ public class StripeMockClient {
         String payload = TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
         setupResponse(payload, "/v1/charges/" + gatewayTransactionId + "/capture", 402);
     }
+    
+    public void mockRefundError() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_ERROR_RESPONSE);
+        setupResponse(payload, "/v1/refunds", 402);
+    }
 
     public void mockUnauthorizedResponse() {
         Map<String, Object> unauthorizedResponse = ImmutableMap.of("error", ImmutableMap.of(
@@ -92,6 +97,11 @@ public class StripeMockClient {
     }
 
     public void mockCancelCharge() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_REFUND_FULL_CHARGE_RESPONSE);
+        setupResponse(payload, "/v1/refunds", 200);
+    }
+
+    public void mockRefund() {
         String payload = TestTemplateResourceLoader.load(STRIPE_REFUND_FULL_CHARGE_RESPONSE);
         setupResponse(payload, "/v1/refunds", 200);
     }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -408,6 +408,18 @@ public class DatabaseTestHelper {
         return ret;
     }
 
+    public Map<String, Object> getRefundByExternalId(String refundExternalId) {
+        Map<String, Object> ret = jdbi.withHandle(h ->
+                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id " +
+                        "FROM refunds " +
+                        "WHERE external_id = :refund_id")
+                        .bind("refund_id", refundExternalId)
+                        .list())
+                .stream()
+                .findFirst().get();
+        return ret;
+    }
+
     public List<Map<String, Object>> getRefundsByChargeId(long chargeId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
                 h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id " +

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -132,6 +132,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_ERROR_RESPONSE_GENERAL = TEMPLATE_BASE_NAME + "/stripe/error_response_general.json";
     public static final String STRIPE_CANCEL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/cancel_charge_response.json";
     public static final String STRIPE_REFUND_FULL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_charge.json";
+    public static final String STRIPE_REFUND_FULL_DESTINATION_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_destination_charge.json";
     public static final String STRIPE_REFUND_ERROR_GREATER_AMOUNT_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_error_greater_amount.json";
     public static final String STRIPE_REFUND_ERROR_ALREADY_REFUNDED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_error_charge_already_refunded.json";
     public static final String STRIPE_TRANSFER_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/transfer_success_response.json";

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -66,6 +66,8 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -65,6 +65,8 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+
 jerseyClient:
   timeout: 500ms
   connectionTimeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -55,6 +55,7 @@ stripe:
   webhookSigningSecrets:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -61,6 +61,7 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -58,6 +58,7 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID:-stripe_platform_account_id}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}

--- a/src/test/resources/templates/stripe/refund_full_destination_charge.json
+++ b/src/test/resources/templates/stripe/refund_full_destination_charge.json
@@ -4,7 +4,7 @@
   "amount": 2000,
   "balance_transaction": "txn_1DRiccHj08_test",
   "charge": {
-    "destination": null,
+    "destination": "account_id",
     "id": "ch_123456",
     "object": "charge",
     "captured": true,


### PR DESCRIPTION
This PR switches Stripe refund to be a two step process. Rather than
using `reverse_transfer: true` to tell Stripe to reverse the transfer
associated with a charge, we now refund the charge without that option, then
make a second call to Stripe to transfer the refund amount from the
Connect account to the Platform account.
The reason for this is that this new method is compatible with both our current
way of authorising and capturing charges, and with the new way that we
are introducing in order to take fees.