### PR TITLE
PP-5386 remove manual state transitions

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -179,7 +179,7 @@ public class ChargeServiceTest {
         when(mockedConfig.getEmitPaymentStateTransitionEvents()).thenReturn(true);
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
-                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedEventQueue, mockedPaymentStateTransitionQueue);
+                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedPaymentStateTransitionQueue);
     }
 
     @Test
@@ -208,27 +208,7 @@ public class ChargeServiceTest {
 
         verify(mockedChargeEventDao).persistChargeEventOf(eq(createdChargeEntity), isNull());
     }
-
-    @Test
-    public void createChargeShouldPutPaymentCreatedEventOnQueue() throws Exception {
-        // ACT
-        service.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        // ASSERT
-        verify(mockedEventQueue).emitEvent(any(PaymentCreated.class));
-    }
-
-    @Test(expected = WebApplicationException.class)
-    public void createChargeThrowsWebApplicationExceptionIfEmittingPaymentCreatedEventFails() throws Exception {
-        doThrow(new QueueException("Queue badness")).when(mockedEventQueue).emitEvent(any(Event.class));
-
-        service.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        // assert that DB record got written
-        verify(mockedChargeDao).persist(any(ChargeEntity.class));
-    }
-
-
+    
     @Test
     public void shouldCreateAChargeWithDelayedCaptureTrue() {
         final ChargeCreateRequest request = requestBuilder.withDelayedCapture(true).build();

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.ConfigOverride;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
@@ -35,7 +36,11 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
+@DropwizardConfig(
+        app = ConnectorApp.class,
+        config = "config/test-it-config.yaml",
+        withDockerSQS = true
+)
 public class WorldpayCardResourceIT extends ChargingITestBase {
 
     private String validAuthorisationDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "visa");
@@ -232,7 +237,6 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
                 .then()
                 .statusCode(204);
 
-        assertFrontendChargeStatusIs(chargeId, CAPTURE_APPROVED.getValue());
         assertApiStateIs(chargeId, EXTERNAL_SUCCESS.getStatus());
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -17,7 +17,6 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
-import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
@@ -51,8 +50,6 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
-    @Mock
-    private EventQueue eventQueue;
 
     @Mock
     private PaymentStateTransitionQueue paymentStateTransitionQueue;
@@ -71,7 +68,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, eventQueue, paymentStateTransitionQueue);
+                null, mockConfiguration, null, paymentStateTransitionQueue);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -6,7 +6,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
@@ -20,8 +19,6 @@ import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.events.Event;
-import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -56,7 +53,6 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -96,9 +92,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     private Counter mockCounter;
 
     @Mock
-    private EventQueue eventQueue;
-
-    @Mock
     private PaymentStateTransitionQueue paymentStateTransitionQueue;
 
     private CardAuthoriseService cardAuthorisationService;
@@ -110,7 +103,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, eventQueue, paymentStateTransitionQueue);
+                null, null, mockConfiguration, null, paymentStateTransitionQueue);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(
@@ -232,25 +225,6 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.get3dsDetails(), is(nullValue()));
         assertThat(charge.getCardDetails(), is(notNullValue()));
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
-    }
-
-    @Test
-    public void doAuthorise_shouldPublishEvent() throws Exception {
-
-        providerWillAuthorise();
-        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
-                .withAddress(null)
-                .build();
-
-        AuthorisationResponse response = cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
-
-        assertTrue(response.getAuthoriseStatus().isPresent());
-        assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
-
-        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(eventQueue, times(1)).emitEvent(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().getResourceExternalId(), is(charge.getExternalId()));
-        assertThat(eventCaptor.getValue().getEventType(), is("PAYMENT_DETAILS_ENTERED"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -30,7 +30,6 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
-import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -55,7 +54,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -100,8 +98,6 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private ConnectorConfiguration mockConfiguration;
     @Mock
     private Environment mockEnvironment;
-    @Mock
-    private EventQueue eventQueue;
 
     @Mock
     private PaymentStateTransitionQueue paymentStateTransitionQueue;
@@ -116,7 +112,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, eventQueue, paymentStateTransitionQueue);
+                null, null, mockConfiguration, null, paymentStateTransitionQueue);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);


### PR DESCRIPTION
We now have a generic way to ensure state transition events are emitted to sqs for all state transitions. This commit removes the code to emit events manually for the PaymentCreation and PaymentDetailsEntered events.