### PR TITLE
PP-5199 Make tests fail less often due to duplicate charge id

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -460,7 +460,7 @@ public class  DatabaseFixtures {
     }
 
     public class TestCharge {
-        Long chargeId = RandomUtils.nextLong(1, 99999);
+        Long chargeId = RandomUtils.nextLong();
         private String description = "Test description";
         String email = "alice.111@mail.test";
         String externalChargeId = RandomIdGenerator.newId();


### PR DESCRIPTION
They shouldn't fail very frequently at all, but make it more rare.

A recent failure on CI:
```
10:41:38  [ERROR] Tests run: 37, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 5.338 s <<< FAILURE! - in uk.gov.pay.connector.it.dao.TransactionDaoITest
10:41:38  [ERROR] searchBySingleRefundStatusAndTransactionType(uk.gov.pay.connector.it.dao.TransactionDaoITest)  Time elapsed: 0.097 s  <<< ERROR!
10:41:38  org.skife.jdbi.v2.exceptions.CallbackFailedException: 
10:41:38  org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException: org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "pk_charges"
10:41:38    Detail: Key (id)=(42413) already exists.
```