### PR TITLE
Run integration tests in parallel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -527,6 +527,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <forkCount>2</forkCount>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This reduces the maven build time on CI from ~14 minutes to ~8 minutes, i.e. ~15% of overall build time