### PR TITLE
PP-5142 Use ErrorResponse to construct responses created by ResponseUtil

### DIFF
--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -4,6 +4,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -92,11 +94,13 @@ public class ResponseUtil {
     }
 
     private static Response responseWithMessageMap(Status status, String message) {
-        return responseWithEntity(status, ImmutableMap.of("message", message));
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, List.of(message));
+        return responseWithEntity(status, errorResponse);
     }
 
     private static Response responseWith(Status status, String message, String reason) {
-        return responseWithEntity(status, ImmutableMap.of("reason", reason, "message", message));
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, List.of(message), reason);
+        return responseWithEntity(status, errorResponse);
     }
 
     private static Response responseWithMessageMap(Status status, Object entity) {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.epdq;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -28,7 +27,7 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
 
     @Test
     public void shouldGenerateNoTransactionId() {
-        Assert.assertThat(provider.generateTransactionId().isPresent(), is(false));
+        assertThat(provider.generateTransactionId().isPresent(), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -5,7 +5,6 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -86,7 +86,7 @@ public class RefundNotificationProcessorTest {
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
         String expectedLogMessage = String.format("%s refund notification could not be used to update charge (missing reference)", paymentGatewayName);
 
-        Assert.assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
+        assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class RefundNotificationProcessorTest {
                 paymentGatewayName,
                 "unknown");
 
-        Assert.assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
+        assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
     }
 
     public static RefundEntityFixture aValidRefundEntity() {

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,13 +45,13 @@ public class SandboxPaymentProviderTest {
 
     @Test
     public void getPaymentGatewayName_shouldGetExpectedName() {
-        Assert.assertThat(provider.getPaymentGatewayName().getName(), is("sandbox"));
+        assertThat(provider.getPaymentGatewayName().getName(), is("sandbox"));
     }
 
     @Test
     public void shouldGenerateTransactionId() {
-        Assert.assertThat(provider.generateTransactionId().isPresent(), is(true));
-        Assert.assertThat(provider.generateTransactionId().get(), is(instanceOf(String.class)));
+        assertThat(provider.generateTransactionId().isPresent(), is(true));
+        assertThat(provider.generateTransactionId().get(), is(instanceOf(String.class)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +60,7 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
         GatewayResponse<BaseAuthoriseResponse> response = provider.authorise(new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails));
 
         assertTrue(response.isSuccessful());
-        assertThat(response.getBaseResponse().isPresent(), CoreMatchers.is(true));
+        assertThat(response.getBaseResponse().isPresent(), is(true));
         String transactionId = response.getBaseResponse().get().getTransactionId();
         assertThat(transactionId, is(not(nullValue())));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +44,7 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
 
     @Test
     public void shouldGenerateTransactionId() {
-        Assert.assertThat(provider.generateTransactionId().isPresent(), is(false));
+        assertThat(provider.generateTransactionId().isPresent(), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -2,13 +2,11 @@ package uk.gov.pay.connector.gateway.stripe;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +36,6 @@ import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import javax.ws.rs.WebApplicationException;
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -113,7 +110,7 @@ public class StripePaymentProviderTest {
 
     @Test
     public void shouldGenerateNoTransactionId() {
-        Assert.assertThat(provider.generateTransactionId().isPresent(), is(false));
+        assertThat(provider.generateTransactionId().isPresent(), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,7 +7,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.*;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayOperation;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ErrorType;
@@ -42,7 +45,6 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -63,13 +65,13 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
 
     @Test
     public void shouldGetPaymentProviderName() {
-        Assert.assertThat(provider.getPaymentGatewayName().getName(), is("worldpay"));
+        assertThat(provider.getPaymentGatewayName().getName(), is("worldpay"));
     }
 
     @Test
     public void shouldGenerateTransactionId() {
-        Assert.assertThat(provider.generateTransactionId().isPresent(), is(true));
-        Assert.assertThat(provider.generateTransactionId().get(), is(instanceOf(String.class)));
+        assertThat(provider.generateTransactionId().isPresent(), is(true));
+        assertThat(provider.generateTransactionId().get(), is(instanceOf(String.class)));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -16,6 +16,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -37,6 +38,7 @@ import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -217,7 +219,8 @@ public class ChargingITestBase {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is(errorMessage));
+                .body("message", contains(errorMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertFrontendChargeStatusIs(chargeId, status);
     }
@@ -229,7 +232,7 @@ public class ChargingITestBase {
     public static String authoriseChargeUrlForGooglePay(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/wallets/google".replace("{chargeId}", chargeId);
     }
-    
+
     public static String authoriseChargeUrlFor(String chargeId) {
         return "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeId);
     }
@@ -308,7 +311,7 @@ public class ChargingITestBase {
                 .body("state.finished", is(true))
                 .body("state.message", is("Payment was cancelled by the service"))
                 .body("state.code", is("P0040"));
-        
+
         return chargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -5,8 +5,6 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.Is;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -198,7 +196,7 @@ public class SmartpayPaymentProviderTest {
 
         CaptureResponse captureGatewayResponse = paymentProvider.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(captureGatewayResponse.isSuccessful());
-        MatcherAssert.assertThat(captureGatewayResponse.state(), Is.is(CaptureResponse.ChargeState.PENDING));
+        assertThat(captureGatewayResponse.state(), is(CaptureResponse.ChargeState.PENDING));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableMap;
 import io.restassured.RestAssured;
 import org.hamcrest.core.Is;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -125,6 +124,6 @@ public class GatewayAuthFailuresITest {
     private void assertThatLastGatewayClientLoggingEventIs(String loggingEvent) {
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        Assert.assertThat(logStatement.get(logStatement.size() - 1).getFormattedMessage(), Is.is(loggingEvent));
+        assertThat(logStatement.get(logStatement.size() - 1).getFormattedMessage(), Is.is(loggingEvent));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresITest.java
@@ -19,6 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -35,6 +36,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.ConnectionConfig.connectionConfig;
 import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -112,7 +114,8 @@ public class GatewayAuthFailuresITest {
                 .then()
                 .statusCode(500)
                 .contentType(JSON)
-                .body("message", is(errorMessage));
+                .body("message", contains(errorMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertThatLastGatewayClientLoggingEventIs(
                 String.format("Gateway returned unexpected status code: 999, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", WIREMOCK_PORT));

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayCaptureFailuresITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayCaptureFailuresITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,6 +11,7 @@ import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static java.lang.String.format;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
@@ -37,7 +37,7 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
 
         assertLastGatewayClientLoggingEventContains(
                 format("Gateway returned unexpected status code: 999, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", port));
-        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -47,7 +47,7 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         
-        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -56,6 +56,6 @@ public class GatewayCaptureFailuresITest extends BaseGatewayITest {
         setupGatewayStub().respondWithSuccessWhenCapture();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
-        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -12,6 +11,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,6 +35,6 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertLastGatewayClientLoggingEventContains("Exception for gateway url=http://gobbledygook.invalid.url");
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayInvalidUrlITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,6 +11,7 @@ import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,6 +35,6 @@ public class GatewayInvalidUrlITest extends BaseGatewayITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
         assertLastGatewayClientLoggingEventContains("Exception for gateway url=http://gobbledygook.invalid.url");
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -16,6 +15,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.dropwizard.testing.ConfigOverride.config;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -43,6 +43,6 @@ public class GatewaySocketErrorITest extends BaseGatewayITest {
 
         assertLastGatewayClientLoggingEventContains(
                 String.format("Gateway returned unexpected status code: 404, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", port));
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketErrorITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,6 +15,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -43,6 +43,6 @@ public class GatewaySocketErrorITest extends BaseGatewayITest {
 
         assertLastGatewayClientLoggingEventContains(
                 String.format("Gateway returned unexpected status code: 404, for gateway url=http://localhost:%s/pal/servlet/soap/Payment with type test", port));
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -12,6 +11,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 
 import static io.dropwizard.testing.ConfigOverride.config;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -36,6 +36,6 @@ public class GatewaySocketReadTimeoutITest extends BaseGatewayITest {
 
         assertLastGatewayClientLoggingEventContains(
                 String.format("Connection timed out error for gateway url=http://localhost:%s/pal/servlet/soap/Payment", port));
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewaySocketReadTimeoutITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,6 +11,7 @@ import uk.gov.pay.connector.rules.GuiceAppWithPostgresRule;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -36,6 +36,6 @@ public class GatewaySocketReadTimeoutITest extends BaseGatewayITest {
 
         assertLastGatewayClientLoggingEventContains(
                 String.format("Connection timed out error for gateway url=http://localhost:%s/pal/servlet/soap/Payment", port));
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import uk.gov.pay.connector.app.ExecutorServiceConfig;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.util.PortFactory;
@@ -17,6 +18,7 @@ import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static java.lang.String.format;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -83,6 +85,7 @@ public class CardAuthorizeDelayedGatewayResponseTest extends ChargingITestBase {
                 .then()
                 .statusCode(202)
                 .contentType(JSON)
-                .body("message", is(format("Authorisation for charge already in progress, %s", chargeId)));
+                .body("message", contains(format("Authorisation for charge already in progress, %s", chargeId)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayITest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -36,7 +37,7 @@ public class CardResourceAuthoriseApplePayITest extends ChargingITestBase {
 
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
-    
+
     public CardResourceAuthoriseApplePayITest() {
         super("sandbox");
     }
@@ -47,7 +48,7 @@ public class CardResourceAuthoriseApplePayITest extends ChargingITestBase {
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
-    
+
     @Test
     public void shouldAuthoriseCharge_ForApplePay() {
         shouldAuthoriseChargeForApplePay("mr payment", "mr@payment.test");
@@ -90,7 +91,8 @@ public class CardResourceAuthoriseApplePayITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
                 .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-                .body("message", contains("Card holder name must be a maximum of 255 chars"));
+                .body("message", contains("Card holder name must be a maximum of 255 chars"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
@@ -109,7 +111,8 @@ public class CardResourceAuthoriseApplePayITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
                 .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-                .body("message", contains("Email must be a maximum of 254 chars"));
+                .body("message", contains("Email must be a maximum of 254 chars"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseGooglePayITest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -39,7 +40,7 @@ public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
 
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
-    
+
     public CardResourceAuthoriseGooglePayITest() {
         super("sandbox");
     }
@@ -50,7 +51,7 @@ public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
-    
+
     @Test
     public void authoriseChargeSuccess() throws IOException {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
@@ -74,7 +75,7 @@ public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
     @Test
     public void tooLongCardHolderName_shouldResultInBadRequest() throws Exception {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
-        String payload = fixture("googlepay/example-auth-request.json").replace("Example Name", 
+        String payload = fixture("googlepay/example-auth-request.json").replace("Example Name",
                 "tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars " +
                         "12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12tenchars12");
         JsonNode googlePayload = Jackson.getObjectMapper().readTree(payload);
@@ -84,7 +85,8 @@ public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-                .body("message", contains("Card holder name must be a maximum of 255 chars"));
+                .body("message", contains("Card holder name must be a maximum of 255 chars"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
@@ -104,7 +106,8 @@ public class CardResourceAuthoriseGooglePayITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-                .body("message", contains("Email must be a maximum of 254 chars"));
+                .body("message", contains("Email must be a maximum of 254 chars"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         verify(mockAppender, times(0)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseITest.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
@@ -23,6 +24,7 @@ import java.util.stream.Collectors;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
@@ -263,7 +265,8 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
                 .then()
                 .statusCode(400)
                 .contentType(JSON)
-                .body("message", is(format("Charge not in correct state to be processed, %s", chargeId)));
+                .body("message", contains(format("Charge not in correct state to be processed, %s", chargeId)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
         assertFrontendChargeStatusIs(chargeId, EXPIRED.getValue());
     }
 
@@ -276,7 +279,8 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
                 .then()
                 .statusCode(404)
                 .contentType(JSON)
-                .body("message", is(format("Charge with id [%s] not found.", unknownId)));
+                .body("message", contains(format("Charge with id [%s] not found.", unknownId)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -292,7 +296,8 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
                 .then()
                 .statusCode(400)
                 .contentType(JSON)
-                .body("message", is(msg));
+                .body("message", contains(msg))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
     }
@@ -307,7 +312,8 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
                 .then()
                 .statusCode(202)
                 .contentType(JSON)
-                .body("message", is(message));
+                .body("message", contains(message))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_READY.getValue());
     }
 
@@ -412,7 +418,8 @@ public class CardResourceAuthoriseITest extends ChargingITestBase {
                 .then()
                 .statusCode(400)
                 .contentType(JSON)
-                .body("message", is("Unsupported card details."));
+                .body("message", contains("Unsupported card details."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private void shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(String chargeId, String randomCardNumber) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureITest.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -13,6 +14,7 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
@@ -105,7 +107,8 @@ public class CardResourceCaptureITest extends ChargingITestBase {
                 .then()
                 .statusCode(expectedStatusCode)
                 .contentType(JSON)
-                .body("message", is(message));
+                .body("message", contains(message))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceITest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.junit.DropwizardConfig;
@@ -18,6 +19,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
@@ -99,7 +101,8 @@ public class ChargeCancelFrontendResourceITest extends ChargingITestBase {
                 .statusCode(ACCEPTED.getStatusCode())
                 .and()
                 .contentType(JSON)
-                .body("message", is(expectedMessage));
+                .body("message", contains(expectedMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -172,7 +175,8 @@ public class ChargeCancelFrontendResourceITest extends ChargingITestBase {
                 .statusCode(NOT_FOUND.getStatusCode())
                 .and()
                 .contentType(JSON)
-                .body("message", is("Charge with id [" + unknownChargeId + "] not found."));
+                .body("message", contains("Charge with id [" + unknownChargeId + "] not found."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -204,7 +208,8 @@ public class ChargeCancelFrontendResourceITest extends ChargingITestBase {
                             .statusCode(BAD_REQUEST.getStatusCode())
                             .and()
                             .contentType(JSON)
-                            .body("message", is(incorrectStateMessage));
+                            .body("message", contains(incorrectStateMessage))
+                            .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
                 });
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceITest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -20,6 +21,7 @@ import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -128,7 +130,8 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .and()
                 .contentType(JSON)
-                .body("message", is(expectedMessage));
+                .body("message", contains(expectedMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -141,7 +144,8 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
                 .statusCode(ACCEPTED.getStatusCode())
                 .and()
                 .contentType(JSON)
-                .body("message", is(expectedMessage));
+                .body("message", contains(expectedMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -153,11 +157,12 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
                 .statusCode(NOT_FOUND.getStatusCode())
                 .and()
                 .contentType(JSON)
-                .body("message", is("Charge with id [" + unknownChargeId + "] not found."));
+                .body("message", contains("Charge with id [" + unknownChargeId + "] not found."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
-    public void respondWith400__IfAccountIdIsMissing() {
+    public void respondWith404_IfAccountIdIsMissing() {
         String chargeId = createNewInPastChargeWithStatus(CREATED);
         String expectedMessage = "HTTP 404 Not Found";
 
@@ -172,7 +177,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void respondWith404__IfAccountIdIsNonNumeric() {
+    public void respondWith404_IfAccountIdIsNonNumeric() {
         String chargeId = createNewInPastChargeWithStatus(CREATED);
         String expectedMessage = "HTTP 404 Not Found";
 
@@ -187,7 +192,7 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
     }
 
     @Test
-    public void respondWith404__IfChargeIdDoNotBelongToAccount() {
+    public void respondWith404_IfChargeIdDoNotBelongToAccount() {
         String chargeId = createNewInPastChargeWithStatus(CREATED);
         String expectedMessage = format("Charge with id [%s] not found.", chargeId);
 
@@ -198,7 +203,8 @@ public class ChargeCancelResourceITest extends ChargingITestBase {
                 .statusCode(NOT_FOUND.getStatusCode())
                 .and()
                 .contentType(JSON)
-                .body("message", is(expectedMessage));
+                .body("message", contains(expectedMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private String createNewInPastChargeWithStatus(ChargeStatus status) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeEventsResourceITest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -21,9 +22,8 @@ import java.time.ZonedDateTime;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
-import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
-import static uk.gov.pay.connector.matcher.TransactionEventMatcher.withState;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
@@ -31,6 +31,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READ
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
+import static uk.gov.pay.connector.matcher.TransactionEventMatcher.withState;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -170,7 +172,8 @@ public class ChargeEventsResourceITest {
                 .getEvents("non-existent-charge")
                 .contentType(JSON)
                 .statusCode(NOT_FOUND.getStatusCode())
-                .body("message", is("Charge with id [non-existent-charge] not found."));
+                .body("message", contains("Charge with id [non-existent-charge] not found."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private DatabaseFixtures.TestCharge createTestCharge() {
@@ -179,16 +182,16 @@ public class ChargeEventsResourceITest {
                 .withAccountId(Long.valueOf(accountId));
 
         return withDatabaseTestHelper(databaseTestHelper)
-                        .aTestCharge()
-                        .withAmount(100L)
-                        .withTestAccount(testAccount)
-                        .withChargeStatus(CAPTURED);
+                .aTestCharge()
+                .withAmount(100L)
+                .withTestAccount(testAccount)
+                .withChargeStatus(CAPTURED);
     }
 
     private DatabaseFixtures.TestChargeEvent createTestChargeEvent(DatabaseFixtures.TestCharge testCharge) {
         return withDatabaseTestHelper(databaseTestHelper)
-                        .aTestChargeEvent()
-                        .withTestCharge(testCharge);
+                .aTestChargeEvent()
+                .withTestCharge(testCharge);
     }
 
     private DatabaseFixtures.TestRefundHistory createTestRefundHistory(DatabaseFixtures.TestRefund testRefund) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -295,7 +295,8 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .contentType(JSON)
                 .header("Location", is(nullValue()))
                 .body(JSON_CHARGE_KEY, is(nullValue()))
-                .body(JSON_MESSAGE_KEY, is("Unknown gateway account: " + missingGatewayAccount));
+                .body(JSON_MESSAGE_KEY, contains("Unknown gateway account: " + missingGatewayAccount))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.it.resources;
 
 import com.google.common.collect.ImmutableMap;
 import io.restassured.response.ValidatableResponse;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.postgresql.util.PGobject;
@@ -625,7 +624,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .statusCode(400)
                 .contentType(JSON)
                 .body("message", contains("Field [metadata] must be an object of JSON key-value pairs"))
-                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -648,7 +647,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .statusCode(400)
                 .contentType(JSON)
                 .body("message", contains("Field [metadata] must be an object of JSON key-value pairs"))
-                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private String expectedChargeLocationFor(String accountId, String chargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsITest.java
@@ -10,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.GatewayAccountPayload;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -21,6 +22,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.ACCOUNTS_FRONTEND_URL;
 import static uk.gov.pay.connector.it.resources.GatewayAccountResourceTestBase.createAGatewayAccountFor;
@@ -90,7 +92,8 @@ public class ChargesApiResourceAllowWebPaymentsITest {
                 .body(payload)
                 .patch("/v1/api/accounts/" + accountIdWithoutGatewayAccountCredentials)
                 .then()
-                .body("message", is("Account Credentials are required to set a Gateway Merchant ID"))
+                .body("message", contains("Account Credentials are required to set a Gateway Merchant ID"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()))
                 .and()
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
     }    
@@ -104,7 +107,8 @@ public class ChargesApiResourceAllowWebPaymentsITest {
                 .body(payload)
                 .patch("/v1/api/accounts/" + accountIdWithNotDigitalWalletSupportedGateway)
                 .then()
-                .body("message", is("Gateway epdq does not support digital wallets."))
+                .body("message", contains("Gateway epdq does not support digital wallets."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()))
                 .and()
                 .statusCode(HttpStatus.SC_BAD_REQUEST);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -610,7 +610,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .statusCode(NOT_FOUND.getStatusCode())
                 .contentType(JSON)
                 .body(JSON_MESSAGE_KEY, contains("Charge with id [i-do-not-exist] not found."))
-                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -627,7 +627,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .statusCode(CONFLICT.getStatusCode())
                 .contentType(JSON)
                 .body(JSON_MESSAGE_KEY, contains(expectedErrorMessage))
-                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private void createCharge(String externalChargeId, long chargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -476,7 +476,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .statusCode(NOT_FOUND.getStatusCode())
                 .contentType(JSON)
                 .body(JSON_MESSAGE_KEY, contains(format("Charge with id [%s] not found.", chargeId)))
-                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceITest.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -35,6 +36,7 @@ import static javax.ws.rs.core.Response.Status.NO_CONTENT;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang.math.RandomUtils.nextInt;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
@@ -303,7 +305,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("results[0].charge_id", is(externalChargeId))
                 .body("results[0].wallet_type", is(WalletType.APPLE_PAY.toString()));
     }
-    
+
     @Test
     public void shouldReturnWalletTypeWhenNotNull_v2() {
         long chargeId = nextInt();
@@ -342,7 +344,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
         long chargeId = nextInt();
         String externalChargeId = RandomIdGenerator.newId();
         long feeCollected = 100L;
-        
+
 
         createCharge(externalChargeId, chargeId);
         databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
@@ -355,19 +357,19 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .contentType(JSON)
                 .body("fee", is(100));
     }
-    
+
     @Test
     public void shouldReturnNetAmountIfFeeExists() {
         long chargeId = nextInt();
         String externalChargeId = RandomIdGenerator.newId();
         long feeCollected = 100L;
-        
+
         long defaultAmount = 6234L;
         long defaultCorporateSurchargeAmount = 150L;
-        
+
         createCharge(externalChargeId, chargeId);
         databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
-        
+
         connectorRestApiClient
                 .withAccountId(accountId)
                 .withChargeId(externalChargeId)
@@ -377,7 +379,7 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .body("fee", is(100))
                 .body("net_amount", is(Long.valueOf(defaultAmount + defaultCorporateSurchargeAmount - feeCollected).intValue()));
     }
-    
+
     @Test
     public void shouldReturnFeeInSearchResultsV1IfFeeExists() {
         long chargeId = nextInt();
@@ -473,7 +475,8 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .getCharge()
                 .statusCode(NOT_FOUND.getStatusCode())
                 .contentType(JSON)
-                .body(JSON_MESSAGE_KEY, is(format("Charge with id [%s] not found.", chargeId)));
+                .body(JSON_MESSAGE_KEY, contains(format("Charge with id [%s] not found.", chargeId)))
+                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -606,7 +609,8 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .postMarkChargeAsCaptureApproved()
                 .statusCode(NOT_FOUND.getStatusCode())
                 .contentType(JSON)
-                .body(JSON_MESSAGE_KEY, is("Charge with id [i-do-not-exist] not found."));
+                .body(JSON_MESSAGE_KEY, contains("Charge with id [i-do-not-exist] not found."))
+                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -622,7 +626,8 @@ public class ChargesApiResourceITest extends ChargingITestBase {
                 .postMarkChargeAsCaptureApproved()
                 .statusCode(CONFLICT.getStatusCode())
                 .contentType(JSON)
-                .body(JSON_MESSAGE_KEY, is(expectedErrorMessage));
+                .body(JSON_MESSAGE_KEY, contains(expectedErrorMessage))
+                .body("error_identifier", Matchers.is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private void createCharge(String externalChargeId, long chargeId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -25,6 +26,7 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItems;
@@ -38,11 +40,11 @@ import static org.junit.Assert.assertThat;
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceTestBase {
-    
+
     private static final String ACCOUNTS_CARD_TYPE_FRONTEND_URL = "v1/frontend/accounts/{accountId}/card-types";
-    
+
     private Gson gson = new Gson();
-    
+
     @Test
     public void shouldGetGatewayAccountForExistingAccount() {
         String accountId = createAGatewayAccountFor("worldpay");
@@ -171,7 +173,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
                 .get(ACCOUNTS_FRONTEND_URL + nonExistingGatewayAccount)
                 .then()
                 .statusCode(404)
-                .body("message", is("Account with id '12345' not found"));
+                .body("message", contains("Account with id '12345' not found"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
     }
 
@@ -239,7 +242,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountCredentialsWith(accountId, new HashMap<>())
                 .then()
                 .statusCode(400)
-                .body("message", is("Field(s) missing: [credentials]"));
+                .body("message", contains("Field(s) missing: [credentials]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -254,9 +258,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountCredentialsWith(accountId, credentials)
                 .then()
                 .statusCode(400)
-                .body("message", is("Field(s) missing: [password]"));
-        //TODO: For backward compatibility. Enable once the selfservice/e2e/acceptest changes are done
-//                .body("message", is("Field(s) missing: [password, merchant_id]"));
+                .body("message", contains("Field(s) missing: [password]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -272,7 +275,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountCredentialsWith(accountId, credentials)
                 .then()
                 .statusCode(400)
-                .body("message", is("Field(s) missing: [merchant_id]"));
+                .body("message", contains("Field(s) missing: [merchant_id]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -287,7 +291,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountCredentialsWith(accountId, credentials)
                 .then()
                 .statusCode(400)
-                .body("message", is("Field(s) missing: [password, merchant_id]"));
+                .body("message", contains("Field(s) missing: [password, merchant_id]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -310,7 +315,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountCredentialsWith(nonExistingAccountId, credentials)
                 .then()
                 .statusCode(404)
-                .body("message", is("The gateway account id '111111111' does not exist"));
+                .body("message", contains("The gateway account id '111111111' does not exist"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -336,7 +342,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountServiceNameWith(accountId, new HashMap<>())
                 .then()
                 .statusCode(400)
-                .body("message", is("Field(s) missing: [service_name]"));
+                .body("message", contains("Field(s) missing: [service_name]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -349,7 +356,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountServiceNameWith(accountId, gatewayAccountPayload.buildServiceNamePayload())
                 .then()
                 .statusCode(400)
-                .body("message", is("Field(s) are too big: [service_name]"));
+                .body("message", contains("Field(s) are too big: [service_name]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -372,7 +380,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountServiceNameWith(nonExistingAccountId, serviceNamePayload)
                 .then()
                 .statusCode(404)
-                .body("message", is("The gateway account id '111111111' does not exist"));
+                .body("message", contains("The gateway account id '111111111' does not exist"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -383,7 +392,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountCardTypesWith(accountRecord.getAccountId(), body)
                 .then()
                 .statusCode(400)
-                .body("message", is("Field(s) missing: [card_types]"));
+                .body("message", contains("Field(s) missing: [card_types]"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -400,7 +410,8 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         updateGatewayAccountCardTypesWith(accountRecord.getAccountId(), body)
                 .then()
                 .statusCode(400)
-                .body("message", is(expectedMessage));
+                .body("message", contains(expectedMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceITest.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -431,7 +430,7 @@ public class GatewayAccountFrontendResourceITest extends GatewayAccountResourceT
         List<Map<String, Object>> acceptedCardTypes =
                 databaseTestHelper.getAcceptedCardTypesByAccountId(accountRecord.getAccountId());
 
-        MatcherAssert.assertThat(acceptedCardTypes, containsInAnyOrder(
+        assertThat(acceptedCardTypes, containsInAnyOrder(
                 allOf(
                         hasEntry("label", mastercardCreditCard.getLabel()),
                         hasEntry("type", mastercardCreditCard.getType().toString()),

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceITest.java
@@ -8,6 +8,7 @@ import org.hamcrest.core.Is;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -17,6 +18,7 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -28,7 +30,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;
-    
+
     @Test
     public void getAccountShouldReturn404IfAccountIdIsUnknown() {
         String unknownAccountId = "92348739";
@@ -93,7 +95,7 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
 
     @Test
     public void getAccountShouldReturn3dsSetting() {
-        String gatewayAccountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "stripe",  "desc", null,"true"));
+        String gatewayAccountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "stripe", "desc", null, "true"));
         givenSetup()
                 .get(ACCOUNTS_API_URL + gatewayAccountId)
                 .then()
@@ -403,7 +405,8 @@ public class GatewayAccountResourceITest extends GatewayAccountResourceTestBase 
                 .then()
                 .contentType(ContentType.JSON)
                 .statusCode(BAD_REQUEST.getStatusCode())
-                .body("message", is("Credentials update failure: Invalid password length"));
+                .body("message", contains("Credentials update failure: Invalid password length"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchRefundsResourceITest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -19,6 +20,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
@@ -48,12 +50,12 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
                 ServicePaymentReference.of("ref"), null, email);
         databaseTestHelper.addCharge(chargeId2, "charge2", "123", AMOUNT, AUTHORISATION_SUCCESS, returnUrl, null,
                 ServicePaymentReference.of("ref"), null, email);
-        
+
         String refundExternalId1 = randomAlphanumeric(10);
         String refundExternalId2 = randomAlphanumeric(10);
         String refundDate1 = "2016-02-03T00:00:00.000Z";
         String refundDate2 = "2016-02-02T00:00:00.000Z";
-        
+
         databaseTestHelper.addRefund(refundExternalId1, "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId, randomAlphanumeric(10), ZonedDateTime.parse(refundDate1));
         databaseTestHelper.addRefund(refundExternalId2, "refund-2-provider-reference", 2L, REFUNDED, chargeId, randomAlphanumeric(10), ZonedDateTime.parse(refundDate2));
         databaseTestHelper.addRefund("shouldnotberetrieved", "refund-1-provider-reference", 1L, REFUND_SUBMITTED, chargeId2, randomAlphanumeric(10), ZonedDateTime.parse(refundDate1));
@@ -116,6 +118,7 @@ public class SearchRefundsResourceITest extends ChargingITestBase {
                 .withHeader(HttpHeaders.ACCEPT, APPLICATION_JSON)
                 .getRefunds()
                 .statusCode(NOT_FOUND.getStatusCode())
-                .body("message", is(format("Gateway account with id %s does not exist", INVALID_ACCOUNT_ID)));
+                .body("message", contains(format("Gateway account with id %s does not exist", INVALID_ACCOUNT_ID)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/SecurityTokensResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SecurityTokensResourceITest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -16,6 +17,7 @@ import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -76,7 +78,8 @@ public class SecurityTokensResourceITest {
     @Test
     public void shouldReturn404WhenTokenNotFound() {
         findTokenGetsStatusCode("non-existant-secure-redirect-token", 404)
-                .body("message", is("Token invalid!"));
+                .body("message", contains("Token invalid!"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -87,7 +90,8 @@ public class SecurityTokensResourceITest {
                 .statusCode(204)
                 .body(emptyOrNullString());
         findTokenGetsStatusCode(defaultTestToken.getSecureRedirectToken(), 404)
-                .body("message", is("Token invalid!"));
+                .body("message", contains("Token invalid!"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private ValidatableResponse findTokenGetsStatusCode(String secureRedirectToken, int expectedStatusCode) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
@@ -173,7 +174,8 @@ public class SandboxRefundITest extends ChargingITestBase {
         postRefundFor(testCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("pending"))
-                .body("message", is(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())));
+                .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -195,7 +197,8 @@ public class SandboxRefundITest extends ChargingITestBase {
         postRefundFor(externalChargeId, 1L, defaultTestCharge.getAmount() - refundAmount)
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("full"))
-                .body("message", is(format("Charge with id [%s] not available for refund.", externalChargeId)));
+                .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -205,7 +208,8 @@ public class SandboxRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
-                .body("message", is("Not sufficient amount available for refund"));
+                .body("message", contains("Not sufficient amount available for refund"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -222,11 +226,12 @@ public class SandboxRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
-                .body("message", is("Not sufficient amount available for refund"));
+                .body("message", contains("Not sufficient amount available for refund"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
-        
+
         List<String> refundsHistory = databaseTestHelper.getRefundsHistoryByChargeId(defaultTestCharge.getChargeId()).stream().map(x -> x.get("status").toString()).collect(Collectors.toList());
         assertThat(refundsHistory.size(), is(0));
     }
@@ -239,7 +244,8 @@ public class SandboxRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_min_validation"))
-                .body("message", is("Validation error for amount. Minimum amount for a refund is 1"));
+                .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -263,7 +269,8 @@ public class SandboxRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount)
                 .statusCode(400)
                 .body("reason", is("amount_not_available"))
-                .body("message", is("Not sufficient amount available for refund"));
+                .body("message", contains("Not sufficient amount available for refund"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId1 = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId1.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
@@ -147,7 +148,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
         postRefundFor(testCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("pending"))
-                .body("message", is(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())));
+                .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -167,7 +169,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
         postRefundFor(externalChargeId, 1L, 0L)
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("full"))
-                .body("message", is(format("Charge with id [%s] not available for refund.", externalChargeId)));
+                .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(chargeId);
         assertThat(refundsFoundByChargeId.size(), is(1));
@@ -180,7 +183,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
-                .body("message", is("Not sufficient amount available for refund"));
+                .body("message", contains("Not sufficient amount available for refund"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -194,7 +198,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
-                .body("message", is("Not sufficient amount available for refund"));
+                .body("message", contains("Not sufficient amount available for refund"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -208,7 +213,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_min_validation"))
-                .body("message", is("Validation error for amount. Minimum amount for a refund is 1"));
+                .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -230,7 +236,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
         postRefundFor(defaultTestCharge.getExternalChargeId(), secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount)
                 .statusCode(400)
                 .body("reason", is("amount_not_available"))
-                .body("message", is("Not sufficient amount available for refund"));
+                .body("message", contains("Not sufficient amount available for refund"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId1 = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId1.size(), is(1));
@@ -244,7 +251,7 @@ public class SmartpayRefundITest extends ChargingITestBase {
         smartpayMockClient.mockRefundError();
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
-                .body("message", is("SmartPay refund response " +
+                .body("message", contains("SmartPay refund response " +
                         "(faultcode: soap:Server, faultstring: security 901 Invalid Merchant Account)"));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
@@ -340,7 +347,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 nonExistentAccountId, defaultTestCharge.getExternalChargeId(), testRefund.getExternalRefundId());
 
         validatableResponse.statusCode(NOT_FOUND.getStatusCode())
-                .body("message", is(format("Charge with id [%s] not found.", defaultTestCharge.getExternalChargeId())));
+                .body("message", contains(format("Charge with id [%s] not found.", defaultTestCharge.getExternalChargeId())))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -358,7 +366,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 defaultTestAccount.getAccountId(), nonExistentChargeId, testRefund.getExternalRefundId());
 
         validatableResponse.statusCode(NOT_FOUND.getStatusCode())
-                .body("message", is(format("Charge with id [%s] not found.", nonExistentChargeId)));
+                .body("message", contains(format("Charge with id [%s] not found.", nonExistentChargeId)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -376,7 +385,8 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 defaultTestAccount.getAccountId(), defaultTestCharge.getExternalChargeId(), nonExistentRefundId);
 
         validatableResponse.statusCode(NOT_FOUND.getStatusCode())
-                .body("message", is(format("Refund with id [%s] not found.", nonExistentRefundId)));
+                .body("message", contains(format("Refund with id [%s] not found.", nonExistentRefundId)))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     private ValidatableResponse postRefundFor(String chargeId, Long refundAmount, Long refundAmountAvlbl) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundITest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
@@ -26,6 +27,7 @@ import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.eclipse.jetty.http.HttpStatus.ACCEPTED_202;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
@@ -149,7 +151,8 @@ public class StripeRefundITest extends ChargingITestBase {
                         .replace("{chargeId}", externalChargeId))
                 .then()
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
-                .body("message", is("Stripe refund response (error code: expired_card, error: Your card has expired.)"));
+                .body("message", contains("Stripe refund response (error code: expired_card, error: Your card has expired.)"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -130,7 +130,8 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlFor(externalChargeId))
                 .then()
                 .statusCode(BAD_REQUEST_400)
-                .body("message", is("Your card has expired."));
+                .body("message", contains("Your card has expired."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -233,7 +234,8 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlFor(externalChargeId))
                 .then()
                 .statusCode(INTERNAL_SERVER_ERROR_500)
-                .body("message", containsString("There was an internal server error authorising charge_external_id: " + externalChargeId));
+                .body("message", contains("There was an internal server error authorising charge_external_id: " + externalChargeId))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -7,19 +7,20 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import java.io.IOException;
-import java.util.Collections;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
@@ -40,7 +41,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
 
     private String validAuthorisationDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "visa");
     private String validApplePayAuthorisationDetails = buildJsonApplePayAuthorisationDetails("mr payment", "mr@payment.test");
-    
+
     public WorldpayCardResourceITest() {
         super("worldpay");
     }
@@ -60,7 +61,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
     }
-    
+
     @Test
     public void shouldAuthoriseChargeWithApplePay_ForValidAuthorisationDetails() {
 
@@ -74,7 +75,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))
                 .statusCode(200);
 
-        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString()); 
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
     }
 
     @Test
@@ -89,11 +90,12 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("This transaction was declined."));
+                .body("message", contains("This transaction was declined."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_REJECTED.getValue());
     }
-    
+
     @Test
     public void shouldAuthoriseChargeWithGooglePay() throws IOException {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
@@ -123,7 +125,8 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is("This transaction was declined."));
+                .body("message", contains("This transaction was declined."))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_REJECTED.getValue());
     }
@@ -139,7 +142,8 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .post(authoriseChargeUrlForGooglePay(chargeId))
                 .then()
                 .statusCode(422)
-                .body("message", is(Collections.singletonList("Field [signature] must not be empty")));
+                .body("message", contains("Field [signature] must not be empty"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test
@@ -260,7 +264,8 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", is(expectedErrorMessage));
+                .body("message", contains(expectedErrorMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_REJECTED.getValue());
     }
@@ -278,7 +283,8 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .then()
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
                 .contentType(JSON)
-                .body("message", is(expectedErrorMessage));
+                .body("message", contains(expectedErrorMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_ERROR.getValue());
     }
@@ -296,7 +302,8 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .then()
                 .statusCode(INTERNAL_SERVER_ERROR.getStatusCode())
                 .contentType(JSON)
-                .body("message", is(expectedErrorMessage));
+                .body("message", contains(expectedErrorMessage))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_ERROR.getValue());
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceITest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.it.resources.worldpay;
 
 import com.amazonaws.util.json.Jackson;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -56,7 +55,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .body(validAuthorisationDetails)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
-                .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))
+                .body("status", is(AUTHORISATION_SUCCESS.toString()))
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
@@ -72,7 +71,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .body(validApplePayAuthorisationDetails)
                 .post(authoriseChargeUrlForApplePay(chargeId))
                 .then()
-                .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))
+                .body("status", is(AUTHORISATION_SUCCESS.toString()))
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
@@ -158,7 +157,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .body(corporateCreditAuthDetails)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
-                .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))
+                .body("status", is(AUTHORISATION_SUCCESS.toString()))
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
@@ -176,7 +175,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .body(authDetails)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
-                .body("status", Matchers.is(AUTHORISATION_SUCCESS.toString()))
+                .body("status", is(AUTHORISATION_SUCCESS.toString()))
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
@@ -191,7 +190,7 @@ public class WorldpayCardResourceITest extends ChargingITestBase {
                 .body(validAuthorisationDetails)
                 .post(authoriseChargeUrlFor(chargeId))
                 .then()
-                .body("status", Matchers.is(AUTHORISATION_3DS_REQUIRED.toString()))
+                .body("status", is(AUTHORISATION_3DS_REQUIRED.toString()))
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_3DS_REQUIRED.toString());

--- a/src/test/java/uk/gov/pay/connector/it/scheduler/CaptureProcessSchedulerITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/scheduler/CaptureProcessSchedulerITest.java
@@ -7,7 +7,6 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -29,6 +28,7 @@ import uk.gov.pay.connector.util.DatabaseTestHelper;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -99,7 +99,7 @@ public class CaptureProcessSchedulerITest {
         verify(mockAppender, times(4)).doAppend(loggingEventArgumentCaptor.capture());
         assertThatTwoThreadsAreCompletingCaptureProcess(loggingEventArgumentCaptor);
 
-        assertThat(databaseTestHelper.getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+        assertThat(databaseTestHelper.getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 
     private void assertThatTwoThreadsAreCompletingCaptureProcess(ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor) {

--- a/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.epdq;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.it.service.CardCaptureProcessBaseITest;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.EpdqMockClient;
 
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -29,7 +29,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 
     @Test
@@ -40,7 +40,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -64,6 +64,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/epdq/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.epdq;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.EpdqMockClient;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -29,7 +29,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 
     @Test
@@ -40,7 +40,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -51,7 +51,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -64,6 +64,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.sandbox;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.it.service.CardCaptureProcessBaseITest;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -27,7 +27,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURED.getValue()));
     }
 
     @Test
@@ -38,6 +38,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/sandbox/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.sandbox;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
@@ -27,7 +27,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURED.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURED.getValue()));
     }
 
     @Test
@@ -38,6 +38,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.smartpay;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.it.service.CardCaptureProcessBaseITest;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.SmartpayMockClient;
 
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -29,7 +29,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 
     @Test
@@ -39,7 +39,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         new SmartpayMockClient().mockCaptureSuccess();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -63,6 +63,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/smartpay/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.smartpay;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.SmartpayMockClient;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -29,7 +29,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 
     @Test
@@ -39,7 +39,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         new SmartpayMockClient().mockCaptureSuccess();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -63,6 +63,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.stripe;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -15,6 +14,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
@@ -44,7 +44,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
                 .withRequestBody(containing("source_transaction=" + testCharge.getTransactionId()))
                 .withRequestBody(containing("amount=" + (testCharge.getAmount()))));
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURED.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURED.getValue()));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -90,6 +90,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/stripe/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.stripe;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +14,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
@@ -44,7 +44,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
                 .withRequestBody(containing("source_transaction=" + testCharge.getTransactionId()))
                 .withRequestBody(containing("amount=" + (testCharge.getAmount()))));
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURED.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURED.getValue()));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         new StripeMockClient().mockCaptureSuccess(testCharge.getTransactionId());
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -77,7 +77,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -90,6 +90,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.worldpay;
 
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.it.service.CardCaptureProcessBaseITest;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 
+import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -29,7 +29,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_SUBMITTED.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 
     @Test
@@ -39,7 +39,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         new WorldpayMockClient().mockCaptureSuccess();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(ENTERING_CARD_DETAILS.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_APPROVED_RETRY.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -63,6 +63,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), Matchers.is(CAPTURE_ERROR.getValue()));
+        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/service/worldpay/CardCaptureProcessITest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.service.worldpay;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -10,6 +9,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
@@ -29,7 +29,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_SUBMITTED.getValue()));
     }
 
     @Test
@@ -39,7 +39,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         new WorldpayMockClient().mockCaptureSuccess();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(ENTERING_CARD_DETAILS.getValue()));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).loadCaptureQueue();
         app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_APPROVED_RETRY.getValue()));
     }
 
     @Test
@@ -63,6 +63,6 @@ public class CardCaptureProcessITest extends CardCaptureProcessBaseITest {
             app.getInstanceFromGuiceContainer(CardCaptureProcess.class).runCapture(1);
         }
 
-        Assert.assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
+        assertThat(app.getDatabaseTestHelper().getChargeStatus(testCharge.getChargeId()), is(CAPTURE_ERROR.getValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/FirstDigitsCardNumberTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/FirstDigitsCardNumberTest.java
@@ -1,24 +1,24 @@
 package uk.gov.pay.connector.model;
 
-import org.junit.Assert;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class FirstDigitsCardNumberTest {
 
 
     @Test
     public void shouldConvertValidFirstSixDigitsOfCard() {
-        Assert.assertThat(FirstDigitsCardNumber.of("123456").toString(), is("123456"));
-        Assert.assertThat(FirstDigitsCardNumber.ofNullable("123456").toString(), is("123456"));
+        assertThat(FirstDigitsCardNumber.of("123456").toString(), is("123456"));
+        assertThat(FirstDigitsCardNumber.ofNullable("123456").toString(), is("123456"));
     }
 
     @Test
     public void shouldReturnNullIfStringIsNull() {
-        Assert.assertThat(FirstDigitsCardNumber.ofNullable(null), is(nullValue()));
+        assertThat(FirstDigitsCardNumber.ofNullable(null), is(nullValue()));
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/uk/gov/pay/connector/model/LastDigitsCardNumberTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/LastDigitsCardNumberTest.java
@@ -1,24 +1,24 @@
 package uk.gov.pay.connector.model;
 
-import org.junit.Assert;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 public class LastDigitsCardNumberTest {
 
 
     @Test
     public void shouldConvertValidLastFourDigitsOfCard() {
-        Assert.assertThat(LastDigitsCardNumber.of("1234").toString(), is("1234"));
-        Assert.assertThat(LastDigitsCardNumber.ofNullable("1234").toString(), is("1234"));
+        assertThat(LastDigitsCardNumber.of("1234").toString(), is("1234"));
+        assertThat(LastDigitsCardNumber.ofNullable("1234").toString(), is("1234"));
     }
 
     @Test
     public void shouldReturnNullIfStringIsNull() {
-        Assert.assertThat(LastDigitsCardNumber.ofNullable(null), is(nullValue()));
+        assertThat(LastDigitsCardNumber.ofNullable(null), is(nullValue()));
     }
 
     @Test(expected = RuntimeException.class)

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
@@ -17,18 +15,19 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.util.AuthUtils;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -189,8 +188,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
             card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
             fail("Exception not thrown.");
         } catch (OperationAlreadyInProgressRuntimeException e) {
-            Map<String, String> expectedMessage = ImmutableMap.of("message", format("Authorisation for charge already in progress, %s", charge.getExternalId()));
-            assertThat(e.getResponse().getEntity(), is(expectedMessage));
+            ErrorResponse response = (ErrorResponse)e.getResponse().getEntity();
+            assertThat(response.getMessages(), contains(format("Authorisation for charge already in progress, %s", charge.getExternalId())));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
 import com.codahale.metrics.Counter;
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
@@ -18,6 +17,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
@@ -34,7 +34,6 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -44,6 +43,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -62,8 +62,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
@@ -553,8 +553,8 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
             cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
             fail("Exception not thrown.");
         } catch (OperationAlreadyInProgressRuntimeException e) {
-            Map<String, String> expectedMessage = ImmutableMap.of("message", format("Authorisation for charge already in progress, %s", charge.getExternalId()));
-            assertThat(e.getResponse().getEntity(), is(expectedMessage));
+            ErrorResponse response = (ErrorResponse)e.getResponse().getEntity();
+            assertThat(response.getMessages(), contains(format("Authorisation for charge already in progress, %s", charge.getExternalId())));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -6,11 +6,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.codahale.metrics.Counter;
-import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -372,7 +370,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
         String expectedLogMessage = String.format("CAPTURE_ERROR for charge [charge_external_id=%s] - reached maximum number of capture attempts", charge.getExternalId());
-        Assert.assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
+        assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/SearchRefundsServiceTest.java
@@ -8,9 +8,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import uk.gov.pay.connector.charge.dao.SearchParams;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.dao.SearchParams;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
@@ -29,6 +30,7 @@ import static java.util.Arrays.asList;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.UriBuilder.fromUri;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -96,14 +98,13 @@ public class SearchRefundsServiceTest {
 
         Response response = searchRefundsService.getAllRefunds(uriInfo, searchParams);
 
-        ImmutableMap<String, Object> actualResponse = (ImmutableMap<String, Object>) response.getEntity();
+        ErrorResponse errorResponse = (ErrorResponse)response.getEntity();
+        assertThat(errorResponse.getMessages(), contains("the requested page not found"));
+
         Response.StatusType statusType = response.getStatusInfo();
         int statusCode = response.getStatus();
-        ImmutableMap<String, String> expectedMessage = ImmutableMap.of(
-                "message", "the requested page not found");
         assertThat(statusType, is(NOT_FOUND));
         assertThat(statusCode, is(NOT_FOUND.getStatusCode()));
-        assertThat(actualResponse, is(expectedMessage));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -7,7 +7,6 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.amazonaws.util.json.Jackson;
 import com.codahale.metrics.Counter;
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
@@ -25,6 +24,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -39,7 +39,6 @@ import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -48,6 +47,7 @@ import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -283,8 +283,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
             walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
             fail("Exception not thrown.");
         } catch (OperationAlreadyInProgressRuntimeException e) {
-            Map<String, String> expectedMessage = ImmutableMap.of("message", format("Authorisation for charge already in progress, %s", charge.getExternalId()));
-            assertThat(e.getResponse().getEntity(), is(expectedMessage));
+            ErrorResponse response = (ErrorResponse)e.getResponse().getEntity();
+            assertThat(response.getMessages(), contains(format("Authorisation for charge already in progress, %s", charge.getExternalId())));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.connector.wallets.applepay;
 
 import com.google.common.collect.ImmutableMap;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -16,6 +18,7 @@ import uk.gov.pay.connector.wallets.applepay.api.ApplePayAuthRequest;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -85,6 +88,7 @@ public class ApplePayServiceTest {
 
         verify(mockedApplePayAuthoriseService).doAuthorise(externalChargeId, validData);
         assertThat(authorisationResponse.getStatus(), is(500));
-        assertThat(authorisationResponse.getEntity(), is(ImmutableMap.of("message", "oops")));
+        ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
+        MatcherAssert.assertThat(response.getMessages(), contains("oops"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.wallets.applepay;
 
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
@@ -89,6 +89,6 @@ public class ApplePayServiceTest {
         verify(mockedApplePayAuthoriseService).doAuthorise(externalChargeId, validData);
         assertThat(authorisationResponse.getStatus(), is(500));
         ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
-        MatcherAssert.assertThat(response.getMessages(), contains("oops"));
+        assertThat(response.getMessages(), contains("oops"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.wallets.googlepay;
 
 import com.amazonaws.util.json.Jackson;
 import com.google.common.collect.ImmutableMap;
-import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -80,6 +79,6 @@ public class GooglePayServiceTest {
         verify(mockedWalletAuthoriseService).doAuthorise(externalChargeId, googlePayAuthRequest);
         assertThat(authorisationResponse.getStatus(), is(500));
         ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
-        MatcherAssert.assertThat(response.getMessages(), contains("oops"));
+        assertThat(response.getMessages(), contains("oops"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
@@ -2,11 +2,13 @@ package uk.gov.pay.connector.wallets.googlepay;
 
 import com.amazonaws.util.json.Jackson;
 import com.google.common.collect.ImmutableMap;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -18,6 +20,7 @@ import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -76,6 +79,7 @@ public class GooglePayServiceTest {
 
         verify(mockedWalletAuthoriseService).doAuthorise(externalChargeId, googlePayAuthRequest);
         assertThat(authorisationResponse.getStatus(), is(500));
-        assertThat(authorisationResponse.getEntity(), is(ImmutableMap.of("message", "oops")));
+        ErrorResponse response = (ErrorResponse)authorisationResponse.getEntity();
+        MatcherAssert.assertThat(response.getMessages(), contains("oops"));
     }
 }


### PR DESCRIPTION
- Modify ResponseUtil so that most of the methods that construct an error response use the ErrorResponse model.
- Modify tests to expect a "messages" array and to assert on the "error_identifier" - which has a value of "GENERIC" for all responses currently.
- Not all responses have been converted to use ErrorResponse yet.

