### PR TITLE
PP-5190 Treat Stripe auth failures as `AUTHORISATION_REJECTED`

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCancelHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCaptureHandler;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
+import uk.gov.pay.connector.gateway.stripe.json.StripeAuthorisationFailedResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeCharge;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeSourcesResponse;
@@ -65,7 +66,6 @@ import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
-import static uk.gov.pay.connector.gateway.model.GatewayError.genericGatewayError;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED;
 
 @Singleton
@@ -149,9 +149,8 @@ public class StripePaymentProvider implements PaymentProvider {
                 StripeErrorResponse stripeErrorResponse = jsonObjectMapper.getObject(e.getResponseFromGateway(), StripeErrorResponse.class);
                 logger.error("Authorisation failed for charge {}. Failure code from Stripe: {}, failure message from Stripe: {}. Response code from Stripe: {}",
                         request.getChargeExternalId(), stripeErrorResponse.getError().getCode(), stripeErrorResponse.getError().getMessage(), e.getStatus());
-                GatewayError gatewayError = genericGatewayError(stripeErrorResponse.getError().getMessage());
 
-                return responseBuilder.withGatewayError(gatewayError).build();
+                return responseBuilder.withResponse(StripeAuthorisationFailedResponse.of(stripeErrorResponse)).build();
             }
             
             logger.info("Unrecognised response status when authorising. Charge_id={}, status={}, response={}",

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+
+import java.util.Optional;
+
+public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse {
+
+    private StripeErrorResponse errorResponse;
+
+    private StripeAuthorisationFailedResponse(StripeErrorResponse errorResponse) {
+        this.errorResponse = errorResponse;
+    }
+
+    public static StripeAuthorisationFailedResponse of(StripeErrorResponse stripeErrorResponse) {
+        return new StripeAuthorisationFailedResponse(stripeErrorResponse);
+    }
+
+    @Override
+    public String getTransactionId() {
+        return errorResponse.getError().getCharge();
+    }
+
+    @Override
+    public AuthoriseStatus authoriseStatus() {
+        return AuthoriseStatus.REJECTED;
+    }
+
+    @Override
+    public Optional<? extends GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String getErrorCode() {
+        return null;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -26,6 +26,8 @@ public class StripeErrorResponse {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public class Error {
 
+        @JsonProperty("charge")
+        private String charge;
         @JsonProperty("code")
         private String code;
         @JsonProperty("message")
@@ -37,6 +39,10 @@ public class StripeErrorResponse {
 
         public String getMessage() {
             return message;
+        }
+
+        public String getCharge() {
+            return charge;
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeITest.java
@@ -52,10 +52,7 @@ import static org.eclipse.jetty.http.HttpStatus.OK_200;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.*;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
@@ -131,8 +128,10 @@ public class StripeResourceAuthorizeITest {
                 .post(authoriseChargeUrlFor(externalChargeId))
                 .then()
                 .statusCode(BAD_REQUEST_400)
-                .body("message", contains("Your card has expired."))
+                .body("message", contains("This transaction was declined."))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+
+        assertFrontendChargeStatusIs(externalChargeId, AUTHORISATION_REJECTED.toString());
     }
 
     @Test


### PR DESCRIPTION
## WHAT
Currently when a charge fails authorisation (card cvc check fails, insufficient funds, and so on),
these are treated as authorisation errors (AUTHORISATION_ERROR) and frontend displays standard
error page with message "We’re experiencing technical problems", in which case users may see Pay's platform as having issue and may retry using same card.

As the errors are authorisation failures, categorising them to AUTHORISATION_REJECTED would be sensible and frontend can show 'payment declined' page.