### PR TITLE
BAU remove generics from events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/Event.java
@@ -13,13 +13,13 @@ import java.time.ZonedDateTime;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public abstract class Event<T extends EventDetails> {
+public abstract class Event {
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
 
     public abstract ResourceType getResourceType();
     public abstract String getResourceExternalId();
     public abstract String getEventType();
-    public abstract T getEventDetails();
+    public abstract EventDetails getEventDetails();
     @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
     public abstract ZonedDateTime getTimestamp();
     

--- a/src/main/java/uk/gov/pay/connector/events/PaymentCreatedEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentCreatedEvent.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.events.eventdetails.PaymentCreatedEventDetails;
 
 import java.time.ZonedDateTime;
 
-public class PaymentCreatedEvent extends PaymentEvent<PaymentCreatedEventDetails> {
+public class PaymentCreatedEvent extends PaymentEvent {
 
     private final ChargeEntity charge;
 

--- a/src/main/java/uk/gov/pay/connector/events/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentEvent.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.connector.events;
 
-import uk.gov.pay.connector.events.eventdetails.EventDetails;
-
-public abstract class PaymentEvent<T extends EventDetails> extends Event<T> {
+public abstract class PaymentEvent extends Event {
     @Override
     public ResourceType getResourceType() {
         return ResourceType.PAYMENT;


### PR DESCRIPTION
when you have a composite object ie. A has-a B, then if you also
use a generic to parameterise the type of B then you end up in a world of
pain.. ie A<T extends B> overspecifies the type of B that A has..

you don’t need to do that. You can just allow A to have a B and the B can be
any subclass of B. The consumers of A don't care what kind of B the B is.