### PR TITLE
PP-5385 Payment event factory, build payment events with ChargeEventEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/PaymentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentCreated.java
@@ -2,25 +2,16 @@ package uk.gov.pay.connector.events;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
-import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.eventdetails.PaymentCreatedEventDetails;
 
 import java.time.ZonedDateTime;
 
 public class PaymentCreated extends PaymentEvent {
 
-    public PaymentCreated(String resourceExternalId, PaymentCreatedEventDetails paymentCreatedEventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, paymentCreatedEventDetails, timestamp);
+    public PaymentCreated(String resourceExternalId, PaymentCreatedEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
     }
 
-    // @TODO(sfount) add factory to create event given
-    //               - ChargeEvent
-    //               - Event Class type
-    // @TODO(sfount) make all events work magically with factory
-    // @TODO(sfount) submit PR
-    // @TODO(sfount) rebase feature branch with this PR
-    // @TODO(sfount) instantiate event through factory after having polled state transition queue
-    // @TODO(sfount) emit the event - profit
     public static PaymentCreated from(ChargeEventEntity event) {
         return new PaymentCreated(
                 event.getChargeEntity().getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/events/PaymentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentCreated.java
@@ -1,20 +1,31 @@
 package uk.gov.pay.connector.events;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.events.eventdetails.PaymentCreatedEventDetails;
 
 import java.time.ZonedDateTime;
 
 public class PaymentCreated extends PaymentEvent {
 
-    public PaymentCreated(String resourceExternalId, PaymentCreatedEventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    private PaymentCreated(String resourceExternalId, PaymentCreatedEventDetails paymentCreatedEventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, paymentCreatedEventDetails, timestamp);
     }
 
-    public static PaymentCreated from(ChargeEntity charge) {
+    // @TODO(sfount) add factory to create event given
+    //               - ChargeEvent
+    //               - Event Class type
+    // @TODO(sfount) make all events work magically with factory
+    // @TODO(sfount) submit PR
+    // @TODO(sfount) rebase feature branch with this PR
+    // @TODO(sfount) instantiate event through factory after having polled state transition queue
+    // @TODO(sfount) emit the event - profit
+    public static PaymentCreated from(ChargeEventEntity event) {
         return new PaymentCreated(
-                charge.getExternalId(), 
-                PaymentCreatedEventDetails.from(charge),
-                charge.getCreatedDate());
+                event.getChargeEntity().getExternalId(),
+                PaymentCreatedEventDetails.from(event.getChargeEntity()),
+                event.getUpdated()
+        );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/PaymentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentCreated.java
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime;
 
 public class PaymentCreated extends PaymentEvent {
 
-    private PaymentCreated(String resourceExternalId, PaymentCreatedEventDetails paymentCreatedEventDetails, ZonedDateTime timestamp) {
+    public PaymentCreated(String resourceExternalId, PaymentCreatedEventDetails paymentCreatedEventDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, paymentCreatedEventDetails, timestamp);
     }
 
@@ -26,6 +26,14 @@ public class PaymentCreated extends PaymentEvent {
                 event.getChargeEntity().getExternalId(),
                 PaymentCreatedEventDetails.from(event.getChargeEntity()),
                 event.getUpdated()
+        );
+    }
+
+    public static PaymentCreated from(ChargeEntity charge) {
+        return new PaymentCreated(
+                charge.getExternalId(),
+                PaymentCreatedEventDetails.from(charge),
+                charge.getCreatedDate()
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/PaymentDetailsEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentDetailsEvent.java
@@ -38,6 +38,16 @@ public class PaymentDetailsEvent extends PaymentEvent {
                 lastEventDate);
     }
 
+    public static PaymentDetailsEvent from (ChargeEventEntity chargeEvent) {
+        ChargeEntity charge = chargeEvent.getChargeEntity();
+
+        return new PaymentDetailsEvent(
+                charge.getExternalId(),
+                PaymentDetailsEnteredEventDetails.from(charge),
+                chargeEvent.getUpdated()
+        );
+    }
+
     public String getTitle() { return "Payment details entered event"; }
     public String getDescription() { return "The event happens when the payment details are entered"; }
 }

--- a/src/main/java/uk/gov/pay/connector/events/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentEvent.java
@@ -16,6 +16,12 @@ public class PaymentEvent extends Event {
         this.timestamp = timestamp;
     }
 
+    public PaymentEvent(String resourceExternalId, ZonedDateTime timestamp) {
+        this.resourceExternalId = resourceExternalId;
+        this.timestamp = timestamp;
+        this.eventDetails = new EmptyEventDetails();
+    }
+
     @Override
     public String getResourceExternalId() {
         return resourceExternalId;

--- a/src/main/java/uk/gov/pay/connector/events/PaymentEventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentEventFactory.java
@@ -7,14 +7,16 @@ import java.time.ZonedDateTime;
 
 public class PaymentEventFactory {
 
-    public static PaymentEvent create(Class<? extends PaymentEvent> eventClass, ChargeEventEntity chargeEventEntity) {
+    public static PaymentEvent create(Class<? extends PaymentEvent> eventClass, ChargeEventEntity chargeEvent) {
         try {
             if (eventClass == PaymentCreated.class) {
-                return PaymentCreated.from(chargeEventEntity);
+                return PaymentCreated.from(chargeEvent);
+            } else if (eventClass == PaymentDetailsEvent.class) {
+                return PaymentDetailsEvent.from(chargeEvent);
             } else {
                 return eventClass.getConstructor(String.class, ZonedDateTime.class).newInstance(
-                        chargeEventEntity.getChargeEntity().getExternalId(),
-                        chargeEventEntity.getUpdated()
+                        chargeEvent.getChargeEntity().getExternalId(),
+                        chargeEvent.getUpdated()
                 );
             }
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {

--- a/src/main/java/uk/gov/pay/connector/events/PaymentEventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentEventFactory.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.events;
+
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.ZonedDateTime;
+
+public class PaymentEventFactory {
+
+    public static PaymentEvent create(Class<? extends PaymentEvent> eventClass, ChargeEventEntity chargeEventEntity) {
+        try {
+            if (eventClass == PaymentCreated.class) {
+                return PaymentCreated.from(chargeEventEntity);
+            } else {
+                return eventClass.getConstructor(String.class, ZonedDateTime.class).newInstance(
+                        chargeEventEntity.getChargeEntity().getExternalId(),
+                        chargeEventEntity.getUpdated()
+                );
+            }
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new IllegalArgumentException(String.format("Could not construct payment event: %s", eventClass));
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/PaymentEventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/PaymentEventFactoryTest.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.events;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.PaymentCreatedEventDetails;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaymentEventFactoryTest {
+
+    private final ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+
+    @Mock
+    private ChargeEventEntity chargeEvent;
+
+    @Before
+    public void setUp() {
+        when(chargeEvent.getChargeEntity()).thenReturn(charge);
+        when(chargeEvent.getUpdated()).thenReturn(ZonedDateTime.now());
+    }
+
+    @Test
+    public void givenAPaymentCreatedTypeShouldCreateAPaymentCreatedEvent() {
+        PaymentEvent event = PaymentEventFactory.create(PaymentCreated.class, chargeEvent);
+
+        assertThat(event, instanceOf(PaymentCreated.class));
+        assertThat(event.getEventDetails(), instanceOf(PaymentCreatedEventDetails.class));
+        assertThat(event.getResourceExternalId(), is(charge.getExternalId()));
+    }
+
+    @Test
+    public void givenANonPayloadPaymentEventTypeShouldCreateTheCorrectPaymentEventType() {
+        PaymentEvent event = PaymentEventFactory.create(CaptureAbandonedAfterTooManyRetries.class, chargeEvent);
+
+        assertThat(event, instanceOf(CaptureAbandonedAfterTooManyRetries.class));
+        assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
+    }
+}


### PR DESCRIPTION
Use `ChargeEventEntity` in favour of `ChargeEntity` for building payment events, this allows a uniform way of accessing the events timestamp to always get the correct database time. The charge can still be accessed through the entities `getCharge()`. 

* Factory that knows how to build payment entity from an event type and a charge event entity 
* Tests known and unknown payment types (those with payloads and the default no payload case)

with @mrlumbu 