### PR TITLE
PP-5249 Use event queue to emit PaymentCreated event

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
@@ -1,6 +1,12 @@
 package uk.gov.pay.connector.it.resources;
 
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.PurgeQueueRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import io.restassured.response.ValidatableResponse;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.postgresql.util.PGobject;
@@ -9,13 +15,19 @@ import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.util.ExternalMetadataConverter;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.ConfigOverride;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import javax.ws.rs.core.Response.Status;
+import java.sql.Timestamp;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static io.restassured.http.ContentType.JSON;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -35,6 +47,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.Assert.assertNull;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.events.MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
 import static uk.gov.pay.connector.matcher.ResponseContainsLinkMatcher.containsLink;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -42,7 +55,12 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJsonWithNulls;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+@DropwizardConfig(
+        app = ConnectorApp.class,
+        config = "config/test-it-config.yaml",
+        withDockerSQS = true, 
+        configOverrides = {@ConfigOverride(key = "eventQueue.eventQueueEnabled", value = "true")}
+)
 public class ChargesApiCreateResourceIT extends ChargingITestBase {
 
     private static final String FRONTEND_CARD_DETAILS_URL = "/secure";
@@ -75,6 +93,13 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
 
     public ChargesApiCreateResourceIT() {
         super(PROVIDER_NAME);
+    }
+    
+    @Before
+    @Override
+    public void setup() {
+        purgeEventQueue();
+        super.setup();
     }
 
     @Test
@@ -696,6 +721,50 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
                 .contentType(JSON)
                 .body("message", contains("Field [metadata] must be an object of JSON key-value pairs"))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+    }
+    
+    @Test
+    public void shouldEmitPaymentCreatedEventWhenChargeIsSuccessfullyCreated() {
+        String postBody = toJson(Map.of(
+                JSON_AMOUNT_KEY, AMOUNT,
+                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
+                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
+                JSON_RETURN_URL_KEY, RETURN_URL
+        ));
+
+        final ValidatableResponse response = connectorRestApiClient
+                .postCreateCharge(postBody)
+                .statusCode(201);
+
+        String chargeExternalId = response.extract().path(JSON_CHARGE_KEY);
+        final Map<String, Object> persistedCharge = databaseTestHelper.getChargeByExternalId(chargeExternalId);
+        final ZonedDateTime persistedCreatedDate = ZonedDateTime.ofInstant(((Timestamp) persistedCharge.get("created_date")).toInstant(), ZoneOffset.UTC);
+
+        List<Message> messages = readMessagesFromEventQueue();
+        
+        assertThat(messages.size(), is(1));
+        final Message message = messages.get(0);
+        assertThat(message.getBody(), hasJsonPath("$.event_type", equalTo("PaymentCreated")));
+        assertThat(message.getBody(), hasJsonPath("$.time", equalTo(MICROSECOND_FORMATTER.format(persistedCreatedDate))));
+    }
+
+    private List<Message> readMessagesFromEventQueue() {
+        AmazonSQS sqsClient = testContext.getInstanceFromGuiceContainer(AmazonSQS.class);
+
+        ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(testContext.getEventQueueUrl());
+        receiveMessageRequest
+                .withMessageAttributeNames()
+                .withWaitTimeSeconds(1)
+                .withMaxNumberOfMessages(10);
+
+        ReceiveMessageResult receiveMessageResult = sqsClient.receiveMessage(receiveMessageRequest);
+
+        return receiveMessageResult.getMessages();
+    }
+    
+    private void purgeEventQueue() {
+        AmazonSQS sqsClient = testContext.getInstanceFromGuiceContainer(AmazonSQS.class);
+        sqsClient.purgeQueue(new PurgeQueueRequest(testContext.getEventQueueUrl()));
     }
 
     private String expectedChargeLocationFor(String accountId, String chargeId) {

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardJUnitRunner.java
@@ -68,8 +68,9 @@ public final class DropwizardJUnitRunner extends JUnitParamsRunner {
         }
 
         if (dropwizardConfigAnnotation.withDockerSQS()) {
-            SqsTestDocker.initialise("capture-queue");
+            SqsTestDocker.initialise("capture-queue", "event-queue");
             configOverride.add(config("sqsConfig.captureQueueUrl", getQueueUrl("capture-queue")));
+            configOverride.add(config("sqsConfig.eventQueueUrl", getQueueUrl("event-queue")));
         }
 
         if (dropwizardConfigAnnotation.configOverrides().length > 0) {

--- a/src/test/java/uk/gov/pay/connector/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/connector/junit/TestContext.java
@@ -58,4 +58,8 @@ public class TestContext {
     String getDatabasePassword() {
         return databasePassword;
     }
+    
+    public String getEventQueueUrl() {
+        return connectorConfiguration.getSqsConfig().getEventQueueUrl();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
@@ -16,6 +17,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
@@ -48,6 +50,8 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
+    @Mock
+    private EventQueue eventQueue;
 
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
     private ChargeService chargeService;
@@ -63,7 +67,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null);
+                null, mockConfiguration, null, eventQueue);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -88,6 +89,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private Counter mockCounter;
 
+    @Mock
+    private EventQueue eventQueue;
+
     private CardAuthoriseService cardAuthorisationService;
 
     @Before
@@ -97,7 +101,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null);
+                null, null, mockConfiguration, null, eventQueue);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -98,6 +99,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private ConnectorConfiguration mockConfiguration;
     @Mock
     private Environment mockEnvironment;
+    @Mock
+    private EventQueue eventQueue;
 
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
@@ -109,7 +112,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null);
+                null, null, mockConfiguration, null, eventQueue);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
@@ -87,6 +88,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private Counter mockCounter;
+    @Mock
+    private EventQueue eventQueue;
 
     private WalletAuthoriseService walletAuthoriseService;
     
@@ -110,7 +113,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null);
+                null, null, mockConfiguration, null, eventQueue);
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
Use the event queue to emit PaymentCreated event on payment creation.
The event is emitted after the new payment is committed to the database.
This ensures that an event is emitted if and only if the payment is 
successfully created. If the event emission fails the whole request 
will fail, and the payment journey will be aborted.