### PR TITLE
PP-5385 Payment state transition queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransition.java
+++ b/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransition.java
@@ -4,13 +4,32 @@ import java.util.concurrent.Delayed;
 import java.util.concurrent.TimeUnit;
 
 public class PaymentStateTransition implements Delayed {
+    private final long chargeEventId;
+    private final Long readTime;
+
+    private long delayDurationInMilliseconds = 100L;
+
+    public PaymentStateTransition(long chargeEventId) {
+        this.chargeEventId = chargeEventId;
+        this.readTime = System.currentTimeMillis() + delayDurationInMilliseconds;
+    }
+
     @Override
     public long getDelay(TimeUnit unit) {
-        return 0;
+        long diff = readTime - System.currentTimeMillis();
+        return unit.convert(diff, TimeUnit.MILLISECONDS);
     }
 
     @Override
     public int compareTo(Delayed o) {
-        return 0;
+        return (int) (readTime - ((PaymentStateTransition) o).readTime);
+    }
+
+    public long getChargeEventId() {
+        return chargeEventId;
+    }
+
+    public long getDelayDurationInMilliseconds() {
+        return delayDurationInMilliseconds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransition.java
+++ b/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransition.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.queue;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+
+public class PaymentStateTransition implements Delayed {
+    @Override
+    public long getDelay(TimeUnit unit) {
+        return 0;
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return 0;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueue.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.queue;
+
+import java.util.Queue;
+import java.util.concurrent.DelayQueue;
+
+public class PaymentStateTransitionQueue {
+    private final Queue<PaymentStateTransition> queue = new DelayQueue<>();
+    
+    public boolean offer(PaymentStateTransition paymentStateTransition) {
+        return queue.offer(paymentStateTransition);
+    }
+    
+    public PaymentStateTransition poll() {
+        return queue.poll();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueueTest.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.queue;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class PaymentStateTransitionQueueTest {
+    @Test
+    public void shouldNotReturnElementBeforeDelay() throws InterruptedException {
+        PaymentStateTransitionQueue queue = new PaymentStateTransitionQueue();
+        PaymentStateTransition transition = new PaymentStateTransition(1L);
+
+        queue.offer(transition);
+        
+        PaymentStateTransition readTransition = queue.poll();
+        
+        assertNull(readTransition);
+    }
+    
+    @Test
+    public void shouldReturnElementAfterDelay() throws InterruptedException {        
+        long chargeEventId = 1L;
+        long delayBufferInMilliseconds = 100L;
+        PaymentStateTransitionQueue queue = new PaymentStateTransitionQueue();
+        PaymentStateTransition transition = new PaymentStateTransition(chargeEventId);
+        
+        queue.offer(transition);
+        
+        Thread.sleep(transition.getDelayDurationInMilliseconds() + delayBufferInMilliseconds);
+        
+        PaymentStateTransition readTransition = queue.poll();
+        
+        assertThat(readTransition.getChargeEventId(), is(chargeEventId));
+    }
+}


### PR DESCRIPTION
* Introduce PaymentStateTransitionQueue 
* Introduce PaymentStateTransition entity wrapping a charge event ID and allowing a delay to be set before consuming
* Test delay queue behaviour

with @mrlumbu 
