### PR TITLE
PP-5386 Unify all updateChargeStatus calls

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -83,7 +83,7 @@ public class CardCaptureService {
 
         if (!charge.isDelayedCapture())
             addChargeToCaptureQueue(charge);
-        
+
         return charge;
     }
 
@@ -91,7 +91,7 @@ public class CardCaptureService {
     void markChargeAsCaptureError(String chargeId) {
         LOG.error("CAPTURE_ERROR for charge [charge_external_id={}] - reached maximum number of capture attempts",
                 chargeId);
-        chargeService.updateChargeStatus(chargeId, CAPTURE_ERROR);
+        chargeService.transitionChargeState(chargeId, CAPTURE_ERROR);
     }
 
     public ChargeEntity markChargeAsCaptureApproved(String externalId) {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -186,18 +186,13 @@ public class CardCaptureServiceTest extends CardServiceTest {
         inOrder.verify(chargeSpy).setStatus(CAPTURED);
 
         ArgumentCaptor<ChargeEntity> chargeEntityCaptor = ArgumentCaptor.forClass(ChargeEntity.class);
-        ArgumentCaptor<ZonedDateTime> bookingDateCaptor = ArgumentCaptor.forClass(ZonedDateTime.class);
 
         // charge progresses from CAPTURE_SUBMITTED to CAPTURED, so two calls
         // first invocation will add a captured date
-        verify(mockedChargeEventDao, times(1)).persistChargeEventOf(chargeEntityCaptor.capture(), bookingDateCaptor.capture());
+        verify(mockedChargeEventDao, times(2)).persistChargeEventOf(chargeEntityCaptor.capture());
         // second invocation will NOT add a captured date
-        verify(mockedChargeEventDao, times(1)).persistChargeEventOf(chargeEntityCaptor.capture());
         assertThat(chargeEntityCaptor.getValue().getStatus(), is(CAPTURED.getValue()));
-
         // only the CAPTURED has a bookingDate, so there's only one value captured
-        assertThat(bookingDateCaptor.getAllValues().size(), is(1));
-        assertThat(bookingDateCaptor.getAllValues().get(0), is(notNullValue()));
 
         ArgumentCaptor<CaptureGatewayRequest> request = ArgumentCaptor.forClass(CaptureGatewayRequest.class);
         verify(mockedPaymentProvider, times(1)).capture(request.capture());


### PR DESCRIPTION
* introduce new `transitionChargeState` call to unify before including emit event
* make sure everything that uses current special case branching logic
(update to capture submitted before capture)