### PR TITLE
PP-5142 Add error_identifiers for create refund error responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/ErrorIdentifier.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ErrorIdentifier.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.common.model.api;
 
 public enum ErrorIdentifier {
-    GENERIC
+    GENERIC,
+    REFUND_NOT_AVAILABLE,
+    REFUND_AMOUNT_AVAILABLE_MISMATCH
 }

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
@@ -29,6 +29,14 @@ public class ErrorResponse {
         this(identifier, messages, null);
     }
 
+    public ErrorResponse(ErrorIdentifier identifier, String message) {
+        this(identifier, List.of(message), null);
+    }
+    
+    public ErrorResponse(ErrorIdentifier identifier, String message, String reason) {
+        this(identifier, List.of(message), reason);
+    }
+
     public ErrorIdentifier getIdentifier() {
         return identifier;
     }

--- a/src/main/java/uk/gov/pay/connector/refund/exception/RefundException.java
+++ b/src/main/java/uk/gov/pay/connector/refund/exception/RefundException.java
@@ -1,37 +1,37 @@
 package uk.gov.pay.connector.refund.exception;
 
+import uk.gov.pay.connector.common.model.api.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 
 import static java.lang.String.format;
-import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
-import static uk.gov.pay.connector.util.ResponseUtil.preconditionFailedResponse;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.PRECONDITION_FAILED;
+import static uk.gov.pay.connector.common.model.api.ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH;
+import static uk.gov.pay.connector.common.model.api.ErrorIdentifier.REFUND_NOT_AVAILABLE;
 
 public class RefundException extends WebApplicationException {
 
-    public static RefundException refundAmountAvailableMismatchException(String message){
-        return new RefundException(message);
+    public static RefundException refundAmountAvailableMismatchException(String message) {
+        return new RefundException(message, REFUND_AMOUNT_AVAILABLE_MISMATCH, PRECONDITION_FAILED, null);
     }
 
-    public static RefundException refundException(String message, ErrorCode code) {
-        return new RefundException(message, code);
-    }
-
-    private RefundException(String message, ExternalChargeRefundAvailability refundAvailability) {
-        super(badRequestResponse(refundAvailability.getStatus(), message));
-    }
-
-    private RefundException(String message, ErrorCode errorCode) {
-        super(badRequestResponse(errorCode.getValue(), message));
-    }
-
-    private RefundException(String message) {
-        super(preconditionFailedResponse(message));
+    public static RefundException notAvailableForRefundException(String message, ErrorCode code) {
+        return new RefundException(message, REFUND_NOT_AVAILABLE, BAD_REQUEST, code.getValue());
     }
 
     public static RefundException notAvailableForRefundException(String chargeId, ExternalChargeRefundAvailability currentAvailability) {
-        return new RefundException(format("Charge with id [%s] not available for refund.", chargeId), currentAvailability);
+        return new RefundException(format("Charge with id [%s] not available for refund.", chargeId),
+                REFUND_NOT_AVAILABLE, BAD_REQUEST, currentAvailability.getStatus());
+    }
+
+    private RefundException(String message, ErrorIdentifier errorIdentifier, Response.Status status, String reason) {
+        super(Response.status(status)
+                .entity(new ErrorResponse(errorIdentifier, message, reason))
+                .build());
     }
 
     public enum ErrorCode {

--- a/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
@@ -57,10 +57,10 @@ public class ChargeRefundsResource {
 
     private void validateRefundRequest(long amount) {
         if (MAX_AMOUNT < amount) {
-            throw RefundException.refundException("Not sufficient amount available for refund", NOT_SUFFICIENT_AMOUNT_AVAILABLE);
+            throw RefundException.notAvailableForRefundException("Not sufficient amount available for refund", NOT_SUFFICIENT_AMOUNT_AVAILABLE);
         }
         if (MIN_AMOUNT > amount) {
-            throw RefundException.refundException("Validation error for amount. Minimum amount for a refund is " + MIN_AMOUNT, RefundException.ErrorCode.MINIMUM_AMOUNT);
+            throw RefundException.notAvailableForRefundException("Validation error for amount. Minimum amount for a refund is " + MIN_AMOUNT, RefundException.ErrorCode.MINIMUM_AMOUNT);
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -190,7 +190,7 @@ public class ChargeRefundService {
                     totalAmountToBeRefunded,
                     refundRequest.getAmount());
 
-            throw RefundException.refundException("Not sufficient amount available for refund", NOT_SUFFICIENT_AMOUNT_AVAILABLE);
+            throw RefundException.notAvailableForRefundException("Not sufficient amount available for refund", NOT_SUFFICIENT_AMOUNT_AVAILABLE);
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -50,21 +50,11 @@ public class ResponseUtil {
         return buildErrorResponse(BAD_REQUEST, message);
     }
 
-    public static Response badRequestResponse(String code, String message) {
-        logger.error(message);
-        return buildErrorResponse(BAD_REQUEST, message, code);
-    }
-
     public static Response badRequestResponse(List<String> messages) {
         logger.error(messages.toString());
         return buildErrorResponse(BAD_REQUEST, messages);
     }
-
-    public static Response preconditionFailedResponse(String message) {
-        logger.info(message);
-        return buildErrorResponse(PRECONDITION_FAILED, message);
-    }
-
+    
     public static Response notFoundResponse(String message) {
         logger.error(message);
         return buildErrorResponse(NOT_FOUND, message);
@@ -95,11 +85,6 @@ public class ResponseUtil {
 
     private static Response buildErrorResponse(Status status, List<String> messages) {
         ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, messages);
-        return responseWithEntity(status, errorResponse);
-    }
-
-    private static Response buildErrorResponse(Status status, String message, String reason) {
-        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, List.of(message), reason);
         return responseWithEntity(status, errorResponse);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundITest.java
@@ -167,7 +167,7 @@ public class EpdqRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("pending"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -188,7 +188,7 @@ public class EpdqRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("full"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(chargeId);
         assertThat(refundsFoundByChargeId.size(), is(1));
@@ -202,7 +202,7 @@ public class EpdqRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -217,7 +217,7 @@ public class EpdqRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -232,7 +232,7 @@ public class EpdqRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_min_validation"))
                 .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -256,7 +256,7 @@ public class EpdqRefundITest extends ChargingITestBase {
                 .statusCode(400)
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId1 = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId1.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundITest.java
@@ -103,8 +103,10 @@ public class SandboxRefundITest extends ChargingITestBase {
         String refundId = assertRefundResponseWith(refundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
         //second refund request with wrong refundAmountAvailable
-        validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
-        validatableResponse.statusCode(PRECONDITION_FAILED.getStatusCode());
+        postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
+            .statusCode(PRECONDITION_FAILED.getStatusCode())
+            .body("message", contains("Refund Amount Available Mismatch"))
+            .body("error_identifier", is(ErrorIdentifier.REFUND_AMOUNT_AVAILABLE_MISMATCH.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));
@@ -175,7 +177,7 @@ public class SandboxRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("pending"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -198,7 +200,7 @@ public class SandboxRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("full"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
     }
 
     @Test
@@ -209,7 +211,7 @@ public class SandboxRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -227,7 +229,7 @@ public class SandboxRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -245,7 +247,7 @@ public class SandboxRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_min_validation"))
                 .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -270,7 +272,7 @@ public class SandboxRefundITest extends ChargingITestBase {
                 .statusCode(400)
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId1 = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId1.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundITest.java
@@ -149,7 +149,7 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("pending"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -170,7 +170,7 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("full"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(chargeId);
         assertThat(refundsFoundByChargeId.size(), is(1));
@@ -184,7 +184,7 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -199,7 +199,7 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -214,7 +214,7 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_min_validation"))
                 .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -237,7 +237,7 @@ public class SmartpayRefundITest extends ChargingITestBase {
                 .statusCode(400)
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId1 = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId1.size(), is(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundITest.java
@@ -149,7 +149,7 @@ public class WorldpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("pending"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", testCharge.getExternalChargeId())))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -170,7 +170,7 @@ public class WorldpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("full"))
                 .body("message", contains(format("Charge with id [%s] not available for refund.", externalChargeId)))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(chargeId);
         assertThat(refundsFoundByChargeId.size(), is(1));
@@ -184,7 +184,7 @@ public class WorldpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -199,7 +199,7 @@ public class WorldpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -214,7 +214,7 @@ public class WorldpayRefundITest extends ChargingITestBase {
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_min_validation"))
                 .body("message", contains("Validation error for amount. Minimum amount for a refund is 1"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(0));
@@ -238,7 +238,7 @@ public class WorldpayRefundITest extends ChargingITestBase {
                 .statusCode(400)
                 .body("reason", is("amount_not_available"))
                 .body("message", contains("Not sufficient amount available for refund"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("error_identifier", is(ErrorIdentifier.REFUND_NOT_AVAILABLE.toString()));
 
         List<Map<String, Object>> refundsFoundByChargeId1 = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId1.size(), is(1));


### PR DESCRIPTION
Currently, in public api we make some presumptions about the error responses based on the HTTP status code in order to return a meaningful error response to the consumer. Adding in an error_identifier for these cases will allow us to return the errors without making these presumptions.
