### PR TITLE
PP-5171 retry capture on failed processing

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -243,6 +243,19 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .getSingleResult()).intValue();
     }
 
+    public int countCaptureRetriesForChargeExternalId(String externalId) {
+        String query = "SELECT count(ce) FROM ChargeEventEntity ce WHERE " +
+                "    ce.chargeEntity.externalId = :externalId AND " +
+                "    (ce.status = :captureApprovedStatus OR ce.status = :captureApprovedRetryStatus)";
+
+        return ((Number) entityManager.get()
+                .createQuery(query)
+                .setParameter("externalId", externalId)
+                .setParameter("captureApprovedStatus", CAPTURE_APPROVED)
+                .setParameter("captureApprovedRetryStatus", CAPTURE_APPROVED_RETRY)
+                .getSingleResult()).intValue();
+    }
+
     public List<ChargeEntity> findByIdAndLimit(Long id, int limit) {
         return entityManager.get()
                 .createQuery("SELECT c FROM ChargeEntity c WHERE c.id > :id ORDER BY c.id", ChargeEntity.class)

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
@@ -54,6 +54,13 @@ public class CaptureResponse {
         return Optional.ofNullable(gatewayError);
     }
 
+    public String getErrorMessage() {
+        if (getError().isPresent()) {
+            return getError().get().getMessage();
+        }
+        return "";
+    }
+
     /**
      * To avoid returning a null, one must call isSuccessful first to determine if there is an error
      */

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
@@ -54,11 +54,8 @@ public class CaptureResponse {
         return Optional.ofNullable(gatewayError);
     }
 
-    public String getErrorMessage() {
-        if (getError().isPresent()) {
-            return getError().get().getMessage();
-        }
-        return "";
+    public Optional<String> getErrorMessage() {
+        return getError().map(error -> error.getMessage());
     }
 
     /**

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcess.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcess.java
@@ -62,7 +62,7 @@ public class CardCaptureMessageProcess {
             LOGGER.info(
                     "Failed to capture [externalChargeId={}] due to: {}",
                     externalChargeId,
-                    gatewayResponse.getError().get().getMessage()
+                    gatewayResponse.getErrorMessage()
             );
             handleCaptureRetry(captureMessage);
         }
@@ -73,7 +73,7 @@ public class CardCaptureMessageProcess {
         ChargeEntity charge = chargeDao.findByExternalId(captureMessage.getChargeId())
                 .orElseThrow(() -> new QueueException("Invalid message on capture retry " + captureMessage.getChargeId()));
 
-        boolean shouldRetry = chargeDao.countCaptureRetriesForCharge(charge.getId()) >= maximumCaptureRetries;
+        boolean shouldRetry = chargeDao.countCaptureRetriesForCharge(charge.getId()) < maximumCaptureRetries;
 
         if (shouldRetry) {
             captureQueue.scheduleMessageForRetry(captureMessage);

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcess.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcess.java
@@ -69,11 +69,8 @@ public class CardCaptureMessageProcess {
     }
 
     private void handleCaptureRetry(ChargeCaptureMessage captureMessage) throws QueueException {
-        // @TODO(sfount) charge entity read could all be moved to the charge dao under get retries for external id
-        ChargeEntity charge = chargeDao.findByExternalId(captureMessage.getChargeId())
-                .orElseThrow(() -> new QueueException("Invalid message on capture retry " + captureMessage.getChargeId()));
-
-        boolean shouldRetry = chargeDao.countCaptureRetriesForCharge(charge.getId()) < maximumCaptureRetries;
+        int numberOfChargeRetries = chargeDao.countCaptureRetriesForChargeExternalId(captureMessage.getChargeId());
+        boolean shouldRetry = numberOfChargeRetries <= maximumCaptureRetries;
 
         if (shouldRetry) {
             captureQueue.scheduleMessageForRetry(captureMessage);

--- a/src/main/java/uk/gov/pay/connector/queue/CaptureQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/CaptureQueue.java
@@ -74,6 +74,8 @@ public class CaptureQueue {
     }
 
     public void scheduleMessageForRetry(ChargeCaptureMessage message) throws QueueException {
-        sqsQueueService.deferMessage(this.captureQueueUrl, message.getReceiptHandle());
+        // @TODO(sfount) this should be configured by environment with other receive params
+        int captureMessageDeferTimeout = 3600;
+        sqsQueueService.deferMessage(this.captureQueueUrl, message.getReceiptHandle(), captureMessageDeferTimeout);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/CaptureQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/CaptureQueue.java
@@ -20,7 +20,7 @@ public class CaptureQueue {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final JsonObjectMapper jsonObjectMapper;
-    
+
     private final String captureQueueUrl;
     private SqsQueueService sqsQueueService;
 
@@ -30,7 +30,7 @@ public class CaptureQueue {
     @Inject
     public CaptureQueue(
             SqsQueueService sqsQueueService,
-            ConnectorConfiguration connectorConfiguration, JsonObjectMapper jsonObjectMapper) { 
+            ConnectorConfiguration connectorConfiguration, JsonObjectMapper jsonObjectMapper) {
         this.sqsQueueService = sqsQueueService;
         this.captureQueueUrl = connectorConfiguration.getSqsConfig().getCaptureQueueUrl();
         this.jsonObjectMapper = jsonObjectMapper;
@@ -46,12 +46,12 @@ public class CaptureQueue {
 
         logger.info("Charge [{}] added to capture queue. Message ID [{}]", charge.getExternalId(), queueMessage.getMessageId());
     }
-    
+
     public List<ChargeCaptureMessage> retrieveChargesForCapture() throws QueueException {
         List<QueueMessage> queueMessages = sqsQueueService
                 .receiveMessages(this.captureQueueUrl, CAPTURE_MESSAGE_ATTRIBUTE_NAME);
-        
-        return queueMessages 
+
+        return queueMessages
                 .stream()
                 .map(this::getChargeCaptureMessage)
                 .filter(Objects::nonNull)
@@ -69,7 +69,11 @@ public class CaptureQueue {
         }
     }
 
-    public void markMessageAsProcessed(ChargeCaptureMessage message) throws QueueException {    
+    public void markMessageAsProcessed(ChargeCaptureMessage message) throws QueueException {
         sqsQueueService.deleteMessage(this.captureQueueUrl, message.getReceiptHandle());
+    }
+
+    public void scheduleMessageForRetry(ChargeCaptureMessage message) throws QueueException {
+        sqsQueueService.deferMessage(this.captureQueueUrl, message.getReceiptHandle());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
@@ -1,14 +1,20 @@
 package uk.gov.pay.connector.queue.sqs;
 
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.*;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import com.amazonaws.services.sqs.model.DeleteMessageRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageResult;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.AmazonSQSException;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityResult;
+import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
 
 import javax.inject.Inject;
-import java.lang.UnsupportedOperationException;
 import java.util.List;
 
 public class SqsQueueService {
@@ -55,8 +61,6 @@ public class SqsQueueService {
 
     public DeleteMessageResult deleteMessage(String queueUrl, String messageReceiptHandle) throws QueueException {
         try {
-            DeleteMessageRequest deleteMessageRequest = new DeleteMessageRequest(queueUrl, messageReceiptHandle);
-
             return sqsClient.deleteMessage(new DeleteMessageRequest(queueUrl, messageReceiptHandle));
         } catch (AmazonSQSException | UnsupportedOperationException e) {
             logger.error("Failed to delete message from SQS queue - {}", e.getMessage());

--- a/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/sqs/SqsQueueService.java
@@ -68,14 +68,12 @@ public class SqsQueueService {
         }
     }
 
-    public ChangeMessageVisibilityResult deferMessage(String queueUrl, String messageReceiptHandle) throws QueueException {
+    public ChangeMessageVisibilityResult deferMessage(String queueUrl, String messageReceiptHandle, int timeoutInSeconds) throws QueueException {
         try {
-            // @TODO(sfount) this should be configured by environment with other receive params
-            int deferTimeout = 3600;
             ChangeMessageVisibilityRequest changeMessageVisibilityRequest = new ChangeMessageVisibilityRequest(
                     queueUrl,
                     messageReceiptHandle,
-                    deferTimeout);
+                    timeoutInSeconds);
 
             return sqsClient.changeMessageVisibility(changeMessageVisibilityRequest);
         } catch (AmazonSQSException | UnsupportedOperationException e) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -1536,7 +1536,39 @@ public class ChargeDaoIT extends DaoITestBase {
                 .insert();
 
         assertThat(chargeDao.countCaptureRetriesForCharge(chargeId), is(2));
+    }
 
+    @Test
+    public void countCaptureRetriesForChargeExternalId_shouldReturnNumberOfRetries() {
+        long chargeId = nextLong();
+        String externalChargeId = RandomIdGenerator.newId();
+
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withCreatedDate(now().minusHours(2))
+                .withChargeStatus(CAPTURE_APPROVED)
+                .insert();
+
+        assertThat(chargeDao.countCaptureRetriesForChargeExternalId(externalChargeId), is(0));
+
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestChargeEvent()
+                .withChargeId(chargeId)
+                .withChargeStatus(CAPTURE_APPROVED)
+                .insert();
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestChargeEvent()
+                .withChargeId(chargeId)
+                .withChargeStatus(CAPTURE_APPROVED_RETRY)
+                .insert();
+
+        assertThat(chargeDao.countCaptureRetriesForChargeExternalId(externalChargeId), is(2));
     }
 
     @Test
@@ -1566,7 +1598,7 @@ public class ChargeDaoIT extends DaoITestBase {
     @Test
     public void getChargeWithAFee_shouldReturnFeeOnCharge() {
         insertTestCharge();
-        
+
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestFee()
@@ -1578,7 +1610,7 @@ public class ChargeDaoIT extends DaoITestBase {
         assertThat(chargeDao
                 .findById(defaultTestCharge.getChargeId())
                 .flatMap(ChargeEntity::getFeeAmount)
-                .get(), 
+                .get(),
                 is(10L)
         );
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcessTest.java
@@ -1,0 +1,128 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.CaptureProcessConfig;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.queue.CaptureQueue;
+import uk.gov.pay.connector.queue.ChargeCaptureMessage;
+import uk.gov.pay.connector.queue.QueueException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CardCaptureMessageProcessTest {
+
+    private static final int RETRIABLE_NUMBER_OF_CAPTURE_ATTEMPTS = 1;
+    private static final int MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS = 10;
+
+    @Mock
+    CaptureQueue captureQueue;
+
+    @Mock
+    CardCaptureService cardCaptureService;
+
+    @Mock
+    ConnectorConfiguration connectorConfiguration;
+
+    @Mock
+    ChargeDao chargeDao;
+
+    @Mock
+    CaptureResponse captureResponse;
+
+    @Mock
+    ChargeCaptureMessage chargeCaptureMessage;
+
+    private static final Long chargeId = 1L;
+    private static final String chargeExternalId = "some-charge-id";
+
+    CardCaptureMessageProcess cardCaptureMessageProcess;
+
+    private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
+
+    @Before
+    public void setUp() throws Exception {
+        List<ChargeCaptureMessage> messages = Arrays.asList(chargeCaptureMessage);
+        CaptureProcessConfig captureProcessConfig = mock(CaptureProcessConfig.class);
+        ChargeEntity chargeEntity = mock(ChargeEntity.class);
+
+        Logger root = (Logger) LoggerFactory.getLogger(CardCaptureMessageProcess.class);
+        root.setLevel(Level.WARN);
+        root.addAppender(mockAppender);
+
+        when(chargeCaptureMessage.getChargeId()).thenReturn(chargeExternalId);
+        when(captureQueue.retrieveChargesForCapture()).thenReturn(messages);
+        when(captureProcessConfig.getCaptureUsingSQS()).thenReturn(true);
+        when(captureProcessConfig.getMaximumRetries()).thenReturn(MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS);
+        when(connectorConfiguration.getCaptureProcessConfig()).thenReturn(captureProcessConfig);
+        when(cardCaptureService.doCapture(anyString())).thenReturn(captureResponse);
+        when(chargeEntity.getId()).thenReturn(chargeId);
+        when(chargeDao.findByExternalId(chargeExternalId)).thenReturn(Optional.of(chargeEntity));
+
+        cardCaptureMessageProcess = new CardCaptureMessageProcess(captureQueue, cardCaptureService, connectorConfiguration, chargeDao);
+    }
+
+    @Test
+    public void shouldMarkMessageAsProcessedGivenSuccessfulChargeCapture() throws QueueException {
+        when(captureResponse.isSuccessful()).thenReturn(true);
+
+        cardCaptureMessageProcess.handleCaptureMessages();
+
+        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage);
+    }
+
+    @Test
+    public void shouldScheduleRetriableMessageGivenUnsuccessfulChargeCapture() throws QueueException {
+        when(captureResponse.isSuccessful()).thenReturn(false);
+        when(chargeDao.countCaptureRetriesForCharge(chargeId)).thenReturn(RETRIABLE_NUMBER_OF_CAPTURE_ATTEMPTS);
+
+        cardCaptureMessageProcess.handleCaptureMessages();
+
+        verify(captureQueue).scheduleMessageForRetry(chargeCaptureMessage);
+    }
+
+    @Test
+    public void shouldMarkNonRetribaleMessageAsProcessed_MarkChargeAsCaptureErrorGivenUnsuccessfulChargeCapture() throws QueueException {
+        when(captureResponse.isSuccessful()).thenReturn(false);
+        when(chargeDao.countCaptureRetriesForCharge(chargeId)).thenReturn(MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS);
+
+        cardCaptureMessageProcess.handleCaptureMessages();
+
+        verify(cardCaptureService).markChargeAsCaptureError(chargeExternalId);
+        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage);
+    }
+
+    @Test
+    public void shouldThrowQueueExceptionGivenNonExistingCharge_UneccessfulChargeCapture() throws QueueException {
+        when(captureResponse.isSuccessful()).thenReturn(false);
+        when(chargeDao.findByExternalId(chargeExternalId)).thenReturn(Optional.empty());
+
+        cardCaptureMessageProcess.handleCaptureMessages();
+
+        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Error capturing charge from SQS message [Invalid message on capture retry " + chargeExternalId + "]")), is(true));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcessTest.java
@@ -1,21 +1,13 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
-import ch.qos.logback.core.Appender;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.queue.CaptureQueue;
 import uk.gov.pay.connector.queue.ChargeCaptureMessage;
@@ -23,12 +15,11 @@ import uk.gov.pay.connector.queue.QueueException;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CardCaptureMessageProcessTest {
@@ -54,23 +45,14 @@ public class CardCaptureMessageProcessTest {
     @Mock
     ChargeCaptureMessage chargeCaptureMessage;
 
-    private static final Long chargeId = 1L;
     private static final String chargeExternalId = "some-charge-id";
 
     CardCaptureMessageProcess cardCaptureMessageProcess;
-
-    private Appender<ILoggingEvent> mockAppender = mock(Appender.class);
-    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
 
     @Before
     public void setUp() throws Exception {
         List<ChargeCaptureMessage> messages = Arrays.asList(chargeCaptureMessage);
         CaptureProcessConfig captureProcessConfig = mock(CaptureProcessConfig.class);
-        ChargeEntity chargeEntity = mock(ChargeEntity.class);
-
-        Logger root = (Logger) LoggerFactory.getLogger(CardCaptureMessageProcess.class);
-        root.setLevel(Level.WARN);
-        root.addAppender(mockAppender);
 
         when(chargeCaptureMessage.getChargeId()).thenReturn(chargeExternalId);
         when(captureQueue.retrieveChargesForCapture()).thenReturn(messages);
@@ -78,8 +60,6 @@ public class CardCaptureMessageProcessTest {
         when(captureProcessConfig.getMaximumRetries()).thenReturn(MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS);
         when(connectorConfiguration.getCaptureProcessConfig()).thenReturn(captureProcessConfig);
         when(cardCaptureService.doCapture(anyString())).thenReturn(captureResponse);
-        when(chargeEntity.getId()).thenReturn(chargeId);
-        when(chargeDao.findByExternalId(chargeExternalId)).thenReturn(Optional.of(chargeEntity));
 
         cardCaptureMessageProcess = new CardCaptureMessageProcess(captureQueue, cardCaptureService, connectorConfiguration, chargeDao);
     }
@@ -96,7 +76,7 @@ public class CardCaptureMessageProcessTest {
     @Test
     public void shouldScheduleRetriableMessageGivenUnsuccessfulChargeCapture() throws QueueException {
         when(captureResponse.isSuccessful()).thenReturn(false);
-        when(chargeDao.countCaptureRetriesForCharge(chargeId)).thenReturn(RETRIABLE_NUMBER_OF_CAPTURE_ATTEMPTS);
+        when(chargeDao.countCaptureRetriesForChargeExternalId(chargeExternalId)).thenReturn(RETRIABLE_NUMBER_OF_CAPTURE_ATTEMPTS);
 
         cardCaptureMessageProcess.handleCaptureMessages();
 
@@ -106,23 +86,11 @@ public class CardCaptureMessageProcessTest {
     @Test
     public void shouldMarkNonRetribaleMessageAsProcessed_MarkChargeAsCaptureErrorGivenUnsuccessfulChargeCapture() throws QueueException {
         when(captureResponse.isSuccessful()).thenReturn(false);
-        when(chargeDao.countCaptureRetriesForCharge(chargeId)).thenReturn(MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS);
+        when(chargeDao.countCaptureRetriesForChargeExternalId(chargeExternalId)).thenReturn(MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS + 1);
 
         cardCaptureMessageProcess.handleCaptureMessages();
 
         verify(cardCaptureService).markChargeAsCaptureError(chargeExternalId);
         verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage);
-    }
-
-    @Test
-    public void shouldThrowQueueExceptionGivenNonExistingCharge_UneccessfulChargeCapture() throws QueueException {
-        when(captureResponse.isSuccessful()).thenReturn(false);
-        when(chargeDao.findByExternalId(chargeExternalId)).thenReturn(Optional.empty());
-
-        cardCaptureMessageProcess.handleCaptureMessages();
-
-        verify(mockAppender, atLeastOnce()).doAppend(loggingEventArgumentCaptor.capture());
-        List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
-        assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Error capturing charge from SQS message [Invalid message on capture retry " + chargeExternalId + "]")), is(true));
     }
 }


### PR DESCRIPTION
On failure:
* defer queue message for 1 hour with [visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html)

Given too many retries:
* mark charge as capture error
* mark queue message as finally processed


- [x] needs to be rebased to https://github.com/alphagov/pay-connector/pull/1330 when this is merged into `master`

- [x] ~~should verify integration between message receiver and retry logic (if > maximum retries, if < maximum retries -- depends on integration decisions made in https://github.com/alphagov/pay-connector/pull/1330)~~
- [x] unit tests for handling retry behaviour + configuration