### PR TITLE
BAU: Include `CAPTURE_SUBMITTED` in capture handler

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -437,9 +437,10 @@ public class ChargeService {
         return numberOfChargeRetries <= captureProcessConfig.getMaximumRetries();
     }
 
-    public boolean isChargeCaptured(String externalId) {
+    public boolean isChargeCaptureSuccess(String externalId) {
         ChargeEntity charge = findChargeById(externalId);
-        return ChargeStatus.fromString(charge.getStatus()) == CAPTURED;
+        ChargeStatus status = ChargeStatus.fromString(charge.getStatus());
+        return status == CAPTURED || status == CAPTURE_SUBMITTED;
     }
 
     private CardDetailsEntity buildCardDetailsEntity(AuthCardDetails authCardDetails) {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcess.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcess.java
@@ -90,12 +90,19 @@ public class CardCaptureMessageProcess {
     }
 
     private void handleCapturedInvalidTransition(ChargeCaptureMessage captureMessage, IllegalStateRuntimeException e) throws QueueException {
-        if (chargeService.isChargeCaptured(captureMessage.getChargeId())) {
-            LOGGER.info("Charge capture message [{}] already captured - marking as processed.", captureMessage.getChargeId());
+        if (chargeService.isChargeCaptureSuccess(captureMessage.getChargeId())) {
+            LOGGER.info(
+                    "Charge capture message [{}] already captured - marking as processed. [chargeId={}]",
+                    captureMessage.getQueueMessageId(),
+                    captureMessage.getChargeId());
             captureQueue.markMessageAsProcessed(captureMessage);
             return;
         }
 
+        LOGGER.info(
+                "Capture process non-success illegal state transition for message {} [chargeId={}]",
+                captureMessage.getQueueMessageId(),
+                captureMessage.getChargeId());
         throw e;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureMessageProcessTest.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CardCaptureMessageProcessTest {
-    
+
     @Mock
     CaptureQueue captureQueue;
 
@@ -94,7 +94,7 @@ public class CardCaptureMessageProcessTest {
     @Test
     public void shouldMarkMessageAsProcessedGivenChargeInCapturedState() throws QueueException {
         when(cardCaptureService.doCapture(anyString())).thenThrow(IllegalStateRuntimeException.class);
-        when(chargeService.isChargeCaptured(anyString())).thenReturn(true);
+        when(chargeService.isChargeCaptureSuccess(anyString())).thenReturn(true);
 
         cardCaptureMessageProcess.handleCaptureMessages();
 


### PR DESCRIPTION
Connector is reporting errors on processing any message in the `CAPTURE_SUBMITTED` state -- this state should be considered final according to the capture process. 

* Add `CAPTURE_SUBMITTED` state to success handler
* Log any illegal state transitions not following the happy path