### PR TITLE
PP-5360 add pact state to connector

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -421,4 +421,8 @@ public class TransactionsApiContractTest {
                 .withCorporateSurcharge(250L)
                 .build());
     }
+
+    @State("a charge does not exist")
+    public void chargeDoesNotExist() {
+    }
 }


### PR DESCRIPTION
* added "charge does not exist" pact state to connector

Related to https://github.com/alphagov/pay-publicapi/pull/580
Another way of addressing ^^ would be to separate the test file (to test ledger contract separately) and have a wiremock stub for Connector response.
I will do that if this way is not recommended (it feels a little bit hacky).
