### PR TITLE
BAU fix docker cleanup for inline e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
 
       post {
         always {
-          shell(
+          sh(
               '''|#!/bin/bash
                  |set -e
                  |bundle install --path gems

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,13 +95,15 @@ pipeline {
 
       post {
         always {
-          sh(
-              '''|#!/bin/bash
-                 |set -e
-                 |bundle install --path gems
-                 |bundle exec ruby ./jenkins/ruby-scripts/pay-tests.rb down
-              '''.stripMargin()
-          )
+          dir('e2e-pay-scripts') {
+            sh(
+                '''|#!/bin/bash
+                   |set -e
+                   |bundle install --path gems
+                   |bundle exec ruby ./jenkins/ruby-scripts/pay-tests.rb down
+                '''.stripMargin()
+            )
+          }
 
           archiveArtifacts artifacts: '**/target/docker*.log,**/target/screenshots/*.png'
           junit testResults: "**/target/surefire-reports/*.xml,**/target/failsafe-reports/*.xml"


### PR DESCRIPTION
Executing a shell script block uses the `sh` command, not `shell`