### PR TITLE
PP-5409 Improve cancellation with gateways

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ExpirableChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ExpirableChargeStatus.java
@@ -7,17 +7,18 @@ import java.util.stream.Stream;
 public enum ExpirableChargeStatus {
     CREATED(ChargeStatus.CREATED, AuthorisationStage.PRE_AUTHORISATION, ExpiryThresholdType.REGULAR),
     ENTERING_CARD_DETAILS(ChargeStatus.ENTERING_CARD_DETAILS, AuthorisationStage.PRE_AUTHORISATION, ExpiryThresholdType.REGULAR),
+    AUTHORISATION_READY(ChargeStatus.AUTHORISATION_READY, AuthorisationStage.DURING_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_3DS_REQUIRED(ChargeStatus.AUTHORISATION_3DS_REQUIRED, AuthorisationStage.DURING_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_3DS_READY(ChargeStatus.AUTHORISATION_3DS_READY, AuthorisationStage.DURING_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_SUCCESS(ChargeStatus.AUTHORISATION_SUCCESS, AuthorisationStage.POST_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AWAITING_CAPTURE_REQUEST(ChargeStatus.AWAITING_CAPTURE_REQUEST, AuthorisationStage.POST_AUTHORISATION, ExpiryThresholdType.DELAYED);
-    
+
     ExpirableChargeStatus(ChargeStatus chargeStatus, AuthorisationStage authorisationStage, ExpiryThresholdType expiryThresholdType) {
         this.chargeStatus = chargeStatus;
         this.authorisationStage = authorisationStage;
         this.expiryThresholdType = expiryThresholdType;
     }
-    
+
     private final AuthorisationStage authorisationStage;
     private final ChargeStatus chargeStatus;
     private final ExpiryThresholdType expiryThresholdType;
@@ -25,7 +26,7 @@ public enum ExpirableChargeStatus {
     public static Stream<ExpirableChargeStatus> getValuesAsStream() {
         return Arrays.stream(values());
     }
-    
+
     public static ExpirableChargeStatus of(ChargeStatus chargeStatus) {
         return getValuesAsStream()
                 .filter(expirableChargeStatus -> expirableChargeStatus.getChargeStatus().equals(chargeStatus))
@@ -45,16 +46,16 @@ public enum ExpirableChargeStatus {
     public boolean isRegularThresholdType() {
         return expiryThresholdType.equals(ExpiryThresholdType.REGULAR);
     }
-    
+
     public boolean isDelayedThresholdType() {
         return expiryThresholdType.equals(ExpiryThresholdType.DELAYED);
     }
 
     public enum ExpiryThresholdType {
         REGULAR,
-        DELAYED 
+        DELAYED
     }
-    
+
     public enum AuthorisationStage {
         PRE_AUTHORISATION,
         DURING_AUTHORISATION,

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -1,12 +1,11 @@
 package uk.gov.pay.connector.charge.service;
 
-import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ExpirableChargeStatus;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.gateway.GatewayException;
@@ -15,18 +14,13 @@ import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
+import uk.gov.pay.connector.paymentprocessor.service.QueryService;
 
 import javax.inject.Inject;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.service.StatusFlow.SYSTEM_CANCELLATION_FLOW;
 import static uk.gov.pay.connector.charge.service.StatusFlow.USER_CANCELLATION_FLOW;
 
@@ -34,19 +28,18 @@ public class ChargeCancelService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private static List<ChargeStatus> nonGatewayStatuses = ImmutableList.of(
-            CREATED, ENTERING_CARD_DETAILS, AUTHORISATION_3DS_REQUIRED
-    );
-
     private final ChargeDao chargeDao;
+    private QueryService queryService;
     private final PaymentProviders providers;
     private final ChargeService chargeService;
 
     @Inject
     public ChargeCancelService(ChargeDao chargeDao,
                                PaymentProviders providers,
+                               QueryService queryService,
                                ChargeService chargeService) {
         this.chargeDao = chargeDao;
+        this.queryService = queryService;
         this.providers = providers;
         this.chargeService = chargeService;
     }
@@ -68,23 +61,38 @@ public class ChargeCancelService {
     }
 
     private void doCancel(ChargeEntity chargeEntity, StatusFlow statusFlow) {
-        if (gatewayIsNotAwareOfCharge(chargeEntity)) {
-            nonGatewayCancel(chargeEntity, statusFlow);
-        } else {
+        ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+        if (statusFlow.isStarted(chargeStatus)) {
+            throw new OperationAlreadyInProgressRuntimeException(statusFlow.getName(), chargeEntity.getExternalId());
+        }
+        
+        validateChargeStatus(statusFlow, chargeEntity);
+        
+        ExpirableChargeStatus.AuthorisationStage authorisationStage = ExpirableChargeStatus
+                .of(chargeStatus).getAuthorisationStage();
+
+        boolean cancellableWithGateway = authorisationStage == ExpirableChargeStatus.AuthorisationStage.POST_AUTHORISATION
+                || (authorisationStage == ExpirableChargeStatus.AuthorisationStage.DURING_AUTHORISATION
+                && queryService.isTerminableWithGateway(chargeEntity));
+
+        if (cancellableWithGateway) {
             cancelChargeWithGatewayCleanup(chargeEntity, statusFlow);
+        } else {
+            nonGatewayCancel(chargeEntity, statusFlow);
         }
     }
 
     private void cancelChargeWithGatewayCleanup(ChargeEntity chargeEntity, StatusFlow statusFlow) {
         prepareForTerminate(chargeEntity, statusFlow);
 
-        ChargeStatus chargeStatus = null;
-        String stringifiedResponse = null;
+        ChargeStatus chargeStatus;
+        String stringifiedResponse;
 
         try {
             final GatewayResponse<BaseCancelResponse> gatewayResponse = doGatewayCancel(chargeEntity);
-
-            if (!gatewayResponse.getBaseResponse().isPresent()) gatewayResponse.throwGatewayError();
+            if (gatewayResponse.getBaseResponse().isEmpty()) {
+                gatewayResponse.throwGatewayError();
+            }
 
             chargeStatus = determineTerminalState(gatewayResponse.getBaseResponse().get(), statusFlow);
             stringifiedResponse = gatewayResponse.getBaseResponse().get().toString();
@@ -126,17 +134,10 @@ public class ChargeCancelService {
         chargeService.transitionChargeState(chargeEntity.getExternalId(), completeStatus);
     }
 
-    private boolean gatewayIsNotAwareOfCharge(ChargeEntity chargeEntity) {
-        return nonGatewayStatuses.contains(ChargeStatus.fromString(chargeEntity.getStatus()));
-    }
-
     private void prepareForTerminate(ChargeEntity chargeEntity, StatusFlow statusFlow) {
-        ChargeStatus newStatus = statusFlow.getLockState();
+        ChargeStatus lockStatus = statusFlow.getLockState();
         ChargeStatus currentStatus = ChargeStatus.fromString(chargeEntity.getStatus());
-
-        validateChargeStatus(statusFlow, chargeEntity, newStatus, currentStatus);
-
-        // Used by Sumo Logic saved search
+        
         logger.info("Card cancel request sent - charge_external_id={}, charge_status={}, account_id={}, transaction_id={}, amount={}, operation_type={}, provider={}, provider_type={}, locking_status={}",
                 chargeEntity.getExternalId(),
                 currentStatus,
@@ -146,19 +147,14 @@ public class ChargeCancelService {
                 OperationType.CANCELLATION.getValue(),
                 chargeEntity.getGatewayAccount().getGatewayName(),
                 chargeEntity.getGatewayAccount().getType(),
-                newStatus);
+                lockStatus);
 
-        chargeService.transitionChargeState(chargeEntity.getExternalId(), newStatus);
+        chargeService.transitionChargeState(chargeEntity.getExternalId(), lockStatus);
     }
 
-    private void validateChargeStatus(StatusFlow statusFlow, ChargeEntity chargeEntity, ChargeStatus newStatus, ChargeStatus oldStatus) {
-        if (!chargeIsInTerminatableStatus(statusFlow, oldStatus)) {
-            if (newStatus.equals(oldStatus)) {
-                throw new OperationAlreadyInProgressRuntimeException(statusFlow.getName(), chargeEntity.getExternalId());
-            } else if (Arrays.asList(AUTHORISATION_READY, AUTHORISATION_3DS_READY).contains(oldStatus)) {
-                throw new ConflictRuntimeException(chargeEntity.getExternalId());
-            }
-
+    private void validateChargeStatus(StatusFlow statusFlow, ChargeEntity chargeEntity) {
+        ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+        if (!chargeIsInTerminableStatus(statusFlow, chargeStatus)) {
             logger.error("Charge is not in one of the legal states. charge_external_id={}, status={}, legal_states={}",
                     chargeEntity.getExternalId(), chargeEntity.getStatus(), getLegalStatusNames(statusFlow.getTerminatableStatuses()));
 
@@ -166,7 +162,7 @@ public class ChargeCancelService {
         }
     }
 
-    private static boolean chargeIsInTerminatableStatus(StatusFlow statusFlow, ChargeStatus chargeStatus) {
+    private static boolean chargeIsInTerminableStatus(StatusFlow statusFlow, ChargeStatus chargeStatus) {
         return statusFlow.getTerminatableStatuses().contains(chargeStatus);
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -87,7 +87,7 @@ public class ChargeExpiryService {
         Map<Boolean, List<ChargeEntity>> chargesPartitionedByNeedForExpiryWithGateway =
                 getNullSafeList(chargesGroupedByAuthStage.get(DURING_AUTHORISATION))
                         .stream()
-                        .collect(Collectors.partitioningBy(this::isExpirableWithGateway));
+                        .collect(Collectors.partitioningBy(queryService::isTerminableWithGateway));
 
         List<ChargeEntity> toExpireWithoutGateway = new ImmutableList.Builder<ChargeEntity>()
                 .addAll(getNullSafeList(chargesGroupedByAuthStage.get(PRE_AUTHORISATION)))
@@ -114,19 +114,6 @@ public class ChargeExpiryService {
 
     private AuthorisationStage getAuthorisationStage(ChargeEntity chargeEntity) {
         return ExpirableChargeStatus.of(ChargeStatus.fromString(chargeEntity.getStatus())).getAuthorisationStage();
-    }
-
-    private boolean isExpirableWithGateway(ChargeEntity charge) {
-        try {
-            return queryService
-                    .getChargeGatewayStatus(charge)
-                    .getMappedStatus()
-                    .map(chargeStatus -> !chargeStatus.toExternal().isFinished())
-                    .orElse(false);
-        } catch (WebApplicationException | UnsupportedOperationException | GatewayException | IllegalArgumentException e) {
-            logger.info("Unable to retrieve status for charge {}: {}", charge.getExternalId(), e.getMessage());
-            return false;
-        }
     }
 
     public Map<String, Integer> sweepAndExpireChargesAndTokens() {

--- a/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
@@ -1,16 +1,11 @@
 package uk.gov.pay.connector.charge.service;
 
-import com.google.common.collect.ImmutableList;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ExpirableChargeStatus;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_FAILED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
@@ -26,24 +21,20 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_
 
 public class StatusFlow {
 
+    private static final List<ChargeStatus> TERMINABLE_STATUSES = ExpirableChargeStatus.getValuesAsStream()
+            .map(ExpirableChargeStatus::getChargeStatus)
+            .collect(Collectors.toList());
+    
     public static final StatusFlow USER_CANCELLATION_FLOW = new StatusFlow("User Cancellation",
-            ImmutableList.of(
-                    ENTERING_CARD_DETAILS,
-                    AUTHORISATION_SUCCESS
-            ),
+            TERMINABLE_STATUSES,
             USER_CANCEL_READY,
             USER_CANCELLED,
             USER_CANCEL_SUBMITTED,
             USER_CANCEL_ERROR
     );
-
+    
     public static final StatusFlow SYSTEM_CANCELLATION_FLOW = new StatusFlow("System Cancellation",
-            ImmutableList.of(
-                    CREATED,
-                    ENTERING_CARD_DETAILS,
-                    AUTHORISATION_SUCCESS,
-                    AWAITING_CAPTURE_REQUEST
-            ),
+            TERMINABLE_STATUSES,
             SYSTEM_CANCEL_READY,
             SYSTEM_CANCELLED,
             SYSTEM_CANCEL_SUBMITTED,
@@ -51,9 +42,7 @@ public class StatusFlow {
     );
 
     public static final StatusFlow EXPIRE_FLOW = new StatusFlow("Expiration",
-            ExpirableChargeStatus.getValuesAsStream()
-                    .map(ExpirableChargeStatus::getChargeStatus)
-                    .collect(Collectors.toList()), 
+            TERMINABLE_STATUSES, 
             EXPIRE_CANCEL_READY,
             EXPIRED,
             EXPIRE_CANCEL_SUBMITTED,
@@ -67,9 +56,9 @@ public class StatusFlow {
     private final ChargeStatus submittedState;
     private final ChargeStatus failureTerminalState;
 
-    private StatusFlow(String name, List<ChargeStatus> terminatableStatuses, ChargeStatus lockState, ChargeStatus successTerminalState, ChargeStatus submittedState, ChargeStatus failureTerminalState) {
+    private StatusFlow(String name, List<ChargeStatus> terminableStatuses, ChargeStatus lockState, ChargeStatus successTerminalState, ChargeStatus submittedState, ChargeStatus failureTerminalState) {
         this.name = name;
-        this.terminatableStatuses = terminatableStatuses;
+        this.terminatableStatuses = terminableStatuses;
         this.lockState = lockState;
         this.successTerminalState = successTerminalState;
         this.submittedState = submittedState;
@@ -98,5 +87,9 @@ public class StatusFlow {
 
     public ChargeStatus getFailureTerminalState() {
         return failureTerminalState;
+    }
+    
+    public boolean isStarted(ChargeStatus chargeStatus) { 
+        return List.of(lockState, submittedState).contains(chargeStatus);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -98,6 +98,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(ENTERING_CARD_DETAILS, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRED, ModelledEvent.of(PaymentExpired.class));
+        graph.putEdgeValue(AUTHORISATION_READY, EXPIRED, ModelledEvent.of(PaymentExpired.class));
 
         graph.putEdgeValue(CREATED, ENTERING_CARD_DETAILS, ModelledEvent.of(PaymentStarted.class));
         graph.putEdgeValue(CREATED, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
@@ -114,6 +115,10 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_3DS_REQUIRED, ModelledEvent.of(GatewayRequires3dsAuthorisation.class));
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_CANCELLED, ModelledEvent.of(AuthorisationCancelled.class));
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_SUBMITTED, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
+        graph.putEdgeValue(AUTHORISATION_READY, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+        graph.putEdgeValue(AUTHORISATION_READY, USER_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_READY, SYSTEM_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_READY, EXPIRE_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(AUTHORISATION_SUBMITTED, AUTHORISATION_SUCCESS, ModelledEvent.of(AuthorisationSucceeded.class));
         graph.putEdgeValue(AUTHORISATION_SUBMITTED, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(AUTHORISATION_SUBMITTED, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
@@ -124,10 +129,17 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_CANCELLED, ModelledEvent.of(AuthorisationCancelled.class));
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, EXPIRE_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+        graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, USER_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, SYSTEM_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_SUCCESS, ModelledEvent.of(AuthorisationSucceeded.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRE_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, USER_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, SYSTEM_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_CANCELLED, ModelledEvent.of(AuthorisationCancelled.class));
         graph.putEdgeValue(AUTHORISATION_SUCCESS, CAPTURE_APPROVED, ModelledEvent.of(UserApprovedForCapture.class));
         graph.putEdgeValue(AUTHORISATION_SUCCESS, CAPTURE_READY, ModelledEvent.none());

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -1,13 +1,19 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentProviders;
-import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 
 public class QueryService {
+    
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    
     private final PaymentProviders providers;
 
     @Inject
@@ -17,5 +23,17 @@ public class QueryService {
     
     public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) throws GatewayException {
         return providers.byName(charge.getPaymentGatewayName()).queryPaymentStatus(charge);
+    }
+
+    public boolean isTerminableWithGateway(ChargeEntity charge) {
+        try {
+            return getChargeGatewayStatus(charge)
+                    .getMappedStatus()
+                    .map(chargeStatus -> !chargeStatus.toExternal().isFinished())
+                    .orElse(false);
+        } catch (WebApplicationException | UnsupportedOperationException | GatewayException | IllegalArgumentException e) {
+            logger.info("Unable to retrieve status for charge {}: {}", charge.getExternalId(), e.getMessage());
+            return false;
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -1,13 +1,17 @@
 package uk.gov.pay.connector.charge.service;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.internal.hamcrest.HamcrestArgumentMatcher;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -20,15 +24,18 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayCancelResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayCancelResponse;
+import uk.gov.pay.connector.paymentprocessor.service.QueryService;
 
 import java.util.Optional;
 
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.ignoreStubs;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -37,20 +44,12 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCELL
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 
-@RunWith(MockitoJUnitRunner.class)
-/*
- * PP-2626 FIXME: Cancellation and expirations statuses needs revisiting
- * For `non gateway operations` seems the statuses are not all the required ones.
- * This won't make the system broken but doing unnecessary processing.
- *
- * Spying on chargeEntity.setStatus can't be done with current implementation since,
- * TransactionContext stores instances mapped with the correspondent class, so these
- * tests are testing as blackbox unit tests (which is fine, but since it test a lot
- * of underlying code was ideal at least to make sure to get to final cancellation
- * status, needed to go through the previous ones - lock, submitted and so on).
- * A consequence of a no TDD approach
- */
+@RunWith(JUnitParamsRunner.class)
 public class ChargeCancelServiceTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
     @Mock
     private ChargeDao mockChargeDao;
 
@@ -59,9 +58,12 @@ public class ChargeCancelServiceTest {
 
     @Mock
     private PaymentProvider mockPaymentProvider;
-
+    
     @Mock
     private ChargeService chargeService;
+    
+    @Mock
+    private QueryService mockQueryService;
 
     @InjectMocks
     private ChargeCancelService chargeCancelService;
@@ -83,7 +85,69 @@ public class ChargeCancelServiceTest {
     }
 
     @Test
-    public void doSystemCancel_shouldCancel_havingChargeStatusThatNeedsCancellationInGatewayProvider_withCancelledGatewayResponse() throws Exception {
+    @Parameters({
+            "AUTHORISATION READY",
+            "AUTHORISATION 3DS REQUIRED",
+            "AUTHORISATION 3DS READY"
+    })
+    public void doSystemCancel_chargeStatusDuringAuthorisation_DoesNotNeedCancellationWithProvider(String chargeStatus) throws Exception {
+        var status = ChargeStatus.fromString(chargeStatus);
+
+        String externalChargeId = "external-charge-id";
+        Long gatewayAccountId = nextLong();
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withExternalId(externalChargeId)
+                .withTransactionId("transaction-id")
+                .withStatus(status)
+                .build();
+
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(false);
+        when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
+
+        chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
+
+        verify(mockPaymentProvider, never()).cancel(any());
+        verify(chargeService).transitionChargeState(externalChargeId, SYSTEM_CANCELLED);
+        verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
+    }
+    
+    @Test
+    @Parameters({
+            "AUTHORISATION READY",
+            "AUTHORISATION 3DS REQUIRED",
+            "AUTHORISATION 3DS READY",
+            "AUTHORISATION SUCCESS"
+    })
+    public void doSystemCancel_chargeStatusDuringAuthorisation_needsCancellationWithProvider(String chargeStatus) throws Exception {
+        var status = ChargeStatus.fromString(chargeStatus);
+
+        String externalChargeId = "external-charge-id";
+        Long gatewayAccountId = nextLong();
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withExternalId(externalChargeId)
+                .withTransactionId("transaction-id")
+                .withStatus(status)
+                .build();
+
+        WorldpayCancelResponse worldpayResponse = mock(WorldpayCancelResponse.class);
+        when(worldpayResponse.cancelStatus()).thenReturn(BaseCancelResponse.CancelStatus.CANCELLED);
+        GatewayResponse.GatewayResponseBuilder<WorldpayCancelResponse> gatewayResponseBuilder = responseBuilder();
+        GatewayResponse cancelResponse = gatewayResponseBuilder.withResponse(worldpayResponse).build();
+
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
+        when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
+        when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
+        when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
+
+        chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
+
+        verify(mockPaymentProvider).cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)));
+        verify(chargeService).transitionChargeState(externalChargeId, SYSTEM_CANCELLED);
+        verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
+    }
+
+    @Test
+    public void doSystemCancel_chargeStatusAfterAuthorisation_cancelledWithProvider() throws Exception {
         String externalChargeId = "external-charge-id";
         Long gatewayAccountId = nextLong();
         ChargeEntity chargeEntity = aValidChargeEntity()
@@ -97,12 +161,14 @@ public class ChargeCancelServiceTest {
         GatewayResponse.GatewayResponseBuilder<WorldpayCancelResponse> gatewayResponseBuilder = responseBuilder();
         GatewayResponse cancelResponse = gatewayResponseBuilder.withResponse(worldpayResponse).build();
 
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
+        verify(mockPaymentProvider).cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)));
         verify(chargeService).transitionChargeState(externalChargeId, SYSTEM_CANCELLED);
         verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
     }
@@ -135,7 +201,67 @@ public class ChargeCancelServiceTest {
     }
 
     @Test
-    public void doUserCancel_shouldCancel_havingChargeStatusThatNeedsCancellationInGatewayProvider_withCancelledGatewayResponse() throws Exception {
+    @Parameters({
+            "AUTHORISATION READY",
+            "AUTHORISATION 3DS REQUIRED",
+            "AUTHORISATION 3DS READY"
+    })
+    public void doUserCancel_chargeStatusDuringAuthorisation_DoesNotNeedCancellationWithProvider(String chargeStatus) throws Exception {
+        var status = ChargeStatus.fromString(chargeStatus);
+
+        String externalChargeId = "external-charge-id";
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withExternalId(externalChargeId)
+                .withTransactionId("transaction-id")
+                .withStatus(status)
+                .build();
+
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(false);
+        when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
+
+        chargeCancelService.doUserCancel(externalChargeId);
+
+        verify(mockPaymentProvider, never()).cancel(any());
+        verify(chargeService).transitionChargeState(externalChargeId, USER_CANCELLED);
+        verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
+    }
+
+    @Test
+    @Parameters({
+            "AUTHORISATION READY",
+            "AUTHORISATION 3DS REQUIRED",
+            "AUTHORISATION 3DS READY",
+            "AUTHORISATION SUCCESS"
+    })
+    public void doUserCancel_chargeStatusDuringAuthorisation_needsCancellationWithProvider(String chargeStatus) throws Exception {
+        var status = ChargeStatus.fromString(chargeStatus);
+
+        String externalChargeId = "external-charge-id";
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withExternalId(externalChargeId)
+                .withTransactionId("transaction-id")
+                .withStatus(status)
+                .build();
+
+        WorldpayCancelResponse worldpayResponse = mock(WorldpayCancelResponse.class);
+        when(worldpayResponse.cancelStatus()).thenReturn(BaseCancelResponse.CancelStatus.CANCELLED);
+        GatewayResponse.GatewayResponseBuilder<WorldpayCancelResponse> gatewayResponseBuilder = responseBuilder();
+        GatewayResponse cancelResponse = gatewayResponseBuilder.withResponse(worldpayResponse).build();
+
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
+        when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
+        when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
+        when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
+
+        chargeCancelService.doUserCancel(externalChargeId);
+
+        verify(mockPaymentProvider).cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)));
+        verify(chargeService).transitionChargeState(externalChargeId, USER_CANCELLED);
+        verifyNoMoreInteractions(ignoreStubs(mockChargeDao));
+    }
+    
+    @Test
+    public void doUserCancel_shouldCancel_chargeStatusAfterAuthorisation_cancelledWithProvider() throws Exception {
         String externalChargeId = "external-charge-id";
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId(externalChargeId)

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -1,18 +1,21 @@
 package uk.gov.pay.connector.charge.service;
 
 import com.google.common.collect.ImmutableList;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import uk.gov.pay.connector.app.ChargeSweepConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -46,6 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -54,11 +58,14 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_FAILED;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(JUnitParamsRunner.class)
 public class ChargeExpiryServiceTest {
 
     private ChargeExpiryService chargeExpiryService;
 
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
     @Mock
     private ChargeDao mockChargeDao;
 
@@ -89,16 +96,10 @@ public class ChargeExpiryServiceTest {
     private static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = ImmutableList.of(
             CREATED,
             ENTERING_CARD_DETAILS,
+            AUTHORISATION_READY,
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_3DS_READY,
             AUTHORISATION_SUCCESS
-    );
-
-    private static final List<ChargeStatus> GATEWAY_CANCELLABLE_STATUSES = ImmutableList.of(
-            AUTHORISATION_3DS_READY,
-            AUTHORISATION_3DS_REQUIRED,
-            AUTHORISATION_SUCCESS,
-            AWAITING_CAPTURE_REQUEST
     );
 
     private static final List<ChargeStatus> EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS = ImmutableList.of(
@@ -176,24 +177,61 @@ public class ChargeExpiryServiceTest {
     }
 
     @Test
-    public void shouldExpireChargesWithoutCallingProviderToCancel() {
-        EXPIRABLE_REGULAR_STATUSES.stream()
-                .filter(status -> !GATEWAY_CANCELLABLE_STATUSES.contains(status))
-                .forEach(status -> {
-                    ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                            .withAmount(200L)
-                            .withCreatedDate(ZonedDateTime.now())
-                            .withStatus(status)
-                            .withGatewayAccountEntity(gatewayAccount)
-                            .build();
-                    chargeExpiryService.expire(singletonList(chargeEntity));
+    @Parameters({
+            "CREATED",
+            "ENTERING CARD DETAILS",
+            "AUTHORISATION READY",
+            "AUTHORISATION 3DS REQUIRED",
+            "AUTHORISATION 3DS READY"
+    })
+    public void shouldExpireChargesWithoutCallingProviderToCancel(String chargeStatus) throws Exception {
+        var status = ChargeStatus.fromString(chargeStatus);
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+                .withAmount(200L)
+                .withCreatedDate(ZonedDateTime.now())
+                .withStatus(status)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
 
-                    try {
-                        verify(mockPaymentProvider, never()).cancel(any());
-                    } catch (GatewayException ignored) {}
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(false);
 
-                    verify(mockChargeService).transitionChargeState(chargeEntity.getExternalId(), EXPIRED);
-                });
+        chargeExpiryService.expire(singletonList(chargeEntity));
+        
+        verify(mockPaymentProvider, never()).cancel(any());
+        verify(mockChargeService).transitionChargeState(chargeEntity.getExternalId(), EXPIRED);
+    }
+
+    @Test
+    @Parameters({
+            "AUTHORISATION READY",
+            "AUTHORISATION 3DS REQUIRED",
+            "AUTHORISATION 3DS READY"
+    })
+    public void shouldExpireWithPaymentProvider_whenGatewayStateIsCancellable(String chargeStatus) throws Exception {
+        var status = ChargeStatus.fromString(chargeStatus);
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+                .withAmount(200L)
+                .withCreatedDate(ZonedDateTime.now())
+                .withStatus(status)
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
+
+        when(mockWorldpayCancelResponse.cancelStatus()).thenReturn(CancelStatus.CANCELLED);
+
+        when(mockChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
+        ArgumentCaptor<CancelGatewayRequest> cancelCaptor = ArgumentCaptor.forClass(CancelGatewayRequest.class);
+
+        ChargeEntity expiredCharge = mockExpiredChargeEntity();
+        when(mockChargeService.transitionChargeState(any(String.class), any())).thenReturn(expiredCharge);
+
+        chargeExpiryService.expire(singletonList(chargeEntity));
+
+        verify(mockPaymentProvider).cancel(cancelCaptor.capture());
+        assertThat(cancelCaptor.getValue().getTransactionId(), is(chargeEntity.getGatewayTransactionId()));
+        verify(mockChargeService).transitionChargeState(chargeEntity.getExternalId(), EXPIRED);
     }
 
     @Test
@@ -264,7 +302,7 @@ public class ChargeExpiryServiceTest {
 
         when(mockChargeDao.findByExternalId(preAuthorisationCharge.getExternalId())).thenReturn(Optional.of(preAuthorisationCharge));
 
-        when(mockQueryService.getChargeGatewayStatus(preAuthorisationCharge)).thenReturn(new ChargeQueryResponse(AUTHORISATION_SUCCESS, "Raw response"));
+        when(mockQueryService.isTerminableWithGateway(preAuthorisationCharge)).thenReturn(true);
         when(mockWorldpayCancelResponse.cancelStatus()).thenReturn(CancelStatus.CANCELLED);
 
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
@@ -275,7 +313,7 @@ public class ChargeExpiryServiceTest {
 
         Map<String, Integer> sweepResult = chargeExpiryService.sweepAndExpireChargesAndTokens();
 
-        verify(mockChargeService).transitionChargeState(preAuthorisationCharge.getExternalId(),     EXPIRED);
+        verify(mockChargeService).transitionChargeState(preAuthorisationCharge.getExternalId(), EXPIRED);
         assertThat(sweepResult.get("expiry-success"), is(1));
         assertNull(sweepResult.get("expiry-failure"));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
@@ -70,7 +70,7 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
     @Test
     public void respondWith204WithNoLockingState_whenCancellationBeforeAuth() {
 
-        String chargeId = addCharge(ENTERING_CARD_DETAILS, "ref", ZonedDateTime.now().minusHours(1), "irrelvant");
+        String chargeId = addCharge(ENTERING_CARD_DETAILS, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
         userCancelChargeAndCheckApiStatus(chargeId, USER_CANCELLED, 204);
         List<String> events = databaseTestHelper.getInternalEvents(chargeId);
         assertThat(events.size(), is(2));
@@ -93,7 +93,7 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
 
     @Test
     public void respondWith202_whenCancelAlreadyInProgress() {
-        String chargeId = addCharge(USER_CANCEL_READY, "ref", ZonedDateTime.now().minusHours(1), "irrelvant");
+        String chargeId = addCharge(USER_CANCEL_READY, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
         String expectedMessage = "User Cancellation for charge already in progress, " + chargeId;
         connectorRestApiClient
                 .withChargeId(chargeId)
@@ -121,29 +121,13 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void respondWith204With3DSRequeirdState_whenCancellationBeforeAuth() {
+    public void respondWith204With3DSRequiredState_whenCancellationBeforeAuth() {
 
-        String chargeId = addCharge(AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelvant");
+        String chargeId = addCharge(AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
         userCancelChargeAndCheckApiStatus(chargeId, USER_CANCELLED, 204);
         List<String> events = databaseTestHelper.getInternalEvents(chargeId);
         assertThat(events.size(), is(2));
         assertThat(events, hasItems(AUTHORISATION_3DS_REQUIRED.getValue(), USER_CANCELLED.getValue()));
-    }
-
-    @Test
-    public void respondWith409_whenCancellationDuringAuth3DSReady() {
-        String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", ZonedDateTime.now().minusHours(1), "transaction-id");
-        worldpayMockClient.mockCancelSuccess();
-
-        connectorRestApiClient
-                .withChargeId(chargeId)
-                .postFrontendChargeCancellation()
-                .statusCode(409);
-
-        connectorRestApiClient
-                .withChargeId(chargeId)
-                .getCharge()
-                .body("state.status", is("started"));
     }
 
     private String userCancelChargeAndCheckApiStatus(String chargeId, ChargeStatus targetState, int httpStatusCode) {
@@ -177,22 +161,6 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
                 .contentType(JSON)
                 .body("message", contains("Charge with id [" + unknownChargeId + "] not found."))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
-    }
-
-    @Test
-    public void respondWith409_whenCancellationDuringAuthReady() {
-        String chargeId = addCharge(AUTHORISATION_READY, "ref", ZonedDateTime.now().minusHours(1), "transaction-id");
-        worldpayMockClient.mockCancelSuccess();
-
-        connectorRestApiClient
-                .withChargeId(chargeId)
-                .postFrontendChargeCancellation()
-                .statusCode(409);
-
-        connectorRestApiClient
-                .withChargeId(chargeId)
-                .getCharge()
-                .body("state.status", is("started"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
+import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+@RunWith(JUnitParamsRunner.class)
+public class QueryServiceTest {
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+    
+    @Mock 
+    private PaymentProvider paymentProvider;
+    
+    @Mock
+    private PaymentProviders paymentProviders;
+    
+    @InjectMocks
+    private QueryService queryService;
+
+    @Before
+    public void setUp() {
+        when(paymentProviders.byName(any())).thenReturn(paymentProvider);
+    }
+
+    @Test
+    public void isTerminableWithGateway_returnsTrueForNotFinishedExternalStatus() throws Exception {
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+        
+        ChargeQueryResponse response = new ChargeQueryResponse(AUTHORISATION_3DS_REQUIRED, "a-response");
+        when(paymentProvider.queryPaymentStatus(chargeEntity)).thenReturn(response);
+        
+        assertThat(queryService.isTerminableWithGateway(chargeEntity), is(true));
+    }
+
+    @Test
+    public void isTerminableWithGateway_returnsFalseForFinishedExternalStatus() throws Exception {
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+
+        ChargeQueryResponse response = new ChargeQueryResponse(CAPTURED, "a-response");
+        when(paymentProvider.queryPaymentStatus(chargeEntity)).thenReturn(response);
+
+        assertThat(queryService.isTerminableWithGateway(chargeEntity), is(false));
+    }
+}


### PR DESCRIPTION
Use same methodology as charge expiry to determine whether charges need cancelling with the gateway. This groups charge statuses into PRE_AUTHORISATION, DURING_AUTHORISATION and POST_AUTHORISATION. For charges with statuses in the DURING_AUTHORISATION category, we check with the gateway to determine whether we need to send a cancellation request.

Also add the ability to cancel charges in AUTHORISATION_READY and AUTHORISATION_3DS_READY statuses, as we should be able to cancel a charge at any point when it isn't in a terminal state.