### PR TITLE
BAU Queue polling - log error message vs. full stack trace

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
@@ -76,7 +76,7 @@ public class QueueMessageReceiver implements Managed {
         try {
             paymentStateTransitionEmitterProcess.handleStateTransitionMessages();
         } catch (Exception e) {
-            LOGGER.error("State transition message polling thread failed for [exception={}]", e);
+            LOGGER.error("State transition message polling thread failed to process message due to [message={}]", e.getMessage());
         }
     }
 
@@ -84,7 +84,7 @@ public class QueueMessageReceiver implements Managed {
         try {
             cardCaptureProcess.handleCaptureMessages();
         } catch (Exception e) {
-            LOGGER.error("Queue message chargeCaptureMessageReceiver thread exception [{}]", e);
+            LOGGER.error("Queue message chargeCaptureMessageReceiver thread exception [message={}]", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
Favour error `getMessage` in favour of spamming Splunk with individual stack trace lines.