### PR TITLE
PP-5280 Fix SQSClient for non-standard SQS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 | `STRIPE_TRANSACTION_FEE_PERCENTAGE` | - | percentage of total charge amount to recover GOV.UK Pay platform costs. |
 | `STRIPE_PLATFORM_ACCOUNT_ID` | - | the account ID for the Stripe Connect GOV.UK Pay platform. |
 
+
+### Queues
+| Varible | Default | Purpose |
+|---------|---------|---------|
+| `AWS_SQS_REGION`            | - | SQS capture queue region |
+| `AWS_SQS_CAPTURE_QUEUE_URL` | - | SQS capture queue URL  |
+| `AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT`  | false | Set to true to use non standard (eg: http://my-own-sqs-endpoint) SQS endpoint |
+| `AWS_SQS_ENDPOINT`          | - |  URL that is the entry point for SQS. Only required when AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT is `true` |
+| `AWS_SECRET_KEY`            | - | Secret key. Only required when AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT is `true` |
+| `AWS_ACCESS_KEY`            | - | Access key. Only required when AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT is `true`|
+
 ### Background captures
 
 The background capture mechanism will capture all payments in the `CAPTURE_APPROVED` state. 
@@ -42,9 +53,6 @@ The following variables control the background process:
 | `CAPTURE_PROCESS_BATCH_SIZE` | `10` | limits the batch window size processed at each polling attempt. If connector is not managing to clear the queue of captures, increase this value. |
 | `CAPTURE_PROCESS_RETRY_FAILURES_EVERY` | `60 minutes` | a failed capture attempt will be returned to the queue, and will not be retried until this time has passed |
 | `CAPTURE_PROCESS_MAXIMUM_RETRIES` | `48` | connector keeps track of the number of times capture has been attempted for each charge. If a charge fails this number of times or more it will be marked as a permanent failure. An error log message will be written as well. This should *never* happen and if it does it should be investigated. |
-| `AWS_SQS_ENDPOINT` | - |  URL that is the entry point for SQS. Not required when AWS_SQS_REGION is set or can be set if using a non-standard SQS endpoint   |
-| `AWS_SQS_CAPTURE_QUEUE_ID` | - | SQS capture queue URL  |
-| `AWS_SQS_REGION` | - | SQS capture queue region |
 
 ## Integration tests
 

--- a/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
@@ -4,9 +4,12 @@ import io.dropwizard.Configuration;
 
 public class SqsConfig extends Configuration {
 
+    private boolean nonStandardServiceEndpoint;
     private String endpoint;
     private String captureQueueUrl;
     private String region;
+    private String accessKey;
+    private String secretKey;
 
     public String getEndpoint() {
         return endpoint;
@@ -18,5 +21,17 @@ public class SqsConfig extends Configuration {
 
     public String getRegion() {
         return region;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public boolean isNonStandardServiceEndpoint() {
+        return nonStandardServiceEndpoint;
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -108,8 +108,11 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
+  nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-false}
   endpoint: ${AWS_SQS_ENDPOINT:-}
   region: ${AWS_SQS_REGION}
+  secretKey: ${AWS_SECRET_KEY}
+  accessKey: ${AWS_ACCESS_KEY}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueIT.java
@@ -35,13 +35,13 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL
         configOverrides = {@ConfigOverride(key = "captureProcessConfig.captureUsingSQS", value = "true")},
         withDockerSQS = true
 )
-public class CardResourceCaptureWithSqsQueueITest extends ChargingITestBase {
+public class CardResourceCaptureWithSqsQueueIT extends ChargingITestBase {
 
     private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
     private String captureApproveUrl;
 
-    public CardResourceCaptureWithSqsQueueITest() {
+    public CardResourceCaptureWithSqsQueueIT() {
         super("sandbox");
     }
 

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -100,8 +100,11 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
+  nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
   endpoint: ${AWS_SQS_ENDPOINT:-localhost}
   region: ${AWS_SQS_REGION:-region}
+  secretKey: ${AWS_SECRET_KEY}
+  accessKey: ${AWS_ACCESS_KEY}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -99,8 +99,11 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
+  nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
   endpoint: ${AWS_SQS_ENDPOINT:-localhost}
   region: ${AWS_SQS_REGION:-region}
+  secretKey: ${AWS_SECRET_KEY:-secret-key}
+  accessKey: ${AWS_ACCESS_KEY:-access-key}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -53,8 +53,8 @@ stripe:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecrets:
-      test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
-      live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+    test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+    live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
@@ -89,8 +89,11 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
+  nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
   endpoint: ${AWS_SQS_ENDPOINT:-localhost}
   region: ${AWS_SQS_REGION:-region}
+  secretKey: ${AWS_SECRET_KEY:-secret-key}
+  accessKey: ${AWS_ACCESS_KEY:-access-key}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -80,8 +80,11 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
+  nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
   endpoint: ${AWS_SQS_ENDPOINT:-localhost}
   region: ${AWS_SQS_REGION}
+  secretKey: ${AWS_SECRET_KEY:-secret-key}
+  accessKey: ${AWS_ACCESS_KEY:-access-key}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
 
 transactionsPaginationServiceConfig:

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -77,9 +77,12 @@ captureProcessConfig:
   captureUsingSQS: ${CAPTURE_USING_SQS_FEATURE_FLAG:-false}
 
 sqsConfig:
+  nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
   endpoint: ${AWS_SQS_ENDPOINT:-localhost}
   region: ${AWS_SQS_REGION:-region-1}
   captureQueueUrl: ${AWS_SQS_CAPTURE_QUEUE_URL}
+  secretKey: ${AWS_SECRET_KEY:-secret-key}
+  accessKey: ${AWS_ACCESS_KEY:-access-key}
 
 transactionsPaginationServiceConfig:
   displayPageSize: ${TRANSACTION_LIST_DISPLAY_SIZE:-500}


### PR DESCRIPTION
## WHAT YOU DID
- AWS SQS SDK defines non-standard endpoint as a custom SQS url (http://own-sqs-url).
  While endpoint is not needed in EC2 environment (SQS SDK will determine based on region),
  it is required (along with credentials)  while spinning up SQS equivalent containers for development/CI.

  The change includes initiating SQSClient with `endpoint and also credentials` required for development and CI

- Renamed `CardResourceCaptureWithSqsQueueITest` -> CardResourceCaptureWithSqsQueueIT (to failsafe plug way for integration tests)

## How to test

- CI should continue to pass
- Should pass locally with the below command even when `.aws` folder (with credentials) doesn't exists in users' home directory
   ` mvn verify -Dit.test=uk.gov.pay.connector.it.resources.CardResourceCaptureWithSqsQueueIT`
## Code review checklist

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable

