### PR TITLE
PP-5273 Write to Queue after DB transaction

### DIFF
--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -494,12 +494,13 @@ public class CardCaptureServiceTest extends CardServiceTest {
                 mockConfiguration);
 
         String externalId = "external-id";
-        ChargeEntity charge = createNewChargeWith("worldpay", 1L, EXPIRED, "gatewayTxId");
+        ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_SUCCESS, "gatewayTxId");
         when(mockedChargeDao.findByExternalId(externalId)).thenReturn(Optional.of(charge));
 
         try {
             cardCaptureService.markChargeAsEligibleForCapture(externalId);
         } catch (WebApplicationException e) {
+            verify(mockCaptureQueue).sendForCapture(charge);
             verify(mockedChargeDao).findByExternalId(externalId);
             verify(mockedChargeEventDao, never()).persistChargeEventOf(any(ChargeEntity.class), any(ZonedDateTime.class));
             verifyNoMoreInteractions(mockedChargeDao);


### PR DESCRIPTION
## WHAT YOU DID
- Updating/Committing charge status (for CAPTURE_APPROVED) before sending the charge to queue so that
    - queue message receiver won't receive the charge before the charge status commited to CAPTURE_APPROVED state.

Receiving charge from queue and processing (before charge being committed with CAPTURE_APPROVED state) will lead to below exception as charge will be read/updated concurrently by `CardCaptureService` and `CardCaptureMessageProcess`

`org.eclipse.persistence.exceptions.OptimisticLockException
The object [uk.gov.pay.connector.charge.model.domain.ChargeEntity@xxxxxx] cannot be updated because it has changed or been deleted since it was last read.`

