### PR TITLE
PP-5143 Allow zero amount charges if gateway account allows it

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -25,6 +25,7 @@ import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import uk.gov.pay.commons.utils.logging.LoggingFilter;
 import uk.gov.pay.commons.utils.xray.Xray;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
+import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.resource.ChargesFrontendResource;
 import uk.gov.pay.connector.chargeevent.resource.ChargeEventsResource;
@@ -100,11 +101,12 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new ConstraintViolationExceptionMapper());
         environment.jersey().register(new ValidationExceptionMapper());
         environment.jersey().register(new UnsupportedOperationExceptionMapper());
-        environment.jersey().register(new LoggingExceptionMapper<Throwable>() {
-        });
+        environment.jersey().register(new LoggingExceptionMapper<>() {});
         environment.jersey().register(new JsonProcessingExceptionMapper());
         environment.jersey().register(new EarlyEofExceptionMapper());
         environment.jersey().register(new JsonMappingExceptionMapper());
+        environment.jersey().register(new JsonMappingExceptionMapper());
+        environment.jersey().register(new ZeroAmountNotAllowedForGatewayAccountExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/ZeroAmountNotAllowedForGatewayAccountException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/ZeroAmountNotAllowedForGatewayAccountException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception;
+
+public class ZeroAmountNotAllowedForGatewayAccountException extends RuntimeException {
+
+    public ZeroAmountNotAllowedForGatewayAccountException(long gatewayAccountId) {
+        super("Attempt to create a zero amount charge for gateway account " + gatewayAccountId + ", which does not have zero amount charges enabled");
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/ZeroAmountNotAllowedForGatewayAccountExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/ZeroAmountNotAllowedForGatewayAccountExceptionMapper.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class ZeroAmountNotAllowedForGatewayAccountExceptionMapper implements ExceptionMapper<ZeroAmountNotAllowedForGatewayAccountException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZeroAmountNotAllowedForGatewayAccountExceptionMapper.class);
+
+    private static final String RESPONSE_ERROR_MESSAGE = "Zero amount charges are not enabled for this gateway account";
+
+    @Override
+    public Response toResponse(ZeroAmountNotAllowedForGatewayAccountException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.ZERO_AMOUNT_NOT_ALLOWED, List.of(RESPONSE_ERROR_MESSAGE));
+
+        return Response.status(422)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -19,10 +19,10 @@ import java.util.Optional;
 public class ChargeCreateRequest {
 
     @NotNull(message = "Field [amount] cannot be null")
-    @Min(value = 1, message = "Field [amount] can be between 1 and 10_000_000")
-    @Max(value = 10_000_000, message = "Field [amount] can be between 1 and 10_000_000")
+    @Min(value = 0, message = "Field [amount] can be between 0 and 10_000_000")
+    @Max(value = 10_000_000, message = "Field [amount] can be between 0 and 10_000_000")
     @JsonProperty("amount")
-    private long amount;
+    private Long amount;
 
     @NotNull(message = "Field [description] cannot be null")
     @Length(max = 255, message = "Field [description] can have a size between 0 and 255")

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountException;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.ChargeCreateRequest;
@@ -112,6 +113,10 @@ public class ChargeService {
     public Optional<ChargeResponse> create(ChargeCreateRequest chargeRequest, Long accountId, UriInfo uriInfo) {
         return gatewayAccountDao.findById(accountId).map(gatewayAccount -> {
 
+            if (chargeRequest.getAmount() == 0L && !gatewayAccount.isAllowZeroAmount()) {
+                throw new ZeroAmountNotAllowedForGatewayAccountException(gatewayAccount.getId());
+            }
+            
             if (gatewayAccount.isLive() && !chargeRequest.getReturnUrl().startsWith("https://")) {
                 logger.info(String.format("Gateway account %d is LIVE, but is configured to use a non-https return_url", accountId));
             }

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -361,4 +361,8 @@ public class ChargingITestBase {
         createdDateStrings.forEach(aDateString -> dateTimes.add(toUTCZonedDateTime(aDateString).get()));
         return dateTimes;
     }
+    
+    protected void allowZeroAmountForGatewayAccount() {
+        databaseTestHelper.updateGatewayAccountAllowZeroAmount(Long.valueOf(accountId), true);
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -111,7 +111,17 @@ public class DatabaseTestHelper {
     public void addGatewayAccount(String accountId, String paymentProvider, Map<String, String> credentials, String serviceName, GatewayAccountEntity.Type type, String description, String analyticsId, long corporateCreditCardSurchargeAmount, long corporateDebitCardSurchargeAmount, long corporatePrepaidCreditCardSurchargeAmount, long corporatePrepaidDebitCardSurchargeAmount) {
         addGatewayAccount(accountId, paymentProvider, credentials, serviceName, type, description, analyticsId, EmailCollectionMode.MANDATORY, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount, corporatePrepaidCreditCardSurchargeAmount, corporatePrepaidDebitCardSurchargeAmount);
     }
-    
+
+    public void updateGatewayAccountAllowZeroAmount(long gatewayAccountId, boolean allowZeroAmount) {
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("UPDATE gateway_accounts SET allow_zero_amount=:allow_zero_amount WHERE id=:gateway_account_id")
+                        .bind("gateway_account_id", gatewayAccountId)
+                        .bind("allow_zero_amount", allowZeroAmount)
+                        .execute()
+        );
+    }
+
     public void addCharge(AddChargeParams addChargeParams) {
         PGobject jsonMetadata = new PGobject();
         jsonMetadata.setType("json");


### PR DESCRIPTION
If a gateway account is has `allow_zero_amount` set to `true`, allow a payment to be created with an amount of 0. If `allow_zero_amount` is `false`, return a 422 response with a new error:

```json
{
    "error_identifier": "ZERO_AMOUNT_NOT_ALLOWED",
    "message": ["Zero amount charges are not enabled for this gateway account"]
}
```

Details:

- Change the validation for amount from being `@Min(value = 1)` to `@Min(value = 0)`
- Make amount in `ChargeCreateRequest` a boxed type so that if it’s missing in the request it doesn’t default to 0 and then pass validation — this changes the error message returned if the amount is missing to explicitly complain it’s null (rather than just between the accepted values) but this is actually more accurate
- Update the amount out of range validation error message so it describes the new minimum of 0 rather than 1
- Put a check in `ChargeService` that throws a `ZeroAmountNotAllowedForGatewayAccountException` if an amount of 0 is provided but the gateway account has `allow_zero_amount` set to `false`
- Add an exception mapper to map the `ZeroAmountNotAllowedForGatewayAccountException` to the appropriate response