### PR TITLE
PP-5386 Undefined charge status

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -53,6 +53,7 @@ import java.util.Optional;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.UNDEFINED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
 import static uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions.isValidTransition;
 
@@ -148,7 +149,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
     public ChargeEntity(Long amount, String returnUrl, String description, ServicePaymentReference reference,
                         GatewayAccountEntity gatewayAccount, String email, SupportedLanguage language,
                         boolean delayedCapture, ExternalMetadata externalMetadata) {
-        this(amount, CREATED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture, externalMetadata);
+        this(amount, UNDEFINED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture, externalMetadata);
     }
 
     // Only the ChargeEntityFixture should directly call this constructor

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
@@ -19,6 +19,7 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
 
 public enum ChargeStatus implements Status {
+    UNDEFINED("UNDEFINED", EXTERNAL_CREATED),
     CREATED("CREATED", EXTERNAL_CREATED),
     ENTERING_CARD_DETAILS("ENTERING CARD DETAILS", EXTERNAL_STARTED),
     AUTHORISATION_ABORTED("AUTHORISATION ABORTED", EXTERNAL_FAILED_REJECTED),

--- a/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
@@ -20,6 +20,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READ
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.UNDEFINED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_FULL;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_PENDING;
@@ -28,6 +29,7 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailabi
 public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefundAvailabilityCalculator {
 
     private static final List<ChargeStatus> STATUSES_THAT_MAP_TO_EXTERNAL_PENDING = ImmutableList.of(
+            UNDEFINED,
             CREATED,
             ENTERING_CARD_DETAILS,
             AUTHORISATION_READY,


### PR DESCRIPTION
Introduces a new undefined charge status, and on charge creation initialises a charge as undefined, then transitions it to created. This means a PaymentCreated event is emitted in the same way all other events are emitted.
The charge entity needs to be merged after transitioning to created, because for some reason that I haven't got totally to the bottom of, after the call to persist the charge entity is detached. I have chosen to do the merge as a one off thing, rather than move it into the transitionChargeStatus method, as it is seemingly only needed after entity creation.

