### PR TITLE
PP-5439 Administrative find charge by gateway transaction id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -66,6 +66,17 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .findFirst();
     }
 
+    public Optional<ChargeEntity> findByGatewayTransactionId(String gatewayTransactionId) {
+        String query = "SELECT c from ChargeEntity c WHERE c.gateway_transaction_id=:gatewayTransactionId";
+
+        return entityManager.get()
+                .createQuery(query, ChargeEntity.class)
+                .setParameter("gatewayTransactionId", gatewayTransactionId)
+                .getResultList()
+                .stream()
+                .findFirst();
+    }
+
     public Optional<ChargeEntity> findByExternalIdAndGatewayAccount(String externalId, Long accountId) {
 
         String query = "SELECT c FROM ChargeEntity c " +

--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -67,7 +67,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
     }
 
     public Optional<ChargeEntity> findByGatewayTransactionId(String gatewayTransactionId) {
-        String query = "SELECT c from ChargeEntity c WHERE c.gateway_transaction_id=:gatewayTransactionId";
+        String query = "SELECT c from ChargeEntity c WHERE c.gatewayTransactionId=:gatewayTransactionId";
 
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -50,6 +50,7 @@ import static uk.gov.pay.connector.charge.service.SearchService.TYPE.CHARGE;
 import static uk.gov.pay.connector.charge.service.SearchService.TYPE.TRANSACTION;
 import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 import static uk.gov.pay.connector.util.ResponseUtil.responseWithChargeNotFound;
+import static uk.gov.pay.connector.util.ResponseUtil.responseWithGatewayTransactionNotFound;
 import static uk.gov.pay.connector.util.ResponseUtil.successResponseWithEntity;
 
 @Path("/")
@@ -246,6 +247,15 @@ public class ChargesApiResource {
     public Response expireCharges(@Context UriInfo uriInfo) {
         Map<String, Integer> resultMap = chargeExpiryService.sweepAndExpireChargesAndTokens();
         return successResponseWithEntity(resultMap);
+    }
+
+    @GET
+    @Path("/v1/api/charges/gateway_transaction/{gatewayTransactionId}")
+    @Produces(APPLICATION_JSON)
+    public Response getChargeForGatewayTransactionId(@PathParam("gatewayTransactionId") String gatewayTransactionId, @Context UriInfo uriInfo) {
+        return chargeService.findChargeByGatewayTransactionId(gatewayTransactionId, uriInfo)
+                .map(chargeResponse -> Response.ok(chargeResponse).build())
+                .orElseGet(() -> responseWithGatewayTransactionNotFound(gatewayTransactionId));
     }
 
     private ZonedDateTime parseDate(String date) {

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -200,6 +200,13 @@ public class ChargeService {
     }
 
     @Transactional
+    public Optional<ChargeResponse> findChargeByGatewayTransactionId(String gatewayTransactionId, UriInfo uriInfo) {
+        return chargeDao
+                .findByGatewayTransactionId(gatewayTransactionId)
+                .map(chargeEntity -> populateResponseBuilderWith(aChargeResponseBuilder(), uriInfo, chargeEntity, false).build());
+    }
+
+    @Transactional
     public Optional<ChargeEntity> updateCharge(String chargeId, PatchRequestBuilder.PatchRequest chargePatchRequest) {
         return chargeDao.findByExternalId(chargeId)
                 .map(chargeEntity -> {

--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -41,7 +41,7 @@ public class ResponseUtil {
 
     public static Response responseWithGatewayTransactionNotFound(String gatewayTransactionId) {
         String message = format("Charge with gateway transaction id [%s] not found.", gatewayTransactionId);
-        return notFoundResponse(gatewayTransactionId);
+        return notFoundResponse(message);
     }
 
     public static Response responseWithRefundNotFound(String refundId) {

--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -39,6 +39,11 @@ public class ResponseUtil {
         return notFoundResponse(message);
     }
 
+    public static Response responseWithGatewayTransactionNotFound(String gatewayTransactionId) {
+        String message = format("Charge with gateway transaction id [%s] not found.", gatewayTransactionId);
+        return notFoundResponse(gatewayTransactionId);
+    }
+
     public static Response responseWithRefundNotFound(String refundId) {
         String message = format("Refund with id [%s] not found.", refundId);
         return notFoundResponse(message);
@@ -52,7 +57,7 @@ public class ResponseUtil {
         logger.error(messages.toString());
         return buildErrorResponse(BAD_REQUEST, messages);
     }
-    
+
     public static Response notFoundResponse(String message) {
         logger.error(message);
         return buildErrorResponse(NOT_FOUND, message);

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -1563,6 +1563,23 @@ public class ChargeDaoIT extends DaoITestBase {
     }
 
     @Test
+    public void findByGatewayTransactionId() {
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withExternalChargeId("some-external-id")
+                .withTransactionId("gateway-transaction-id")
+                .insert();
+
+        ChargeEntity chargeEntity = chargeDao.
+                findByGatewayTransactionId("gateway-transaction-id")
+                .get();
+
+        assertThat(chargeEntity.getExternalId(), is("some-external-id"));
+    }
+
+    @Test
     public void getChargeWithAFee_shouldReturnFeeOnCharge() {
         insertTestCharge();
 
@@ -1588,7 +1605,7 @@ public class ChargeDaoIT extends DaoITestBase {
 
         assertThat(chargeDao.findMaxId(), is(defaultTestCharge.getChargeId()));
     }
-    
+
     private void insertTestAccount() {
         this.defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)


### PR DESCRIPTION
* Stripe payments before 03 May 2019 store no meta data on Stripe regarding GOV.UK Pay charge information, the only link is the `gateway_transaction_id` on the charge table 
* expose internal resource to get a charge by this ID, allowing for intermediate payout reconciliation on older Stripe payouts