### PR TITLE
PP-4886: Set metadata to null if empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <eclipselink.version>2.7.4</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <jackson.version>2.9.8</jackson.version>
-        <pay-java-commons.version>1.0.20190508054814</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20190509103516</pay-java-commons.version>
         <surefire.version>2.22.2</surefire.version>
         <javax.persistence.version>2.2.1</javax.persistence.version>
         <jooq.version>3.11.11</jooq.version>

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.junit.Assert.assertNull;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.matcher.ResponseContainsLinkMatcher.containsLink;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
@@ -545,8 +546,9 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .contentType(JSON)
                 .body("$", not(hasKey("metadata")));
 
+        String chargeExternalId = response.extract().path(JSON_CHARGE_KEY);
         connectorRestApiClient
-                .withChargeId(response.extract().path(JSON_CHARGE_KEY))
+                .withChargeId(chargeExternalId)
                 .getCharge()
                 .body("$", not(hasKey("metadata")));
         
@@ -554,6 +556,8 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
                 .withQueryParam("reference", reference)
                 .getChargesV1()
                 .body("results[0]", not(hasKey("metadata")));
+        
+        assertNull(databaseTestHelper.getChargeByExternalId(chargeExternalId).get("metadata"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceITest.java
@@ -530,7 +530,7 @@ public class ChargesApiCreateResourceITest extends ChargingITestBase {
     
     @Test
     public void shouldReturnChargeWithNoMetadataField_whenCreatedWithEmptyMetadata() {
-        String reference = UUID.randomUUID().toString();
+        String reference = "no metadata reference";
         String postBody = toJson(ImmutableMap.builder()
                 .put(JSON_AMOUNT_KEY, AMOUNT)
                 .put(JSON_REFERENCE_KEY, reference)


### PR DESCRIPTION
If a payment was created with empty metadata
```
"metadata":{}
```

The payment shoud be treated as if there were no metadata.
