### PR TITLE
BAU Ensure stable ordering in getInternalEvents

### DIFF
--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -610,7 +610,7 @@ public class DatabaseTestHelper {
 
     public List<String> getInternalEvents(String externalChargeId) {
         return jdbi.withHandle(h ->
-                h.createQuery("SELECT status from charge_events WHERE charge_id = (SELECT id from charges WHERE external_id=:external_id)")
+                h.createQuery("SELECT status from charge_events WHERE charge_id = (SELECT id from charges WHERE external_id=:external_id) order by charge_events.id")
                         .bind("external_id", externalChargeId)
                         .map(StringColumnMapper.INSTANCE)
                         .list()


### PR DESCRIPTION
There are tests that check the order of internal events

however this SQL query did not specify an explicit ordering on events. Without
an explicit `ORDER BY` clause there is no guarantee of the order of events
returned by the query, so this test could be flaky (and has been observed to be
flaky at least in local development environments) due ot the unstable ordering.

This PR adds an explicit stable ordering to the test helper.