### PR TITLE
BAU: changed serialization for gatewayEventDate

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureConfirmedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureConfirmedEventDetails.java
@@ -1,11 +1,14 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 import java.time.ZonedDateTime;
 
 public class CaptureConfirmedEventDetails extends EventDetails {
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
     private final ZonedDateTime gatewayEventDate;
     private final Long fee;
     private final Long netAmount;


### PR DESCRIPTION
* serialisation to number causes pain when creating pact test for CaptureConfirmed event
* changing to ISO formatting will be more human readable (and shouldn't cause pain with pact test)

Unless someone has better idea how to resolve https://build.ci.pymnt.uk/job/pay-ledger/job/PR-148/13/console. (I've spent enough time - don't want to waste any more)