### PR TITLE
PP-5386 Charge cancel service use transition state

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -44,14 +44,17 @@ public class ChargeCancelService {
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;
     private final PaymentProviders providers;
+    private final ChargeService chargeService;
 
     @Inject
     public ChargeCancelService(ChargeDao chargeDao,
                                ChargeEventDao chargeEventDao,
-                               PaymentProviders providers) {
+                               PaymentProviders providers,
+                               ChargeService chargeService) {
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
         this.providers = providers;
+        this.chargeService = chargeService;
     }
 
     public Optional<ChargeEntity> doSystemCancel(String chargeId, Long accountId) {
@@ -86,9 +89,9 @@ public class ChargeCancelService {
 
         try {
             final GatewayResponse<BaseCancelResponse> gatewayResponse = doGatewayCancel(chargeEntity);
-            
+
             if (!gatewayResponse.getBaseResponse().isPresent()) gatewayResponse.throwGatewayError();
-            
+
             chargeStatus = determineTerminalState(gatewayResponse.getBaseResponse().get(), statusFlow);
             stringifiedResponse = gatewayResponse.getBaseResponse().get().toString();
         } catch (GatewayException e) {
@@ -158,8 +161,7 @@ public class ChargeCancelService {
     @SuppressWarnings("WeakerAccess") // Guice requires @Transactional methods to be public
     public void setChargeStatusTo(String chargeEntityExternalId, ChargeStatus chargeStatus) {
         chargeDao.findByExternalId(chargeEntityExternalId).ifPresentOrElse(chargeEntity -> {
-            chargeEntity.setStatus(chargeStatus);
-            chargeEventDao.persistChargeEventOf(chargeEntity);
+            chargeService.transitionChargeState(chargeEntity, chargeStatus);
         }, () -> {
             throw new ChargeNotFoundRuntimeException(chargeEntityExternalId);
         });

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -8,7 +8,6 @@ import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
@@ -42,17 +41,14 @@ public class ChargeCancelService {
     );
 
     private final ChargeDao chargeDao;
-    private final ChargeEventDao chargeEventDao;
     private final PaymentProviders providers;
     private final ChargeService chargeService;
 
     @Inject
     public ChargeCancelService(ChargeDao chargeDao,
-                               ChargeEventDao chargeEventDao,
                                PaymentProviders providers,
                                ChargeService chargeService) {
         this.chargeDao = chargeDao;
-        this.chargeEventDao = chargeEventDao;
         this.providers = providers;
         this.chargeService = chargeService;
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -68,9 +68,12 @@ public class ChargeCancelServiceTest {
     @Mock
     private PaymentProvider mockPaymentProvider;
 
+    @Mock
+    private ChargeService chargeService;
+
     @Before
     public void setup() {
-        chargeCancelService = new ChargeCancelService(mockChargeDao, mockChargeEventDao, mockPaymentProviders);
+        chargeCancelService = new ChargeCancelService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, chargeService);
     }
 
     @Test
@@ -87,9 +90,7 @@ public class ChargeCancelServiceTest {
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
-        assertThat(chargeEntity.getStatus(), is(SYSTEM_CANCELLED.getValue()));
-
-        verify(mockChargeEventDao).persistChargeEventOf(chargeEntity);
+        verify(chargeService).transitionChargeState(chargeEntity, SYSTEM_CANCELLED);
     }
 
     @Test
@@ -114,10 +115,7 @@ public class ChargeCancelServiceTest {
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
-        assertThat(chargeEntity.getStatus(), is(SYSTEM_CANCELLED.getValue()));
-
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
-
+        verify(chargeService).transitionChargeState(chargeEntity, SYSTEM_CANCELLED);
         verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
     }
 
@@ -145,8 +143,7 @@ public class ChargeCancelServiceTest {
 
         chargeCancelService.doUserCancel(externalChargeId);
 
-        assertThat(chargeEntity.getStatus(), is(USER_CANCELLED.getValue()));
-        verify(mockChargeEventDao).persistChargeEventOf(chargeEntity);
+        verify(chargeService).transitionChargeState(chargeEntity, USER_CANCELLED);
     }
 
     @Test
@@ -169,10 +166,7 @@ public class ChargeCancelServiceTest {
 
         chargeCancelService.doUserCancel(externalChargeId);
 
-        assertThat(chargeEntity.getStatus(), is(USER_CANCELLED.getValue()));
-
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(USER_CANCELLED)));
-
+        verify(chargeService).transitionChargeState(chargeEntity, USER_CANCELLED);
         verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
     }
 
@@ -208,10 +202,7 @@ public class ChargeCancelServiceTest {
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
-        assertThat(chargeEntity.getStatus(), is(SYSTEM_CANCELLED.getValue()));
-
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
-
+        verify(chargeService).transitionChargeState(chargeEntity, SYSTEM_CANCELLED);
         verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
     }
 
@@ -238,10 +229,7 @@ public class ChargeCancelServiceTest {
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
-        assertThat(chargeEntity.getStatus(), is(SYSTEM_CANCELLED.getValue()));
-
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
-
+        verify(chargeService).transitionChargeState(chargeEntity, SYSTEM_CANCELLED);
         verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
     }
 
@@ -267,10 +255,7 @@ public class ChargeCancelServiceTest {
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
-        assertThat(chargeEntity.getStatus(), is(SYSTEM_CANCELLED.getValue()));
-
-        verify(mockChargeEventDao, atLeastOnce()).persistChargeEventOf(argThat(chargeEntityHasStatus(SYSTEM_CANCELLED)));
-
+        verify(chargeService).transitionChargeState(chargeEntity, SYSTEM_CANCELLED);
         verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -2,16 +2,15 @@ package uk.gov.pay.connector.charge.service;
 
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -28,7 +27,6 @@ import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.ignoreStubs;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -53,14 +51,8 @@ import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidCharge
  * A consequence of a no TDD approach
  */
 public class ChargeCancelServiceTest {
-
-    private ChargeCancelService chargeCancelService;
-
     @Mock
     private ChargeDao mockChargeDao;
-
-    @Mock
-    private ChargeEventDao mockChargeEventDao;
 
     @Mock
     private PaymentProviders mockPaymentProviders;
@@ -71,10 +63,8 @@ public class ChargeCancelServiceTest {
     @Mock
     private ChargeService chargeService;
 
-    @Before
-    public void setup() {
-        chargeCancelService = new ChargeCancelService(mockChargeDao, mockChargeEventDao, mockPaymentProviders, chargeService);
-    }
+    @InjectMocks
+    private ChargeCancelService chargeCancelService;
 
     @Test
     public void doSystemCancel_shouldCancel_withStatusThatDoesNotNeedCancellationInGatewayProvider() {


### PR DESCRIPTION
* Use newly introduced `transitionChargeState` instead of manually setting status