### PR TITLE
PP-5492 Fix delayed capture on confirmation page

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -90,14 +90,6 @@ public class ChargeService {
 
     private static final List<ChargeStatus> CURRENT_STATUSES_ALLOWING_UPDATE_TO_NEW_STATUS = newArrayList(CREATED, ENTERING_CARD_DETAILS);
 
-    private static final List<ChargeStatus> IGNORABLE_CAPTURE_STATES = ImmutableList.of(
-            CAPTURE_APPROVED,
-            CAPTURE_APPROVED_RETRY,
-            CAPTURE_READY,
-            CAPTURE_SUBMITTED,
-            CAPTURED
-    );
-
     private final ChargeDao chargeDao;
     private final ChargeEventDao chargeEventDao;
     private final CardTypeDao cardTypeDao;
@@ -500,28 +492,30 @@ public class ChargeService {
     @Transactional
     public ChargeEntity markDelayedCaptureChargeAsCaptureApproved(String externalId) {
         return chargeDao.findByExternalId(externalId).map(charge -> {
+            switch (fromString(charge.getStatus())) {
+                case AWAITING_CAPTURE_REQUEST:
+                    try {
+                        transitionChargeState(charge, CAPTURE_APPROVED);
+                    } catch (InvalidStateTransitionException e) {
+                        throw new ConflictRuntimeException(charge.getExternalId(),
+                                "attempt to perform delayed capture on invalid charge state " + e.getMessage());
+                    }
 
-            ChargeStatus currentStatus = fromString(charge.getStatus());
+                    return charge;
 
-            if (chargeCanBeSkipped(charge)) {
-                logger.info("Skipping charge [charge_external_id={}] with status [{}] from marking as CAPTURE APPROVED", currentStatus, externalId);
-                return charge;
-            }
+                case CAPTURE_APPROVED:
+                case CAPTURE_APPROVED_RETRY:
+                case CAPTURE_READY:
+                case CAPTURE_SUBMITTED:
+                case CAPTURED:
+                    return charge;
 
-            if (currentStatus == AWAITING_CAPTURE_REQUEST) {
-                try {
-                    transitionChargeState(charge, CAPTURE_APPROVED);
-                } catch (InvalidStateTransitionException e) {
+                default:
                     throw new ConflictRuntimeException(charge.getExternalId(),
-                            format("attempt to perform delayed capture on invalid charge state"));
-                }
-            } else {
-                throw new ConflictRuntimeException(charge.getExternalId(),
-                        format("attempt to perform delayed capture on charge not in %s state.", AWAITING_CAPTURE_REQUEST));
+                            format("attempt to perform delayed capture on charge not in %s state.", AWAITING_CAPTURE_REQUEST)
+                    );
             }
 
-
-            return charge;
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(externalId));
     }
 
@@ -623,9 +617,5 @@ public class ChargeService {
 
     private boolean chargeIsInLockedStatus(OperationType operationType, ChargeEntity chargeEntity) {
         return operationType.getLockingStatus().equals(ChargeStatus.fromString(chargeEntity.getStatus()));
-    }
-
-    private boolean chargeCanBeSkipped(ChargeEntity charge) {
-        return IGNORABLE_CAPTURE_STATES.contains(ChargeStatus.fromString(charge.getStatus()));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -142,7 +142,7 @@ public class CardResource {
                                                 @PathParam("chargeId") String chargeId,
                                                 @Context UriInfo uriInfo) {
         logger.info("Mark charge as CAPTURE APPROVED [charge_external_id={}]", chargeId);
-        cardCaptureService.markChargeAsCaptureApproved(chargeId);
+        cardCaptureService.markDelayedCaptureChargeAsCaptureApproved(chargeId);
         return ResponseUtil.noContentResponse();
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -5,7 +5,6 @@ import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.FeeEntity;
@@ -94,8 +93,8 @@ public class CardCaptureService {
         chargeService.transitionChargeState(chargeId, CAPTURE_ERROR);
     }
 
-    public ChargeEntity markChargeAsCaptureApproved(String externalId) {
-        ChargeEntity charge = chargeService.markChargeAsCaptureApproved(externalId);
+    public ChargeEntity markDelayedCaptureChargeAsCaptureApproved(String externalId) {
+        ChargeEntity charge = chargeService.markDelayedCaptureChargeAsCaptureApproved(externalId);
         addChargeToCaptureQueue(charge);
         return charge;
     }


### PR DESCRIPTION
* charge service marking charge method only seem to be used by delayed
capture, update their names to reflect this
* add explicit check for `AWAITING_CAPTURE` - this makes the method line
up with the exception thrown as `transitionChargeState` will allow
`AUTHORISATION_SUCCESS` to transition to `CAPTURE_APPROVED`
* verify the behaviour

Expected behaviour: 
* calling the delayed charge end point before the user has pressed 'confirm' during the payment flow should be rejected 
* the delayed charge end point should continue to be idempotent for successful already captured charges