### PR TITLE
PP-4993 Authorise stripe charges without setting destination

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -365,7 +365,6 @@ public class StripePaymentProvider implements PaymentProvider {
         String stripeAccountId = getStripeAccountId(externalId, gatewayAccount);
 
         params.add(new BasicNameValuePair("on_behalf_of", stripeAccountId));
-        params.add(new BasicNameValuePair("transfer_data[destination]", stripeAccountId));
         return URLEncodedUtils.format(params, UTF_8);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -344,7 +344,6 @@ public class StripeResourceAuthorizeITest {
         params.add(new BasicNameValuePair("capture", "false"));
         params.add(new BasicNameValuePair("transfer_group", chargeExternalId));
         params.add(new BasicNameValuePair("on_behalf_of", stripeAccountId));
-        params.add(new BasicNameValuePair("transfer_data[destination]", stripeAccountId));
         return URLEncodedUtils.format(params, UTF_8);
     }
 


### PR DESCRIPTION
In order to start taking fees via the method of doing a net transfer
from our Stripe platform account to the relevant Stripe connect
account, we need to stop telling Stripe to automatically transfer
a charge to a connect account on capture. This PR does that.

Whilst this change is small, it will have a quite a big effect, as
it will activate the code path here
https://github.com/alphagov/pay-connector/blob/master/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeCaptureHandler.java#L50

which will mean captures will now be processed by a two stage process.
Therefore, to test this PR I recommend testing locally against real Stripe
gateway and ensuring that authorisation, capture, and refund all behave as expected.