### PR TITLE
PP-4060 clean up expired tokens sweep database migration

### DIFF
--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
@@ -28,7 +28,7 @@ public class TokenEntity extends AbstractVersionedEntity {
 
     @Column(name = "secure_redirect_token")
     private String token;
-
+    
     @ManyToOne
     @JoinColumn(name = "charge_id", nullable = false)
     private ChargeEntity chargeEntity;
@@ -41,6 +41,7 @@ public class TokenEntity extends AbstractVersionedEntity {
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChargeEntity(chargeEntity);
         tokenEntity.setToken(UUID.randomUUID().toString());
+        
         return tokenEntity;
     }
 
@@ -59,7 +60,7 @@ public class TokenEntity extends AbstractVersionedEntity {
     public void setToken(String token) {
         this.token = token;
     }
-
+    
     public ChargeEntity getChargeEntity() {
         return chargeEntity;
     }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1129,4 +1129,28 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add created_date to tokens table" author="">
+        <addColumn tableName="tokens">
+            <column name="created_date" type="timestamp without timezone">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add default date to created_date on tokens table" author="">
+        <addDefaultValue tableName="tokens" columnName="created_date" columnDataType="timestamp without timezone" defaultValueComputed="(now() at time zone 'utc')" />
+    </changeSet>
+
+    <changeSet id="update created_date with default value on tokens table" author="">
+        <update tableName="tokens">
+            <column name ="created_date" valueComputed="(now() at time zone 'utc')" />
+        </update>
+    </changeSet>
+
+    <changeSet id="add index concurrently to created_date column on tokens table" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_created_date on tokens(created_date);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -61,7 +61,7 @@ public class ChargeExpiryServiceTest {
 
     @Mock
     private ChargeEventDao mockChargeEventDao;
-
+    
     @Mock
     private PaymentProviders mockPaymentProviders;
 


### PR DESCRIPTION
## WHAT YOU DID

This PR adds a: 

1. **created_date** column with data type 'timestamp without timezone' to the Tokens table in Connector's database with a default value of now().

2. **created_date** field in TokenEntity. The TokenEntity constructor fills this out with the created_date field from ChargeEntity