### PR TITLE
PP-5209 Specify `Stripe-Version` on all API requests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -14,7 +14,9 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 
 public class AuthUtil {
-    
+    private static final String STRIPE_VERSION_HEADER = "Stripe-Version";
+    private static final String STRIPE_API_VERSION = "2019-05-16";
+
     private static String encode(String username, String password) {
         return "Basic " + Base64.encodeAsString(username + ":" + password);
     }
@@ -22,9 +24,12 @@ public class AuthUtil {
     public static Map<String, String> getStripeAuthHeader(StripeGatewayConfig stripeGatewayConfig, boolean isLiveAccount) {
         StripeAuthTokens authTokens = stripeGatewayConfig.getAuthTokens();
         String value = format("Bearer %s", isLiveAccount ? authTokens.getLive() : authTokens.getTest());
-        return ImmutableMap.of(AUTHORIZATION, value);
+        return ImmutableMap.of(
+                AUTHORIZATION, value,
+                STRIPE_VERSION_HEADER, STRIPE_API_VERSION
+        );
     }
-    
+
     public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(GatewayAccountEntity gae) {
         String value = encode(gae.getCredentials().get(CREDENTIALS_USERNAME), gae.getCredentials().get(CREDENTIALS_PASSWORD));
         return ImmutableMap.of(AUTHORIZATION, value);


### PR DESCRIPTION
**Actions:**
* introduce stripe version header to all Stripe requests
* specify version as string in code, no reason to allow environment
configuration for now
* this will allow soft upgrades before committing to a default API
version on the platform Stripe configuration

**Rollout plan:**
1. fix connector Stripe API version in code to allow "soft" rollback-able upgrade 
2. update Stripe API version for entire platform 
3. allow removal of code fixed version if everything successful, may decide to keep this configuration
