### PR TITLE
Pp 5463 emit payment refund events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
+++ b/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
@@ -6,19 +6,16 @@ import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.exception.StateTransitionMessageProcessException;
 import uk.gov.pay.connector.events.model.Event;
-import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import uk.gov.pay.connector.events.model.charge.PaymentEventFactory;
-import uk.gov.pay.connector.events.model.refund.RefundEvent;
 import uk.gov.pay.connector.events.model.refund.RefundEventFactory;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
-import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.RefundStateTransition;
 import uk.gov.pay.connector.queue.StateTransition;
-import uk.gov.pay.connector.refund.dao.RefundDao;
-import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 
 import javax.inject.Inject;
+import java.util.List;
 import java.util.Optional;
 
 public class StateTransitionEmitterProcess {
@@ -26,46 +23,45 @@ public class StateTransitionEmitterProcess {
 
     private final StateTransitionQueue stateTransitionQueue;
     private final EventQueue eventQueue;
+    private final RefundEventFactory refundEventFactory;
     private final ChargeEventDao chargeEventDao;
-    private final RefundDao refundDao;
 
     @Inject
     public StateTransitionEmitterProcess(
             StateTransitionQueue stateTransitionQueue,
             EventQueue eventQueue,
-            ChargeEventDao chargeEventDao,
-            RefundDao refundDao
+            RefundEventFactory refundEventFactory,
+            ChargeEventDao chargeEventDao
     ) {
         this.stateTransitionQueue = stateTransitionQueue;
         this.eventQueue = eventQueue;
+        this.refundEventFactory = refundEventFactory;
         this.chargeEventDao = chargeEventDao;
-        this.refundDao = refundDao;
     }
 
     public void handleStateTransitionMessages() {
         Optional.ofNullable(stateTransitionQueue.poll())
-                .ifPresent(this::emitEvent);
+                .ifPresent(this::emitEvents);
     }
 
-    private void emitEvent(StateTransition stateTransition) {
+    private void emitEvents(StateTransition stateTransition) {
         if (stateTransition.shouldAttempt()) {
-
             try {
-                Event event = createEvent(stateTransition);
-                eventQueue.emitEvent(event);
+                createEvents(stateTransition)
+                        .forEach(event -> {
+                            try {
+                                eventQueue.emitEvent(event);
+                            } catch (QueueException e) {
+                                handleException(e, stateTransition);
+                            }
+                        });
                 LOGGER.info(
                         "Emitted new state transition event for [eventId={}] [eventType={}]",
                         stateTransition.getIdentifier(),
                         stateTransition.getStateTransitionEventClass().getSimpleName()
                 );
-            } catch (StateTransitionMessageProcessException | QueueException e) {
-                LOGGER.warn(
-                        "Failed to emit new event for state transition [eventId={}] [eventType={}] [error={}]",
-                        stateTransition.getIdentifier(),
-                        stateTransition.getStateTransitionEventClass().getSimpleName(),
-                        e.getMessage()
-                );
-                stateTransitionQueue.offer(stateTransition.getNext());
+            } catch (StateTransitionMessageProcessException e) {
+                handleException(e, stateTransition);
             }
         } else {
             LOGGER.error(
@@ -76,30 +72,27 @@ public class StateTransitionEmitterProcess {
         }
     }
 
-    private Event createEvent(StateTransition stateTransition) throws StateTransitionMessageProcessException {
+    private void handleException(Exception e, StateTransition stateTransition) {
+        LOGGER.warn(
+                "Failed to emit new event for state transition [eventId={}] [eventType={}] [error={}]",
+                stateTransition.getIdentifier(),
+                stateTransition.getStateTransitionEventClass().getSimpleName(),
+                e.getMessage()
+        );
+        stateTransitionQueue.offer(stateTransition.getNext());
+    }
+
+    private List<? extends Event> createEvents(StateTransition stateTransition) throws StateTransitionMessageProcessException {
         if (stateTransition instanceof PaymentStateTransition) {
             PaymentStateTransition paymentStateTransition = (PaymentStateTransition) stateTransition;
             return chargeEventDao.findById(ChargeEventEntity.class, paymentStateTransition.getChargeEventId())
-                    .map(chargeEvent -> createEvent(chargeEvent, paymentStateTransition.getStateTransitionEventClass()))
+                    .map(chargeEvent -> List.of(PaymentEventFactory.create(paymentStateTransition.getStateTransitionEventClass(), chargeEvent)))
                     .orElseThrow(() -> new StateTransitionMessageProcessException(String.valueOf(paymentStateTransition.getChargeEventId())));
         } else if (stateTransition instanceof RefundStateTransition) {
             RefundStateTransition refundStateTransition = (RefundStateTransition) stateTransition;
-            return refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
-                    refundStateTransition.getRefundExternalId(),
-                    refundStateTransition.getRefundStatus())
-                    .map(refundHistory -> createEvent(refundHistory, stateTransition.getStateTransitionEventClass()))
-                    .orElseThrow(() -> new StateTransitionMessageProcessException(refundStateTransition.getRefundExternalId()));
+            return refundEventFactory.create(refundStateTransition);
         } else {
             throw new StateTransitionMessageProcessException(stateTransition.getIdentifier());
         }
-    }
-
-    private RefundEvent createEvent(RefundHistory refundHistory, Class<? extends RefundEvent> refundEventClass) {
-        return RefundEventFactory.create(refundEventClass, refundHistory);
-
-    }
-
-    private PaymentEvent createEvent(ChargeEventEntity chargeEvent, Class<? extends PaymentEvent> paymentEventClass) {
-        return PaymentEventFactory.create(paymentEventClass, chargeEvent);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.util.RefundCalculator;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class RefundAvailabilityUpdatedEventDetails extends EventDetails {
+    private Long amountAvailable;
+    private Long amountRefunded;
+    private String availability;
+
+    private RefundAvailabilityUpdatedEventDetails(Long amountAvailable, Long amountRefunded, String availability) {
+        this.amountAvailable = amountAvailable;
+        this.amountRefunded = amountRefunded;
+        this.availability = availability;
+    }
+    
+
+    public static RefundAvailabilityUpdatedEventDetails from(ChargeEntity charge, ExternalChargeRefundAvailability availability) {
+        return new RefundAvailabilityUpdatedEventDetails(
+                RefundCalculator.getTotalAmountAvailableToBeRefunded(charge),
+                RefundCalculator.getRefundedAmount(charge),
+                availability.getStatus()
+        );
+    }
+
+    public Long getRefundAmountAvailable() {
+        return amountAvailable;
+    }
+
+    public Long getRefundAmountRefunded() {
+        return amountRefunded;
+    }
+
+    public String getRefundStatus() {
+        return availability;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentRefundCreatedByUser.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+import java.time.ZonedDateTime;
+
+public class PaymentRefundCreatedByUser extends PaymentEvent {
+    public PaymentRefundCreatedByUser(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
+
+import java.time.ZonedDateTime;
+
+public class RefundAvailabilityUpdated extends PaymentEvent {
+
+    public RefundAvailabilityUpdated(String resourceExternalId, RefundAvailabilityUpdatedEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEventFactory.java
@@ -1,13 +1,57 @@
 package uk.gov.pay.connector.events.model.refund;
 
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.events.exception.StateTransitionMessageProcessException;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.queue.RefundStateTransition;
+import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
+import javax.inject.Inject;
 import java.lang.reflect.InvocationTargetException;
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class RefundEventFactory {
-    public static RefundEvent create(Class<? extends RefundEvent> eventClass, RefundHistory refundHistory) {
+    private final ChargeService chargeService;
+    private final RefundDao refundDao;
+    private final PaymentProviders paymentProviders;
+    private static final List<Class<? extends RefundEvent>> eventsAffectingRefundAvailability = List.of(
+            RefundCreatedByUser.class,
+            RefundCreatedByService.class,
+            RefundError.class
+    );
+
+    @Inject
+    public RefundEventFactory(ChargeService chargeService, RefundDao refundDao, PaymentProviders paymentProviders) {
+        this.chargeService = chargeService;
+        this.refundDao = refundDao;
+        this.paymentProviders = paymentProviders;
+    }
+
+    public List<Event> create(RefundStateTransition refundStateTransition) throws StateTransitionMessageProcessException {
+        RefundHistory refundHistory = refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
+                refundStateTransition.getRefundExternalId(),
+                refundStateTransition.getRefundStatus())
+                .orElseThrow(() -> new StateTransitionMessageProcessException(refundStateTransition.getIdentifier()));
+
+        Event refundEvent = createRefundEvent(refundHistory, refundStateTransition.getStateTransitionEventClass());
+        Optional<Event> refundAvailabilityEvent = createRefundAvailabilityUpdatedEvent(
+                refundHistory, refundStateTransition.getStateTransitionEventClass());
+
+        return List.of(Optional.of(refundEvent), refundAvailabilityEvent)
+                .stream()
+                .flatMap(Optional::stream)
+                .collect(Collectors.toList());
+    }
+
+    private Event createRefundEvent(RefundHistory refundHistory, Class<? extends RefundEvent> eventClass) {
         try {
             if (eventClass == RefundCreatedByService.class) {
                 return RefundCreatedByService.from(refundHistory);
@@ -25,4 +69,25 @@ public class RefundEventFactory {
             throw new IllegalArgumentException(String.format("Could not construct refund event: %s", eventClass));
         }
     }
+
+    private Optional<Event> createRefundAvailabilityUpdatedEvent(
+            RefundHistory refundHistory, Class<? extends RefundEvent> eventClass) {
+        if (eventsAffectingRefundAvailability.contains(eventClass)) {
+            return Optional.ofNullable(chargeService.findChargeById(refundHistory.getChargeEntity().getExternalId()))
+                    .map(charge -> new RefundAvailabilityUpdated(
+                                charge.getExternalId(),
+                                RefundAvailabilityUpdatedEventDetails.from(
+                                        charge,
+                                        paymentProviders
+                                                .byName(charge.getPaymentGatewayName())
+                                                .getExternalChargeRefundAvailability(charge)
+                                ),
+                                refundHistory.getHistoryStartDate()
+                        )
+                    );
+        }
+
+        return Optional.empty();
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/StateTransitionEmitterProcessTest.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentEvent;
+import uk.gov.pay.connector.events.model.refund.RefundEventFactory;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
 import uk.gov.pay.connector.queue.StateTransitionQueue;
@@ -44,7 +45,7 @@ public class StateTransitionEmitterProcessTest {
     ChargeEventDao chargeEventDao;
 
     @Mock
-    private RefundDao refundDao;
+    private RefundEventFactory refundEventFactory;
     
     @InjectMocks
     StateTransitionEmitterProcess stateTransitionEmitterProcess;
@@ -96,7 +97,7 @@ public class StateTransitionEmitterProcessTest {
     @Test
     public void shouldNotPutPaymentTransitionBackOnQueueIfItHasExceededMaxAttempts() {
         StateTransitionQueue spyQueue = spy(new StateTransitionQueue());
-        StateTransitionEmitterProcess stateTransitionEmitterProcess = new StateTransitionEmitterProcess(spyQueue, eventQueue, chargeEventDao, refundDao);
+        StateTransitionEmitterProcess stateTransitionEmitterProcess = new StateTransitionEmitterProcess(spyQueue, eventQueue, refundEventFactory, chargeEventDao);
         PaymentStateTransition paymentStateTransition = new PaymentStateTransition(100L, PaymentEvent.class, 0);
 
         when(chargeEventDao.findById(ChargeEventEntity.class, 100L)).thenReturn(Optional.empty());

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import java.time.ZonedDateTime;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+public class RefundAvailabilityUpdatedTest {
+    private final ChargeEntityFixture chargeEntity = aValidChargeEntity();
+
+    @Test
+    public void serialisesRefundAvailabilityEventDetails() throws JsonProcessingException {
+
+        ChargeEntity charge = chargeEntity.build();
+        
+        String event = new RefundAvailabilityUpdated(
+                charge.getExternalId(),
+                RefundAvailabilityUpdatedEventDetails.from(charge, ExternalChargeRefundAvailability.EXTERNAL_FULL),
+                ZonedDateTime.now()
+        ).toJsonString();
+        
+        assertThat(event, hasJsonPath("$.event_type", equalTo("REFUND_AVAILABILITY_UPDATED")));
+        assertThat(event, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(event, hasJsonPath("$.resource_external_id", equalTo(charge.getExternalId())));
+
+        assertThat(event, hasJsonPath("$.event_details.refund_status", equalTo("full")));
+        assertThat(event, hasJsonPath("$.event_details.refund_amount_available", equalTo(500)));
+        assertThat(event, hasJsonPath("$.event_details.refund_amount_refunded", equalTo(0)));
+    }
+
+
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundEventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundEventFactoryTest.java
@@ -1,55 +1,195 @@
 package uk.gov.pay.connector.events.model.refund;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByUserEventDetails;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.pact.RefundHistoryEntityFixture;
+import uk.gov.pay.connector.queue.RefundStateTransition;
+import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
-import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-
+@RunWith(MockitoJUnitRunner.class)
 public class RefundEventFactoryTest {
 
     private final ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-    private ZonedDateTime createdDate = ZonedDateTime.now().minusSeconds(5L);
-    private UTCDateTimeConverter timeConverter = new UTCDateTimeConverter();
 
+    @Mock
+    private ChargeService chargeService;
+    @Mock
+    private RefundDao refundDao;
+    @Mock
+    private PaymentProviders paymentProviders;
+    
+    private RefundEventFactory refundEventFactory;
+    
+    @Before
+    public void setUp() {
+        when(chargeService.findChargeById(charge.getExternalId())).thenReturn(charge);
+        
+        PaymentProvider paymentProvider = new SandboxPaymentProvider();
+        when(paymentProviders.byName(any(PaymentGatewayName.class))).thenReturn(paymentProvider);
+        
+        refundEventFactory = new RefundEventFactory(chargeService, refundDao, paymentProviders);
+    }
+    
     @Test
-    public void givenARefundCreatedTypeShouldCreateARefundCreatedByUserEvent() {
-        RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L, RefundStatus.CREATED.getValue(),
-                charge.getId(), timeConverter.convertToDatabaseColumn(createdDate), 1L,
-                null, timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
-                timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
-                "user_external_id", null, charge.getExternalId());
-        RefundCreatedByUser refundEvent = (RefundCreatedByUser) RefundEventFactory.create(RefundCreatedByUser.class, refundHistory);
-
-        assertThat(refundEvent.getParentResourceExternalId(), is(charge.getExternalId()));
-        assertThat(((RefundCreatedByUserEventDetails)refundEvent.getEventDetails()).getRefundedBy(), is("user_external_id"));
-        assertThat(refundEvent.getResourceType(), is(ResourceType.REFUND));
-        assertThat(refundEvent.getEventDetails(), is(instanceOf(RefundCreatedByUserEventDetails.class)));
+    public void shouldCreateCorrectEventsFromRefundCreatedStateTransition() throws Exception {
+        RefundHistory refundCreatedHistory = RefundHistoryEntityFixture.aValidRefundHistoryEntity()
+                .withStatus(RefundStatus.CREATED.getValue())
+                .withUserExternalId("user_external_id")
+                .withChargeExternalId(charge.getExternalId())
+                .withAmount(charge.getAmount())
+                .build();
+        when(refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
+                refundCreatedHistory.getExternalId(),
+                refundCreatedHistory.getStatus())
+        ).thenReturn(Optional.of(refundCreatedHistory));
+        
+        
+        RefundStateTransition refundStateTransition = new RefundStateTransition(
+                refundCreatedHistory.getExternalId(), refundCreatedHistory.getStatus(), RefundCreatedByUser.class
+        );
+        List<Event> refundEvents = refundEventFactory.create(refundStateTransition);
+        
+        
+        assertThat(refundEvents.size(), is(2));
+        
+        RefundCreatedByUser refundCreatedByUser = (RefundCreatedByUser) refundEvents.stream()
+                .filter(e -> ResourceType.REFUND.equals(e.getResourceType()))
+                .findFirst().get();
+        assertThat(refundCreatedByUser.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(((RefundCreatedByUserEventDetails) refundCreatedByUser.getEventDetails()).getRefundedBy(), is("user_external_id"));
+        assertThat(refundCreatedByUser.getResourceType(), is(ResourceType.REFUND));
+        assertThat(refundCreatedByUser.getEventDetails(), is(instanceOf(RefundCreatedByUserEventDetails.class)));
+        
+        RefundAvailabilityUpdated refundAvailabilityUpdated = (RefundAvailabilityUpdated) refundEvents.stream()
+                .filter(e -> ResourceType.PAYMENT.equals(e.getResourceType()))
+                .findFirst().get();
+        assertThat(refundAvailabilityUpdated.getResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundAvailabilityUpdated.getResourceType(), is(ResourceType.PAYMENT));
+        assertThat(refundAvailabilityUpdated.getEventDetails(), is(instanceOf(RefundAvailabilityUpdatedEventDetails.class)));
     }
 
     @Test
-    public void givenARefundSubmittedEventTypeShouldCreateTheCorrectPaymentEventType() {
-        RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L, RefundStatus.REFUND_SUBMITTED.getValue(),
-                charge.getId(), new UTCDateTimeConverter().convertToDatabaseColumn(createdDate), 1L,
-                "refund_reference", new UTCDateTimeConverter().convertToDatabaseColumn(createdDate.plusSeconds(1L)),
-                new UTCDateTimeConverter().convertToDatabaseColumn(createdDate.plusSeconds(2L)),
-                "user_external_id", "gateway_transaction_id", charge.getExternalId());
+    public void shouldCreateCorrectEventsFromRefundSubmittedStateTransition() throws Exception {
+        RefundHistory refundSubmittedHistory = RefundHistoryEntityFixture.aValidRefundHistoryEntity()
+                .withStatus(RefundStatus.REFUND_SUBMITTED.getValue())
+                .withUserExternalId("user_external_id")
+                .withChargeExternalId(charge.getExternalId())
+                .withAmount(charge.getAmount())
+                .build();
+        when(refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
+                refundSubmittedHistory.getExternalId(),
+                refundSubmittedHistory.getStatus())
+        ).thenReturn(Optional.of(refundSubmittedHistory));
+        
+        
+        RefundStateTransition refundStateTransition = new RefundStateTransition(
+                refundSubmittedHistory.getExternalId(), refundSubmittedHistory.getStatus(), RefundSubmitted.class
+        );
+        List<Event> refundEvents = refundEventFactory.create(refundStateTransition);
 
-        RefundSubmitted refundEvent = (RefundSubmitted) RefundEventFactory.create(RefundSubmitted.class, refundHistory);
+        
+        assertThat(refundEvents.size(), is(1));
 
-        assertThat(refundEvent.getParentResourceExternalId(), is(charge.getExternalId()));
-        assertThat(refundEvent.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
-        assertThat(((RefundEventWithReferenceDetails)refundEvent.getEventDetails()).getReference(), is("refund_reference"));
+        RefundSubmitted refundSubmitted = (RefundSubmitted) refundEvents.get(0);
+        
+        assertThat(refundSubmitted.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundSubmitted.getResourceExternalId(), is(refundSubmittedHistory.getExternalId()));
+        assertThat(refundSubmitted.getResourceType(), is(ResourceType.REFUND));
+        assertThat(refundSubmitted.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
+    }
+
+    @Test
+    public void shouldCreateCorrectEventsFromRefundSucceededStateTransition() throws Exception {
+        RefundHistory refundSucceededHistory = RefundHistoryEntityFixture.aValidRefundHistoryEntity()
+                .withStatus(RefundStatus.REFUNDED.getValue())
+                .withUserExternalId("user_external_id")
+                .withChargeExternalId(charge.getExternalId())
+                .withAmount(charge.getAmount())
+                .build();
+        when(refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
+                refundSucceededHistory.getExternalId(),
+                refundSucceededHistory.getStatus())
+        ).thenReturn(Optional.of(refundSucceededHistory));
+        
+        
+        RefundStateTransition refundStateTransition = new RefundStateTransition(
+                refundSucceededHistory.getExternalId(), refundSucceededHistory.getStatus(), RefundSucceeded.class
+        );
+        List<Event> refundEvents = refundEventFactory.create(refundStateTransition);
+
+        
+        assertThat(refundEvents.size(), is(1));
+
+        RefundSucceeded refundSucceeded = (RefundSucceeded) refundEvents.get(0);
+
+        assertThat(refundSucceeded.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundSucceeded.getResourceExternalId(), is(refundSucceededHistory.getExternalId()));
+        assertThat(refundSucceeded.getResourceType(), is(ResourceType.REFUND));
+        assertThat(refundSucceeded.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
+    }
+
+    @Test
+    public void shouldCreateCorrectEventsFromRefundErrorStateTransition() throws Exception {
+        RefundHistory refundErrorHistory = RefundHistoryEntityFixture.aValidRefundHistoryEntity()
+                .withStatus(RefundStatus.REFUND_ERROR.getValue())
+                .withUserExternalId("user_external_id")
+                .withChargeExternalId(charge.getExternalId())
+                .withAmount(charge.getAmount())
+                .build();
+        when(refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
+                refundErrorHistory.getExternalId(),
+                refundErrorHistory.getStatus())
+        ).thenReturn(Optional.of(refundErrorHistory));
+        
+        
+        RefundStateTransition refundStateTransition = new RefundStateTransition(
+                refundErrorHistory.getExternalId(), refundErrorHistory.getStatus(), RefundError.class
+        );
+        List<Event> refundEvents = refundEventFactory.create(refundStateTransition);
+
+        
+        assertThat(refundEvents.size(), is(2));
+
+        RefundError refundError = (RefundError) refundEvents.stream()
+                .filter(e -> ResourceType.REFUND.equals(e.getResourceType()))
+                .findFirst().get();
+        assertThat(refundError.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(((RefundEventWithReferenceDetails) refundError.getEventDetails()).getReference(), is(refundErrorHistory.getReference()));
+        assertThat(refundError.getResourceType(), is(ResourceType.REFUND));
+        assertThat(refundError.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
+
+        RefundAvailabilityUpdated refundAvailabilityUpdated = (RefundAvailabilityUpdated) refundEvents.stream()
+                .filter(e -> ResourceType.PAYMENT.equals(e.getResourceType()))
+                .findFirst().get();
+        assertThat(refundAvailabilityUpdated.getResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundAvailabilityUpdated.getResourceType(), is(ResourceType.PAYMENT));
+        assertThat(refundAvailabilityUpdated.getEventDetails(), is(instanceOf(RefundAvailabilityUpdatedEventDetails.class)));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -34,7 +34,7 @@ import static uk.gov.pay.connector.pact.RefundHistoryEntityFixture.aValidRefundH
 
 @RunWith(PactRunner.class)
 @Provider("connector")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"ledger"})
 @IgnoreNoPactsToVerify
@@ -46,7 +46,7 @@ public class QueueMessageContractTest {
     private String resourceId = "anExternalResourceId";
 
     @PactVerifyProvider("a payment created message")
-    public String verifyPaymentCreatedEvent() throws Exception{
+    public String verifyPaymentCreatedEvent() throws Exception {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCorporateSurcharge(55L)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
@@ -49,4 +49,14 @@ public class RefundHistoryEntityFixture {
         this.reference = reference;
         return this;
     }
+    
+    public RefundHistoryEntityFixture withChargeExternalId(String chargeExternalId) {
+        this.chargeExternalId = chargeExternalId;
+        return this;
+    }
+
+    public RefundHistoryEntityFixture withAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
 }


### PR DESCRIPTION
In order to keep track of the amount available to be refunded
in ledger, we need to emit `RefundAvailabilityUpdated` eevnts from
connector whenever refundability of a payment might change.
To do this I have changed how refund state transtions are
handled, so that rather than triggering the emsission of a single
external event it can emit a sequence of events (currently only
a sequence of either 1 or 2). The logic for all this has been moved
to the RefundEventFactory.
The refund availability of a payment only changes on refund creation
when the amount available to be refunded goes down) and refund error
(when it goes back up). The actual payload of the events is calculated
using the same tools that are currently used to populate responses,
so everything will line up.