### PR TITLE
PP-5317: emitting PaymentDetailsEnteredEvent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/exception/ChargeEventNotFoundRuntimeException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/ChargeEventNotFoundRuntimeException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+
+public class ChargeEventNotFoundRuntimeException extends WebApplicationException {
+    public ChargeEventNotFoundRuntimeException(String externalId) {
+        super(notFoundResponse(format("Charge with id [%s] does not have any events.", externalId)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -317,7 +317,7 @@ public class ChargeService {
         return chargeEntity;
     }
 
-    public ChargeEntity updateChargeAndEmitEventPostAuthorisation(String chargeExternalId,
+    private ChargeEntity updateChargeAndEmitEventPostAuthorisation(String chargeExternalId,
                                                                   ChargeStatus status,
                                                                   AuthCardDetails authCardDetails,
                                                                   Optional<String> transactionId,
@@ -333,6 +333,7 @@ public class ChargeService {
         return chargeEntity;
     }
 
+    // cannot be private: Guice requires @Transactional methods to be public
     @Transactional
     public ChargeEntity updateChargePostAuthorisation(String chargeExternalId,
                                                       ChargeStatus status,

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -38,6 +38,8 @@ import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeEx
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
+import uk.gov.pay.connector.events.PaymentDetailsEnteredEvent;
+import uk.gov.pay.connector.events.Event;
 import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.events.PaymentCreatedEvent;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -123,17 +125,17 @@ public class ChargeService {
     public Optional<ChargeResponse> create(ChargeCreateRequest chargeRequest, Long accountId, UriInfo uriInfo) {
         return createCharge(chargeRequest, accountId, uriInfo)
                 .map(charge -> {
-                    emitCreationEvent(charge);
+                    emitEvent(PaymentCreatedEvent.from(charge));
                     return populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, charge, false).build();
                 });
     }
 
-    private void emitCreationEvent(ChargeEntity charge) {
+    private void emitEvent(Event event) {
         try {
-            eventQueue.emitEvent(PaymentCreatedEvent.from(charge));
+            eventQueue.emitEvent(event);
         } catch (QueueException e) {
-            logger.error("Error emitting payment creation event: {}", e.getMessage());
-            throw new WebApplicationException(String.format("Error emitting payment creation event: %s", e.getMessage()));
+            logger.error("Error emitting {} event: {}", event.getEventType(), e.getMessage());
+            throw new WebApplicationException(String.format("Error emitting %s event: %s", event.getEventType(), e.getMessage()));
         }
     }
 
@@ -291,19 +293,63 @@ public class ChargeService {
         return !buildForSearchResult && !chargeStatus.toExternal().isFinished() && !chargeStatus.equals(AWAITING_CAPTURE_REQUEST);
     }
 
+    public ChargeEntity updateChargePostCardAuthorisation(String chargeExternalId,
+                                                          ChargeStatus status,
+                                                          Optional<String> transactionId,
+                                                          Optional<Auth3dsDetailsEntity> auth3dsDetails,
+                                                          Optional<String> sessionIdentifier,
+                                                          AuthCardDetails authCardDetails) {
+        return updateChargeAndEmitEventPostAuthorisation(chargeExternalId, status, authCardDetails, transactionId, auth3dsDetails, sessionIdentifier,
+                Optional.empty(), Optional.empty());
+
+    }
+
+    public ChargeEntity updateChargePostWalletAuthorisation(String chargeExternalId,
+                                                            ChargeStatus status,
+                                                            Optional<String> transactionId,
+                                                            Optional<String> sessionIdentifier,
+                                                            AuthCardDetails authCardDetails,
+                                                            WalletType walletType,
+                                                            String emailAddress) {
+        ChargeEntity chargeEntity = updateChargeAndEmitEventPostAuthorisation(chargeExternalId, status, authCardDetails, transactionId, Optional.empty(), sessionIdentifier,
+                Optional.ofNullable(walletType), Optional.ofNullable(emailAddress));
+
+        return chargeEntity;
+    }
+
+    public ChargeEntity updateChargeAndEmitEventPostAuthorisation(String chargeExternalId,
+                                                                  ChargeStatus status,
+                                                                  AuthCardDetails authCardDetails,
+                                                                  Optional<String> transactionId,
+                                                                  Optional<Auth3dsDetailsEntity> auth3dsDetails,
+                                                                  Optional<String> sessionIdentifier,
+                                                                  Optional<WalletType> walletType,
+                                                                  Optional<String> emailAddress) {
+        ChargeEntity chargeEntity = updateChargePostAuthorisation(chargeExternalId, status, authCardDetails, transactionId,
+                auth3dsDetails, sessionIdentifier, walletType, emailAddress);
+
+        emitEvent(PaymentDetailsEnteredEvent.from(chargeEntity));
+
+        return chargeEntity;
+    }
+
     @Transactional
     public ChargeEntity updateChargePostAuthorisation(String chargeExternalId,
                                                       ChargeStatus status,
-                                                      Optional<String> transactionId,
+                                                      AuthCardDetails authCardDetails, Optional<String> transactionId,
                                                       Optional<Auth3dsDetailsEntity> auth3dsDetails,
                                                       Optional<String> sessionIdentifier,
-                                                      AuthCardDetails authCardDetails) {
+                                                      Optional<WalletType> walletType,
+                                                      Optional<String> emailAddress) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             charge.setStatus(status);
 
             setTransactionId(charge, transactionId);
             sessionIdentifier.ifPresent(charge::setProviderSessionId);
             auth3dsDetails.ifPresent(charge::set3dsDetails);
+            walletType.ifPresent(charge::setWalletType);
+            emailAddress.ifPresent(charge::setEmail);
+
             CardDetailsEntity detailsEntity = buildCardDetailsEntity(authCardDetails);
             charge.setCardDetails(detailsEntity);
 
@@ -314,21 +360,6 @@ public class ChargeService {
 
             return charge;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
-    }
-
-    @Transactional
-    public ChargeEntity updateChargePostWalletAuthorisation(String chargeExternalId,
-                                                            ChargeStatus status,
-                                                            Optional<String> transactionId,
-                                                            Optional<Auth3dsDetailsEntity> auth3dsDetails,
-                                                            Optional<String> sessionIdentifier,
-                                                            AuthCardDetails authCardDetails,
-                                                            WalletType walletType,
-                                                            String emailAddress) {
-        ChargeEntity chargeEntity = updateChargePostAuthorisation(chargeExternalId, status, transactionId, auth3dsDetails, sessionIdentifier, authCardDetails);
-        chargeEntity.setWalletType(walletType);
-        chargeEntity.setEmail(emailAddress);
-        return chargeEntity;
     }
 
     @Transactional

--- a/src/main/java/uk/gov/pay/connector/events/EventQueue.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventQueue.java
@@ -22,7 +22,7 @@ public class EventQueue {
         this.eventQueueUrl = connectorConfiguration.getSqsConfig().getEventQueueUrl();
         this.eventQueueEnabled = connectorConfiguration.getEventQueueConfig().getEventQueueEnabled();
     }
-    
+
     public void emitEvent(Event event) throws QueueException {
         if (eventQueueEnabled) {
             try {

--- a/src/main/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEvent.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.events;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.PaymentDetailsEnteredEventDetails;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+public class PaymentDetailsEnteredEvent extends PaymentEvent {
+
+    private String resourceExternalId;
+    private PaymentDetailsEnteredEventDetails eventDetails;
+    private ZonedDateTime timestamp;
+
+    public PaymentDetailsEnteredEvent(String resourceExternalId, PaymentDetailsEnteredEventDetails eventDetails,
+                                      ZonedDateTime timestamp) {
+
+        this.resourceExternalId = resourceExternalId;
+        this.eventDetails = eventDetails;
+        this.timestamp = timestamp;
+    }
+
+    public static PaymentDetailsEnteredEvent from(ChargeEntity charge) {
+        ZonedDateTime lastEventDate = charge.getEvents().stream()
+                .map(ChargeEventEntity::getUpdated)
+                .max(ZonedDateTime::compareTo)
+                .orElse(null);
+
+        return new PaymentDetailsEnteredEvent(
+                charge.getExternalId(),
+                PaymentDetailsEnteredEventDetails.from(charge),
+                lastEventDate);
+    }
+
+    @Override
+    public String getResourceExternalId() {
+        return resourceExternalId;
+    }
+
+    @Override
+    public String getEventType() {
+        return "PAYMENT_DETAILS_EVENT";
+    }
+
+    @Override
+    public PaymentDetailsEnteredEventDetails getEventDetails() {
+        return eventDetails;
+    }
+
+    @Override
+    public ZonedDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public String getTitle() { return "Payment details entered event"; }
+
+    public String getDescription() { return "The event happens when the payment details are entered"; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentDetailsEnteredEvent that = (PaymentDetailsEnteredEvent) o;
+        return resourceExternalId.equals(that.resourceExternalId) &&
+                eventDetails.equals(that.eventDetails) &&
+                timestamp.equals(that.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceExternalId, eventDetails, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEvent.java
@@ -1,6 +1,8 @@
 package uk.gov.pay.connector.events;
 
+import uk.gov.pay.connector.charge.exception.ChargeEventNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.PaymentDetailsEnteredEventDetails;
 
@@ -23,9 +25,10 @@ public class PaymentDetailsEnteredEvent extends PaymentEvent {
 
     public static PaymentDetailsEnteredEvent from(ChargeEntity charge) {
         ZonedDateTime lastEventDate = charge.getEvents().stream()
+                .filter(e -> e.getStatus() == ChargeStatus.fromString(charge.getStatus()))
                 .map(ChargeEventEntity::getUpdated)
                 .max(ZonedDateTime::compareTo)
-                .orElse(null);
+                .orElseThrow(() -> new ChargeEventNotFoundRuntimeException(charge.getExternalId()));
 
         return new PaymentDetailsEnteredEvent(
                 charge.getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/PaymentDetailsEnteredEventDetails.java
@@ -1,0 +1,159 @@
+package uk.gov.pay.connector.events.eventdetails;
+
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class PaymentDetailsEnteredEventDetails extends EventDetails {
+
+    private final Long corporateSurcharge;
+    private final String email;
+    private final String cardBrand;
+    private final String firstDigitsCardNumber;
+    private final String lastDigitsCardNumber;
+    private final String gatewayTransactionId;
+    private final String cardholderName;
+    private final String expiryDate;
+    private final String addressLine1;
+    private final String addressLine2;
+    private final String addressPostcode;
+    private final String addressCity;
+    private final String addressCounty;
+    private final String addressCountry;
+    private final String wallet;
+
+    public PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardBrand,
+                                             String gatewayTransactionId, String firstDigitsCardNumber,
+                                             String lastDigitsCardNumber, String cardholderName, String expiryDate,
+                                             String addressLine1, String addressLine2, String addressPostcode,
+                                             String addressCity, String addressCounty, String addressCountry,
+                                             String wallet) {
+
+        this.corporateSurcharge = corporateSurcharge;
+        this.email = email;
+        this.cardBrand = cardBrand;
+        this.gatewayTransactionId = gatewayTransactionId;
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.cardholderName = cardholderName;
+        this.expiryDate = expiryDate;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.addressPostcode = addressPostcode;
+        this.addressCity = addressCity;
+        this.addressCounty = addressCounty;
+        this.addressCountry = addressCountry;
+        this.wallet = wallet;
+    }
+
+    public static PaymentDetailsEnteredEventDetails from(ChargeEntity charge) {
+        return new PaymentDetailsEnteredEventDetails(
+                charge.getCorporateSurcharge().orElse(null),
+                charge.getEmail(),
+                charge.getCardDetails().getCardBrand(),
+                charge.getGatewayTransactionId(),
+                Optional.ofNullable(charge.getCardDetails().getFirstDigitsCardNumber()).map(FirstDigitsCardNumber::toString).orElse(null),
+                charge.getCardDetails().getLastDigitsCardNumber().toString(),
+                charge.getCardDetails().getCardHolderName(),
+                charge.getCardDetails().getExpiryDate(),
+                charge.getCardDetails().getBillingAddress().map(a -> a.getLine1()).orElse(null),
+                charge.getCardDetails().getBillingAddress().map(a -> a.getLine2()).orElse(null),
+                charge.getCardDetails().getBillingAddress().map(a -> a.getPostcode()).orElse(null),
+                charge.getCardDetails().getBillingAddress().map(a -> a.getCity()).orElse(null),
+                charge.getCardDetails().getBillingAddress().map(a -> a.getCounty()).orElse(null),
+                charge.getCardDetails().getBillingAddress().map(a -> a.getCountry()).orElse(null),
+                Optional.ofNullable(charge.getWalletType()).map(Enum::toString).orElse(null)
+        );
+    }
+
+    public Long getCorporateSurcharge() {
+        return corporateSurcharge;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public String getFirstDigitsCardNumber() {
+        return firstDigitsCardNumber;
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getAddressPostcode() {
+        return addressPostcode;
+    }
+
+    public String getAddressCity() {
+        return addressCity;
+    }
+
+    public String getAddressCounty() {
+        return addressCounty;
+    }
+
+    public String getAddressCountry() {
+        return addressCountry;
+    }
+
+    public String getWallet() {
+        return wallet;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentDetailsEnteredEventDetails that = (PaymentDetailsEnteredEventDetails) o;
+        return Objects.equals(corporateSurcharge, that.corporateSurcharge) &&
+                Objects.equals(email, that.email) &&
+                Objects.equals(cardBrand, that.cardBrand) &&
+                Objects.equals(firstDigitsCardNumber, that.firstDigitsCardNumber) &&
+                Objects.equals(lastDigitsCardNumber, that.lastDigitsCardNumber) &&
+                Objects.equals(gatewayTransactionId, that.gatewayTransactionId) &&
+                Objects.equals(cardholderName, that.cardholderName) &&
+                Objects.equals(expiryDate, that.expiryDate) &&
+                Objects.equals(addressLine1, that.addressLine1) &&
+                Objects.equals(addressLine2, that.addressLine2) &&
+                Objects.equals(addressPostcode, that.addressPostcode) &&
+                Objects.equals(addressCity, that.addressCity) &&
+                Objects.equals(addressCounty, that.addressCounty) &&
+                Objects.equals(addressCountry, that.addressCountry) &&
+                Objects.equals(wallet, that.wallet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(corporateSurcharge, email, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
+                gatewayTransactionId, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode,
+                addressCounty, addressCountry, wallet);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -53,11 +53,11 @@ public class WalletAuthoriseService {
             ChargeStatus chargeStatus = null;
             String responseFromPaymentGateway = null;
             String requestStatus = "failure";
-            
+
             try {
                 operationResponse = authorise(charge, walletAuthorisationData);
                 Optional<BaseAuthoriseResponse> baseResponse = operationResponse.getBaseResponse();
-                
+
                 if (baseResponse.isPresent()) {
                     requestStatus = "success";
                     chargeStatus = baseResponse.get().authoriseStatus().getMappedChargeStatus();
@@ -69,18 +69,18 @@ public class WalletAuthoriseService {
                 }
 
             } catch (GatewayException e) {
-                
+
                 logger.error("Error occurred authorising charge. Charge external id: {}; message: {}", charge.getExternalId(), e.getMessage());
-                
+
                 if (e instanceof GatewayErrorException) {
                     logger.error("Response from gateway: {}", ((GatewayErrorException) e).getResponseFromGateway());
                 }
-                
+
                 chargeStatus = CardAuthoriseBaseService.mapFromGatewayErrorException(e);
                 responseFromPaymentGateway = e.getMessage();
                 operationResponse = GatewayResponse.GatewayResponseBuilder.responseBuilder().withGatewayError(e.toGatewayError()).build();
             }
-                
+
             logMetrics(charge, operationResponse, requestStatus, walletAuthorisationData.getWalletType());
 
             processGatewayAuthorisationResponse(
@@ -107,11 +107,11 @@ public class WalletAuthoriseService {
                             GatewayResponse<BaseAuthoriseResponse> operationResponse,
                             String successOrFailure,
                             WalletType walletType) {
-        
-        logger.info("{} authorisation {} - charge_external_id={}, payment provider response={}", 
+
+        logger.info("{} authorisation {} - charge_external_id={}, payment provider response={}",
                 walletType.toString(), successOrFailure, chargeEntity.getExternalId(), operationResponse.toString());
-        metricRegistry.counter(format("gateway-operations.%s.%s.%s.authorise.%s.result.%s", 
-                chargeEntity.getGatewayAccount().getGatewayName(), 
+        metricRegistry.counter(format("gateway-operations.%s.%s.%s.authorise.%s.result.%s",
+                chargeEntity.getGatewayAccount().getGatewayName(),
                 chargeEntity.getGatewayAccount().getType(),
                 chargeEntity.getGatewayAccount().getId(),
                 walletType.equals(WalletType.GOOGLE_PAY)? "google-pay" : "apple-pay",
@@ -120,11 +120,15 @@ public class WalletAuthoriseService {
 
     @Transactional
     private ChargeEntity prepareChargeForAuthorisation(String chargeId) {
-        ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
-        getPaymentProviderFor(charge)
-                .generateTransactionId()
-                .ifPresent(charge::setGatewayTransactionId);
-        return charge;
+        try {
+            ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
+            getPaymentProviderFor(charge)
+                    .generateTransactionId()
+                    .ifPresent(charge::setGatewayTransactionId);
+            return charge;
+        } catch (Exception e) {
+            throw e;
+        }
     }
 
     private void processGatewayAuthorisationResponse(
@@ -142,7 +146,6 @@ public class WalletAuthoriseService {
                 chargeExternalId,
                 status,
                 transactionId,
-                Optional.empty(),
                 sessionIdentifier,
                 authCardDetailsToBePersisted,
                 walletAuthorisationData.getWalletType(),

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -114,21 +114,17 @@ public class WalletAuthoriseService {
                 chargeEntity.getGatewayAccount().getGatewayName(),
                 chargeEntity.getGatewayAccount().getType(),
                 chargeEntity.getGatewayAccount().getId(),
-                walletType.equals(WalletType.GOOGLE_PAY)? "google-pay" : "apple-pay",
+                walletType.equals(WalletType.GOOGLE_PAY) ? "google-pay" : "apple-pay",
                 successOrFailure)).inc();
     }
 
     @Transactional
     private ChargeEntity prepareChargeForAuthorisation(String chargeId) {
-        try {
-            ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
-            getPaymentProviderFor(charge)
-                    .generateTransactionId()
-                    .ifPresent(charge::setGatewayTransactionId);
-            return charge;
-        } catch (Exception e) {
-            throw e;
-        }
+        ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, OperationType.AUTHORISATION);
+        getPaymentProviderFor(charge)
+                .generateTransactionId()
+                .ifPresent(charge::setGatewayTransactionId);
+        return charge;
     }
 
     private void processGatewayAuthorisationResponse(

--- a/src/test/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEventTest.java
@@ -1,0 +1,113 @@
+package uk.gov.pay.connector.events;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.wallets.WalletType;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class PaymentDetailsEnteredEventTest {
+
+    private final String paymentId = "jweojfewjoifewj";
+    private final String time = "2018-03-12T16:25:01.123456Z";
+    private final String validTransactionId = "validTransactionId";
+
+    private ChargeEntityFixture chargeEntityFixture;
+
+    @Before
+    public void setUp() {
+        ZonedDateTime latestDateTime = ZonedDateTime.parse(time);
+
+        List<ChargeEventEntity> list = List.of(
+                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, latestDateTime.minusHours(3), Optional.empty()),
+                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_SUCCESS, latestDateTime, Optional.empty()),
+                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.ENTERING_CARD_DETAILS, latestDateTime.minusHours(1), Optional.empty())
+        );
+
+        chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.parse(time))
+                .withExternalId(paymentId)
+                .withTransactionId(validTransactionId)
+                .withCorporateSurcharge(10L)
+                .withCardDetails(AuthCardDetailsFixture.anAuthCardDetails().getCardDetailsEntity())
+                .withAmount(100L)
+                .withEvents(list)
+                .withWalletType(WalletType.APPLE_PAY);
+    }
+
+    @Test
+    public void whenAllTheDataIsAvailable() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        String actual = PaymentDetailsEnteredEvent.from(chargeEntity).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_DETAILS_EVENT")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.title", equalTo("Payment details entered event")));
+        assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are entered")));
+
+        assertThat(actual, hasJsonPath("$.event_details.corporate_surcharge", equalTo(10)));
+        assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
+        assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(validTransactionId)));
+        assertThat(actual, hasJsonPath("$.event_details.first_digits_card_number", equalTo("424242")));
+        assertThat(actual, hasJsonPath("$.event_details.last_digits_card_number", equalTo("4242")));
+        assertThat(actual, hasJsonPath("$.event_details.cardholder_name", equalTo("Mr Test")));
+        assertThat(actual, hasJsonPath("$.event_details.expiry_date", equalTo("12/99")));
+        assertThat(actual, hasJsonPath("$.event_details.address_line1", equalTo("125 Kingsway")));
+        assertThat(actual, hasJsonPath("$.event_details.address_line2", equalTo("Aviation House")));
+        assertThat(actual, hasJsonPath("$.event_details.address_postcode", equalTo("WC2B 6NH")));
+        assertThat(actual, hasJsonPath("$.event_details.address_city", equalTo("London")));
+        assertThat(actual, hasJsonPath("$.event_details.address_county", equalTo("London")));
+        assertThat(actual, hasJsonPath("$.event_details.address_country", equalTo("GB")));
+        assertThat(actual, hasJsonPath("$.event_details.wallet", equalTo("APPLE_PAY")));
+    }
+
+    @Test
+    public void whenNotAllTheDataIsAvailable() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture
+                .withCardDetails(AuthCardDetailsFixture.anAuthCardDetails().withAddress(null).withCardNo("4242").getCardDetailsEntity())
+                .withWalletType(null)
+                .withCorporateSurcharge(null)
+                .build();
+
+        String actual = PaymentDetailsEnteredEvent.from(chargeEntity).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_DETAILS_EVENT")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.title", equalTo("Payment details entered event")));
+        assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are entered")));
+
+        assertThat(actual, hasNoJsonPath("$.event_details.corporate_surcharge"));
+        assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
+        assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(validTransactionId)));
+        assertThat(actual, hasNoJsonPath("$.event_details.first_digits_card_number"));
+        assertThat(actual, hasJsonPath("$.event_details.last_digits_card_number", equalTo("4242")));
+        assertThat(actual, hasJsonPath("$.event_details.cardholder_name", equalTo("Mr Test")));
+        assertThat(actual, hasJsonPath("$.event_details.expiry_date", equalTo("12/99")));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_line1"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_line2"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_postcode"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_city"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_county"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_country"));
+        assertThat(actual, hasNoJsonPath("$.event_details.wallet"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/PaymentDetailsEnteredEventTest.java
@@ -39,6 +39,7 @@ public class PaymentDetailsEnteredEventTest {
 
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.parse(time))
+                .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
                 .withExternalId(paymentId)
                 .withTransactionId(validTransactionId)
                 .withCorporateSurcharge(10L)

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -192,6 +192,10 @@ public class ChargingITestBase {
         return createNewChargeWith(CREATED, "");
     }
 
+    protected String createNewChargeWithNoTransactionIdOrEmailAddress(ChargeStatus status) {
+        return createNewChargeWithAccountId(status, null, accountId, databaseTestHelper, null).toString();
+    }
+
     protected String createNewChargeWithNoTransactionId(ChargeStatus status) {
         return createNewChargeWith(status, null);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
@@ -64,7 +64,7 @@ public class CardResourceAuthoriseApplePayIT extends ChargingITestBase {
     }
 
     private String shouldAuthoriseChargeForApplePay(String cardHolderName, String email) {
-        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        String chargeId = createNewChargeWithNoTransactionIdOrEmailAddress(ENTERING_CARD_DETAILS);
 
         givenSetup()
                 .body(buildJsonApplePayAuthorisationDetails(cardHolderName, email))

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -13,7 +13,7 @@ public class ChargeUtils {
     public static String createChargePostBody(String accountId) {
         return createChargePostBody("description", 100, accountId, "http://nothing", "default@email.invalid");
     }
-    
+
     public static String createChargePostBody(String description, long expectedAmount, String accountId, String returnUrl, String email) {
         return toJson(ImmutableMap.builder()
                 .put("reference", "Test reference")
@@ -24,8 +24,8 @@ public class ChargeUtils {
                 .put("email", email)
                 .put("delayed_capture", true).build());
     }
-    
-    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, DatabaseTestHelper databaseTestHelper) {
+
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, DatabaseTestHelper databaseTestHelper, String emailAddress) {
         long chargeId = RandomUtils.nextInt();
         ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(anAddChargeParams()
@@ -35,9 +35,13 @@ public class ChargeUtils {
                 .withAmount(6234L)
                 .withStatus(status)
                 .withTransactionId(gatewayTransactionId)
-                .withEmail("email@fake.test")
+                .withEmail(emailAddress)
                 .build());
         return externalChargeId;
+    }
+
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, DatabaseTestHelper databaseTestHelper) {
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper, "email@fake.test");
     }
 
     public static class ExternalChargeId {

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -1,5 +1,10 @@
 package uk.gov.pay.connector.model.domain;
 
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.charge.model.AddressEntity;
+import uk.gov.pay.connector.charge.model.CardDetailsEntity;
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
@@ -78,6 +83,24 @@ public final class AuthCardDetailsFixture {
     public AuthCardDetailsFixture withPayersCardPrepaidStatus(PayersCardPrepaidStatus payersCardPrepaidStatus) {
         this.payersCardPrepaidStatus = payersCardPrepaidStatus;
         return this;
+    }
+
+    public CardDetailsEntity getCardDetailsEntity() {
+        CardDetailsEntity cardDetailsEntity = new CardDetailsEntity();
+        cardDetailsEntity.setCardBrand(cardBrand);
+        cardDetailsEntity.setCardHolderName(cardHolder);
+        cardDetailsEntity.setExpiryDate(endDate);
+        if(cardNo.length() > 6) {
+            cardDetailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of(StringUtils.left(cardNo, 6)));
+        }
+
+        cardDetailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of(StringUtils.right(cardNo, 4)));
+
+        if(address != null) {
+            cardDetailsEntity.setBillingAddress(new AddressEntity(address));
+        }
+
+        return cardDetailsEntity;
     }
 
     public AuthCardDetails build() {

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.model.domain;
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
+import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -49,6 +50,7 @@ public class ChargeEntityFixture {
     private Long fee = null;
     private WalletType walletType = null;
     private ExternalMetadata externalMetadata = null;
+    private CardDetailsEntity cardDetails = null;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -75,6 +77,11 @@ public class ChargeEntityFixture {
             FeeEntity fee = new FeeEntity(chargeEntity, this.fee);
             chargeEntity.setFee(fee);
         }
+
+        if(cardDetails != null) {
+            chargeEntity.setCardDetails(cardDetails);
+        }
+
         chargeEntity.setWalletType(walletType);
         return chargeEntity;
     }
@@ -163,12 +170,12 @@ public class ChargeEntityFixture {
         this.corporateSurcharge = corporateSurcharge;
         return this;
     }
-    
+
     public ChargeEntityFixture withWalletType(WalletType walletType) {
         this.walletType = walletType;
         return this;
     }
-    
+
     public ChargeEntityFixture withFee(Long amount) {
         this.fee = amount;
         return this;
@@ -176,6 +183,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withExternalMetadata(ExternalMetadata externalMetadata) {
         this.externalMetadata = externalMetadata;
+        return this;
+    }
+
+    public ChargeEntityFixture withCardDetails(CardDetailsEntity cardDetailsEntity) {
+        this.cardDetails = cardDetailsEntity;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -9,10 +9,15 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.mock;
 
@@ -32,6 +37,17 @@ public abstract class CardServiceTest {
                 .aValidChargeEntity()
                 .withId(chargeId)
                 .withStatus(status)
+                .withEvents(List.of(
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, ZonedDateTime.now().minusHours(3), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_SUCCESS, ZonedDateTime.now(), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.ENTERING_CARD_DETAILS, ZonedDateTime.now().minusHours(2), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_TIMEOUT, ZonedDateTime.now().minusHours(1), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_ERROR, ZonedDateTime.now().minusHours(1), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_3DS_REQUIRED, ZonedDateTime.now().minusHours(1), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_CANCELLED, ZonedDateTime.now().minusHours(1), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_REJECTED, ZonedDateTime.now().minusHours(1), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR, ZonedDateTime.now().minusHours(1), Optional.empty())
+                ))
                 .build();
         entity.setCardDetails(new CardDetailsEntity());
         return entity;


### PR DESCRIPTION
* add `PaymentDetailsEnteredEvent` (tests covering producing the JSON)
* refactor `ChargeService` with proxy methods
* update definition of `emitEvent` in `ChargeService`

Questions/Doubts:
* I've refactored how wallet payment is being updated - instead of first calling `updateChargePostAuthorisation` and then setting email and wallet type (in Transactional context) it passes optional email and wallet and the `updateChargePostAuthorisation` updates the values if they exist. It caused one of the test to fail (the setup was putting an email address in the charge and the test was authorising with null value) - Is it deliberate behaviour? Is there a scenario where we have the email/wallet type already in the charge and we want to update them to `null` values?
* the other thing is: the timestamp is supposed to be taken from db (not part of this PR) when the `ChargeEventEntity` is inserted - the current logic retrieves all the charge events and gets the latest timestamp - the potential risk is that there might be another `ChargeEventEntity` inserted in the meantime.

Comments/Thoughts more than welcome.