### PR TITLE
PP-5142 Return new error response structure for WebApplicationExceptions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -67,6 +67,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
 import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
+import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
 @Singleton
 public class StripePaymentProvider implements PaymentProvider {
@@ -374,7 +375,8 @@ public class StripePaymentProvider implements PaymentProvider {
         if (StringUtils.isBlank(stripeAccountId)) {
             logger.error("Unable to process charge [{}]. There is no stripe_account_id for corresponding gateway account with id {}",
                     externalId, gatewayAccount.getId());
-            throw new WebApplicationException(format("There is no stripe_account_id for gateway account with id %s", gatewayAccount.getId()));
+            throw new WebApplicationException(serviceErrorResponse(
+                    format("There is no stripe_account_id for gateway account with id %s", gatewayAccount.getId())));
         }
         return stripeAccountId;
     }

--- a/src/main/java/uk/gov/pay/connector/util/JsonObjectMapper.java
+++ b/src/main/java/uk/gov/pay/connector/util/JsonObjectMapper.java
@@ -9,6 +9,7 @@ import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 
 import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
 public class JsonObjectMapper {
     private final Logger logger = LoggerFactory.getLogger(JsonObjectMapper.class);
@@ -24,7 +25,9 @@ public class JsonObjectMapper {
             return objectMapper.readValue(jsonResponse, targetType);
         } catch (IOException e) {
             logger.info("There was an exception parsing the payload [{}] into an [{}]", jsonResponse, targetType);
-            throw new WebApplicationException(format("There was an exception parsing the payload [%s] into an [%s], e=[%s]", jsonResponse, targetType, e.getMessage()));
+            throw new WebApplicationException(serviceErrorResponse(
+                    format("There was an exception parsing the payload [%s] into an [%s], e=[%s]",
+                    jsonResponse, targetType, e.getMessage())));
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -251,7 +251,8 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlFor(externalChargeId))
                 .then()
                 .statusCode(500)
-                .body("message", containsString("There is no stripe_account_id for gateway account with id"));
+                .body("message", contains(containsString("There is no stripe_account_id for gateway account with id")))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test


### PR DESCRIPTION
Use the WebApplicationException structure that takes a Response, and construct this using ResponseUtils so that the entity used to construct the response body is an ErrorResponse.