### PR TITLE
BAU don't pact test against everything

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -18,7 +18,7 @@ import java.time.ZonedDateTime;
 
 @RunWith(PactRunner.class)
 @Provider("connector")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"ledger"})
 public class QueueMessageContractTest {

--- a/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/TransactionsApiContractTest.java
@@ -43,7 +43,7 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 
 @RunWith(PactRunner.class)
 @Provider("connector")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice", "publicapi"})
 public class TransactionsApiContractTest {

--- a/src/test/java/uk/gov/pay/connector/pact/WalletApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/WalletApiContractTest.java
@@ -26,7 +26,7 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 
 @RunWith(PactRunner.class)
 @Provider("connector")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"frontend"})
 public class WalletApiContractTest {


### PR DESCRIPTION
when running provider tests we are provided with an environment variable `PACT_CONSUMER_TAG`.

When running a branch or master build of the provider this will be set to
`master`. So in this scenario we would test the provider agasint the master
build of the consumer.

When running a provider test in the context of a consumer build via:
  https://github.com/alphagov/pay-jenkins-library/blob/master/vars/runProviderContractTests.groovy

eg. https://github.com/alphagov/pay-publicapi/blob/master/Jenkinsfile#L98-L116

the `PACT_CONSUMER_TAG` will be set to the git sha of the consumer. The
consumer will have run and published its pacts and tagged them immediately
before this step.

In neither of these circumstances is it useful to have the provider also check
against the `test`, `staging` or `production` versions of the pacts.

Having these additional checks makes it harder (or maybe impossible?) to evolve
contracts between services.

Those checks can happen upon deployment eg.

https://github.com/alphagov/pay-connector/blob/master/Jenkinsfile#L144