### PR TITLE
PP-4060 clean up expired tokens sweep method

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -244,7 +244,7 @@ public class ChargesApiResource {
     @Path("/v1/tasks/expired-charges-sweep")
     @Produces(APPLICATION_JSON)
     public Response expireCharges(@Context UriInfo uriInfo) {
-        Map<String, Integer> resultMap = chargeExpiryService.sweepAndExpireCharges();
+        Map<String, Integer> resultMap = chargeExpiryService.sweepAndExpireChargesAndTokens();
         return successResponseWithEntity(resultMap);
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -55,7 +55,7 @@ public class ChargeExpiryService {
 
     private static final String EXPIRY_SUCCESS = "expiry-success";
     private static final String EXPIRY_FAILED = "expiry-failed";
-    private static final long DAYS_TILL_EXPIRY = -7;
+    private static final long TOKEN_EXPIRY_DAYS = 7;
 
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;
@@ -144,8 +144,8 @@ public class ChargeExpiryService {
     }
     
     private int deleteTokensOlderThanSpecifiedDate() {
-        ZonedDateTime cut_off_date = ZonedDateTime.now(ZoneId.of("UTC")).plusDays(DAYS_TILL_EXPIRY);
-        return tokenDao.deleteTokensOlderThanSpecifiedDate(cut_off_date);
+        ZonedDateTime cutOffDate = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(TOKEN_EXPIRY_DAYS);
+        return tokenDao.deleteTokensOlderThanSpecifiedDate(cutOffDate);
     }
     
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -56,7 +56,7 @@ public class ChargeExpiryService {
     private static final String EXPIRY_SUCCESS = "expiry-success";
     private static final String EXPIRY_FAILED = "expiry-failed";
     private static final long TOKEN_EXPIRY_DAYS = 7;
-
+    
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;
     private final TokenDao tokenDao;
@@ -130,7 +130,7 @@ public class ChargeExpiryService {
         }
     }
 
-    public Map<String, Integer> sweepAndExpireCharges() {
+    public Map<String, Integer> sweepAndExpireChargesAndTokens() {
         List<ChargeEntity> chargesToExpire = new ImmutableList.Builder<ChargeEntity>()
                 .addAll(getChargesToExpireWithRegularExpiryThreshold())
                 .addAll(getChargesToExpireWithDelayedExpiryThreshold())

--- a/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
+++ b/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.token.model.domain.TokenEntity;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 @Transactional
@@ -31,5 +32,12 @@ public class TokenDao extends JpaDao<TokenEntity> {
                 .setParameter("chargeId", chargeId)
                 .getResultList().stream()
                 .findFirst();
+    }
+
+    public int deleteTokensOlderThanSpecifiedDate(ZonedDateTime cut_off_date) {
+        return entityManager.get()
+                .createQuery("DELETE FROM TokenEntity t WHERE t.createdDate < :cut_off_date", TokenEntity.class)
+                .setParameter("cut_off_date", cut_off_date)
+                .executeUpdate();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
+++ b/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
@@ -34,10 +34,10 @@ public class TokenDao extends JpaDao<TokenEntity> {
                 .findFirst();
     }
 
-    public int deleteTokensOlderThanSpecifiedDate(ZonedDateTime cut_off_date) {
+    public int deleteTokensOlderThanSpecifiedDate(ZonedDateTime cutOffDate) {
         return entityManager.get()
-                .createQuery("DELETE FROM TokenEntity t WHERE t.createdDate < :cut_off_date", TokenEntity.class)
-                .setParameter("cut_off_date", cut_off_date)
+                .createQuery("DELETE FROM TokenEntity t WHERE t.createdDate < :cutOffDate", TokenEntity.class)
+                .setParameter("cutOffDate", cutOffDate)
                 .executeUpdate();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
+++ b/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
@@ -33,7 +33,7 @@ public class TokenDao extends JpaDao<TokenEntity> {
                 .getResultList().stream()
                 .findFirst();
     }
-
+    
     public int deleteTokensOlderThanSpecifiedDate(ZonedDateTime cutOffDate) {
         return entityManager.get()
                 .createQuery("DELETE FROM TokenEntity t WHERE t.createdDate < :cutOffDate", TokenEntity.class)

--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
@@ -3,8 +3,10 @@ package uk.gov.pay.connector.token.model.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
+import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -13,6 +15,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 @Entity
@@ -28,6 +31,10 @@ public class TokenEntity extends AbstractVersionedEntity {
 
     @Column(name = "secure_redirect_token")
     private String token;
+    
+    @Column(name = "created_date")
+    @Convert(converter = UTCDateTimeConverter.class)
+    private ZonedDateTime createdDate;
     
     @ManyToOne
     @JoinColumn(name = "charge_id", nullable = false)
@@ -60,7 +67,15 @@ public class TokenEntity extends AbstractVersionedEntity {
     public void setToken(String token) {
         this.token = token;
     }
-    
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(ZonedDateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
     public ChargeEntity getChargeEntity() {
         return chargeEntity;
     }

--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
@@ -47,6 +47,7 @@ public class TokenEntity extends AbstractVersionedEntity {
     public static TokenEntity generateNewTokenFor(ChargeEntity chargeEntity) {
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChargeEntity(chargeEntity);
+        tokenEntity.setCreatedDate(chargeEntity.getCreatedDate());
         tokenEntity.setToken(UUID.randomUUID().toString());
         
         return tokenEntity;

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -236,7 +236,7 @@ public class ChargeExpiryServiceTest {
         when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS))).thenReturn(singletonList(chargeEntityAwaitingCapture));
         when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(chargeEntityAuthorisationSuccess));
 
-        chargeExpiryService.sweepAndExpireCharges();
+        chargeExpiryService.sweepAndExpireChargesAndTokens();
 
         assertThat(chargeEntityAwaitingCapture.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
         assertThat(chargeEntityAuthorisationSuccess.getStatus(), is(ChargeStatus.EXPIRED.getValue()));
@@ -261,7 +261,7 @@ public class ChargeExpiryServiceTest {
         doNothing().when(mockChargeEventDao).persistChargeEventOf(any(ChargeEntity.class));
         when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(preAuthorisationCharge));
 
-        Map<String, Integer> sweepResult = chargeExpiryService.sweepAndExpireCharges();
+        Map<String, Integer> sweepResult = chargeExpiryService.sweepAndExpireChargesAndTokens();
 
         assertThat(sweepResult.get("expiry-success"), is(1));
         assertNull(sweepResult.get("expiry-failure"));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayCancelResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.paymentprocessor.service.QueryService;
+import uk.gov.pay.connector.token.dao.TokenDao;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -61,6 +62,9 @@ public class ChargeExpiryServiceTest {
 
     @Mock
     private ChargeEventDao mockChargeEventDao;
+    
+    @Mock
+    private TokenDao mockTokenDao;
     
     @Mock
     private PaymentProviders mockPaymentProviders;
@@ -105,7 +109,7 @@ public class ChargeExpiryServiceTest {
     @Before
     public void setup() {
         when(mockedConfig.getChargeSweepConfig()).thenReturn(mockedChargeSweepConfig);
-        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, mockQueryService, mockedConfig);
+        chargeExpiryService = new ChargeExpiryService(mockChargeDao, mockChargeEventDao, mockTokenDao, mockPaymentProviders, mockQueryService, mockedConfig);
         when(mockPaymentProviders.byName(PaymentGatewayName.WORLDPAY)).thenReturn(mockPaymentProvider);
         GatewayResponseBuilder<BaseCancelResponse> gatewayResponseBuilder = responseBuilder();
         gatewayResponse = gatewayResponseBuilder.withResponse(mockWorldpayCancelResponse).build();
@@ -221,7 +225,7 @@ public class ChargeExpiryServiceTest {
                 .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
-
+        
         when(mockWorldpayCancelResponse.cancelStatus()).thenReturn(CancelStatus.CANCELLED);
 
         when(mockChargeDao.findByExternalId(chargeEntityAwaitingCapture.getExternalId())).thenReturn(Optional.of(chargeEntityAwaitingCapture));

--- a/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
@@ -111,35 +111,35 @@ public class TokenDaoJpaIT extends DaoITestBase {
     @Test
     public void deleteByCutOffDate_shouldDeleteOlderTokens() {
         
-        long days_till_expiry = -7;
-        long days_longer_than_expiry = -8;
-        ZonedDateTime cut_off_date = ZonedDateTime.now(ZoneId.of("UTC")).plusDays(days_till_expiry);
+        long daysTillExpiry = 7;
+        long daysLongerThanExpiry = 8;
+        ZonedDateTime cut_off_date = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(daysTillExpiry);
         ZonedDateTime today = ZonedDateTime.now(ZoneId.of("UTC"));
-        ZonedDateTime eight_days_old = ZonedDateTime.now(ZoneId.of("UTC")).plusDays(days_longer_than_expiry);
+        ZonedDateTime eight_days_old = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(daysLongerThanExpiry);
         
-        String present_day_tokenId = "token1";
-        String eight_days_old_tokenId = "token2";
+        String presentDayTokenId = "token1";
+        String eightDaysOldTokenId = "token2";
         
         ChargeEntity ChargeTestEntity = new ChargeEntity();
         ChargeTestEntity.setId(defaultTestCharge.getChargeId());
         
         TokenEntity present_day_token = TokenEntity.generateNewTokenFor(ChargeTestEntity);
         present_day_token.setCreatedDate(today);
-        present_day_token.setToken(present_day_tokenId);
+        present_day_token.setToken(presentDayTokenId);
         tokenDao.persist(present_day_token);
         
         TokenEntity eight_day_old_token = TokenEntity.generateNewTokenFor(ChargeTestEntity);
         eight_day_old_token.setCreatedDate(eight_days_old);
-        eight_day_old_token.setToken(eight_days_old_tokenId);
+        eight_day_old_token.setToken(eightDaysOldTokenId);
         tokenDao.persist(eight_day_old_token);
         
         tokenDao.deleteTokensOlderThanSpecifiedDate(cut_off_date);
         
-        assertThat(tokenDao.findByTokenId(eight_days_old_tokenId), is(Optional.empty()));
+        assertThat(tokenDao.findByTokenId(eightDaysOldTokenId), is(Optional.empty()));
 
-        TokenEntity present_token = tokenDao.findByTokenId(present_day_tokenId).get();
+        TokenEntity present_token = tokenDao.findByTokenId(presentDayTokenId).get();
         assertThat(present_token.getId(), is(notNullValue()));
-        assertThat(present_token.getToken(), is(present_day_tokenId));
+        assertThat(present_token.getToken(), is(presentDayTokenId));
         assertThat(present_token.getCreatedDate(), is(today));
         
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
@@ -113,9 +113,9 @@ public class TokenDaoJpaIT extends DaoITestBase {
         
         long daysTillExpiry = 7;
         long daysLongerThanExpiry = 8;
-        ZonedDateTime cut_off_date = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(daysTillExpiry);
+        ZonedDateTime cutOffDate = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(daysTillExpiry);
         ZonedDateTime today = ZonedDateTime.now(ZoneId.of("UTC"));
-        ZonedDateTime eight_days_old = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(daysLongerThanExpiry);
+        ZonedDateTime eightDaysOld = ZonedDateTime.now(ZoneId.of("UTC")).minusDays(daysLongerThanExpiry);
         
         String presentDayTokenId = "token1";
         String eightDaysOldTokenId = "token2";
@@ -123,24 +123,25 @@ public class TokenDaoJpaIT extends DaoITestBase {
         ChargeEntity ChargeTestEntity = new ChargeEntity();
         ChargeTestEntity.setId(defaultTestCharge.getChargeId());
         
-        TokenEntity present_day_token = TokenEntity.generateNewTokenFor(ChargeTestEntity);
-        present_day_token.setCreatedDate(today);
-        present_day_token.setToken(presentDayTokenId);
-        tokenDao.persist(present_day_token);
+        TokenEntity presentDayToken = TokenEntity.generateNewTokenFor(ChargeTestEntity);
+        presentDayToken.setCreatedDate(today);
+        presentDayToken.setToken(presentDayTokenId);
+
+        tokenDao.persist(presentDayToken);
         
-        TokenEntity eight_day_old_token = TokenEntity.generateNewTokenFor(ChargeTestEntity);
-        eight_day_old_token.setCreatedDate(eight_days_old);
-        eight_day_old_token.setToken(eightDaysOldTokenId);
-        tokenDao.persist(eight_day_old_token);
+        TokenEntity eightDayOldToken = TokenEntity.generateNewTokenFor(ChargeTestEntity);
+        eightDayOldToken.setCreatedDate(eightDaysOld);
+        eightDayOldToken.setToken(eightDaysOldTokenId);
         
-        tokenDao.deleteTokensOlderThanSpecifiedDate(cut_off_date);
+        tokenDao.persist(eightDayOldToken);
+        
+        tokenDao.deleteTokensOlderThanSpecifiedDate(cutOffDate);
         
         assertThat(tokenDao.findByTokenId(eightDaysOldTokenId), is(Optional.empty()));
 
-        TokenEntity present_token = tokenDao.findByTokenId(presentDayTokenId).get();
-        assertThat(present_token.getId(), is(notNullValue()));
-        assertThat(present_token.getToken(), is(presentDayTokenId));
-        assertThat(present_token.getCreatedDate(), is(today));
-        
+        TokenEntity presentToken = tokenDao.findByTokenId(presentDayTokenId).get();
+        assertThat(presentToken.getId(), is(notNullValue()));
+        assertThat(presentToken.getToken(), is(presentDayTokenId));
+        assertThat(presentToken.getCreatedDate(), is(today));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

- Adds a createdDate field to the TokenEntity class
- Fills the createdDate field by getting the createdDate from the ChargeEntity when passed into the constructor
- Adds a method (deleteTokensOlderThanSpecifiedDate) in tokenDao to delete tokens which have expired for more than 7 days
- Adds a method (deleteTokensOlderThanSpecifiedDate) in ChargeExpiryService
- Calls deleteTokensOlderThanSpecifiedDate in the sweepAndExpireCharges() method in ChargeExpiryService

## Code review checklist

- Check logic of tokenDao delete tokens method
