### PR TITLE
PP-5166 SQS container for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
             <groupId>uk.gov.pay</groupId>
             <artifactId>utils</artifactId>
             <version>${pay-java-commons.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.amazonaws</groupId>
+                    <artifactId>aws-xray-recorder-sdk-aws-sdk-instrumentor</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.pay</groupId>
@@ -438,6 +444,12 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>
             <version>1.1.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.11.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardConfig.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardConfig.java
@@ -55,6 +55,13 @@ public @interface DropwizardConfig {
      * @return boolean
      */
     boolean withDockerPostgres() default true;
+
+    /**
+     * Run a Test container with SQS image as a dependency for given Dropwizard Application
+     *
+     * @return boolean
+     */
+    boolean withDockerSQS() default true;
     
     ConfigOverride[] configOverrides() default {};
 }

--- a/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
@@ -1,0 +1,118 @@
+package uk.gov.pay.connector.junit;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.ListQueuesResult;
+import com.google.common.base.Stopwatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Start a Generic Test container with SQS docker image and creates queues if required.
+ * No need to call stop() as container will be stopped after executing the tests
+ */
+final class SqsTestDocker {
+
+    private static final Logger logger = LoggerFactory.getLogger(SqsTestDocker.class);
+
+    private static GenericContainer sqsContainer;
+
+    public static void initialise(String... queues) {
+        try {
+            createContainer();
+            waitForSQSContainerToStart();
+            createQueues(queues);
+        } catch (Exception e) {
+            logger.error("Exception initialising SQS Container - {}", e.getMessage());
+            throw new SqsTestDockerException(e);
+        }
+    }
+
+    private static void createContainer() {
+        if (sqsContainer == null) {
+            // wait at least 3 minutes for container to startup to avoid timeout exception. Default is 60 seconds
+            sqsContainer = new GenericContainer("roribio16/alpine-sqs")
+                    .withStartupTimeout(Duration.ofMinutes(3));
+
+            sqsContainer.start();
+        }
+    }
+
+    private static void waitForSQSContainerToStart() throws InterruptedException {
+        Stopwatch timer = Stopwatch.createStarted();
+
+        boolean succeeded;
+        for (succeeded = false; !succeeded && timer.elapsed(TimeUnit.SECONDS) < 15L;
+             succeeded = checkSQSAvailability()) {
+            Thread.sleep(500L);
+        }
+
+        if (!succeeded) {
+            throw new RuntimeException("SQS Container did not start in 15 seconds.");
+        } else {
+            logger.info("SQS docker container started in {}.", timer.elapsed(TimeUnit.MILLISECONDS));
+        }
+    }
+
+    private static void createQueues(String... queues) {
+        AmazonSQS amazonSQS = getSqsClient();
+        if (queues != null) {
+            for (String queue : queues) {
+                amazonSQS.createQueue(queue);
+            }
+        }
+    }
+
+    public static String getQueueUrl(String queueName) {
+        return getEndpoint() + "/queue/" + queueName;
+    }
+
+    private static String getEndpoint() {
+        return "http://localhost:" + sqsContainer.getMappedPort(9324);
+    }
+
+    /**
+     * Checks for `default` queue which indicates SQS server is started and ready to use
+     *
+     * @return true if `default` queue exists and false otherwise
+     */
+    private static boolean checkSQSAvailability() {
+        AmazonSQS amazonSQS = getSqsClient();
+
+        try {
+            ListQueuesResult result = amazonSQS.listQueues();
+
+            for (String queueUrl : result.getQueueUrls()) {
+                if (queueUrl.contains("/queue/default"))
+                    return true;
+            }
+        }
+        // exceptions (ignored) are thrown if container is not ready yet
+        catch (Exception ignored) {
+
+        }
+
+        return false;
+    }
+
+    private static AmazonSQS getSqsClient() {
+        // random credentials required by AWS SDK to build SQS client
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials("x", "x");
+
+        return AmazonSQSClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .withEndpointConfiguration(
+                        new AwsClientBuilder.EndpointConfiguration(
+                                getEndpoint(),
+                                "region-1"
+                        ))
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
+++ b/src/test/java/uk/gov/pay/connector/junit/SqsTestDocker.java
@@ -5,14 +5,10 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.amazonaws.services.sqs.model.ListQueuesResult;
-import com.google.common.base.Stopwatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 /**
  * Start a Generic Test container with SQS docker image and creates queues if required.
@@ -27,7 +23,6 @@ final class SqsTestDocker {
     public static void initialise(String... queues) {
         try {
             createContainer();
-            waitForSQSContainerToStart();
             createQueues(queues);
         } catch (Exception e) {
             logger.error("Exception initialising SQS Container - {}", e.getMessage());
@@ -37,27 +32,11 @@ final class SqsTestDocker {
 
     private static void createContainer() {
         if (sqsContainer == null) {
-            // wait at least 3 minutes for container to startup to avoid timeout exception. Default is 60 seconds
             sqsContainer = new GenericContainer("roribio16/alpine-sqs")
-                    .withStartupTimeout(Duration.ofMinutes(3));
+                    .withExposedPorts(9324)
+                    .waitingFor(Wait.forHttp("/?Action=GetQueueUrl&QueueName=default"));
 
             sqsContainer.start();
-        }
-    }
-
-    private static void waitForSQSContainerToStart() throws InterruptedException {
-        Stopwatch timer = Stopwatch.createStarted();
-
-        boolean succeeded;
-        for (succeeded = false; !succeeded && timer.elapsed(TimeUnit.SECONDS) < 15L;
-             succeeded = checkSQSAvailability()) {
-            Thread.sleep(500L);
-        }
-
-        if (!succeeded) {
-            throw new RuntimeException("SQS Container did not start in 15 seconds.");
-        } else {
-            logger.info("SQS docker container started in {}.", timer.elapsed(TimeUnit.MILLISECONDS));
         }
     }
 
@@ -76,30 +55,6 @@ final class SqsTestDocker {
 
     private static String getEndpoint() {
         return "http://localhost:" + sqsContainer.getMappedPort(9324);
-    }
-
-    /**
-     * Checks for `default` queue which indicates SQS server is started and ready to use
-     *
-     * @return true if `default` queue exists and false otherwise
-     */
-    private static boolean checkSQSAvailability() {
-        AmazonSQS amazonSQS = getSqsClient();
-
-        try {
-            ListQueuesResult result = amazonSQS.listQueues();
-
-            for (String queueUrl : result.getQueueUrls()) {
-                if (queueUrl.contains("/queue/default"))
-                    return true;
-            }
-        }
-        // exceptions (ignored) are thrown if container is not ready yet
-        catch (Exception ignored) {
-
-        }
-
-        return false;
     }
 
     private static AmazonSQS getSqsClient() {

--- a/src/test/java/uk/gov/pay/connector/junit/SqsTestDockerException.java
+++ b/src/test/java/uk/gov/pay/connector/junit/SqsTestDockerException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.junit;
+
+class SqsTestDockerException extends RuntimeException {
+
+    public SqsTestDockerException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
## WHAT

- Adds support to start SQS container (using org.testcontainers) for tests.
  Creating Dropwizard annotation with flag `withDockerSQS` set to true starts SQS test container before the tests

      @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml",
        configOverrides = {@ConfigOverride(key = "captureProcessConfig.captureUsingSQS", value = "true")},
        withDockerSQS = true
      )
- Excluded `aws-xray-recorder-sdk-aws-sdk-instrumentor` as library automatically instruments all SDK clients (SQS Client currently).
  Required clients can still be instrumented manually https://docs.aws.amazon.com/xray/latest/devguide/scorekeep-sdkclients.html


## HOW

- Spins up SQS container for tests but not used yet. CI builds should continue to pass