### PR TITLE
PP-5388: rename duplicated events in a given payment flow

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -8,9 +8,18 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.events.AuthorisationCancelled;
 import uk.gov.pay.connector.events.AuthorisationRejected;
 import uk.gov.pay.connector.events.AuthorisationSucceeded;
+import uk.gov.pay.connector.events.CancelByExpirationFailed;
+import uk.gov.pay.connector.events.CancelByExpirationSubmitted;
+import uk.gov.pay.connector.events.CancelByExternalServiceFailed;
+import uk.gov.pay.connector.events.CancelByExternalServiceSubmitted;
+import uk.gov.pay.connector.events.CancelByUserFailed;
+import uk.gov.pay.connector.events.CancelByUserSubmitted;
+import uk.gov.pay.connector.events.CancelledByExpiration;
+import uk.gov.pay.connector.events.CancelledByExternalService;
+import uk.gov.pay.connector.events.CancelledByUser;
 import uk.gov.pay.connector.events.CaptureAbandonedAfterTooManyRetries;
 import uk.gov.pay.connector.events.CaptureConfirmed;
-import uk.gov.pay.connector.events.CaptureError;
+import uk.gov.pay.connector.events.CaptureErrored;
 import uk.gov.pay.connector.events.CaptureSubmitted;
 import uk.gov.pay.connector.events.Event;
 import uk.gov.pay.connector.events.GatewayErrorDuringAuthorisation;
@@ -90,16 +99,14 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(CREATED, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, EXPIRED, ModelledEvent.of(PaymentExpired.class));
-        graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRED, ModelledEvent.of(PaymentExpired.class));
-        graph.putEdgeValue(EXPIRE_CANCEL_SUBMITTED, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRED, ModelledEvent.of(PaymentExpired.class));
 
         graph.putEdgeValue(CREATED, ENTERING_CARD_DETAILS, ModelledEvent.of(PaymentStarted.class));
-        graph.putEdgeValue(CREATED, SYSTEM_CANCELLED, ModelledEvent.of(SystemCancelled.class));
+        graph.putEdgeValue(CREATED, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_READY, ModelledEvent.none());
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_ABORTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, USER_CANCELLED, ModelledEvent.of(UserCancelled.class));
-        graph.putEdgeValue(ENTERING_CARD_DETAILS, SYSTEM_CANCELLED, ModelledEvent.of(SystemCancelled.class));
+        graph.putEdgeValue(ENTERING_CARD_DETAILS, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_ABORTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_SUCCESS, ModelledEvent.of(AuthorisationSucceeded.class));
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
@@ -140,25 +147,31 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(CAPTURE_APPROVED_RETRY, CAPTURE_READY, ModelledEvent.none());
         graph.putEdgeValue(CAPTURE_APPROVED_RETRY, CAPTURE_ERROR, ModelledEvent.of(CaptureAbandonedAfterTooManyRetries.class));
         graph.putEdgeValue(CAPTURE_APPROVED_RETRY, CAPTURED, ModelledEvent.of(CaptureConfirmed.class));
+
         graph.putEdgeValue(CAPTURE_READY, CAPTURE_SUBMITTED, ModelledEvent.of(CaptureSubmitted.class));
-        graph.putEdgeValue(CAPTURE_READY, CAPTURE_ERROR, ModelledEvent.of(CaptureError.class));
+        graph.putEdgeValue(CAPTURE_READY, CAPTURE_ERROR, ModelledEvent.of(CaptureErrored.class));
         graph.putEdgeValue(CAPTURE_READY, CAPTURE_APPROVED_RETRY, ModelledEvent.none());
         graph.putEdgeValue(CAPTURE_READY, CAPTURED, ModelledEvent.of(CaptureConfirmed.class));
-        graph.putEdgeValue(CAPTURE_SUBMITTED, CAPTURED, ModelledEvent.of(CaptureConfirmed.class));
-        graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRE_CANCEL_SUBMITTED, ModelledEvent.of(PaymentExpired.class));
-        graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRE_CANCEL_FAILED, ModelledEvent.of(PaymentExpired.class));
 
