### PR TITLE
PP-5292 - Modifies populateResponseBuilderWith(...) to not generate tokens and next_url/next_url_post for search results

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeSearchStrategy.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeSearchStrategy.java
@@ -34,6 +34,6 @@ public class ChargeSearchStrategy extends AbstractSearchStrategy<ChargeEntity, C
 
     @Override
     public ChargeResponse buildResponse(UriInfo uriInfo, ChargeEntity chargeEntity) {
-        return chargeService.populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity).build();
+        return chargeService.populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity, true).build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -288,7 +288,7 @@ public class ChargeService {
 
     private boolean needsNextUrl(ChargeEntity chargeEntity, boolean buildForSearchResult) {
         ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
-        return !buildForSearchResult && !chargeStatus.toExternal().isFinished() && !chargeStatus.equals(ChargeStatus.AWAITING_CAPTURE_REQUEST);
+        return !buildForSearchResult && !chargeStatus.toExternal().isFinished() && !chargeStatus.equals(AWAITING_CAPTURE_REQUEST);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -124,7 +124,7 @@ public class ChargeService {
         return createCharge(chargeRequest, accountId, uriInfo)
                 .map(charge -> {
                     emitCreationEvent(charge);
-                    return populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, charge).build();
+                    return populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, charge, false).build();
                 });
     }
 
@@ -193,7 +193,7 @@ public class ChargeService {
     public Optional<ChargeResponse> findChargeForAccount(String chargeId, Long accountId, UriInfo uriInfo) {
         return chargeDao
                 .findByExternalIdAndGatewayAccount(chargeId, accountId)
-                .map(chargeEntity -> populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity).build());
+                .map(chargeEntity -> populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity, false).build());
     }
 
     @Transactional
@@ -222,7 +222,7 @@ public class ChargeService {
                 }).orElse(Optional.empty());
     }
 
-    public <T extends AbstractChargeResponseBuilder<T, R>, R> AbstractChargeResponseBuilder<T, R> populateResponseBuilderWith(AbstractChargeResponseBuilder<T, R> responseBuilder, UriInfo uriInfo, ChargeEntity chargeEntity) {
+    public <T extends AbstractChargeResponseBuilder<T, R>, R> AbstractChargeResponseBuilder<T, R> populateResponseBuilderWith(AbstractChargeResponseBuilder<T, R> responseBuilder, UriInfo uriInfo, ChargeEntity chargeEntity, boolean buildForSearchResult) {
         String chargeId = chargeEntity.getExternalId();
         PersistedCard persistedCard = null;
         if (chargeEntity.getCardDetails() != null) {
@@ -273,8 +273,7 @@ public class ChargeService {
         // @TODO(sfount) consider if total and net columns could be calculation columns in postgres (single source of truth)
         chargeEntity.getNetAmount().ifPresent(builderOfResponse::withNetAmount);
 
-        ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
-        if (!chargeStatus.toExternal().isFinished() && !chargeStatus.equals(ChargeStatus.AWAITING_CAPTURE_REQUEST)) {
+        if (needsNextUrl(chargeEntity, buildForSearchResult)) {
             TokenEntity token = createNewChargeEntityToken(chargeEntity);
             Map<String, Object> params = new HashMap<>();
             params.put("chargeTokenId", token.getToken());
@@ -282,9 +281,14 @@ public class ChargeService {
             return builderOfResponse
                     .withLink("next_url", GET, nextUrl(token.getToken()))
                     .withLink("next_url_post", POST, nextUrl(), APPLICATION_FORM_URLENCODED, params);
+        } else {
+            return builderOfResponse;
         }
+    }
 
-        return builderOfResponse;
+    private boolean needsNextUrl(ChargeEntity chargeEntity, boolean buildForSearchResult) {
+        ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+        return !buildForSearchResult && !chargeStatus.toExternal().isFinished() && !chargeStatus.equals(ChargeStatus.AWAITING_CAPTURE_REQUEST);
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/it/resources/SearchChargesByDateResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/SearchChargesByDateResourceIT.java
@@ -74,6 +74,7 @@ public class SearchChargesByDateResourceIT {
     public void whenTheChargeCreatedDateIsBetweenTheFromDateAndTheToDate_shouldReturnTheCharge() {
         int millis = 299000000;
         String chargeId = addCharge(ZonedDateTime.of(2016, 2, 2, 0, 0, 0, millis, ZoneId.of("UTC")));
+        
         connectorRestApiClient
                 .withAccountId(accountId)
                 .withQueryParam("from_date", "2016-02-01T00:00:00Z")
@@ -87,7 +88,7 @@ public class SearchChargesByDateResourceIT {
                 .body("results[0].amount", is(AMOUNT))
                 .body("results[0].description", is("Test description"))
                 .body("results[0].state.status", is("created"))
-                .body("results[0].links.size()", is(4))
+                .body("results[0].links.size()", is(2))
                 .body("results[0].return_url", is("http://return.invalid/1"))
                 .body("results[0].created_date", is("2016-02-02T00:00:00.299Z"))
                 .body("results[0].reference", is("Test reference"));


### PR DESCRIPTION
## WHAT YOU DID
This PR modifies the populateResponseBuilderWith(...) method in ChargeService so that when we are generating search results it does not generate a token nor displays next_url or next_url_post however it continues to generate a token for finding a charge. This is done by adding a boolean buildForSearchResult parameter in populateResponseBuilderWith(...)

It adds a needsNextUrl method in ChargeService which takes a ChargeEntity as well as a boolean value buildForSearchResult. This method is then called within populateResponseBuilderWith(...)

The buildResponse method in ChargeSearchStrategy has buildForSearchResult set to true. All other calls to the populateResponseBuilderWith(...) have the buildForSearchResult set to false.

The whenTheChargeCreatedDateIsBetweenTheFromDateAndTheToDate_shouldReturnTheCharge() test in SearchChargesByDateResourceIT has the matcher changed to 2 for results[0].links.size() to reflect that next_url and next_url_post is no longer exposed in the search results.