### PR TITLE
PP-5159 Authorise request with idempotency key

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.inject.Inject;
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequest.java
@@ -1,0 +1,85 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Map;
+
+public class StripeAuthoriseRequest extends StripeRequest {
+
+    private final String amount;
+    private final String description;
+    private final String sourceId;
+    private final String transferGroup;
+    private OrderRequestType orderRequestType;
+
+    private StripeAuthoriseRequest(
+            String amount,
+            String description,
+            String sourceId,
+            String transferGroup,
+            OrderRequestType orderRequestType,
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.amount = amount;
+        this.description = description;
+        this.sourceId = sourceId;
+        this.transferGroup = transferGroup;
+        this.orderRequestType = orderRequestType;
+    }
+    
+    public static StripeAuthoriseRequest of(String sourceId, CardAuthorisationGatewayRequest authorisationRequest, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeAuthoriseRequest(
+                authorisationRequest.getAmount(),
+                authorisationRequest.getDescription(),
+                sourceId,
+                authorisationRequest.getChargeExternalId(),
+                OrderRequestType.AUTHORISE,
+                authorisationRequest.getGatewayAccount(),
+                authorisationRequest.getChargeExternalId(),
+                stripeGatewayConfig
+        );
+    }
+    
+    public static StripeAuthoriseRequest of(String sourceId, Auth3dsResponseGatewayRequest authorisationRequest, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeAuthoriseRequest(
+                authorisationRequest.getAmount(),
+                authorisationRequest.getDescription(),
+                sourceId,
+                authorisationRequest.getChargeExternalId(),
+                OrderRequestType.AUTHORISE_3DS,
+                authorisationRequest.getGatewayAccount(),
+                authorisationRequest.getChargeExternalId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return this.orderRequestType;
+    }
+
+    @Override
+    protected String urlPath() {
+        return "/v1/charges";
+    }
+
+    @Override
+    protected Map<String, String> params() {
+        return Map.of(
+                "amount", amount,
+                "currency", "GBP",
+                "description", description,
+                "source", sourceId,
+                "capture", "false",
+                "transfer_group", transferGroup,
+                "on_behalf_of", stripeConnectAccountId
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
@@ -1,0 +1,108 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeAuthoriseRequestTest {
+    private final String stripeSourceId = "stripeSourceId";
+    private final String stripeConnectAccountId = "stripeConnectAccountId";
+    private final String description = "chargeDescription";
+    private final String chargeExternalId = "payChargeExternalId";
+    private final String stripeBaseUrl = "stripeUrl";
+    private final long amount = 123L;
+
+    private CardAuthorisationGatewayRequest authorisationGatewayRequest;
+    private StripeAuthoriseRequest stripeAuthoriseRequest;
+
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+        when(charge.getExternalId()).thenReturn(chargeExternalId);
+        when(charge.getDescription()).thenReturn(description);
+        when(charge.getAmount()).thenReturn(amount);
+
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+        
+        authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+
+        stripeAuthoriseRequest = StripeAuthoriseRequest.of(stripeSourceId, authorisationGatewayRequest, stripeGatewayConfig);
+    }
+
+    @Test
+    public void shouldCreateAuthoriseCaptureUrl() {
+        assertThat(
+                stripeAuthoriseRequest.getUrl(),
+                is(URI.create(stripeBaseUrl + "/v1/charges"))
+        );
+    }
+
+    @Test
+    public void shouldCreateCorrectPayload() {
+        String payload = stripeAuthoriseRequest.getGatewayOrder().getPayload();
+
+        Assert.assertThat(payload, CoreMatchers.containsString("amount=" + amount));
+        Assert.assertThat(payload, CoreMatchers.containsString("transfer_group=" + chargeExternalId));
+        Assert.assertThat(payload, CoreMatchers.containsString("currency=GBP"));
+        Assert.assertThat(payload, CoreMatchers.containsString("source=" + stripeSourceId));
+        Assert.assertThat(payload, CoreMatchers.containsString("capture=false"));
+        Assert.assertThat(payload, CoreMatchers.containsString("on_behalf_of=" + stripeConnectAccountId));
+        Assert.assertThat(payload, CoreMatchers.containsString("description=" + description));
+    }
+
+    @Test
+    public void shouldSetCorrectOrderRequestTypeForAuthorisationWithout3DS() {
+        assertThat(stripeAuthoriseRequest.getGatewayOrder().getOrderRequestType(), is(OrderRequestType.AUTHORISE));
+
+    }
+
+    @Test
+    public void shouldSetCorrectOrderRequestTypeForAuthorisationWith3DS() {
+        Auth3dsResponseGatewayRequest authorisationGatewayRequest = new Auth3dsResponseGatewayRequest(charge, new Auth3dsDetails());
+
+        assertThat(StripeAuthoriseRequest
+                        .of(stripeSourceId, authorisationGatewayRequest, stripeGatewayConfig)
+                        .getGatewayOrder().getOrderRequestType(),
+                is(OrderRequestType.AUTHORISE_3DS));
+    }
+
+    @Test
+    public void shouldSetCorrectIdempotencyKey() {
+        assertThat(stripeAuthoriseRequest.getHeaders().get("Idempotency-Key"), is("authorise" + chargeExternalId));
+    }
+}


### PR DESCRIPTION
We are going to remove the locking for Stripe authorisation, so in order to
manage the case where we may process two authorise requests for same
charge simultaneously, we need to send an idempotency key to Stripe.
This commit does that by making use of existing StripeRequest base class