-        graph.putEdgeValue(EXPIRE_CANCEL_SUBMITTED, EXPIRE_CANCEL_FAILED, ModelledEvent.of(PaymentExpired.class));
-        graph.putEdgeValue(SYSTEM_CANCEL_READY, SYSTEM_CANCEL_SUBMITTED, ModelledEvent.of(SystemCancelled.class));
-        graph.putEdgeValue(SYSTEM_CANCEL_READY, SYSTEM_CANCEL_ERROR, ModelledEvent.of(SystemCancelled.class));
-        graph.putEdgeValue(SYSTEM_CANCEL_READY, SYSTEM_CANCELLED, ModelledEvent.of(SystemCancelled.class));
-        graph.putEdgeValue(SYSTEM_CANCEL_SUBMITTED, SYSTEM_CANCEL_ERROR, ModelledEvent.of(SystemCancelled.class));
-        graph.putEdgeValue(SYSTEM_CANCEL_SUBMITTED, SYSTEM_CANCELLED, ModelledEvent.of(SystemCancelled.class));
-        graph.putEdgeValue(USER_CANCEL_READY, USER_CANCEL_SUBMITTED, ModelledEvent.of(UserCancelled.class));
-        graph.putEdgeValue(USER_CANCEL_READY, USER_CANCEL_ERROR, ModelledEvent.of(UserCancelled.class));
-        graph.putEdgeValue(USER_CANCEL_READY, USER_CANCELLED, ModelledEvent.of(UserCancelled.class));
-        graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCEL_ERROR, ModelledEvent.of(UserCancelled.class));
-        graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCELLED, ModelledEvent.of(UserCancelled.class));
+        graph.putEdgeValue(CAPTURE_SUBMITTED, CAPTURED, ModelledEvent.of(CaptureConfirmed.class));
+
+        graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRE_CANCEL_SUBMITTED, ModelledEvent.of(CancelByExpirationSubmitted.class));
+        graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRE_CANCEL_FAILED, ModelledEvent.of(CancelByExpirationFailed.class));
+        graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRED, ModelledEvent.of(CancelledByExpiration.class));
+        graph.putEdgeValue(EXPIRE_CANCEL_SUBMITTED, EXPIRE_CANCEL_FAILED, ModelledEvent.of(CancelByExpirationFailed.class));
+        graph.putEdgeValue(EXPIRE_CANCEL_SUBMITTED, EXPIRED, ModelledEvent.of(CancelledByExpiration.class));
+
+        graph.putEdgeValue(SYSTEM_CANCEL_READY, SYSTEM_CANCEL_SUBMITTED, ModelledEvent.of(CancelByExternalServiceSubmitted.class));
+        graph.putEdgeValue(SYSTEM_CANCEL_READY, SYSTEM_CANCEL_ERROR, ModelledEvent.of(CancelByExternalServiceFailed.class));
+        graph.putEdgeValue(SYSTEM_CANCEL_READY, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
+        graph.putEdgeValue(SYSTEM_CANCEL_SUBMITTED, SYSTEM_CANCEL_ERROR, ModelledEvent.of(CancelByExternalServiceFailed.class));
+        graph.putEdgeValue(SYSTEM_CANCEL_SUBMITTED, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
+
+        graph.putEdgeValue(USER_CANCEL_READY, USER_CANCEL_SUBMITTED, ModelledEvent.of(CancelByUserSubmitted.class));
+        graph.putEdgeValue(USER_CANCEL_READY, USER_CANCEL_ERROR, ModelledEvent.of(CancelByUserFailed.class));
+        graph.putEdgeValue(USER_CANCEL_READY, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+        graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCEL_ERROR, ModelledEvent.of(CancelByUserFailed.class));
+        graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
 
         return ImmutableValueGraph.copyOf(graph);
     }

--- a/src/main/java/uk/gov/pay/connector/events/CancelByExpirationFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelByExpirationFailed.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelByExpirationFailed extends PaymentEventWithoutDetails {
+    public CancelByExpirationFailed(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelByExpirationSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelByExpirationSubmitted.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelByExpirationSubmitted extends PaymentEventWithoutDetails {
+    public CancelByExpirationSubmitted(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelByExternalServiceFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelByExternalServiceFailed.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelByExternalServiceFailed extends PaymentEventWithoutDetails {
+    public CancelByExternalServiceFailed(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelByExternalServiceSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelByExternalServiceSubmitted.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelByExternalServiceSubmitted extends PaymentEventWithoutDetails {
+    public CancelByExternalServiceSubmitted(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelByUserFailed.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelByUserFailed.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelByUserFailed extends PaymentEventWithoutDetails {
+    public CancelByUserFailed(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelByUserSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelByUserSubmitted.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelByUserSubmitted extends PaymentEventWithoutDetails {
+    public CancelByUserSubmitted(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelledByExpiration.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelledByExpiration.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelledByExpiration extends PaymentEventWithoutDetails {
+    public CancelledByExpiration(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelledByExternalService.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelledByExternalService.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelledByExternalService extends PaymentEventWithoutDetails {
+    public CancelledByExternalService(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/CancelledByUser.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class CancelledByUser extends PaymentEventWithoutDetails {
+    public CancelledByUser(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/CaptureErrored.java
+++ b/src/main/java/uk/gov/pay/connector/events/CaptureErrored.java
@@ -3,8 +3,8 @@ package uk.gov.pay.connector.events;
 import java.time.ZonedDateTime;
 
 // In rare circumstances.. only smartpay?
-public class CaptureError extends PaymentEventWithoutDetails {
-    public CaptureError(String resourceExternalId, ZonedDateTime timestamp) {
+public class CaptureErrored extends PaymentEventWithoutDetails {
+    public CaptureErrored(String resourceExternalId, ZonedDateTime timestamp) {
         super(resourceExternalId, timestamp);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.events.CaptureAbandonedAfterTooManyRetries;
-import uk.gov.pay.connector.events.CaptureError;
+import uk.gov.pay.connector.events.CaptureErrored;
 import uk.gov.pay.connector.events.CaptureSubmitted;
 import uk.gov.pay.connector.events.Event;
 import uk.gov.pay.connector.events.PaymentExpired;
@@ -51,7 +51,7 @@ public class PaymentGatewayStateTransitionsTest {
     @Test
     public void isValidTransition_deniesTransitionWithInvalidEvent() {
         assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED, new CaptureSubmitted("a", ZonedDateTime.now())), is(true));
-        assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED, new CaptureError("a", ZonedDateTime.now())), is(false));
+        assertThat(PaymentGatewayStateTransitions.isValidTransition(CAPTURE_READY, CAPTURE_SUBMITTED, new CaptureErrored("a", ZonedDateTime.now())), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/events/PaymentStateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/PaymentStateTransitionsIT.java
@@ -62,7 +62,7 @@ public class PaymentStateTransitionsIT extends ChargingITestBase {
         JsonObject message = new JsonParser().parse(messages.get(0).getBody()).getAsJsonObject();
 
         assertThat(message.get("resource_external_id").getAsString(), is(chargeId));
-        assertThat(message.get("event_type").getAsString(), is("SYSTEM_CANCELLED"));
+        assertThat(message.get("event_type").getAsString(), is("CANCELLED_BY_EXTERNAL_SERVICE"));
     }
 
     private List<Message> readMessagesFromEventQueue() {


### PR DESCRIPTION
Some state transitions during the payment flow could result in the same event being emitted for different actions.

i.e 
`SYSTEM_CANCEL_READY` -> `SYSTEM_CANCEL_SUBMITTED` : `SystemCancelled`
`SYSTEM_CANCEL_SUBMITTED` -> `SYSTEM_CANCELLED` : `SystemCancelled` 

This event was reflecting the external state transitioned to rather than the action, update this to remove duplicate events during an individual payment flow.

EDIT: unfortunately file organisation makes it look like structural changes were made - only renaming happened in `PaymentGatewayStateTransitions`