### PR TITLE
PP-5469: PaymentDetailsEntered emits totalAmount

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.events.eventdetails.charge;
 
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 import java.util.Objects;
@@ -24,13 +25,14 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private final String addressCounty;
     private final String addressCountry;
     private final String wallet;
+    private final Long totalAmount;
 
     public PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardBrand,
                                              String gatewayTransactionId, String firstDigitsCardNumber,
                                              String lastDigitsCardNumber, String cardholderName, String expiryDate,
                                              String addressLine1, String addressLine2, String addressPostcode,
                                              String addressCity, String addressCounty, String addressCountry,
-                                             String wallet) {
+                                             String wallet, Long totalAmount) {
 
         this.corporateSurcharge = corporateSurcharge;
         this.email = email;
@@ -47,6 +49,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         this.addressCounty = addressCounty;
         this.addressCountry = addressCountry;
         this.wallet = wallet;
+        this.totalAmount = totalAmount;
     }
 
     public static PaymentDetailsEnteredEventDetails from(ChargeEntity charge) {
@@ -65,8 +68,8 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
                 charge.getCardDetails().getBillingAddress().map(a -> a.getCity()).orElse(null),
                 charge.getCardDetails().getBillingAddress().map(a -> a.getCounty()).orElse(null),
                 charge.getCardDetails().getBillingAddress().map(a -> a.getCountry()).orElse(null),
-                Optional.ofNullable(charge.getWalletType()).map(Enum::toString).orElse(null)
-        );
+                Optional.ofNullable(charge.getWalletType()).map(Enum::toString).orElse(null),
+                CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
     }
 
     public Long getCorporateSurcharge() {
@@ -129,6 +132,10 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         return wallet;
     }
 
+    public Long getTotalAmount() {
+        return totalAmount;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -148,13 +155,14 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
                 Objects.equals(addressCity, that.addressCity) &&
                 Objects.equals(addressCounty, that.addressCounty) &&
                 Objects.equals(addressCountry, that.addressCountry) &&
-                Objects.equals(wallet, that.wallet);
+                Objects.equals(wallet, that.wallet) &&
+                Objects.equals(totalAmount, that.totalAmount);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(corporateSurcharge, email, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
                 gatewayTransactionId, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode,
-                addressCounty, addressCountry, wallet);
+                addressCounty, addressCountry, wallet, totalAmount);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -70,7 +70,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -175,7 +174,7 @@ public class ChargeServiceTest {
         when(mockedConfig.getEmitPaymentStateTransitionEvents()).thenReturn(true);
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
-                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedStateTransitionQueue);
+                mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders, mockedStateTransitionQueue, mockedEventQueue);
     }
 
     @Test
@@ -204,7 +203,7 @@ public class ChargeServiceTest {
 
         verify(mockedChargeEventDao).persistChargeEventOf(eq(createdChargeEntity), isNull());
     }
-    
+
     @Test
     public void shouldCreateAChargeWithDelayedCaptureTrue() {
         final ChargeCreateRequest request = requestBuilder.withDelayedCapture(true).build();

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
-import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.wallets.WalletType;
 
@@ -63,6 +62,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are entered")));
 
         assertThat(actual, hasJsonPath("$.event_details.corporate_surcharge", equalTo(10)));
+        assertThat(actual, hasJsonPath("$.event_details.total_amount", equalTo(110)));
         assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
         assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
         assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(validTransactionId)));
@@ -97,6 +97,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are entered")));
 
         assertThat(actual, hasNoJsonPath("$.event_details.corporate_surcharge"));
+        assertThat(actual, hasJsonPath("$.event_details.total_amount", equalTo(100)));
         assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
         assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
         assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(validTransactionId)));

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -14,12 +14,16 @@ import org.junit.runner.RunWith;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDetails;
+import uk.gov.pay.connector.events.eventdetails.charge.PaymentDetailsEnteredEventDetails;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
+import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 
 import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
 @RunWith(PactRunner.class)
 @Provider("connector")
@@ -59,6 +63,22 @@ public class QueueMessageContractTest {
         CaptureConfirmed captureConfirmedEvent = new CaptureConfirmed(
                 resourceId,
                 CaptureConfirmedEventDetails.from(chargeEventEntity),
+                ZonedDateTime.now()
+        );
+
+        return captureConfirmedEvent.toJsonString();
+    }
+
+    @PactVerifyProvider("a payment details entered message")
+    public String verifyPaymentDetailsEnteredEvent() throws JsonProcessingException {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withCorporateSurcharge(55L)
+                .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
+                .build();
+
+        PaymentDetailsEntered captureConfirmedEvent = new PaymentDetailsEntered(
+                resourceId,
+                PaymentDetailsEnteredEventDetails.from(charge),
                 ZonedDateTime.now()
         );
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
@@ -54,6 +55,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     @Mock
     private StateTransitionQueue stateTransitionQueue;
 
+    @Mock
+    private EventQueue eventQueue;
+
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
     private ChargeService chargeService;
     private Card3dsResponseAuthService card3dsResponseAuthService;
@@ -68,7 +72,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, stateTransitionQueue);
+                null, mockConfiguration, null, stateTransitionQueue, eventQueue);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -102,6 +103,9 @@ public class CardCaptureServiceTest extends CardServiceTest {
     @Mock
     private StateTransitionQueue stateTransitionQueue;
 
+    @Mock
+    private EventQueue eventQueue;
+
     @Captor
     ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
 
@@ -112,7 +116,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, stateTransitionQueue);
+                null, null, mockConfiguration, null, stateTransitionQueue, eventQueue);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);


### PR DESCRIPTION
* PaymentCreated doesn't have enough information to emit corporate_surcharge and final total_amount
* corporate_surcharge is calculate before authorisation therefore PaymentDetailsEntered should be able to emit total_amount (corporate_surcharge is already there)
* add pact for PaymentDetailsEntered event

* revert https://github.com/alphagov/pay-connector/commit/8921622cca305a1ca7d58c445c81f53c7f62b2c2 (to emit `PaymentDetailsEntered` event)