### PR TITLE
BAU: Handle all exceptions to avoid scheduler blowing up

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureMessageProcess;
-import uk.gov.pay.connector.queue.QueueException;
 
 import javax.inject.Inject;
 import java.util.concurrent.ScheduledExecutorService;
@@ -62,7 +61,7 @@ public class QueueMessageReceiver implements Managed {
                 while (!isInterrupted()) {
                     try {
                         cardCaptureMessageProcess.handleCaptureMessages();
-                    } catch (QueueException e) {
+                    } catch (Exception e) {
                         LOGGER.error("Queue message receiver thread exception [{}]", e);
                     }
                 }


### PR DESCRIPTION
## WHAT YOU DID
Avoids capture process being terminated due to unchecked exceptions by SQS client. Similar issue but due to DB exception https://github.com/alphagov/pay-connector/pull/1088

