### PR TITLE
PP-5407 Backfill - emit all charge events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
@@ -19,7 +19,7 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
         super(entityManager);
     }
 
-    public boolean hasBeenEmittedBefore(Event paymentCreatedEvent) {
+    public boolean hasBeenEmittedBefore(Event event) {
         final List<Integer> singleResult = entityManager.get()
                 .createQuery("select 1 from EmittedEventEntity e where " +
                         "e.resourceType = :resource_type AND " +
@@ -27,12 +27,12 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
                         "e.resourceExternalId = :resource_external_id AND " +
                         "e.eventType = :event_type", Integer.class)
                 .setMaxResults(1)
-                .setParameter("resource_type", paymentCreatedEvent.getResourceType().getLowercase())
-                .setParameter("resource_external_id", paymentCreatedEvent.getResourceExternalId())
-                .setParameter("event_type", paymentCreatedEvent.getEventType())
-                .setParameter("event_date", paymentCreatedEvent.getTimestamp())
+                .setParameter("resource_type", event.getResourceType().getLowercase())
+                .setParameter("resource_external_id", event.getResourceExternalId())
+                .setParameter("event_type", event.getEventType())
+                .setParameter("event_date", event.getTimestamp())
                 .getResultList();
-        return singleResult.size() > 0;
+        return !singleResult.isEmpty();
     }
 
     public void recordEmission(Event event) {
@@ -42,7 +42,7 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
                 event.getTimestamp(),
                 ZonedDateTime.now()
         );
-        
+
         persist(emittedEvent);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -99,7 +99,7 @@ public class EventFactory {
                 .collect(Collectors.toList());
     }
 
-    private static PaymentEvent createPaymentEvent(ChargeEventEntity chargeEvent, Class<? extends PaymentEvent> eventClass) {
+    public static PaymentEvent createPaymentEvent(ChargeEventEntity chargeEvent, Class<? extends PaymentEvent> eventClass) {
         try {
             if (eventClass == PaymentCreated.class) {
                 return PaymentCreated.from(chargeEvent);

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
@@ -7,14 +7,22 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.events.EventQueue;
-import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.EventFactory;
+import uk.gov.pay.connector.queue.PaymentStateTransition;
 import uk.gov.pay.connector.queue.QueueException;
 
 import javax.inject.Inject;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.stream.Collectors;
 
 import static uk.gov.pay.connector.filters.RestClientLoggingFilter.HEADER_REQUEST_ID;
 
@@ -36,7 +44,7 @@ public class HistoricalEventEmitterWorker {
     public void execute(Long startId, OptionalLong maybeMaxId) {
         try {
             MDC.put(HEADER_REQUEST_ID, "HistoricalEventEmitterWorker-" + RandomUtils.nextLong(0, 10000));
-            
+
             maxId = maybeMaxId.orElseGet(() -> chargeDao.findMaxId());
             logger.info("Starting from {} up to {}", startId, maxId);
             for (long i = startId; i <= maxId; i++) {
@@ -51,33 +59,68 @@ public class HistoricalEventEmitterWorker {
 
     // needs to be public for transactional annotation
     @Transactional
-    public void emitEventFor(long i) {
-        final Optional<ChargeEntity> maybeCharge = chargeDao.findById(i);
-        
+    public void emitEventFor(long currentId) {
+        final Optional<ChargeEntity> maybeCharge = chargeDao.findById(currentId);
+
         try {
-            maybeCharge.ifPresent((c) -> MDC.put("chargeId", c.getExternalId()) );
+            maybeCharge.ifPresent(c -> MDC.put("chargeId", c.getExternalId()));
 
             if (maybeCharge.isPresent()) {
                 final ChargeEntity charge = maybeCharge.get();
-                final PaymentCreated event = PaymentCreated.from(charge);
-                final boolean emittedBefore = emittedEventDao.hasBeenEmittedBefore(event);
-                if (emittedBefore) {
-                    logger.info("[{}/{}] - found - emitted before", i, maxId);
-                } else {
-                    logger.info("[{}/{}] - found - emitting {}", i, maxId, event);
-                    persistAndEmit(event);
-                }
+                List<ChargeEventEntity> chargeEventEntities = getSortedChargeEvents(charge);
+                processChargeEvents(currentId, chargeEventEntities);
+            } else {
+                logger.info("[{}/{}] - not found", currentId, maxId);
             }
-            else {
-                logger.info("[{}/{}] - not found", i, maxId);
-            }
-        } 
-        finally {
+        } finally {
             MDC.remove("chargeId");
         }
     }
 
-    private void persistAndEmit(PaymentCreated event) {
+    private List<ChargeEventEntity> getSortedChargeEvents(ChargeEntity charge) {
+        return charge.getEvents()
+                .stream()
+                .sorted(Comparator.comparing(ChargeEventEntity::getUpdated))
+                .collect(Collectors.toList());
+    }
+
+    private void processChargeEvents(long currentId, List<ChargeEventEntity> chargeEventEntities) {
+        for (int index = 0; index < chargeEventEntities.size(); index++) {
+            ChargeStatus fromChargeState;
+            ChargeEventEntity chargeEventEntity = chargeEventEntities.get(index);
+
+            if (index == 0) {
+                fromChargeState = ChargeStatus.UNDEFINED;
+            } else {
+                fromChargeState = chargeEventEntities.get(index - 1).getStatus();
+            }
+
+            processSingleChargeEvent(currentId, fromChargeState, chargeEventEntity);
+        }
+    }
+
+    private void processSingleChargeEvent(long currentId, ChargeStatus fromChargeState, ChargeEventEntity chargeEventEntity) {
+        PaymentGatewayStateTransitions.getInstance()
+                .getEventForTransition(fromChargeState, chargeEventEntity.getStatus())
+                .ifPresent(eventType -> {
+                    Event event = getPaymentEvent(chargeEventEntity, eventType);
+                    final boolean emittedBefore = emittedEventDao.hasBeenEmittedBefore(event);
+
+                    if (emittedBefore) {
+                        logger.info("[{}/{}] - found - emitted before", currentId, maxId);
+                    } else {
+                        logger.info("[{}/{}] - found - emitting {} ", currentId, maxId, event);
+                        persistAndEmit(event);
+                    }
+                });
+    }
+
+    private Event getPaymentEvent(ChargeEventEntity chargeEventEntity, Class<Event> eventType) {
+        PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventType);
+        return EventFactory.createPaymentEvent(chargeEventEntity, transition.getStateTransitionEventClass());
+    }
+
+    private void persistAndEmit(Event event) {
         try {
             eventQueue.emitEvent(event);
             emittedEventDao.recordEmission(event);

--- a/src/test/java/uk/gov/pay/connector/pact/ChargeEventEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ChargeEventEntityFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.pact;
 
+import org.apache.commons.lang3.RandomUtils;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
@@ -13,7 +14,7 @@ public class ChargeEventEntityFixture {
     private ChargeStatus chargeStatus = ChargeStatus.CAPTURED;
     private ZonedDateTime updated = ZonedDateTime.now();
     private ZonedDateTime gatewayEventDate;
-    private Long id;
+    private Long id = RandomUtils.nextLong();
     private ChargeEntity charge = aValidChargeEntity()
             .withFee(42L)
             .build();
@@ -23,10 +24,9 @@ public class ChargeEventEntityFixture {
     }
 
     public ChargeEventEntity build() {
-
         ChargeEventEntity chargeEventEntity = new ChargeEventEntity(charge, chargeStatus, updated, Optional.ofNullable(gatewayEventDate));
         chargeEventEntity.setId(id);
-        
+
         return chargeEventEntity;
     }
 
@@ -34,8 +34,7 @@ public class ChargeEventEntityFixture {
         this.gatewayEventDate = value;
         return this;
     }
-    
-    
+
     public ChargeEventEntityFixture withId(Long id) {
         this.id = id;
         return this;
@@ -45,8 +44,14 @@ public class ChargeEventEntityFixture {
         this.charge = charge;
         return this;
     }
-    
-    
-    
-    
+
+    public ChargeEventEntityFixture withTimestamp(ZonedDateTime updated) {
+        this.updated = updated;
+        return this;
+    }
+
+    public ChargeEventEntityFixture withChargeStatus(ChargeStatus chargeStatus) {
+        this.chargeStatus = chargeStatus;
+        return this;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -11,13 +11,13 @@ import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
-import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.events.model.Event;
-import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.pact.ChargeEventEntityFixture;
-import uk.gov.pay.connector.queue.QueueException;
+import uk.gov.pay.connector.queue.StateTransition;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
 
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -42,123 +42,86 @@ public class HistoricalEventEmitterWorkerTest {
     @Mock
     EmittedEventDao emittedEventDao;
     @Mock
-    EventQueue eventQueue;
+    StateTransitionQueue stateTransitionQueue;
 
     @InjectMocks
     HistoricalEventEmitterWorker worker;
-    ChargeEntity chargeEntity;
+    private ChargeEntity chargeEntity;
 
     @Before
     public void setUp() {
         chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
-    }
-
-    @Test
-    public void execute_emitsEventAndRecordsEmission() throws QueueException {
-        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+        ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
                 .withTimestamp(chargeEntity.getCreatedDate())
                 .withCharge(chargeEntity)
                 .withChargeStatus(ChargeStatus.CREATED)
                 .build();
+        chargeEntity.getEvents().add(chargeEventEntity);
+    }
 
-        ChargeEventEntity secondChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
-                .withTimestamp(ZonedDateTime.now().plusMinutes(1))
-                .withCharge(chargeEntity)
-                .withChargeStatus(ChargeStatus.SYSTEM_CANCELLED)
-                .build();
-
-        chargeEntity.getEvents().add(firstChargeEventEntity);
-        chargeEntity.getEvents().add(secondChargeEventEntity);
-
+    @Test
+    public void executeEmitsEventAndRecordsEmission() {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
 
         worker.execute(1L, OptionalLong.empty());
 
-        ArgumentCaptor<Event> argument = ArgumentCaptor.forClass(Event.class);
-        verify(eventQueue, times(2)).emitEvent(argument.capture());
+        ArgumentCaptor<StateTransition> argument = ArgumentCaptor.forClass(StateTransition.class);
+        verify(stateTransitionQueue, times(1)).offer(argument.capture());
 
-        assertThat(argument.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
-        assertThat(argument.getAllValues().get(0).getResourceType(), is(ResourceType.PAYMENT));
-        assertThat(argument.getAllValues().get(0).getResourceExternalId(), is(chargeEntity.getExternalId()));
-        assertThat(argument.getAllValues().get(0).getTimestamp(), is(firstChargeEventEntity.getUpdated()));
-
-        assertThat(argument.getAllValues().get(1).getEventType(), is("CANCELLED_BY_EXTERNAL_SERVICE"));
-        assertThat(argument.getAllValues().get(1).getResourceType(), is(ResourceType.PAYMENT));
-        assertThat(argument.getAllValues().get(1).getResourceExternalId(), is(chargeEntity.getExternalId()));
-        assertThat(argument.getAllValues().get(1).getTimestamp(), is(secondChargeEventEntity.getUpdated()));
+        assertThat(argument.getAllValues().get(0).getStateTransitionEventClass(), is(PaymentCreated.class));
 
         ArgumentCaptor<Event> daoArgumentCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(emittedEventDao, times(2)).recordEmission(daoArgumentCaptor.capture());
+        verify(emittedEventDao, times(1)).recordEmission(daoArgumentCaptor.capture());
         assertThat(daoArgumentCaptor.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
-        assertThat(daoArgumentCaptor.getAllValues().get(1).getEventType(), is("CANCELLED_BY_EXTERNAL_SERVICE"));
 
         verify(chargeDao, never()).findById(2L);
     }
 
     @Test
-    public void execute_shouldNotProcessIfNoEventsFound() throws QueueException {
+    public void executeShouldNotProcessIfNoEventsFound() {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
 
+        chargeEntity.getEvents().clear();
+
         worker.execute(1L, OptionalLong.empty());
 
-        verify(eventQueue, never()).emitEvent(any());
+        verify(stateTransitionQueue, never()).offer(any());
         verify(emittedEventDao, never()).recordEmission(any());
     }
 
     @Test
-    public void iteratesThroughSpecifiedRange() throws QueueException {
-        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
-                .withTimestamp(chargeEntity.getCreatedDate())
-                .withCharge(chargeEntity)
-                .withChargeStatus(ChargeStatus.CREATED)
-                .build();
-
-        chargeEntity.getEvents().add(firstChargeEventEntity);
+    public void iteratesThroughSpecifiedRange() {
         when(chargeDao.findById((any()))).thenReturn(Optional.of(chargeEntity));
 
         worker.execute(1L, OptionalLong.of(100L));
 
         verify(chargeDao, times(100)).findById(and(geq(1L), leq(100L)));
-        verify(eventQueue, times(100)).emitEvent(any());
+        verify(stateTransitionQueue, times(100)).offer(any());
         verify(emittedEventDao, times(100)).recordEmission(any());
     }
 
     @Test
-    public void execute_shouldNotEmitEvent_ifEmittedPreviously() throws QueueException {
-        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
-                .withTimestamp(chargeEntity.getCreatedDate())
-                .withCharge(chargeEntity)
-                .withChargeStatus(ChargeStatus.CREATED)
-                .build();
-
-        chargeEntity.getEvents().add(firstChargeEventEntity);
+    public void executeShouldNotEmitEventIfEmittedPreviously() {
         when(chargeDao.findById((any()))).thenReturn(Optional.of(chargeEntity));
         when(emittedEventDao.hasBeenEmittedBefore(any())).thenReturn(true);
 
         worker.execute(1L, OptionalLong.of(1L));
 
         verify(chargeDao, times(1)).findById(1L);
-        verify(eventQueue, never()).emitEvent(any());
+        verify(stateTransitionQueue, never()).offer(any());
         verify(emittedEventDao, never()).recordEmission(any());
     }
 
     @Test
-    public void execute_shouldIgnoreEventIfStateTransitionIsNotFound() throws QueueException {
-        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
-                .withTimestamp(chargeEntity.getCreatedDate())
-                .withCharge(chargeEntity)
-                .withChargeStatus(ChargeStatus.CREATED)
-                .build();
-
+    public void executeShouldIgnoreEventIfStateTransitionIsNotFound() {
         ChargeEventEntity secondChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
                 .withTimestamp(ZonedDateTime.now().plusMinutes(1))
                 .withCharge(chargeEntity)
                 .withChargeStatus(ChargeStatus.AUTHORISATION_SUCCESS)
                 .build();
 
-        chargeEntity.getEvents().add(firstChargeEventEntity);
         chargeEntity.getEvents().add(secondChargeEventEntity);
 
         when(chargeDao.findMaxId()).thenReturn(1L);
@@ -166,13 +129,10 @@ public class HistoricalEventEmitterWorkerTest {
 
         worker.execute(1L, OptionalLong.empty());
 
-        ArgumentCaptor<Event> argument = ArgumentCaptor.forClass(Event.class);
-        verify(eventQueue, times(1)).emitEvent(argument.capture());
+        ArgumentCaptor<StateTransition> argument = ArgumentCaptor.forClass(StateTransition.class);
+        verify(stateTransitionQueue, times(1)).offer(argument.capture());
 
-        assertThat(argument.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
-        assertThat(argument.getAllValues().get(0).getResourceType(), is(ResourceType.PAYMENT));
-        assertThat(argument.getAllValues().get(0).getResourceExternalId(), is(chargeEntity.getExternalId()));
-        assertThat(argument.getAllValues().get(0).getTimestamp(), is(firstChargeEventEntity.getUpdated()));
+        assertThat(argument.getAllValues().get(0).getStateTransitionEventClass(), is(PaymentCreated.class));
 
         ArgumentCaptor<Event> daoArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         verify(emittedEventDao, times(1)).recordEmission(daoArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -1,21 +1,30 @@
 package uk.gov.pay.connector.tasks;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.EventQueue;
-import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.ResourceType;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.pact.ChargeEventEntityFixture;
 import uk.gov.pay.connector.queue.QueueException;
 
+import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.OptionalLong;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.AdditionalMatchers.leq;
@@ -37,28 +46,136 @@ public class HistoricalEventEmitterWorkerTest {
 
     @InjectMocks
     HistoricalEventEmitterWorker worker;
-    private ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+    ChargeEntity chargeEntity;
+
+    @Before
+    public void setUp() {
+        chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+    }
 
     @Test
     public void execute_emitsEventAndRecordsEmission() throws QueueException {
+        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(chargeEntity.getCreatedDate())
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.CREATED)
+                .build();
+
+        ChargeEventEntity secondChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now().plusMinutes(1))
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.SYSTEM_CANCELLED)
+                .build();
+
+        chargeEntity.getEvents().add(firstChargeEventEntity);
+        chargeEntity.getEvents().add(secondChargeEventEntity);
+
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
 
         worker.execute(1L, OptionalLong.empty());
 
-        verify(eventQueue).emitEvent(PaymentCreated.from(chargeEntity));
-        verify(emittedEventDao).recordEmission(PaymentCreated.from(chargeEntity));
+        ArgumentCaptor<Event> argument = ArgumentCaptor.forClass(Event.class);
+        verify(eventQueue, times(2)).emitEvent(argument.capture());
+
+        assertThat(argument.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
+        assertThat(argument.getAllValues().get(0).getResourceType(), is(ResourceType.PAYMENT));
+        assertThat(argument.getAllValues().get(0).getResourceExternalId(), is(chargeEntity.getExternalId()));
+        assertThat(argument.getAllValues().get(0).getTimestamp(), is(firstChargeEventEntity.getUpdated()));
+
+        assertThat(argument.getAllValues().get(1).getEventType(), is("CANCELLED_BY_EXTERNAL_SERVICE"));
+        assertThat(argument.getAllValues().get(1).getResourceType(), is(ResourceType.PAYMENT));
+        assertThat(argument.getAllValues().get(1).getResourceExternalId(), is(chargeEntity.getExternalId()));
+        assertThat(argument.getAllValues().get(1).getTimestamp(), is(secondChargeEventEntity.getUpdated()));
+
+        ArgumentCaptor<Event> daoArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(emittedEventDao, times(2)).recordEmission(daoArgumentCaptor.capture());
+        assertThat(daoArgumentCaptor.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
+        assertThat(daoArgumentCaptor.getAllValues().get(1).getEventType(), is("CANCELLED_BY_EXTERNAL_SERVICE"));
+
         verify(chargeDao, never()).findById(2L);
     }
 
     @Test
+    public void execute_shouldNotProcessIfNoEventsFound() throws QueueException {
+        when(chargeDao.findMaxId()).thenReturn(1L);
+        when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
+
+        worker.execute(1L, OptionalLong.empty());
+
+        verify(eventQueue, never()).emitEvent(any());
+        verify(emittedEventDao, never()).recordEmission(any());
+    }
+
+    @Test
     public void iteratesThroughSpecifiedRange() throws QueueException {
+        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(chargeEntity.getCreatedDate())
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.CREATED)
+                .build();
+
+        chargeEntity.getEvents().add(firstChargeEventEntity);
         when(chargeDao.findById((any()))).thenReturn(Optional.of(chargeEntity));
-        
+
         worker.execute(1L, OptionalLong.of(100L));
 
         verify(chargeDao, times(100)).findById(and(geq(1L), leq(100L)));
         verify(eventQueue, times(100)).emitEvent(any());
         verify(emittedEventDao, times(100)).recordEmission(any());
+    }
+
+    @Test
+    public void execute_shouldNotEmitEvent_ifEmittedPreviously() throws QueueException {
+        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(chargeEntity.getCreatedDate())
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.CREATED)
+                .build();
+
+        chargeEntity.getEvents().add(firstChargeEventEntity);
+        when(chargeDao.findById((any()))).thenReturn(Optional.of(chargeEntity));
+        when(emittedEventDao.hasBeenEmittedBefore(any())).thenReturn(true);
+
+        worker.execute(1L, OptionalLong.of(1L));
+
+        verify(chargeDao, times(1)).findById(1L);
+        verify(eventQueue, never()).emitEvent(any());
+        verify(emittedEventDao, never()).recordEmission(any());
+    }
+
+    @Test
+    public void execute_shouldIgnoreEventIfStateTransitionIsNotFound() throws QueueException {
+        ChargeEventEntity firstChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(chargeEntity.getCreatedDate())
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.CREATED)
+                .build();
+
+        ChargeEventEntity secondChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now().plusMinutes(1))
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.AUTHORISATION_SUCCESS)
+                .build();
+
+        chargeEntity.getEvents().add(firstChargeEventEntity);
+        chargeEntity.getEvents().add(secondChargeEventEntity);
+
+        when(chargeDao.findMaxId()).thenReturn(1L);
+        when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
+
+        worker.execute(1L, OptionalLong.empty());
+
+        ArgumentCaptor<Event> argument = ArgumentCaptor.forClass(Event.class);
+        verify(eventQueue, times(1)).emitEvent(argument.capture());
+
+        assertThat(argument.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
+        assertThat(argument.getAllValues().get(0).getResourceType(), is(ResourceType.PAYMENT));
+        assertThat(argument.getAllValues().get(0).getResourceExternalId(), is(chargeEntity.getExternalId()));
+        assertThat(argument.getAllValues().get(0).getTimestamp(), is(firstChargeEventEntity.getUpdated()));
+
+        ArgumentCaptor<Event> daoArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        verify(emittedEventDao, times(1)).recordEmission(daoArgumentCaptor.capture());
+        assertThat(daoArgumentCaptor.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

- HistoricalEventEmitterWorker emits all charge events (except `PaymentDetailsEntered` event)
- Uses ordered list of charge events - starting with first charge event created and then the rest in order
- Uses existing `PaymentGatewayStateTransitions` to derive and emit event
