### PR TITLE
PP-5190 Don't send users to 3ds if Stripe advises optional

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeSourcesResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripeSourcesResponse {
 
-    private List<String> threeDSecureRequiredOptions = ImmutableList.of("required", "recommended", "optional");
+    private List<String> threeDSecureRequiredOptions = ImmutableList.of("required", "recommended");
 
     @JsonProperty("id")
     private String id;


### PR DESCRIPTION
On creating a 3DS source with Stripe, Stripe's reply contains an attribute `three_d_secure`
advising on whether the user should be sent down 3ds route. When we originally
integrated with Stripe we decided to make the user do 3ds if at all possible,
since this shifts the liability from us to the bank involved. However,
it also (as we realised back then) increases pain for users. Having
tracked user experiences and problems reported by our partners, the 3ds
step is definitely having a negative impact on the user experience of Pay.
On top of this, we have had 0 chargebacks to date. Therefore this PR
changes the logic so that users will only be directed to 3ds journey when
Stripe advises it is either `required` or `recommended`