### PR TITLE
PP-5391 emit refund state transitions

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -20,7 +20,7 @@ import uk.gov.pay.connector.gateway.epdq.SignatureGenerator;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.pay.connector.util.HashUtil;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -48,7 +48,7 @@ public class ConnectorModule extends AbstractModule {
         bind(HashUtil.class);
         bind(RequestValidator.class);
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
-        bind(PaymentStateTransitionQueue.class).in(Singleton.class);
+        bind(StateTransitionQueue.class).in(Singleton.class);
 
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(GatewayAccountServicesFactory.class));

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -46,7 +46,7 @@ import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 import uk.gov.pay.connector.wallets.WalletType;
@@ -102,14 +102,14 @@ public class ChargeService {
     private final CaptureProcessConfig captureProcessConfig;
     private final PaymentProviders providers;
 
-    private final PaymentStateTransitionQueue paymentStateTransitionQueue;
+    private final StateTransitionQueue stateTransitionQueue;
     private final Boolean shouldEmitPaymentStateTransitionEvents;
 
     @Inject
     public ChargeService(TokenDao tokenDao, ChargeDao chargeDao, ChargeEventDao chargeEventDao,
                          CardTypeDao cardTypeDao, GatewayAccountDao gatewayAccountDao,
                          ConnectorConfiguration config, PaymentProviders providers,
-                         PaymentStateTransitionQueue paymentStateTransitionQueue) {
+                         StateTransitionQueue stateTransitionQueue) {
         this.tokenDao = tokenDao;
         this.chargeDao = chargeDao;
         this.chargeEventDao = chargeEventDao;
@@ -118,7 +118,7 @@ public class ChargeService {
         this.linksConfig = config.getLinks();
         this.providers = providers;
         this.captureProcessConfig = config.getCaptureProcessConfig();
-        this.paymentStateTransitionQueue = paymentStateTransitionQueue;
+        this.stateTransitionQueue = stateTransitionQueue;
         this.shouldEmitPaymentStateTransitionEvents = config.getEmitPaymentStateTransitionEvents();
     }
 
@@ -430,7 +430,7 @@ public class ChargeService {
                 .ifPresent(eventType -> {
                     if (shouldEmitPaymentStateTransitionEvents) {
                         PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventType);
-                        paymentStateTransitionQueue.offer(transition);
+                        stateTransitionQueue.offer(transition);
                         logger.info("Offered payment state transition to emitter queue [from={}] [to={}] [chargeEventId={}] [chargeId={}]", fromChargeState, targetChargeState, chargeEventEntity.getId(), charge.getExternalId());
                     }
                 });

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundCreatedEventDetails.java
@@ -4,13 +4,13 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 abstract class RefundCreatedEventDetails extends EventDetails {
 
-    private Long refundAmount;
+    private Long amount;
 
-    public RefundCreatedEventDetails(Long refundAmount) {
-        this.refundAmount = refundAmount;
+    public RefundCreatedEventDetails(Long amount) {
+        this.amount = amount;
     }
 
-    public Long getRefundAmount() {
-        return refundAmount;
+    public Long getAmount() {
+        return amount;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/exception/StateTransitionMessageProcessException.java
+++ b/src/main/java/uk/gov/pay/connector/events/exception/StateTransitionMessageProcessException.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.events.exception;
 
 public class StateTransitionMessageProcessException extends Exception {
-    public StateTransitionMessageProcessException(Long chargeEventId) {
-        super(String.format("Failed to access charge event during state transition message processing [chargeEventId=%d]", chargeEventId));
+    public StateTransitionMessageProcessException(String id) {
+        super(String.format("Failed to access charge event during state transition message processing [chargeEventId=%s]", id));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/exception/StateTransitionMessageProcessException.java
+++ b/src/main/java/uk/gov/pay/connector/events/exception/StateTransitionMessageProcessException.java
@@ -2,6 +2,6 @@ package uk.gov.pay.connector.events.exception;
 
 public class StateTransitionMessageProcessException extends Exception {
     public StateTransitionMessageProcessException(String id) {
-        super(String.format("Failed to access charge event during state transition message processing [chargeEventId=%s]", id));
+        super(String.format("Failed to handle event during state transition message processing [eventId=%s]", id));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.events.model.refund;
 
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByServiceEventDetails;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
 
@@ -8,5 +9,15 @@ public class RefundCreatedByService extends RefundEvent {
 
     public RefundCreatedByService(String resourceExternalId, String parentResourceExternalId, RefundCreatedByServiceEventDetails eventDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+    }
+
+    public static RefundCreatedByService from(RefundHistory refundHistory) {
+        return new RefundCreatedByService(
+                refundHistory.getExternalId(),
+                refundHistory.getChargeEntity().getExternalId(),
+                new RefundCreatedByServiceEventDetails(refundHistory.getAmount()),
+                refundHistory.getHistoryStartDate()
+        );
+        
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
@@ -18,6 +18,6 @@ public class RefundCreatedByUser extends RefundEvent {
                 new RefundCreatedByUserEventDetails(
                         refundHistory.getAmount(),
                         refundHistory.getUserExternalId()),
-                refundHistory.getCreatedDate());
+                refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEventFactory.java
@@ -20,7 +20,7 @@ public class RefundEventFactory {
                 );
             }
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-            throw new IllegalArgumentException(String.format("Could not construct payment event: %s", eventClass));
+            throw new IllegalArgumentException(String.format("Could not construct refund event: %s", eventClass));
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEventFactory.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.ZonedDateTime;
+
+public class RefundEventFactory {
+    public static RefundEvent create(Class<? extends RefundEvent> eventClass, RefundHistory refundHistory) {
+        try {
+            if (eventClass == RefundCreatedByService.class) {
+                return RefundCreatedByService.from(refundHistory);
+            } else if (eventClass == RefundCreatedByUser.class) {
+                return RefundCreatedByUser.from(refundHistory);
+            } else {
+                return eventClass.getConstructor(String.class, String.class, ZonedDateTime.class).newInstance(
+                        refundHistory.getExternalId(),
+                        refundHistory.getChargeEntity().getExternalId(),
+                        refundHistory.getHistoryStartDate()
+                );
+            }
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new IllegalArgumentException(String.format("Could not construct payment event: %s", eventClass));
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransition.java
+++ b/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransition.java
@@ -1,71 +1,34 @@
 package uk.gov.pay.connector.queue;
 
-import java.util.concurrent.Delayed;
-import java.util.concurrent.TimeUnit;
-
-public final class PaymentStateTransition implements Delayed {
-    private final long chargeEventId;
-    private final Class stateTransitionEventClass;
-    private final Long readTime;
-    private final long delayDurationInMilliseconds;
-    private final int attempts;
-
-    private static final int MAXIMUM_NUMBER_OF_ATTEMPTS = 10;
-    private static final int BASE_ATTEMPTS = 1;
-    private static final long DEFAULT_DELAY_DURATION_IN_MILLISECONDS = 100L;
-
-    private PaymentStateTransition(long chargeEventId, Class stateTransitionEventClass, int numberOfProcessAttempts, long delayDurationInMilliseconds) {
-        this.chargeEventId = chargeEventId;
-        this.stateTransitionEventClass = stateTransitionEventClass;
-        this.attempts = numberOfProcessAttempts;
-        this.delayDurationInMilliseconds = delayDurationInMilliseconds;
-        this.readTime = System.currentTimeMillis() + delayDurationInMilliseconds;
-    }
-
+public final class PaymentStateTransition extends StateTransition {
+    private final long chargeEventId; 
+    
     public PaymentStateTransition(long chargeEventId, Class stateTransitionEventClass) {
-        this(chargeEventId, stateTransitionEventClass, BASE_ATTEMPTS, DEFAULT_DELAY_DURATION_IN_MILLISECONDS);
+        super(stateTransitionEventClass);
+        this.chargeEventId = chargeEventId;
     }
 
     public PaymentStateTransition(long chargeEventId, Class stateTransitionEventClass, long delayDurationInMilliseconds) {
-        this(chargeEventId, stateTransitionEventClass, BASE_ATTEMPTS, delayDurationInMilliseconds);
+        super(stateTransitionEventClass, delayDurationInMilliseconds);
+        this.chargeEventId = chargeEventId;
     }
 
-    public static PaymentStateTransition incrementAttempts(PaymentStateTransition paymentStateTransition) {
-        return new PaymentStateTransition(
-                paymentStateTransition.getChargeEventId(),
-                paymentStateTransition.getStateTransitionEventClass(),
-                paymentStateTransition.getAttempts() + 1,
-                paymentStateTransition.getDelayDurationInMilliseconds());
-    }
-
-    @Override
-    public long getDelay(TimeUnit unit) {
-        long diff = readTime - System.currentTimeMillis();
-        return unit.convert(diff, TimeUnit.MILLISECONDS);
-    }
-
-    @Override
-    public int compareTo(Delayed o) {
-        return (int) (readTime - ((PaymentStateTransition) o).readTime);
-    }
-
-    public boolean shouldAttempt() {
-        return attempts < MAXIMUM_NUMBER_OF_ATTEMPTS;
-    }
-
-    public int getAttempts() {
-        return attempts;
+    public PaymentStateTransition(long chargeEventId, Class stateTransitionEventClass, int numberOfProcessAttempts, long delayDurationInMilliseconds) {
+        super(stateTransitionEventClass, numberOfProcessAttempts, delayDurationInMilliseconds);
+        this.chargeEventId = chargeEventId;
     }
 
     public long getChargeEventId() {
         return chargeEventId;
     }
 
-    public long getDelayDurationInMilliseconds() {
-        return delayDurationInMilliseconds;
+    @Override
+    public PaymentStateTransition getNext() {
+        return new PaymentStateTransition(chargeEventId, getStateTransitionEventClass(), getAttempts() + 1, getDelayDurationInMilliseconds());
     }
 
-    public Class getStateTransitionEventClass() {
-        return stateTransitionEventClass;
+    @Override
+    public String getIdentifier() {
+        return String.valueOf(chargeEventId);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueue.java
@@ -4,13 +4,13 @@ import java.util.Queue;
 import java.util.concurrent.DelayQueue;
 
 public class PaymentStateTransitionQueue {
-    private final Queue<PaymentStateTransition> queue = new DelayQueue<>();
+    private final Queue<StateTransition> queue = new DelayQueue<>();
     
-    public boolean offer(PaymentStateTransition paymentStateTransition) {
+    public boolean offer(StateTransition paymentStateTransition) {
         return queue.offer(paymentStateTransition);
     }
     
-    public PaymentStateTransition poll() {
+    public StateTransition poll() {
         return queue.poll();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/RefundStateTransition.java
+++ b/src/main/java/uk/gov/pay/connector/queue/RefundStateTransition.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.queue;
+
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+public class RefundStateTransition extends StateTransition {
+    private final String refundExternalId;
+    private final RefundStatus refundStatus;
+    
+    
+    public RefundStateTransition(String refundExternalId, RefundStatus refundStatus, Class stateTransitionEventClass) {
+        super(stateTransitionEventClass);
+        this.refundExternalId = refundExternalId;
+        this.refundStatus = refundStatus;
+    }
+
+    public RefundStateTransition(String refundExternalId, RefundStatus refundStatus, Class stateTransitionEventClass, long delayDurationInMilliseconds) {
+        super(stateTransitionEventClass, delayDurationInMilliseconds);
+        this.refundExternalId = refundExternalId;
+        this.refundStatus = refundStatus;
+    }
+
+    public RefundStateTransition(String refundExternalId, RefundStatus refundStatus, Class stateTransitionEventClass, int numberOfProcessAttempts, long delayDurationInMilliseconds) {
+        super(stateTransitionEventClass, numberOfProcessAttempts, delayDurationInMilliseconds);
+        this.refundExternalId = refundExternalId;
+        this.refundStatus = refundStatus;
+    }
+
+    public String getRefundExternalId() {
+        return refundExternalId;
+    }
+
+    public RefundStatus getRefundStatus() {
+        return refundStatus;
+    }
+
+    @Override
+    public String getIdentifier() {
+        return refundExternalId + "_" + refundStatus;
+    }
+
+    @Override
+    public RefundStateTransition getNext() {
+        return new RefundStateTransition(refundExternalId, refundStatus, getStateTransitionEventClass(), getAttempts() + 1, getDelayDurationInMilliseconds());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransition.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransition.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.connector.queue;
+
+import java.util.concurrent.Delayed;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class StateTransition implements Delayed {
+    private final Class stateTransitionEventClass;
+    private final Long readTime;
+    private final long delayDurationInMilliseconds;
+    private final AtomicInteger attempts;
+
+    private static final int MAXIMUM_NUMBER_OF_ATTEMPTS = 10;
+    private static final int BASE_ATTEMPTS = 1;
+    private static final long DEFAULT_DELAY_DURATION_IN_MILLISECONDS = 100L;
+
+    public StateTransition(Class stateTransitionEventClass) {
+        this(stateTransitionEventClass, BASE_ATTEMPTS, DEFAULT_DELAY_DURATION_IN_MILLISECONDS);
+    }
+
+    public StateTransition(Class stateTransitionEventClass, long delayDurationInMilliseconds) {
+        this(stateTransitionEventClass, BASE_ATTEMPTS, delayDurationInMilliseconds);
+    }
+
+    public StateTransition(Class stateTransitionEventClass, int numberOfProcessAttempts, long delayDurationInMilliseconds) {
+        this.stateTransitionEventClass = stateTransitionEventClass;
+        this.attempts = new AtomicInteger(numberOfProcessAttempts);
+        this.delayDurationInMilliseconds = delayDurationInMilliseconds;
+        this.readTime = System.currentTimeMillis() + delayDurationInMilliseconds;
+    }
+    
+    @Override
+    public long getDelay(TimeUnit unit) {
+        long diff = readTime - System.currentTimeMillis();
+        return unit.convert(diff, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public int compareTo(Delayed o) {
+        return (int) (readTime - ((StateTransition) o).readTime);
+    }
+
+    public boolean shouldAttempt() {
+        return attempts.intValue() < MAXIMUM_NUMBER_OF_ATTEMPTS;
+    }
+
+    public Class getStateTransitionEventClass() {
+        return stateTransitionEventClass;
+    }
+
+    public Long getReadTime() {
+        return readTime;
+    }
+
+    public long getDelayDurationInMilliseconds() {
+        return delayDurationInMilliseconds;
+    }
+
+    public int getAttempts() {
+        return attempts.intValue();
+    }
+    
+    public abstract String getIdentifier();
+    
+    public abstract StateTransition getNext();
+}

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
@@ -3,11 +3,11 @@ package uk.gov.pay.connector.queue;
 import java.util.Queue;
 import java.util.concurrent.DelayQueue;
 
-public class PaymentStateTransitionQueue {
+public class StateTransitionQueue {
     private final Queue<StateTransition> queue = new DelayQueue<>();
     
-    public boolean offer(StateTransition paymentStateTransition) {
-        return queue.offer(paymentStateTransition);
+    public boolean offer(StateTransition stateTransition) {
+        return queue.offer(stateTransition);
     }
     
     public StateTransition poll() {

--- a/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
@@ -5,7 +5,7 @@ import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.events.PaymentStateTransitionEmitterProcess;
+import uk.gov.pay.connector.events.StateTransitionEmitterProcess;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 
 import javax.inject.Inject;
@@ -24,13 +24,13 @@ public class QueueMessageReceiver implements Managed {
     private ScheduledExecutorService stateTransitionMessageExecutorService;
 
     private final CardCaptureProcess cardCaptureProcess;
-    private final PaymentStateTransitionEmitterProcess paymentStateTransitionEmitterProcess;
+    private final StateTransitionEmitterProcess stateTransitionEmitterProcess;
 
 
     @Inject
-    public QueueMessageReceiver(CardCaptureProcess cardCaptureProcess, PaymentStateTransitionEmitterProcess paymentStateTransitionEmitterProcess,
+    public QueueMessageReceiver(CardCaptureProcess cardCaptureProcess, StateTransitionEmitterProcess stateTransitionEmitterProcess,
                                 Environment environment, ConnectorConfiguration connectorConfiguration) {
-        this.paymentStateTransitionEmitterProcess = paymentStateTransitionEmitterProcess;
+        this.stateTransitionEmitterProcess = stateTransitionEmitterProcess;
         this.cardCaptureProcess = cardCaptureProcess;
 
         int queueScheduleNumberOfThreads = connectorConfiguration.getCaptureProcessConfig().getQueueSchedulerNumberOfThreads();
@@ -74,7 +74,7 @@ public class QueueMessageReceiver implements Managed {
 
     private void stateTransitionMessageReceiver() {
         try {
-            paymentStateTransitionEmitterProcess.handleStateTransitionMessages();
+            stateTransitionEmitterProcess.handleStateTransitionMessages();
         } catch (Exception e) {
             LOGGER.error("State transition message polling thread failed to process message due to [message={}]", e.getMessage());
         }

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -74,9 +74,11 @@ public class RefundDao extends JpaDao<RefundEntity> {
     }
     
     public Optional<RefundHistory> getRefundHistoryByRefundExternalIdAndRefundStatus(String refundExternalId, RefundStatus refundStatus) {
-        String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, history_start_date, history_end_date, user_external_id, gateway_transaction_id " +
-                "FROM refunds_history r " +
-                "WHERE external_id = ?1 AND status = ?2";
+        String query = "SELECT rh.id, rh.external_id, rh.amount, rh.status, rh.charge_id, rh.created_date, " +
+                "rh.version, rh.reference, rh.history_start_date, rh.history_end_date, rh.user_external_id, " +
+                "rh.gateway_transaction_id, ch.external_id AS charge_external_id " +
+                "FROM refunds_history rh, charges ch " +
+                "WHERE rh.external_id = ?1 AND rh.status = ?2 AND rh.charge_id = ch.id";
 
         return entityManager.get()
                 .createNativeQuery(query, "RefundEntityHistoryMapping")

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -72,6 +72,21 @@ public class RefundDao extends JpaDao<RefundEntity> {
                         refund.get(STATUS).in(statuses));
         return entityManager.get().createQuery(criteriaQuery).getResultList();
     }
+    
+    public Optional<RefundHistory> getRefundHistoryByRefundExternalIdAndRefundStatus(String refundExternalId, RefundStatus refundStatus) {
+        String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, history_start_date, history_end_date, user_external_id, gateway_transaction_id " +
+                "FROM refunds_history r " +
+                "WHERE external_id = ?1 AND status = ?2";
+
+        return entityManager.get()
+                .createNativeQuery(query, "RefundEntityHistoryMapping")
+                .setParameter(1, refundExternalId)
+                .setParameter(2, refundStatus.getValue())
+                .getResultList()
+                .stream()
+                .findFirst();
+        
+    }
 
     public List<RefundHistory> searchHistoryByChargeId(Long chargeId) {
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -45,7 +45,8 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
                         @ColumnResult(name = "history_start_date", type = Timestamp.class),
                         @ColumnResult(name = "history_end_date", type = Timestamp.class),
                         @ColumnResult(name = "user_external_id", type = String.class),
-                        @ColumnResult(name = "gateway_transaction_id", type = String.class)                        
+                        @ColumnResult(name = "gateway_transaction_id", type = String.class),
+                        @ColumnResult(name = "charge_external_id", type = String.class)
                 }))
 
 @Entity

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
@@ -18,8 +18,7 @@ public class RefundHistory extends RefundEntity {
 
     public RefundHistory(Long id, String externalId, Long amount, String status, Long chargeId, Timestamp createdDate, 
                          Long version, String reference, Timestamp historyStartDate, Timestamp historyEndDate, 
-                         String userExternalId,
-                         String gatewayTransactionId) {
+                         String userExternalId, String gatewayTransactionId, String chargeExternalId) {
         super();
         setId(id);
         setExternalId(externalId);
@@ -28,6 +27,7 @@ public class RefundHistory extends RefundEntity {
 
         ChargeEntity charge = new ChargeEntity();
         charge.setId(chargeId);
+        charge.setExternalId(chargeExternalId);
         setChargeEntity(charge);
 
         setUserExternalId(userExternalId);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -40,7 +40,7 @@ import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 import uk.gov.pay.connector.wallets.WalletType;
@@ -128,7 +128,7 @@ public class ChargeServiceTest {
     private EventQueue mockedEventQueue;
 
     @Mock
-    private PaymentStateTransitionQueue mockedPaymentStateTransitionQueue;
+    private StateTransitionQueue mockedStateTransitionQueue;
 
     private ChargeService service;
 
@@ -175,7 +175,7 @@ public class ChargeServiceTest {
         when(mockedConfig.getEmitPaymentStateTransitionEvents()).thenReturn(true);
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
-                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedPaymentStateTransitionQueue);
+                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedStateTransitionQueue);
     }
 
     @Test
@@ -700,7 +700,7 @@ public class ChargeServiceTest {
         service.transitionChargeState(chargeSpy, ENTERING_CARD_DETAILS);
 
         ArgumentCaptor<PaymentStateTransition> paymentStateTransitionArgumentCaptor = ArgumentCaptor.forClass(PaymentStateTransition.class);
-        verify(mockedPaymentStateTransitionQueue).offer(paymentStateTransitionArgumentCaptor.capture());
+        verify(mockedStateTransitionQueue).offer(paymentStateTransitionArgumentCaptor.capture());
 
         assertThat(paymentStateTransitionArgumentCaptor.getValue().getChargeEventId(), is(100L));
         assertThat(paymentStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(PaymentStarted.class));
@@ -720,6 +720,6 @@ public class ChargeServiceTest {
 
         service.transitionChargeState(chargeSpy, AUTHORISATION_READY);
 
-        verifyNoMoreInteractions(mockedPaymentStateTransitionQueue);
+        verifyNoMoreInteractions(mockedStateTransitionQueue);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/PaymentStateTransitionEmitterProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/PaymentStateTransitionEmitterProcessTest.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
 import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
 import uk.gov.pay.connector.queue.QueueException;
+import uk.gov.pay.connector.refund.dao.RefundDao;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -42,6 +43,9 @@ public class PaymentStateTransitionEmitterProcessTest {
     @Mock
     ChargeEventDao chargeEventDao;
 
+    @Mock
+    private RefundDao refundDao;
+    
     @InjectMocks
     PaymentStateTransitionEmitterProcess paymentStateTransitionEmitterProcess;
 
@@ -92,7 +96,7 @@ public class PaymentStateTransitionEmitterProcessTest {
     @Test
     public void shouldNotPutPaymentTransitionBackOnQueueIfItHasExceededMaxAttempts() {
         PaymentStateTransitionQueue spyQueue = spy(new PaymentStateTransitionQueue());
-        PaymentStateTransitionEmitterProcess paymentStateTransitionEmitterProcess = new PaymentStateTransitionEmitterProcess(spyQueue, eventQueue, chargeEventDao);
+        PaymentStateTransitionEmitterProcess paymentStateTransitionEmitterProcess = new PaymentStateTransitionEmitterProcess(spyQueue, eventQueue, chargeEventDao, refundDao);
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(100L, PaymentEvent.class, 0);
 
         when(chargeEventDao.findById(ChargeEventEntity.class, 100L)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 
@@ -30,12 +30,12 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class PaymentStateTransitionEmitterProcessTest {
+public class StateTransitionEmitterProcessTest {
 
     private final ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
 
     @Mock
-    PaymentStateTransitionQueue mockPaymentStateTransitionQueue;
+    StateTransitionQueue mockStateTransitionQueue;
 
     @Mock
     EventQueue eventQueue;
@@ -47,7 +47,7 @@ public class PaymentStateTransitionEmitterProcessTest {
     private RefundDao refundDao;
     
     @InjectMocks
-    PaymentStateTransitionEmitterProcess paymentStateTransitionEmitterProcess;
+    StateTransitionEmitterProcess stateTransitionEmitterProcess;
 
     @Test
     public void shouldEmitPaymentEventGivenStateTransitionMessageOnQueue() throws Exception {
@@ -56,10 +56,10 @@ public class PaymentStateTransitionEmitterProcessTest {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventId, PaymentCreated.class);
 
         when(chargeEvent.getChargeEntity()).thenReturn(charge);
-        when(mockPaymentStateTransitionQueue.poll()).thenReturn(paymentStateTransition);
+        when(mockStateTransitionQueue.poll()).thenReturn(paymentStateTransition);
         when(chargeEventDao.findById(ChargeEventEntity.class, chargeEventId)).thenReturn(Optional.of(chargeEvent));
 
-        paymentStateTransitionEmitterProcess.handleStateTransitionMessages();
+        stateTransitionEmitterProcess.handleStateTransitionMessages();
 
         verify(eventQueue).emitEvent(any(PaymentCreated.class));
     }
@@ -68,13 +68,13 @@ public class PaymentStateTransitionEmitterProcessTest {
     public void shouldPutPaymentTransitionBackOnQueueIfChargeEventNotFound() {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(100L, PaymentEvent.class);
 
-        when(mockPaymentStateTransitionQueue.poll()).thenReturn(paymentStateTransition);
+        when(mockStateTransitionQueue.poll()).thenReturn(paymentStateTransition);
         when(chargeEventDao.findById(ChargeEventEntity.class, 100L)).thenReturn(Optional.empty());
 
-        paymentStateTransitionEmitterProcess.handleStateTransitionMessages();
+        stateTransitionEmitterProcess.handleStateTransitionMessages();
 
         verifyNoMoreInteractions(eventQueue);
-        verify(mockPaymentStateTransitionQueue).offer(any(PaymentStateTransition.class));
+        verify(mockStateTransitionQueue).offer(any(PaymentStateTransition.class));
     }
 
     @Test
@@ -82,21 +82,21 @@ public class PaymentStateTransitionEmitterProcessTest {
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(100L, PaymentEvent.class);
         ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
 
-        when(mockPaymentStateTransitionQueue.poll()).thenReturn(paymentStateTransition);
+        when(mockStateTransitionQueue.poll()).thenReturn(paymentStateTransition);
         when(chargeEvent.getUpdated()).thenReturn(ZonedDateTime.now());
         when(chargeEvent.getChargeEntity()).thenReturn(charge);
         when(chargeEventDao.findById(ChargeEventEntity.class, 100L)).thenReturn(Optional.of(chargeEvent));
         doThrow(QueueException.class).when(eventQueue).emitEvent(any());
 
-        paymentStateTransitionEmitterProcess.handleStateTransitionMessages();
+        stateTransitionEmitterProcess.handleStateTransitionMessages();
 
-        verify(mockPaymentStateTransitionQueue).offer(any(PaymentStateTransition.class));
+        verify(mockStateTransitionQueue).offer(any(PaymentStateTransition.class));
     }
 
     @Test
     public void shouldNotPutPaymentTransitionBackOnQueueIfItHasExceededMaxAttempts() {
-        PaymentStateTransitionQueue spyQueue = spy(new PaymentStateTransitionQueue());
-        PaymentStateTransitionEmitterProcess paymentStateTransitionEmitterProcess = new PaymentStateTransitionEmitterProcess(spyQueue, eventQueue, chargeEventDao, refundDao);
+        StateTransitionQueue spyQueue = spy(new StateTransitionQueue());
+        StateTransitionEmitterProcess stateTransitionEmitterProcess = new StateTransitionEmitterProcess(spyQueue, eventQueue, chargeEventDao, refundDao);
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(100L, PaymentEvent.class, 0);
 
         when(chargeEventDao.findById(ChargeEventEntity.class, 100L)).thenReturn(Optional.empty());
@@ -108,7 +108,7 @@ public class PaymentStateTransitionEmitterProcessTest {
         // try until message attempt limit, factor in initial offer
         for (int i = 0; i < maximumStateTransitionMessageRetries; i++) {
             verify(spyQueue, times(i + 1)).offer(any(PaymentStateTransition.class));
-            paymentStateTransitionEmitterProcess.handleStateTransitionMessages();
+            stateTransitionEmitterProcess.handleStateTransitionMessages();
         }
 
         verify(spyQueue, atMost(maximumStateTransitionMessageRetries)).offer(any());

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByServiceTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByServiceEventDetails;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RefundCreatedByServiceTest {
+
+    private final ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+    private ZonedDateTime createdDate = ZonedDateTime.now().minusSeconds(5L);
+    private UTCDateTimeConverter timeConverter = new UTCDateTimeConverter();
+
+    private RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L, RefundStatus.CREATED.getValue(),
+            charge.getId(), timeConverter.convertToDatabaseColumn(createdDate), 1L,
+            "reference", timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
+            timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
+            null, "gateway_transaction_id", charge.getExternalId());
+
+    @Test
+    public void serializesEventDetailsGivenRefund() {
+        RefundCreatedByService refundCreatedByService = RefundCreatedByService.from(refundHistory);
+
+        assertThat(refundCreatedByService.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundCreatedByService.getResourceExternalId(), is("external_id"));
+
+        RefundCreatedByServiceEventDetails details = (RefundCreatedByServiceEventDetails) refundCreatedByService.getEventDetails();
+
+        assertThat(details.getAmount(), is(50L));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundEventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundEventFactoryTest.java
@@ -1,0 +1,54 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByUserEventDetails;
+import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+
+public class RefundEventFactoryTest {
+
+    private final ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
+    private ZonedDateTime createdDate = ZonedDateTime.now().minusSeconds(5L);
+    private UTCDateTimeConverter timeConverter = new UTCDateTimeConverter();
+
+    @Test
+    public void givenARefundCreatedTypeShouldCreateARefundCreatedByUserEvent() {
+        RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L, RefundStatus.CREATED.getValue(),
+                charge.getId(), timeConverter.convertToDatabaseColumn(createdDate), 1L,
+                "reference", timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
+                timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
+                "user_external_id", "gateway_transaction_id", charge.getExternalId());
+        RefundCreatedByUser refundEvent = (RefundCreatedByUser) RefundEventFactory.create(RefundCreatedByUser.class, refundHistory);
+
+        assertThat(refundEvent.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(((RefundCreatedByUserEventDetails)refundEvent.getEventDetails()).getRefundedBy(), is("user_external_id"));
+        assertThat(refundEvent.getResourceType(), is(ResourceType.REFUND));
+        assertThat(refundEvent.getEventDetails(), is(instanceOf(RefundCreatedByUserEventDetails.class)));
+    }
+
+    @Test
+    public void givenANonPayloadPaymentEventTypeShouldCreateTheCorrectPaymentEventType() {
+        RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L, RefundStatus.REFUND_SUBMITTED.getValue(),
+                charge.getId(), new UTCDateTimeConverter().convertToDatabaseColumn(createdDate), 1L,
+                "reference", new UTCDateTimeConverter().convertToDatabaseColumn(createdDate.plusSeconds(1L)),
+                new UTCDateTimeConverter().convertToDatabaseColumn(createdDate.plusSeconds(2L)),
+                "user_external_id", "gateway_transaction_id", charge.getExternalId());
+
+        RefundSubmitted refundEvent = (RefundSubmitted) RefundEventFactory.create(RefundSubmitted.class, refundHistory);
+
+        assertThat(refundEvent.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundEvent.getEventDetails(), is(instanceOf(EmptyEventDetails.class)));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
@@ -5,8 +5,12 @@ import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.PurgeQueueRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,11 +21,16 @@ import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCELLED;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -34,9 +43,9 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCE
                 @ConfigOverride(key = "eventQueue.eventQueueEnabled", value = "true")
         }
 )
-public class PaymentStateTransitionsIT extends ChargingITestBase {
+public class StateTransitionsIT extends ChargingITestBase {
 
-    public PaymentStateTransitionsIT() {
+    public StateTransitionsIT() {
         super("sandbox");
     }
 
@@ -63,6 +72,52 @@ public class PaymentStateTransitionsIT extends ChargingITestBase {
 
         assertThat(message.get("resource_external_id").getAsString(), is(chargeId));
         assertThat(message.get("event_type").getAsString(), is("CANCELLED_BY_EXTERNAL_SERVICE"));
+    }
+
+    @Test
+    public void shouldBeAbleToRequestARefund_partialAmount() throws Exception{
+        String chargeId = addCharge(CAPTURED, "ref", ZonedDateTime.now().minusHours(1), "transaction-id-transition-it");
+        Long refundAmount = 50L;
+        Long refundAmountAvailable = AMOUNT;
+        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", refundAmount, "refund_amount_available", refundAmountAvailable);
+        String refundPayload = new Gson().toJson(refundData);
+
+        ValidatableResponse response = givenSetup()
+                .body(refundPayload)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                        .replace("{accountId}", accountId)
+                        .replace("{chargeId}", chargeId))
+                .then()
+                .statusCode(202);
+        Thread.sleep(500L);
+
+        String refundId = response.extract().response().jsonPath().get("refund_id");
+        
+        List<Message> messages = readMessagesFromEventQueue();
+
+        assertThat(messages.size(), is(3));
+
+        messages.sort(Comparator.comparing(message -> getTimestampFromMessage(message)));
+
+        JsonObject message1 = new JsonParser().parse(messages.get(0).getBody()).getAsJsonObject();
+        assertThat(message1.get("event_type").getAsString(), is("REFUND_CREATED_BY_SERVICE"));
+        assertThat(message1.get("resource_external_id").getAsString(), is(refundId));
+        assertThat(message1.get("parent_resource_external_id").getAsString(), is(chargeId));
+        assertThat(message1.get("event_details").getAsJsonObject().get("amount").getAsInt(), is(50));
+
+        JsonObject message2 = new JsonParser().parse(messages.get(1).getBody()).getAsJsonObject();
+        assertThat(message2.get("event_type").getAsString(), is("REFUND_SUBMITTED"));
+        assertThat(message2.get("resource_external_id").getAsString(), is(refundId));
+
+        JsonObject message3 = new JsonParser().parse(messages.get(2).getBody()).getAsJsonObject();
+        assertThat(message3.get("event_type").getAsString(), is("REFUND_SUCCESSFUL"));
+        assertThat(message3.get("resource_external_id").getAsString(), is(refundId));
+    }
+
+    private ZonedDateTime getTimestampFromMessage(Message message) {
+        return ZonedDateTime.parse(new JsonParser().parse(message.getBody()).getAsJsonObject().get("timestamp").getAsString());
     }
 
     private List<Message> readMessagesFromEventQueue() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
@@ -745,9 +745,8 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
         final Map<String, Object> persistedCharge = databaseTestHelper.getChargeByExternalId(chargeExternalId);
         final ZonedDateTime persistedCreatedDate = ZonedDateTime.ofInstant(((Timestamp) persistedCharge.get("created_date")).toInstant(), ZoneOffset.UTC);
 
-        Thread.sleep(400);
+        Thread.sleep(100);
         List<Message> messages = readMessagesFromEventQueue();
-        
         
         assertThat(messages.size(), is(1));
         final Message message = messages.get(0);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -21,7 +21,7 @@ import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.util.AuthUtils;
 
 import java.util.Optional;
@@ -52,7 +52,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
     @Mock
-    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+    private StateTransitionQueue stateTransitionQueue;
 
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
     private ChargeService chargeService;
@@ -68,7 +68,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, paymentStateTransitionQueue);
+                null, mockConfiguration, null, stateTransitionQueue);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -33,7 +33,7 @@ import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -92,7 +92,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     private Counter mockCounter;
 
     @Mock
-    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+    private StateTransitionQueue stateTransitionQueue;
 
     private CardAuthoriseService cardAuthorisationService;
 
@@ -103,7 +103,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, paymentStateTransitionQueue);
+                null, null, mockConfiguration, null, stateTransitionQueue);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -35,7 +35,7 @@ import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.queue.CaptureQueue;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
@@ -100,7 +100,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private Environment mockEnvironment;
 
     @Mock
-    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+    private StateTransitionQueue stateTransitionQueue;
 
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
@@ -112,7 +112,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, paymentStateTransitionQueue);
+                null, null, mockConfiguration, null, stateTransitionQueue);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/PaymentStateTransitionQueueTest.java
@@ -14,7 +14,7 @@ public class PaymentStateTransitionQueueTest {
 
         queue.offer(transition);
 
-        PaymentStateTransition readTransition = queue.poll();
+        PaymentStateTransition readTransition = (PaymentStateTransition) queue.poll();
 
         assertNull(readTransition);
     }
@@ -30,7 +30,7 @@ public class PaymentStateTransitionQueueTest {
 
         Thread.sleep(transition.getDelayDurationInMilliseconds() + delayBufferInMilliseconds);
 
-        PaymentStateTransition readTransition = queue.poll();
+        PaymentStateTransition readTransition = (PaymentStateTransition) queue.poll();
 
         assertThat(readTransition.getChargeEventId(), is(chargeEventId));
     }

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionQueueTest.java
@@ -6,10 +6,10 @@ import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
-public class PaymentStateTransitionQueueTest {
+public class StateTransitionQueueTest {
     @Test
     public void shouldNotReturnElementBeforeDelay() throws InterruptedException {
-        PaymentStateTransitionQueue queue = new PaymentStateTransitionQueue();
+        StateTransitionQueue queue = new StateTransitionQueue();
         PaymentStateTransition transition = new PaymentStateTransition(1L, PaymentEvent.class);
 
         queue.offer(transition);
@@ -23,7 +23,7 @@ public class PaymentStateTransitionQueueTest {
     public void shouldReturnElementAfterDelay() throws InterruptedException {
         long chargeEventId = 1L;
         long delayBufferInMilliseconds = 100L;
-        PaymentStateTransitionQueue queue = new PaymentStateTransitionQueue();
+        StateTransitionQueue queue = new StateTransitionQueue();
         PaymentStateTransition transition = new PaymentStateTransition(chargeEventId, PaymentEvent.class);
 
         queue.offer(transition);

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayRefundResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.exception.RefundException;
 import uk.gov.pay.connector.refund.model.RefundRequest;
@@ -77,6 +78,8 @@ public class ChargeRefundServiceTest {
     private PaymentProvider mockProvider;
     @Mock
     private UserNotificationService mockUserNotificationService;
+    @Mock
+    private PaymentStateTransitionQueue mockPaymentStateTransitionQueue;
 
     @Before
     public void setUp() {
@@ -84,7 +87,7 @@ public class ChargeRefundServiceTest {
         when(mockProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockProvider);
         when(mockProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
         chargeRefundService = new ChargeRefundService(
-                mockChargeDao, mockRefundDao, mockProviders, mockUserNotificationService
+                mockChargeDao, mockRefundDao, mockProviders, mockUserNotificationService, mockPaymentStateTransitionQueue
         );
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -21,7 +21,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayRefundResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.exception.RefundException;
 import uk.gov.pay.connector.refund.model.RefundRequest;
@@ -79,7 +79,7 @@ public class ChargeRefundServiceTest {
     @Mock
     private UserNotificationService mockUserNotificationService;
     @Mock
-    private PaymentStateTransitionQueue mockPaymentStateTransitionQueue;
+    private StateTransitionQueue mockStateTransitionQueue;
 
     @Before
     public void setUp() {
@@ -87,7 +87,7 @@ public class ChargeRefundServiceTest {
         when(mockProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockProvider);
         when(mockProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
         chargeRefundService = new ChargeRefundService(
-                mockChargeDao, mockRefundDao, mockProviders, mockUserNotificationService, mockPaymentStateTransitionQueue
+                mockChargeDao, mockRefundDao, mockProviders, mockUserNotificationService, mockStateTransitionQueue
         );
     }
 

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -36,7 +36,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
-import uk.gov.pay.connector.queue.PaymentStateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
@@ -95,7 +95,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     private Counter mockCounter;
 
     @Mock
-    private PaymentStateTransitionQueue paymentStateTransitionQueue;
+    private StateTransitionQueue stateTransitionQueue;
 
     private WalletAuthoriseService walletAuthoriseService;
 
@@ -123,7 +123,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, paymentStateTransitionQueue));
+                null, null, mockConfiguration, null, stateTransitionQueue));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,
@@ -176,7 +176,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
         assertThat(charge.getEmail(), is(validApplePayDetails.getPaymentInfo().getEmail()));
         
-        verify(paymentStateTransitionQueue).offer(any(PaymentStateTransition.class));
+        verify(stateTransitionQueue).offer(any(PaymentStateTransition.class));
     }
 
     @Test
@@ -205,7 +205,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         assertThat(charge.getCorporateSurcharge().isPresent(), is(false));
         assertThat(charge.getEmail(), is(authorisationData.getPaymentInfo().getEmail()));
 
-        verify(paymentStateTransitionQueue).offer(any(PaymentStateTransition.class));
+        verify(stateTransitionQueue).offer(any(PaymentStateTransition.class));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
Emit refund state transition events by hooking into centralised `transitionRefundStatus` method. We re-use the approach taken for emitting payment state transitions, whereby the transitions is put on a queue and then read off and processed, to ensure we only emit events that completed successfully, and to be able to use DB based timestamp.
