### PR TITLE
PP-5147: Upgrade to Java 11.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM govukpay/openjdk:adoptopenjdk-jre-11.0.3.7-alpine
+FROM govukpay/openjdk:adoptopenjdk-jre-11.0.3_7-alpine
 
 RUN apk --no-cache upgrade
 
 RUN apk --no-cache add bash
 
-ENV JAVA_HOME /opt/java/openjdk
 ENV PORT 8080
 ENV ADMIN_PORT 8081
 

--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -6,12 +6,11 @@ RUN_APP=${RUN_APP:-true}
 
 if [ -n "${CERTS_PATH:-}" ]; then
   i=0
-  truststore=$JAVA_HOME/lib/security/cacerts
   truststore_pass=changeit
   for cert in "$CERTS_PATH"/*; do
     [ -f "$cert" ] || continue
-    echo "Adding $cert to $truststore"
-    keytool -importcert -noprompt -keystore "$truststore" -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
+    echo "Adding $cert to default truststore"
+    keytool -importcert -noprompt -cacerts -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
   done
 fi
 


### PR DESCRIPTION
The previous base image actually contained 11.0.2, so upgrade properly.

Also, make use of the new -cacerts option to keytool, which means we no longer
need to set JAVA_HOME (which is already set by adoptopenjdk anyway)

This addresses the following CVEs:

CVE-2019-2602
CVE-2019-2699
CVE-2019-2697
CVE-2019-2698
CVE-2019-2684

The first one is potentially relevant as a DoS or potential crypto sidechannel,
the others less so.
