### PR TITLE
PP-5166 Prep to use SQS Queue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,6 @@
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.carlosbecker</groupId>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -127,7 +127,6 @@ public class ConnectorModule extends AbstractModule {
     }
 
     @Provides
-    @Singleton
     public AmazonSQS sqsClient(ConnectorConfiguration connectorConfiguration) {
 
         if (isEmpty(connectorConfiguration.getSqsConfig().getEndpoint())) {

--- a/src/main/java/uk/gov/pay/connector/queue/CaptureQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/CaptureQueue.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.queue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.queue.sqs.SqsQueueService;
+
+import javax.inject.Inject;
+
+public class CaptureQueue {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final String captureQueueUrl;
+    private SqsQueueService sqsQueueService;
+
+    @Inject
+    public CaptureQueue(SqsQueueService sqsQueueService, ConnectorConfiguration connectorConfiguration) {
+        this.sqsQueueService = sqsQueueService;
+        this.captureQueueUrl = connectorConfiguration.getSqsConfig().getCaptureQueueUrl();
+    }
+
+    public void sendForCapture(String externalId) throws QueueException {
+
+        String message = new GsonBuilder()
+                .create()
+                .toJson(ImmutableMap.of("chargeId", externalId));
+
+        QueueMessage queueMessage = sqsQueueService.sendMessage(captureQueueUrl, message);
+
+        logger.info("Charge [{}] added to capture queue. Message ID [{}]", externalId, queueMessage.getMessageId());
+    }
+
+
+}

--- a/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
 
+import javax.inject.Inject;
 import java.util.List;
 
 public class SqsQueueService {
@@ -17,6 +18,7 @@ public class SqsQueueService {
 
     private AmazonSQS sqsClient;
 
+    @Inject
     public SqsQueueService(AmazonSQS sqsClient) {
         this.sqsClient = sqsClient;
     }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -108,7 +108,7 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
-  endpoint: ${AWS_SQS_ENDPOINT}
+  endpoint: ${AWS_SQS_ENDPOINT:-}
   region: ${AWS_SQS_REGION}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
@@ -75,6 +75,7 @@ public final class DropwizardJUnitRunner extends JUnitParamsRunner {
         configOverride.add(config("epdq.urls.test", "http://localhost:" + WIREMOCK_PORT + "/epdq"));
         configOverride.add(config("smartpay.urls.test", "http://localhost:" + WIREMOCK_PORT + "/pal/servlet/soap/Payment"));
         configOverride.add(config("stripe.url", "http://localhost:" + WIREMOCK_PORT));
+        configOverride.add(config("sqsConfig.captureQueueUrl", "http://localhost:" + WIREMOCK_PORT + "/capture-queue"));
 
         try {
             Optional<DropwizardTestSupport> createdApp = createIfNotRunning(dropwizardConfigAnnotation.app(), dropwizardConfigAnnotation.config(), configOverride.toArray(new ConfigOverride[0]));

--- a/src/test/java/uk/gov/pay/connector/rules/SQSMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/SQSMockClient.java
@@ -1,0 +1,72 @@
+package uk.gov.pay.connector.rules;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.GsonBuilder;
+
+import javax.xml.bind.DatatypeConverter;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_XML;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SQS_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SQS_SEND_MESSAGE_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+
+public class SQSMockClient {
+
+    /**
+     * Mocks sending message to SQS  queue. Response includes MD5 of message body
+     * SQSClient throws `com.amazonaws.AmazonClientException` exception if MD5 doesn't match based on request body
+     * @param chargeId
+     */
+    public void mockSuccessfulSendChargeToQueue(String chargeId) {
+        String body = new GsonBuilder()
+                .create()
+                .toJson(ImmutableMap.of("chargeId", chargeId));
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        md.update(body.getBytes());
+        String md5OfBody = DatatypeConverter.printHexBinary(md.digest()).toLowerCase();
+
+        String sendMessageResponse = load(SQS_SEND_MESSAGE_RESPONSE).replace("{{md5OfMessageBody}}", md5OfBody);
+        sqsSuccessResponse(sendMessageResponse);
+    }
+
+    public void mockSendMessageFail() {
+        String errorResponse = load(SQS_ERROR_RESPONSE);
+        sqsErrorResponse(errorResponse);
+    }
+
+    private void sqsSuccessResponse(String responseBody) {
+        stubFor(
+                post(urlPathEqualTo("/capture-queue"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeader(CONTENT_TYPE, TEXT_XML)
+                                        .withStatus(200)
+                                        .withBody(responseBody)
+                        )
+        );
+    }
+
+    private void sqsErrorResponse(String responseBody) {
+        stubFor(
+                post(urlPathEqualTo("/capture-queue"))
+                        .willReturn(
+                                aResponse()
+                                        .withHeader(CONTENT_TYPE, TEXT_XML)
+                                        .withStatus(400)
+                                        .withBody(responseBody)
+                        )
+        );
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -139,6 +139,9 @@ public class TestTemplateResourceLoader {
 
     public static final String STRIPE_NOTIFICATION_3DS_SOURCE = TEMPLATE_BASE_NAME + "/stripe/notification_3ds_source.json";
 
+    public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.xml";
+    public static final String SQS_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/error-response.xml";
+    
     public static String load(String location) {
         return fixture(location);
     }

--- a/src/test/resources/templates/sqs/error-response.xml
+++ b/src/test/resources/templates/sqs/error-response.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<ErrorResponse>
+    <Error>
+        <Type>Sender</Type>
+        <Code>InvalidParameterValue</Code>
+        <Message>
+            Value (quename_nonalpha) for parameter QueueName is invalid.
+            Must be an alphanumeric String of 1 to 80 in length.
+        </Message>
+    </Error>
+    <RequestId>42d59b56-7407-4c4a-be0f-4c88daeea257</RequestId>
+</ErrorResponse>

--- a/src/test/resources/templates/sqs/send-message-response.xml
+++ b/src/test/resources/templates/sqs/send-message-response.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<SendMessageResponse>
+    <SendMessageResult>
+        <MD5OfMessageBody>{{md5OfMessageBody}}</MD5OfMessageBody>
+        <MD5OfMessageAttributes>3ae8f24a165a8cedc005670c81a27295</MD5OfMessageAttributes>
+        <MessageId>5fea7756-0ea4-451a-a703-a558b933e274</MessageId>
+    </SendMessageResult>
+    <ResponseMetadata>
+        <RequestId>27daac76-34dd-47df-bd01-1f6e873584a0</RequestId>
+    </ResponseMetadata>
+</SendMessageResponse>


### PR DESCRIPTION
## WHAT YOU DID
- Added `CaptureQueue` so it can be used by services to talk to SQS queue
- Inject sqsClient into SqsQueueService

- Wiremock SQS sendMessage to send charge to capture
When sendMessage is called, SQS responds with `SendMessageResponse` which includes `MD5OfMessageBody`. `mockSuccessfulSendChargeToQueue` calculates MD5 of the message body sent capture queue and stubs response

- Stub SQS error message - when AWS SDK fails to send message and gets an error response

To mock a send message response use the snipper below before capturing a charge in tests

`SQSMockClient sqsMockClient = new SQSMockClient()
sqsMockClient.mockSendMessageSuccessful(extChargeId);`

## How to test

- it is a no-op