### PR TITLE
PP-5273 Adds constraints for SQSConfig

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/SqsConfig.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.app;
 import io.dropwizard.Configuration;
 import uk.gov.pay.connector.app.validator.ValidSqsConfig;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
 
 @ValidSqsConfig
@@ -18,7 +19,9 @@ public class SqsConfig extends Configuration {
     private String accessKey;
     private String secretKey;
 
+    @Max(20)
     private int messageMaximumWaitTimeInSeconds;
+    @Max(10)
     private int messageMaximumBatchSize;
 
     public String getEndpoint() {


### PR DESCRIPTION
## WHAT YOU DID

- Adds constraints for SQS configuration so misconfiguration can be detected on container startup.

SQS SDK errors with message ` InvalidParameterValue; see the SQS docs. (Service: AmazonSQS; Status Code: 400; Error Code: InvalidParameterValue; Request ID: 00000000-0000-0000-0000-000000000000` when receiving messages which will be hard to debug

