### PR TITLE
PP-4060 test refactorings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,6 +342,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.npathai</groupId>
+            <artifactId>hamcrest-optional</artifactId>
+            <version>2.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.27.0</version>


### PR DESCRIPTION
Some stylistic tweaks to the test

Feedback welcome. I talked this through with @nimalank7 

What I did:

- string literal rather than local vars for token names. Use of meaningful/intention revealing token names.
- date offsets also don't benefit much from local variables, especially if defined in relation to `today`
- introduce hamcrest matcher for optional which simplifies the assertions

