### PR TITLE
PP-5391 centralise refund state transition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -5,9 +5,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.refund.service.ChargeRefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import java.util.Optional;
@@ -17,13 +17,13 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class RefundNotificationProcessor {
 
     private Logger logger = LoggerFactory.getLogger(getClass());
-    private RefundDao refundDao;
+    private ChargeRefundService refundService;
     private UserNotificationService userNotificationService;
 
     @Inject
-    RefundNotificationProcessor(RefundDao refundDao,
+    RefundNotificationProcessor(ChargeRefundService refundService,
                                 UserNotificationService userNotificationService) {
-        this.refundDao = refundDao;
+        this.refundService = refundService;
         this.userNotificationService = userNotificationService;
     }
 
@@ -34,7 +34,7 @@ public class RefundNotificationProcessor {
             return;
         }
 
-        Optional<RefundEntity> optionalRefundEntity = refundDao.findByProviderAndReference(gatewayName.getName(), reference);
+        Optional<RefundEntity> optionalRefundEntity = refundService.findByProviderAndReference(gatewayName.getName(), reference);
         if (!optionalRefundEntity.isPresent()) {
             logger.error("{} notification '{}' could not be used to update refund (associated refund entity not found)",
                     gatewayName, reference);
@@ -44,7 +44,7 @@ public class RefundNotificationProcessor {
         RefundEntity refundEntity = optionalRefundEntity.get();
         RefundStatus oldStatus = refundEntity.getStatus();
 
-        refundEntity.setStatus(newStatus);
+        refundService.transitionRefundState(refundEntity, newStatus);
 
         if (RefundStatus.REFUNDED.equals(newStatus)) {
             userNotificationService.sendRefundIssuedEmail(refundEntity);

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -92,7 +92,6 @@ public class RefundEntity extends AbstractVersionedEntity {
         this.externalId = RandomIdGenerator.newId();
         this.chargeEntity = chargeEntity;
         this.amount = amount;
-        setStatus(RefundStatus.CREATED);
         this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
         this.userExternalId = userExternalId;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -15,9 +15,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
-import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.refund.service.ChargeRefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import java.util.List;
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 public class RefundNotificationProcessorTest {
 
     @Mock
-    private RefundDao refundDao;
+    private ChargeRefundService refundService;
     @Mock
     private UserNotificationService userNotificationService;
 
@@ -56,9 +56,9 @@ public class RefundNotificationProcessorTest {
         refundEntity = aValidRefundEntity().build();
         Optional<RefundEntity> optionalRefundEntity = Optional.of(refundEntity);
 
-        when(refundDao.findByProviderAndReference(paymentGatewayName.getName(), reference)).thenReturn(optionalRefundEntity);
+        when(refundService.findByProviderAndReference(paymentGatewayName.getName(), reference)).thenReturn(optionalRefundEntity);
 
-        refundNotificationProcessor = new RefundNotificationProcessor(refundDao, userNotificationService);
+        refundNotificationProcessor = new RefundNotificationProcessor(refundService, userNotificationService);
 
         Logger root = (Logger) LoggerFactory.getLogger(RefundNotificationProcessor.class);
         root.setLevel(Level.INFO);

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
@@ -31,7 +31,6 @@ public class RefundEntityTest {
         assertThat(refundEntity.getChargeEntity(), is(chargeEntity));
         assertThat(refundEntity.getReference(), is(nullValue()));
         assertThat(refundEntity.getAmount(), is(amount));
-        assertThat(refundEntity.getStatus(), is(RefundStatus.CREATED));
         assertThat(refundEntity.getUserExternalId(), is(userExternalId));
         assertNotNull(refundEntity.getCreatedDate());
     }

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -138,6 +138,32 @@ public class ChargeRefundServiceTest {
     }
 
     @Test
+    public void shouldCreateARefundEntitySuccessfully() {
+        String externalChargeId = "chargeId";
+        Long refundAmount = 100L;
+        Long accountId = 2L;
+        String providerName = "worldpay";
+
+        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account.setId(accountId);
+        ChargeEntity charge = aValidChargeEntity()
+                .withGatewayAccountEntity(account)
+                .withTransactionId("transaction-id")
+                .withExternalId(externalChargeId)
+                .withStatus(CAPTURED)
+                .build();
+
+        doAnswer(invocation -> {
+            ((RefundEntity) invocation.getArgument(0)).setId(refundId);
+            return null;
+        }).when(mockRefundDao).persist(any(RefundEntity.class));
+        RefundEntity refundEntity = chargeRefundService.createRefundEntity(new RefundRequest(refundAmount, charge.getAmount(), userExternalId), charge);
+
+        assertThat(refundEntity.getAmount(), is(refundAmount));
+        assertThat(refundEntity.getStatus(), is(RefundStatus.CREATED));
+    }
+
+    @Test
     public void shouldRefundSuccessfully_forSmartpay() {
         String externalChargeId = "chargeId";
         Long amount = 100L;


### PR DESCRIPTION
## WHAT YOU DID
- refactor setting the status of refund entity in ChargeRefundService.
This work is to lay the grounds for emitting refund events to ledger from a single point.
