### PR TITLE
PP-5355 Example queue message contract test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,9 +361,15 @@
         </dependency>
         <dependency>
             <groupId>au.com.dius</groupId>
-            <artifactId>pact-jvm-provider-junit_2.12</artifactId>
-            <version>3.6.11</version>
+            <artifactId>pact-jvm-provider-junit</artifactId>
+            <version>4.0.0-beta.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.exparity</groupId>

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/PaymentCreatedEventDetails.java
@@ -55,8 +55,8 @@ public class PaymentCreatedEventDetails extends EventDetails {
         return returnUrl;
     }
 
-    public Long getGatewayAccountId() {
-        return gatewayAccountId;
+    public String getGatewayAccountId() {
+        return gatewayAccountId.toString();
     }
 
     public String getPaymentProvider() {

--- a/src/test/java/uk/gov/pay/connector/events/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/PaymentCreatedTest.java
@@ -61,7 +61,7 @@ public class PaymentCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.description", equalTo("new passport")));
         assertThat(actual, hasJsonPath("$.event_details.reference", equalTo("myref")));
         assertThat(actual, hasJsonPath("$.event_details.return_url", equalTo("http://example.com")));
-        assertThat(actual, hasJsonPath("$.event_details.gateway_account_id", equalTo(chargeEntity.getGatewayAccount().getId().intValue())));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_account_id", equalTo(chargeEntity.getGatewayAccount().getId().toString())));
         assertThat(actual, hasJsonPath("$.event_details.payment_provider", equalTo(chargeEntity.getGatewayAccount().getGatewayName())));
         assertThat(actual, hasJsonPath("$.event_details.language", equalTo(chargeEntity.getLanguage().toString())));
         assertThat(actual, hasJsonPath("$.event_details.delayed_capture", equalTo(chargeEntity.isDelayedCapture())));

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
@@ -6,6 +6,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 
 @Suite.SuiteClasses({
+        QueueMessageContractTest.class,
         TransactionsApiContractTest.class,
         WalletApiContractTest.class
 })

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.pact;
+
+import au.com.dius.pact.provider.PactVerifyProvider;
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import au.com.dius.pact.provider.junit.target.AmqpTarget;
+import au.com.dius.pact.provider.junit.target.Target;
+import au.com.dius.pact.provider.junit.target.TestTarget;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.PaymentCreated;
+import uk.gov.pay.connector.events.eventdetails.PaymentCreatedEventDetails;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import java.time.ZonedDateTime;
+
+@RunWith(PactRunner.class)
+@Provider("connector")
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"ledger"})
+public class QueueMessageContractTest {
+
+    @TestTarget
+    public final Target target = new AmqpTarget();
+
+    @PactVerifyProvider("a payment created message")
+    public String verifyPaymentCreatedEvent() throws Exception{
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+        PaymentCreated paymentCreatedEvent = new PaymentCreated(
+                "anExternalResourceId",
+                PaymentCreatedEventDetails.from(charge),
+                ZonedDateTime.now()
+        );
+        
+        return paymentCreatedEvent.toJsonString();
+    }
+}


### PR DESCRIPTION
Illustrates how to run provider side message contract tests. I have had to upgrade the pact junit library to be a bit bleeding edge, but everything seems to work so probably fine.

The basic idea is that a method annotated with `@PactVerifyProvider` is matched with a corresponding pact based on the description (which acts as a key). That method is then required to produce a message corresponding to that description, which is then verified using the pact (and the test target). It is a bit magic. To understand better how it all fits together it is worth looking at 
https://github.com/DiUS/pact-jvm/blob/master/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/target/AmqpTarget.kt
https://github.com/DiUS/pact-jvm/blob/master/provider/pact-jvm-provider-junit/src/main/kotlin/au/com/dius/pact/provider/junit/PactRunner.kt

