### PR TITLE
PP-4993 Take fees for stripe payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -4,6 +4,7 @@ import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import java.util.Optional;
 
 public class StripeGatewayConfig extends Configuration {
 
@@ -18,9 +19,16 @@ public class StripeGatewayConfig extends Configuration {
     @Valid
     @NotNull
     private StripeWebhookSigningSecrets webhookSigningSecrets;
+    
+    @Valid
+    private Double feePercentage;
 
     @Valid
     private String platformAccountId;
+
+    @Valid
+    @NotNull
+    private Boolean collectFee;
 
     public String getUrl() {
         return url;
@@ -32,6 +40,16 @@ public class StripeGatewayConfig extends Configuration {
 
     public StripeWebhookSigningSecrets getWebhookSigningSecrets() {
         return webhookSigningSecrets;
+    }
+
+
+    public Double getFeePercentage() {
+        return Optional.ofNullable(feePercentage).orElse(0.0);
+    }
+
+
+    public Boolean isCollectFee() {
+        return collectFee;
     }
 
     public String getPlatformAccountId() {

--- a/src/main/java/uk/gov/pay/connector/fee/dao/FeeDao.java
+++ b/src/main/java/uk/gov/pay/connector/fee/dao/FeeDao.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.fee.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+import uk.gov.pay.connector.common.dao.JpaDao;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+@Transactional
+public class FeeDao extends JpaDao<FeeEntity> {
+    @Inject
+    public FeeDao(final Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
@@ -14,12 +14,29 @@ public class CaptureResponse {
     private final ChargeState chargeState;
     private final GatewayError gatewayError;
     private final String stringified;
+    private Long feeAmount;
 
     private CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError, String stringified) {
         this.transactionId = transactionId;
         this.chargeState = chargeState;
         this.gatewayError = gatewayError;
         this.stringified = stringified;
+    }
+
+    private CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError, String stringified, Long feeAmount) {
+        this.transactionId = transactionId;
+        this.chargeState = chargeState;
+        this.gatewayError = gatewayError;
+        this.stringified = stringified;
+        this.feeAmount = feeAmount;
+    }
+
+    public CaptureResponse(String transactionId, ChargeState chargeState, Long feeAmount) {
+        this(transactionId, chargeState, null, null, feeAmount);
+    }
+
+    public CaptureResponse(GatewayError gatewayError, String stringified) {
+        this(null, null, gatewayError, stringified, null);
     }
 
     public static CaptureResponse fromGatewayError(GatewayError gatewayError) {
@@ -50,6 +67,10 @@ public class CaptureResponse {
 
     public boolean isSuccessful() {
         return gatewayError == null;
+    }
+
+    public Optional<Long> getFee() {
+        return Optional.ofNullable(feeAmount);
     }
 
     public enum ChargeState {

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -4,8 +4,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
+import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -127,6 +127,5 @@ public class GatewayClient {
         public Map<String, String> getResponseCookies() {
             return responseCookies;
         }
-
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
@@ -12,10 +12,14 @@ public class CaptureGatewayRequest implements GatewayRequest {
         this.charge = charge;
     }
 
-    public String getAmount() {
+    public String getAmountAsString() {
         return String.valueOf(charge.getAmount());
     }
-
+    
+    public Long getAmount() {
+        return charge.getAmount();
+    }
+    
     public String getTransactionId() {
         return charge.getGatewayTransactionId();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -43,7 +43,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
         return SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withAmount(request.getAmount())
+                .withAmount(request.getAmountAsString())
                 .build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
@@ -10,8 +10,7 @@ import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripeCharge {
-    @Inject 
-    private ObjectMapper mapper;
+    private ObjectMapper mapper = new ObjectMapper();
     
     @JsonProperty("id")
     private String id;

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -43,7 +43,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
         return aWorldpayCaptureOrderRequestBuilder()
                 .withDate(DateTime.now(DateTimeZone.UTC))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withAmount(request.getAmount())
+                .withAmount(request.getAmountAsString())
                 .withTransactionId(request.getTransactionId())
                 .build();
     }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -83,6 +83,8 @@ stripe:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-false}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
@@ -52,24 +53,60 @@ public class StripeCaptureHandlerTest {
 
     private CaptureGatewayRequest captureGatewayRequest;
     private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
+    private GatewayAccountEntity gatewayAccount;
 
     @Before
     public void setup() {
         stripeCaptureHandler = new StripeCaptureHandler(gatewayClient, stripeGatewayConfig, objectMapper);
+        when(stripeGatewayConfig.getFeePercentage()).thenReturn(0.08);
+        when(stripeGatewayConfig.isCollectFee()).thenReturn(true);
 
-        GatewayAccountEntity gatewayAccount = buildGatewayAccountEntity();
+        gatewayAccount = buildGatewayAccountEntity();
 
         final String transactionId = "ch_1231231123123";
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccount)
                 .withTransactionId(transactionId)
+                .withAmount(10000L)
                 .build();
 
         captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
     }
+    
+    public void shouldCaptureWithFeeAndTransferCorrectAmountToConnectAccount() throws Exception {
+        GatewayClient.Response gatewayCaptureResponse = mock(GatewayClient.Response.class);
+        when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_CAPTURE_SUCCESS_RESPONSE));
+        GatewayClient.Response gatewayTransferResponse = mock(GatewayClient.Response.class);
+        when(gatewayTransferResponse.getEntity()).thenReturn(load(STRIPE_TRANSFER_RESPONSE));
+
+        when(gatewayClient.postRequestFor(any(StripeCaptureRequest.class))).thenReturn(gatewayCaptureResponse);
+        when(gatewayClient.postRequestFor(any(StripeTransferOutRequest.class))).thenReturn(gatewayTransferResponse);
+        
+        CaptureResponse captureResponse = stripeCaptureHandler.capture(captureGatewayRequest);
+
+        ArgumentCaptor<StripeTransferOutRequest> transferRequestCaptor = ArgumentCaptor.forClass(StripeTransferOutRequest.class);
+        verify(gatewayClient).postRequestFor(transferRequestCaptor.capture());
+        
+        assertThat(transferRequestCaptor.getValue().getGatewayOrder().getPayload(), containsString("amount=9942"));
+        
+        assertTrue(captureResponse.isSuccessful());
+        assertThat(captureResponse.state(), is(CaptureResponse.ChargeState.COMPLETE));
+        assertThat(captureResponse.getTransactionId().isPresent(), is(true));
+        assertThat(captureResponse.getTransactionId().get(), is("ch_123456"));
+        assertThat(captureResponse.getFee().isPresent(), is(true));
+        assertThat(captureResponse.getFee().get(), is(58L));
+    }
 
     @Test
-    public void shouldCapture() throws Exception {
+    public void shouldCaptureWithFee_feeCalculationShouldAlwaysRoundUp() throws Exception {
+        final String transactionId = "ch_1231231123123";
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withTransactionId(transactionId)
+                .withAmount(10001L)
+                .build();
+
+        captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
         GatewayClient.Response gatewayCaptureResponse = mock(GatewayClient.Response.class);
         when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_CAPTURE_SUCCESS_RESPONSE));
         GatewayClient.Response gatewayTransferResponse = mock(GatewayClient.Response.class);
@@ -79,10 +116,53 @@ public class StripeCaptureHandlerTest {
         when(gatewayClient.postRequestFor(any(StripeTransferOutRequest.class))).thenReturn(gatewayTransferResponse);
 
         CaptureResponse captureResponse = stripeCaptureHandler.capture(captureGatewayRequest);
+        
         assertTrue(captureResponse.isSuccessful());
-        assertThat(captureResponse.state(), is(CaptureResponse.ChargeState.COMPLETE));
-        assertThat(captureResponse.getTransactionId().isPresent(), is(true));
-        assertThat(captureResponse.getTransactionId().get(), is("ch_123456"));
+        assertThat(captureResponse.getFee().get(), is(59L));
+    }
+
+    @Test
+    public void shouldCaptureWithFee_feeCalculationShouldRoundUpTo1() throws Exception {
+        final String transactionId = "ch_1231231123123";
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withTransactionId(transactionId)
+                .withAmount(1L)
+                .build();
+
+        captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
+        GatewayClient.Response gatewayCaptureResponse = mock(GatewayClient.Response.class);
+        when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_CAPTURE_SUCCESS_RESPONSE));
+        GatewayClient.Response gatewayTransferResponse = mock(GatewayClient.Response.class);
+        when(gatewayTransferResponse.getEntity()).thenReturn(load(STRIPE_TRANSFER_RESPONSE));
+
+        when(gatewayClient.postRequestFor(any(StripeCaptureRequest.class))).thenReturn(gatewayCaptureResponse);
+        when(gatewayClient.postRequestFor(any(StripeTransferOutRequest.class))).thenReturn(gatewayTransferResponse);
+
+        CaptureResponse captureResponse = stripeCaptureHandler.capture(captureGatewayRequest);
+
+        assertTrue(captureResponse.isSuccessful());
+        assertThat(captureResponse.getFee().get(), is(51L));
+    }
+    
+    public void shouldCaptureWithoutFee_ifCollectFeeSetToFalse() throws Exception {
+        GatewayClient.Response gatewayCaptureResponse = mock(GatewayClient.Response.class);
+        when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_CAPTURE_SUCCESS_RESPONSE));
+        when(gatewayClient.postRequestFor(any(StripeCaptureRequest.class))).thenReturn(gatewayCaptureResponse);
+        
+        GatewayClient.Response gatewayTransferResponse = mock(GatewayClient.Response.class);
+        when(gatewayTransferResponse.getEntity()).thenReturn(load(STRIPE_TRANSFER_RESPONSE));
+        when(gatewayClient.postRequestFor(any(StripeTransferOutRequest.class))).thenReturn(gatewayTransferResponse);
+
+        when(stripeGatewayConfig.isCollectFee()).thenReturn(false);
+
+        CaptureResponse response = stripeCaptureHandler.capture(captureGatewayRequest);
+        assertTrue(response.isSuccessful());
+        assertThat(response.state(), is(CaptureResponse.ChargeState.COMPLETE));
+        assertThat(response.getTransactionId().isPresent(), is(true));
+        assertThat(response.getTransactionId().get(), is("ch_123456"));
+        assertThat(response.getFee().isPresent(), is(true));
+        assertThat(response.getFee().get(), is(0L));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
@@ -18,7 +17,7 @@ import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
@@ -82,7 +83,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     @Mock
     private UserNotificationService mockUserNotificationService;
     private CardCaptureService cardCaptureService;
-
+    @Mock
+    private FeeDao feeDao;
     @Mock
     private Appender<ILoggingEvent> mockAppender;
 
@@ -100,7 +102,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null);
         
-        cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment);
+        cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment);
 
         Logger root = (Logger) LoggerFactory.getLogger(CardCaptureService.class);
         root.setLevel(Level.INFO);

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -873,4 +873,12 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
+
+    public Map<String, Object> getFeeByChargeId(Long chargeId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("SELECT * from fees WHERE charge_id = :charge_id")
+                        .bind("charge_id", chargeId)
+                        .first()
+        );
+    }
 }

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -67,6 +67,8 @@ stripe:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -66,6 +66,8 @@ stripe:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -56,6 +56,8 @@ stripe:
       test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
       live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -62,6 +62,8 @@ stripe:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -58,6 +58,8 @@ stripe:
   webhookSigningSecrets:
     test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
     live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+  feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
+  collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID:-stripe_platform_account_id}
 
 executorServiceConfig:


### PR DESCRIPTION
This commit alters the stripe capture method to do the following:
- capture the charge
- examine the charge to see if it needs to be transferred (see previous commits)
- if it does, look at the returned Stripe charge and extract the fee Stripe
has charged for the transaction
- use this fee to calculate the total fee we need to charge - there is an additional
amount currently controlled by `STRIPE_TRANSACTION_FEE_PERCENTAGE`
- transfer the total amount - calculated fee to the connect account

This fee is returned up to the capture service as an optional attribute of the
CaptureResponse, where it is persisted if it exists.

`COLLECT_FEE_FEATURE_FLAG` needs to be set to true for this to actually start working. This flag defaults to false.