### PR TITLE
BAU Fix default capture queue write + docker SQS IT

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
@@ -25,7 +25,7 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
 public class CardResourceCaptureIT extends ChargingITestBase {
 
     public CardResourceCaptureIT() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -55,7 +55,7 @@ import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
 public class ChargesApiResourceIT extends ChargingITestBase {
 
     private static final String JSON_CHARGE_KEY = "charge_id";

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
@@ -39,7 +39,7 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthori
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
 public class SmartpayCardResourceIT extends ChargingITestBase {
 
     private String validCardDetails = buildCardDetailsWith("737");
@@ -172,7 +172,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
         String chargeId = createNewChargeWithNoTransactionId(ChargeStatus.ENTERING_CARD_DETAILS);
         JsonNode validPayload = Jackson.getObjectMapper().readTree(
                 fixture("googlepay/example-auth-request.json"));
-        
+
         given().port(testContext.getPort())
                 .contentType(JSON)
                 .body(validPayload)
@@ -182,7 +182,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
                 .body("message", contains("Wallets are not supported for Smartpay"))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
-    
+
     @Test
     public void shouldPersistTransactionIds_duringAuthorisationAndCapture() {
         String externalChargeId = createNewChargeWithNoTransactionId(ChargeStatus.ENTERING_CARD_DETAILS);

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
@@ -63,7 +63,7 @@ import static uk.gov.pay.connector.junit.DropwizardJUnitRunner.WIREMOCK_PORT;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
 public class StripeResourceAuthorizeIT {
     private static final String CARD_HOLDER_NAME = "Scrooge McDuck";
     private static final String CVC = "123";

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -35,7 +35,7 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
 public class WorldpayCardResourceIT extends ChargingITestBase {
 
     private String validAuthorisationDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "visa");


### PR DESCRIPTION
Integration tests currently rely on testcontainers SQS docker container,
now that we are writing to the capture queue by default we
should turn these on -- wiremock to potentially be used in the future.