### PR TITLE
PP-5386 Add state transition to payment event emit queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -81,6 +81,9 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     private Boolean xrayEnabled;
 
+    @NotNull
+    private Boolean emitPaymentStateTransitionEvents;
+
     @Valid
     @NotNull
     @JsonProperty("sqsConfig")
@@ -184,5 +187,9 @@ public class ConnectorConfiguration extends Configuration {
 
     public EventQueueConfig getEventQueueConfig() {
         return eventQueueConfig;
+    }
+
+    public Boolean getEmitPaymentStateTransitionEvents() {
+        return emitPaymentStateTransitionEvents;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -455,12 +455,11 @@ public class ChargeService {
 
         PaymentGatewayStateTransitions.getInstance()
                 .getEventForTransition(fromChargeState, targetChargeState)
-                .map(eventType -> {
+                .ifPresent(eventType -> {
                     try {
                         PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventType);
                         paymentStateTransitionQueue.offer(transition);
                         logger.info("Offered payment state transition to emitter queue [from={}] [to={}] [chargeId={}]", fromChargeState, targetChargeState, chargeEventEntity.getId());
-                        return transition;
                     } catch (Exception e) {
                         logger.warn(
                                 "Failed to write state transition to queue [from={}] [to={}] [error={}]",
@@ -468,7 +467,6 @@ public class ChargeService {
                                 targetChargeState,
                                 e.getMessage()
                         );
-                        return null;
                     }
                 });
         return charge;

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -450,11 +450,12 @@ public class ChargeService {
             ChargeStatus targetChargeState,
             ZonedDateTime gatewayEventTime
     ) {
+        ChargeStatus fromChargeState = ChargeStatus.fromString(charge.getStatus());
         charge.setStatus(targetChargeState);
         ChargeEventEntity chargeEventEntity = chargeEventDao.persistChargeEventOf(charge, gatewayEventTime);
 
         PaymentGatewayStateTransitions.getInstance()
-                .getEventForTransition(ChargeStatus.fromString(charge.getStatus()), targetChargeState)
+                .getEventForTransition(fromChargeState, targetChargeState)
                 .map(eventType -> {
                     PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventType);
                     paymentStateTransitionQueue.offer(transition);

--- a/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
@@ -24,8 +24,10 @@ public class ChargeEventDao extends JpaDao<ChargeEventEntity> {
         this.persistChargeEventOf(chargeEntity, null);
     }
 
-    public void persistChargeEventOf(ChargeEntity chargeEntity, ZonedDateTime gatewayEventDate) {
-        this.persist(ChargeEventEntity.from(chargeEntity, ChargeStatus.fromString(chargeEntity.getStatus()),
-                ZonedDateTime.now(), Optional.ofNullable(gatewayEventDate)));
+    public ChargeEventEntity persistChargeEventOf(ChargeEntity chargeEntity, ZonedDateTime gatewayEventDate) {
+        ChargeEventEntity chargeEventEntity = ChargeEventEntity.from(chargeEntity, ChargeStatus.fromString(chargeEntity.getStatus()),
+                ZonedDateTime.now(), Optional.ofNullable(gatewayEventDate));
+        this.persist(chargeEventEntity);
+        return chargeEventEntity;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/PaymentStateTransitionEmitterProcess.java
+++ b/src/main/java/uk/gov/pay/connector/events/PaymentStateTransitionEmitterProcess.java
@@ -43,9 +43,10 @@ public class PaymentStateTransitionEmitterProcess {
                 eventQueue.emitEvent(paymentEvent);
             } catch (StateTransitionMessageProcessException | QueueException e) {
                 LOGGER.warn(
-                        "Failed to emit payment event for state transition [chargeEventId={}] [eventType={}]",
+                        "Failed to emit payment event for state transition [chargeEventId={}] [eventType={}] [error={}]",
                         paymentStateTransition.getChargeEventId(),
-                        paymentStateTransition.getStateTransitionEventClass().getSimpleName()
+                        paymentStateTransition.getStateTransitionEventClass().getSimpleName(),
+                        e.getMessage()
                 );
                 paymentStateTransitionQueue.offer(PaymentStateTransition.incrementAttempts(paymentStateTransition));
             }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -202,6 +202,8 @@ graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: ${XRAY_ENABLED:-false}
 
+emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
+
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -170,6 +170,7 @@ public class ChargeServiceTest {
 
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
         when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
+        when(mockedConfig.getEmitPaymentStateTransitionEvents()).thenReturn(true);
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedEventQueue, mockedPaymentStateTransitionQueue);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
+import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
 import uk.gov.pay.connector.util.AuthUtils;
 
 import java.util.Optional;
@@ -53,6 +54,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     @Mock
     private EventQueue eventQueue;
 
+    @Mock
+    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
     private ChargeService chargeService;
     private Card3dsResponseAuthService card3dsResponseAuthService;
@@ -67,7 +71,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, eventQueue);
+                null, mockConfiguration, null, eventQueue, paymentStateTransitionQueue);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
+import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
 
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -97,6 +98,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private EventQueue eventQueue;
 
+    @Mock
+    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+
     private CardAuthoriseService cardAuthorisationService;
 
     @Before
@@ -106,7 +110,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, eventQueue);
+                null, null, mockConfiguration, null, eventQueue, paymentStateTransitionQueue);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.queue.CaptureQueue;
+import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
@@ -102,6 +103,9 @@ public class CardCaptureServiceTest extends CardServiceTest {
     @Mock
     private EventQueue eventQueue;
 
+    @Mock
+    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
@@ -112,7 +116,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, eventQueue);
+                null, null, mockConfiguration, null, eventQueue, paymentStateTransitionQueue);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
+import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
@@ -94,6 +95,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private EventQueue eventQueue;
 
+    @Mock
+    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+
     private WalletAuthoriseService walletAuthoriseService;
 
     private final AppleDecryptedPaymentData validApplePayDetails =
@@ -116,7 +120,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, eventQueue);
+                null, null, mockConfiguration, null, eventQueue, paymentStateTransitionQueue);
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -162,6 +162,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -161,6 +161,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -151,6 +151,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -157,6 +157,8 @@ graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
 
+emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
+
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -154,6 +154,7 @@ graphiteHost: ${METRICS_HOST:-localhost}
 graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
+emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}


### PR DESCRIPTION
Relies on processing gubbins in https://github.com/alphagov/pay-connector/pull/1456 and public graph transition exposed in https://github.com/alphagov/pay-connector/pull/1461. 

* write state transition to in-memory queue 
* introduce feature flag, off by default

https://github.com/alphagov/pay-connector/commit/28c5594b50c0e416c7eab76d02271896d90536d1 Connect the transition charge state method to the emission queue process
https://github.com/alphagov/pay-connector/commit/46024f04c9ca4f6ba3248b80e0301c45c553f9f1 cleanup mocks

Supersedes https://github.com/alphagov/pay-connector/pull/1475