### PR TITLE
PP-5386 State transition poller use single method for exectutor

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
@@ -60,7 +60,7 @@ public class QueueMessageReceiver implements Managed {
                 TimeUnit.SECONDS);
 
         stateTransitionMessageExecutorService.scheduleWithFixedDelay(
-                stateTransitionMessageReceiver(),
+                this::stateTransitionMessageReceiver,
                 0,
                 100,
                 TimeUnit.MILLISECONDS);
@@ -72,8 +72,12 @@ public class QueueMessageReceiver implements Managed {
         stateTransitionMessageExecutorService.shutdown();
     }
 
-    private Thread stateTransitionMessageReceiver() {
-        return new Thread(() -> paymentStateTransitionEmitterProcess.handleStateTransitionMessages());
+    private void stateTransitionMessageReceiver() {
+        try {
+            paymentStateTransitionEmitterProcess.handleStateTransitionMessages();
+        } catch (Exception e) {
+            LOGGER.error("State transition message polling thread failed for [exception={}]", e);
+        }
     }
 
     private Thread chargeCaptureMessageReceiver() {


### PR DESCRIPTION
* handle thread errors
* don't spin up a new thread manually