### PR TITLE
PP-5167 Capture queue - add max wait time for long polling

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
@@ -40,9 +40,12 @@ public class SqsQueueService {
 
     public List<QueueMessage> receiveMessages(String queueUrl, String messageAttributeName) throws QueueException {
         try {
+            // @TODO(sfount) this should be configured in the connector environment
+            int longPollingMaxWaitTime = 20;
             ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
             receiveMessageRequest
                     .withMessageAttributeNames(messageAttributeName)
+                    .withWaitTimeSeconds(longPollingMaxWaitTime)
                     .withMaxNumberOfMessages(10);
 
             ReceiveMessageResult receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);


### PR DESCRIPTION
In local environments the client must specify the wait time for a message request to enable long polling, this behaviour should be verified for a configured SQS instance. PR tests "long polling" attribute. 