### PR TITLE
PP-5171 Set SQS Docker flag to false by default

### DIFF
--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardConfig.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardConfig.java
@@ -61,7 +61,7 @@ public @interface DropwizardConfig {
      *
      * @return boolean
      */
-    boolean withDockerSQS() default true;
+    boolean withDockerSQS() default false;
     
     ConfigOverride[] configOverrides() default {};
 }


### PR DESCRIPTION
Only certain specific tests need a docker queue, so default the flag controlling this to false, and allow
config ovveride to set to true when needed.
