### PR TITLE
BAU - Fix regex to convert class name to event_type

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -58,7 +58,7 @@ public abstract class Event {
     }
 
     static String eventTypeForClass(Class clazz) {
-        return clazz.getSimpleName().replaceAll("([^A-Z]+)([A-Z])", "$1_$2").toUpperCase();
+        return clazz.getSimpleName().replaceAll("([^A-Z0-9]+)([A-Z0-9])", "$1_$2").toUpperCase();
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/events/model/EventTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/EventTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.events.model;
 
 import org.junit.Test;
+import uk.gov.pay.connector.events.model.charge.GatewayRequires3dsAuthorisation;
 
 import static org.junit.Assert.assertEquals;
 
@@ -9,5 +10,11 @@ public class EventTest {
     @Test
     public void eventTypeForClass_returnsScreamingSnakeCase() {
         assertEquals("EVENT_TEST", Event.eventTypeForClass(EventTest.class));
+    }
+
+    @Test
+    public void eventTypeForClass_shouldAlsoConsiderNumbers() {
+        assertEquals("GATEWAY_REQUIRES_3DS_AUTHORISATION", 
+                Event.eventTypeForClass(GatewayRequires3dsAuthorisation.class));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
Current regex doesn't consider numbers in class names (GatewayRequires3dsAuthorisation)

   - **Current** : Event type returned for `GatewayRequires3dsAuthorisation` is `GATEWAY_REQUIRES3DS_AUTHORISATION`
   - With the change, event type will be `GATEWAY_REQUIRES_3DS_AUTHORISATION`

