### PR TITLE
[WIP] Pp 5237 Expire charges stuck in Auth Error state

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ExpirableChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ExpirableChargeStatus.java
@@ -10,7 +10,8 @@ public enum ExpirableChargeStatus {
     AUTHORISATION_3DS_REQUIRED(ChargeStatus.AUTHORISATION_3DS_REQUIRED, AuthorisationStage.DURING_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_3DS_READY(ChargeStatus.AUTHORISATION_3DS_READY, AuthorisationStage.DURING_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_SUCCESS(ChargeStatus.AUTHORISATION_SUCCESS, AuthorisationStage.POST_AUTHORISATION, ExpiryThresholdType.REGULAR),
-    AWAITING_CAPTURE_REQUEST(ChargeStatus.AWAITING_CAPTURE_REQUEST, AuthorisationStage.POST_AUTHORISATION, ExpiryThresholdType.DELAYED);
+    AWAITING_CAPTURE_REQUEST(ChargeStatus.AWAITING_CAPTURE_REQUEST, AuthorisationStage.POST_AUTHORISATION, ExpiryThresholdType.DELAYED),
+    AUTHORISATION_ERROR(ChargeStatus.AUTHORISATION_ERROR, AuthorisationStage.POST_AUTHORISATION, ExpiryThresholdType.REGULAR);
     
     ExpirableChargeStatus(ChargeStatus chargeStatus, AuthorisationStage authorisationStage, ExpiryThresholdType expiryThresholdType) {
         this.chargeStatus = chargeStatus;

--- a/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
@@ -67,7 +67,12 @@ public class StatusFlow {
     private final ChargeStatus submittedState;
     private final ChargeStatus failureTerminalState;
 
-    private StatusFlow(String name, List<ChargeStatus> terminatableStatuses, ChargeStatus lockState, ChargeStatus successTerminalState, ChargeStatus submittedState, ChargeStatus failureTerminalState) {
+    private StatusFlow(String name, 
+                       List<ChargeStatus> terminatableStatuses, 
+                       ChargeStatus lockState, 
+                       ChargeStatus successTerminalState, 
+                       ChargeStatus submittedState, 
+                       ChargeStatus failureTerminalState) {
         this.name = name;
         this.terminatableStatuses = terminatableStatuses;
         this.lockState = lockState;

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -76,6 +76,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_ABORTED, "");
         graph.putEdgeValue(ENTERING_CARD_DETAILS, USER_CANCELLED, "user clicked cancel");
         graph.putEdgeValue(ENTERING_CARD_DETAILS, SYSTEM_CANCELLED, "");
+        graph.putEdgeValue(AUTHORISATION_ERROR, EXPIRE_CANCEL_READY, "");
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_ABORTED, "");
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_SUCCESS, "Gateway response: AUTHORISED");
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_REJECTED, "Gateway response: REJECTED");

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.charge.service;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,6 +44,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -80,22 +80,24 @@ public class ChargeExpiryServiceTest {
     @Mock
     private ConnectorConfiguration mockedConfig;
     
-    private static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = ImmutableList.of(
+    private static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = List.of(
             CREATED,
             ENTERING_CARD_DETAILS,
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_3DS_READY,
-            AUTHORISATION_SUCCESS
+            AUTHORISATION_SUCCESS,
+            AUTHORISATION_ERROR
     );
 
-    private static final List<ChargeStatus> GATEWAY_CANCELLABLE_STATUSES = ImmutableList.of(
+    private static final List<ChargeStatus> GATEWAY_CANCELLABLE_STATUSES = List.of(
             AUTHORISATION_3DS_READY,
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_SUCCESS,
-            AWAITING_CAPTURE_REQUEST
+            AWAITING_CAPTURE_REQUEST,
+            AUTHORISATION_ERROR
     );
 
-    private static final List<ChargeStatus> EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS = ImmutableList.of(
+    private static final List<ChargeStatus> EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS = List.of(
             AWAITING_CAPTURE_REQUEST
     );
 

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -317,9 +317,7 @@ public class ChargingITestBase {
         addCharge(chargeId, externalChargeId, status, ServicePaymentReference.of(reference), fromDate, transactionId);
         databaseTestHelper.addToken(chargeId, "tokenId");
         databaseTestHelper.addEvent(chargeId, chargeStatus.getValue());
-        databaseTestHelper.updateChargeCardDetails(
-                chargeId,
-                AuthCardDetailsFixture.anAuthCardDetails().build());
+        databaseTestHelper.updateChargeCardDetails(chargeId, AuthCardDetailsFixture.anAuthCardDetails().build());
         return externalChargeId;
     }
     

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -101,6 +101,8 @@ public class ChargingITestBase {
         databaseTestHelper = testContext.getDatabaseTestHelper();
         databaseTestHelper.addGatewayAccount(accountId, paymentProvider, credentials);
         connectorRestApiClient = new RestAssuredClient(testContext.getPort(), accountId);
+        
+        wireMockRule.resetAll();
     }
 
     @After

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceITest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.restassured.http.ContentType.JSON;
 import static java.util.Arrays.asList;
@@ -75,6 +76,8 @@ public class ChargeExpiryResourceITest extends ChargingITestBase {
 
         assertThat(asList(CREATED.getValue(), EXPIRED.getValue()), is(events1));
         assertThat(asList(AUTHORISATION_SUCCESS.getValue(), EXPIRE_CANCEL_READY.getValue(), EXPIRED.getValue()), is(events2));
+        
+        wireMockRule.verify(1, postRequestedFor(urlEqualTo("/jsp/merchant/xml/paymentService.jsp")));
     }
 
     @Test


### PR DESCRIPTION
When making 3ds Authorisation requests, the EPDQ server sometimes responds with
a 503 status, which causes the charge to be transitioned to AUTHORISATION ERROR
in connector. It appears that despite the 503, the charge will still be in the
AUTHORISED SUCCESS (or 5-Authorised) state. This makes sense as it was already
authorised in the first authorisation request before the 3ds one. This commit
therefore adds the AUTHORISED ERROR state as one of the statuses upon which the
charge should be cancelled.

I had considered using the DiscrepancyService to determine if there is a
discrepancy before cancelling the charge; however looking at EpdqStatusMapper
and WorldpayStatus classes these PSPs never have a state that is equivalent to
our AUTHORISATION ERROR status so I surmise it is always safe to call cancel on
a charge that has errored.

Add test using epdq as a PSP to spice things up.