### PR TITLE
bau: Fix pact upgrade on publicapi side

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -305,10 +305,9 @@ public class ChargeResponse {
     public static ChargeResponseBuilder aChargeResponseBuilder() {
         return new ChargeResponseBuilder();
     }
-
-
-
+    
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+    @JsonInclude(Include.NON_NULL)
     public static class RefundSummary {
 
         @JsonProperty("status")
@@ -398,6 +397,7 @@ public class ChargeResponse {
         }
     }
 
+    @JsonInclude(Include.NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
     public static class SettlementSummary {
         private ZonedDateTime captureSubmitTime, capturedTime;


### PR DESCRIPTION
This fixes https://github.com/alphagov/pay-publicapi/pull/468. Why the PR was failing:

- We have a pact defined in publicapi
  https://github.com/alphagov/pay-publicapi/blob/master/src/test/resources/pacts/publicapi-connector-get-payment-with-gateway-transaction-id.json#L63-L64 which has

```
"settlement_summary": {
  "capture_submit_time": null,
  "captured_date": null
}
```

but this actually gets published as

```
"settlement_summary": {}
```

due to the pact upgrade.

- On the provider side, i.e. connector, it actually returns

```
"settlement_summary": {
  "capture_submit_time": null,
  "captured_date": null
}
```

which causes the matching to fail.

This isn't great as they are equivalent and breaks Postel's Law (see
https://docs.pact.io/getting_started/matching/gotchas):

Be liberal in what you accept  - when verifying a pact in the provider project,
the response body and headers may contain fields that were not defined in the
expectations, on the assumption that any extra field will be ignored by your
consumer. This allows a provider to evolve without breaking existing consumers.

Admittedly this is talking about headers rather than json body.

This commit causes null values to not be returned in the json body which will
fix the issue.
