### PR TITLE
PP-5391 add refund event queue pact tests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.events.model.refund;
 
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
 
@@ -9,5 +10,12 @@ public class RefundError extends RefundEvent {
     public RefundError(String resourceExternalId, String parentResourceExternalId,
                        RefundEventWithReferenceDetails referenceDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+    }
+
+    public RefundError from(RefundHistory refundHistory) {
+        return new RefundError(refundHistory.getExternalId(),
+                refundHistory.getChargeEntity().getExternalId(),
+                new RefundEventWithReferenceDetails(refundHistory.getReference()),
+                refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.events.model.refund;
 
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
 
@@ -9,5 +10,12 @@ public class RefundSubmitted extends RefundEvent {
     public RefundSubmitted(String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithReferenceDetails referenceDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+    }
+
+    public static RefundSubmitted from(RefundHistory refundHistory) {
+        return new RefundSubmitted(refundHistory.getExternalId(),
+                refundHistory.getChargeEntity().getExternalId(),
+                new RefundEventWithReferenceDetails(refundHistory.getReference()),
+                refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.events.model.refund;
 
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
 
@@ -9,5 +10,12 @@ public class RefundSucceeded extends RefundEvent {
     public RefundSucceeded(String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithReferenceDetails referenceDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+    }
+
+    public static RefundSucceeded from(RefundHistory refundHistory) {
+        return new RefundSucceeded(refundHistory.getExternalId(),
+                refundHistory.getChargeEntity().getExternalId(),
+                new RefundEventWithReferenceDetails(refundHistory.getReference()),
+                refundHistory.getHistoryStartDate());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -11,6 +11,7 @@ import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.runner.RunWith;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDetails;
@@ -19,11 +20,17 @@ import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
+import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
+import uk.gov.pay.connector.events.model.refund.RefundSubmitted;
+import uk.gov.pay.connector.events.model.refund.RefundSucceeded;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.time.ZonedDateTime;
 
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.pay.connector.pact.RefundHistoryEntityFixture.aValidRefundHistoryEntity;
 
 @RunWith(PactRunner.class)
 @Provider("connector")
@@ -83,5 +90,35 @@ public class QueueMessageContractTest {
         );
 
         return captureConfirmedEvent.toJsonString();
+    }
+
+    @PactVerifyProvider("a refund created by user message")
+    public String verifyRefundCreatedByUserEvent() throws JsonProcessingException {
+        RefundHistory refundHistory = aValidRefundHistoryEntity()
+                .withUserExternalId(RandomStringUtils.randomAlphanumeric(10))
+                .build();
+        RefundCreatedByUser refundCreatedByUser = RefundCreatedByUser.from(refundHistory);
+
+        return refundCreatedByUser.toJsonString();
+    }
+
+    @PactVerifyProvider("a refund submitted message")
+    public String verifyRefundSubmittedEvent() throws JsonProcessingException {
+        RefundHistory refundHistory = aValidRefundHistoryEntity()
+                .build();
+        RefundSubmitted refundSubmitted = RefundSubmitted.from(refundHistory);
+
+        return refundSubmitted.toJsonString();
+    }
+
+    @PactVerifyProvider("a refund succeeded message")
+    public String verifyRefundedEvent() throws JsonProcessingException {
+        RefundHistory refundHistory = aValidRefundHistoryEntity()
+                .withStatus(RefundStatus.REFUNDED.getValue())
+                .withReference(RandomStringUtils.randomAlphanumeric(14))
+                .build();
+        RefundSucceeded refundSucceeded = RefundSucceeded.from(refundHistory);
+
+        return refundSucceeded.toJsonString();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
@@ -1,0 +1,52 @@
+package uk.gov.pay.connector.pact;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+
+public class RefundHistoryEntityFixture {
+
+    private Long id = 1L;
+    private String externalId = RandomStringUtils.randomAlphanumeric(10);
+    private Long amount = 50L;
+    private String status = RefundStatus.CREATED.getValue();
+    private Long chargeId = 1L;
+    private ZonedDateTime createdDate = ZonedDateTime.now().minusSeconds(5L);
+    private Long version = 1L;
+    private String reference;
+    private ZonedDateTime historyStartDate = createdDate.plusSeconds(2L);
+    private ZonedDateTime historyEndDate = createdDate.plusSeconds(3L);
+    private String userExternalId;
+    private String gatewayTransactionId = null;
+    private String chargeExternalId = RandomStringUtils.randomAlphanumeric(10);
+
+    private RefundHistoryEntityFixture() {}
+
+    public static RefundHistoryEntityFixture aValidRefundHistoryEntity() {
+        return new RefundHistoryEntityFixture();
+    }
+
+    public RefundHistory build() {
+        return new RefundHistory(id, externalId, amount, status, chargeId, Timestamp.valueOf(createdDate.toLocalDateTime()),
+                version, reference, Timestamp.valueOf(historyStartDate.toLocalDateTime()), Timestamp.valueOf(historyEndDate.toLocalDateTime()),
+                userExternalId, gatewayTransactionId, chargeExternalId);
+    }
+
+    public RefundHistoryEntityFixture withStatus(String status) {
+        this.status = status;
+        return this;
+    }
+
+    public RefundHistoryEntityFixture withUserExternalId(String userExternalId) {
+        this.userExternalId = userExternalId;
+        return this;
+    }
+
+    public RefundHistoryEntityFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- add `refund created by user`, `refund submitted` and `refund succeeded` pact tests
- add from(RefundHistory) method to refund event classes
- add RefundHistory fixture
