### PR TITLE
BAU: remove properties from PaymentCreated event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 import java.util.Objects;
@@ -15,12 +14,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
     private final String paymentProvider;
     private final String language;
     private final boolean delayedCapture;
-    private final Long corporateSurcharge;
-    private final Long totalAmount;
 
     public PaymentCreatedEventDetails(Long amount, String description, String reference, String returnUrl,
                                       Long gatewayAccountId, String paymentProvider, String language,
-                                      boolean delayedCapture, Long corporateSurcharge, Long totalAmount) {
+                                      boolean delayedCapture) {
         this.amount = amount;
         this.description = description;
         this.reference = reference;
@@ -29,8 +26,6 @@ public class PaymentCreatedEventDetails extends EventDetails {
         this.paymentProvider = paymentProvider;
         this.language = language;
         this.delayedCapture = delayedCapture;
-        this.corporateSurcharge = corporateSurcharge;
-        this.totalAmount = totalAmount;
     }
 
     public static PaymentCreatedEventDetails from(ChargeEntity charge) {
@@ -42,9 +37,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 charge.getGatewayAccount().getId(),
                 charge.getGatewayAccount().getGatewayName(),
                 charge.getLanguage().toString(),
-                charge.isDelayedCapture(),
-                charge.getCorporateSurcharge().orElse(null),
-                CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
+                charge.isDelayedCapture());
     }
 
     public Long getAmount() {
@@ -79,14 +72,6 @@ public class PaymentCreatedEventDetails extends EventDetails {
         return delayedCapture;
     }
 
-    public Long getCorporateSurcharge() {
-        return corporateSurcharge;
-    }
-
-    public Long getTotalAmount() {
-        return totalAmount;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -99,14 +84,12 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 Objects.equals(gatewayAccountId, that.gatewayAccountId) &&
                 Objects.equals(paymentProvider, that.paymentProvider) &&
                 Objects.equals(language, that.language) &&
-                Objects.equals(delayedCapture, that.delayedCapture) &&
-                Objects.equals(corporateSurcharge, that.corporateSurcharge) &&
-                Objects.equals(totalAmount, that.totalAmount);
+                Objects.equals(delayedCapture, that.delayedCapture);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(amount, description, reference, returnUrl, gatewayAccountId, paymentProvider, language,
-                delayedCapture, corporateSurcharge, totalAmount);
+                delayedCapture);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -85,7 +85,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
     private PaymentCreated aPaymentCreatedEvent() {
         PaymentCreatedEventDetails eventDetails = new PaymentCreatedEventDetails(
                 1L, "desc", "ref", "return_url",
-                100L, "someProvider", "en", false, null, 1L);
+                100L, "someProvider", "en", false);
         return new PaymentCreated("my-resource-external-id", eventDetails, ZonedDateTime.parse("2019-01-01T14:00:00Z"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -66,7 +66,5 @@ public class PaymentCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.payment_provider", equalTo(chargeEntity.getGatewayAccount().getGatewayName())));
         assertThat(actual, hasJsonPath("$.event_details.language", equalTo(chargeEntity.getLanguage().toString())));
         assertThat(actual, hasJsonPath("$.event_details.delayed_capture", equalTo(chargeEntity.isDelayedCapture())));
-        assertThat(actual, hasJsonPath("$.event_details.corporate_surcharge", equalTo(77)));
-        assertThat(actual, hasJsonPath("$.event_details.total_amount", equalTo(177)));
     }
 }


### PR DESCRIPTION
removed corporate_surcharge and total_amount from `PaymentCreated` event (they're in `PaymentDetailsEntered` event)