### PR TITLE
PP-5402 - Adds database migration which drops the not-null constraint on return…

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1175,4 +1175,10 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="update return_url column to allow null values" author="">
+        <dropNotNullConstraint
+                tableName="charges"
+                columnName="return_url" />
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## What you did:
Because the payload for telephone payments do not have a return_url and since we are storing them in the charges table we have to make the return_url allow null values. This PR contains a database migration for this.

