### PR TITLE
PP-5166 Add charge to queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -369,7 +369,7 @@ public class ChargeService {
                 .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
     }
 
-    private ChargeEntity updateChargeStatus(ChargeEntity chargeEntity, ChargeStatus chargeStatus) {
+    public ChargeEntity updateChargeStatus(ChargeEntity chargeEntity, ChargeStatus chargeStatus) {
         if (chargeStatus == CAPTURED) {
             chargeEntity.setStatus(CAPTURE_SUBMITTED);
             chargeEventDao.persistChargeEventOf(chargeEntity);
@@ -390,20 +390,6 @@ public class ChargeService {
 
     public Optional<ChargeEntity> findByProviderAndTransactionId(String paymentGatewayName, String transactionId) {
         return chargeDao.findByProviderAndTransactionId(paymentGatewayName, transactionId);
-    }
-
-    public ChargeEntity markChargeAsEligibleForCapture(String externalId) {
-        return chargeDao.findByExternalId(externalId).map(charge -> {
-            ChargeStatus targetStatus = charge.isDelayedCapture() ? AWAITING_CAPTURE_REQUEST : CAPTURE_APPROVED;
-
-            try {
-                updateChargeStatus(charge, targetStatus);
-            } catch (InvalidStateTransitionException e) {
-                throw new IllegalStateRuntimeException(charge.getExternalId());
-            }
-
-            return charge;
-        }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
     }
 
     public ChargeEntity markChargeAsCaptureApproved(String externalId) {

--- a/src/main/java/uk/gov/pay/connector/queue/QueueException.java
+++ b/src/main/java/uk/gov/pay/connector/queue/QueueException.java
@@ -3,6 +3,10 @@ package uk.gov.pay.connector.queue;
 
 public class QueueException extends Exception {
 
+    public QueueException(){
+        
+    }
+    
     public QueueException(String message) {
         super(message);
     }

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -245,6 +245,12 @@ public class ChargingITestBase {
         return "/v1/frontend/charges/{chargeId}/capture".replace("{chargeId}", chargeId);
     }
 
+    protected static String captureUrlForAwaitingCaptureCharge(String accountId, String chargeId) {
+        return "/v1/api/accounts/{accountId}/charges/{chargeId}/capture"
+                .replace("{accountId}", accountId)
+                .replace("{chargeId}", chargeId);
+    }
+
     public static String cancelChargeUrlFor(String accountId, String chargeId) {
         return "/v1/api/accounts/{accountId}/charges/{chargeId}/cancel".replace("{accountId}", accountId).replace("{chargeId}", chargeId);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueITest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueITest.java
@@ -1,0 +1,91 @@
+package uk.gov.pay.connector.it.resources;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.ConfigOverride;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.queue.CaptureQueue;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml",
+        configOverrides = {@ConfigOverride(key = "captureProcessConfig.captureUsingSQS", value = "true")},
+        withDockerSQS = true
+)
+public class CardResourceCaptureWithSqsQueueITest extends ChargingITestBase {
+
+    private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+    private String captureApproveUrl;
+
+    public CardResourceCaptureWithSqsQueueITest() {
+        super("sandbox");
+    }
+
+    @Before
+    public void setUp() {
+        Logger root = (Logger) LoggerFactory.getLogger(CaptureQueue.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    public void shouldAddChargeToQueueAndSubmitForCapture_IfChargeWasPreviouslyAuthorised() {
+        String chargeId = authoriseNewCharge();
+        givenSetup()
+                .post(captureChargeUrlFor(chargeId))
+                .then()
+                .statusCode(204);
+
+        assertFrontendChargeStatusIs(chargeId, CAPTURE_APPROVED.getValue());
+        assertApiStateIs(chargeId, EXTERNAL_SUCCESS.getStatus());
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Charge [" + chargeId + "] added to capture queue. Message ID [")), is(true));
+    }
+
+    @Test
+    public void shouldAddChargeToQueueAndSubmitForCapture_IfChargeWasAwaitingCapture() {
+        String chargeId = addCharge(AWAITING_CAPTURE_REQUEST, "ref", ZonedDateTime.now().minusHours(48L).plusMinutes(1L), RandomIdGenerator.newId());
+
+        captureApproveUrl = captureUrlForAwaitingCaptureCharge(accountId,chargeId);
+
+        givenSetup()
+                .post(captureApproveUrl)
+                .then()
+                .statusCode(204);
+
+        assertFrontendChargeStatusIs(chargeId, CAPTURE_APPROVED.getValue());
+        assertApiStateIs(chargeId, EXTERNAL_SUCCESS.getStatus());
+
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Charge [" + chargeId + "] added to capture queue. Message ID [")), is(true));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -9,6 +9,7 @@ import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -21,6 +22,7 @@ import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.pact.util.GatewayAccountUtil;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
+import uk.gov.pay.connector.rules.SQSMockClient;
 import uk.gov.pay.connector.util.AddChargeParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
@@ -35,6 +37,7 @@ import static io.restassured.RestAssured.given;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+import static uk.gov.pay.connector.rules.AppWithPostgresRule.WIREMOCK_PORT;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 
 @RunWith(PactRunner.class)
@@ -47,6 +50,11 @@ public class TransactionsApiContractTest {
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
 
+    @ClassRule
+    public static WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);
+
+    private SQSMockClient sqsMockClient = new SQSMockClient();
+    
     @TestTarget
     public static Target target;
     private static DatabaseTestHelper dbHelper;
@@ -137,6 +145,7 @@ public class TransactionsApiContractTest {
     }
 
     private void setUpSingleCharge(String accountId, Long chargeId, String chargeExternalId, ChargeStatus chargeStatus, ZonedDateTime createdDate, boolean delayedCapture) {
+        sqsMockClient.mockSuccessfulSendChargeToQueue(chargeExternalId);
         setUpSingleCharge(accountId, chargeId, chargeExternalId, chargeStatus, createdDate, delayedCapture, "aName", "0001", "123456", "aGatewayTransactionId");
     }
 

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -100,8 +100,8 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
-  endpoint: ${AWS_SQS_ENDPOINT}
-  region: ${AWS_SQS_REGION}
+  endpoint: ${AWS_SQS_ENDPOINT:-localhost}
+  region: ${AWS_SQS_REGION:-region}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -99,8 +99,8 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
-  endpoint: ${AWS_SQS_ENDPOINT}
-  region: ${AWS_SQS_REGION}
+  endpoint: ${AWS_SQS_ENDPOINT:-localhost}
+  region: ${AWS_SQS_REGION:-region}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -89,8 +89,8 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
-  endpoint: ${AWS_SQS_ENDPOINT}
-  region: ${AWS_SQS_REGION}
+  endpoint: ${AWS_SQS_ENDPOINT:-localhost}
+  region: ${AWS_SQS_REGION:-region}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -80,7 +80,7 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
-  endpoint: ${AWS_SQS_ENDPOINT}
+  endpoint: ${AWS_SQS_ENDPOINT:-localhost}
   region: ${AWS_SQS_REGION}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -77,8 +77,8 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
-  endpoint: ${AWS_SQS_ENDPOINT}
-  region: ${AWS_SQS_REGION}
+  endpoint: ${AWS_SQS_ENDPOINT:-localhost}
+  region: ${AWS_SQS_REGION:-region-1}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:


### PR DESCRIPTION
- Sends charge to queue during capture approve action
- Unit tests for adding charges to queue and exception cases
- Integration tests with SQS docker container
- Contract tests uses Wiremock to stub SQS calls - If an SQS container to be used
   `DropwizardAppWithPostgresRule` should spin new SQS docker container
- Moved `markChargeAsEligibleForCapture` from ChargeService to `CardCaptureService`
  as business logic is close to CardCaptureService and adding charge to queue is an
  intermediate step in marking charge as eligible