### PR TITLE
PP-5407 Backfill handle manual payment events

### DIFF
--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -178,7 +178,7 @@ public class HistoricalEventEmitterWorkerTest {
         verify(eventQueue).emitEvent(any(PaymentDetailsEntered.class));
     }
 
-    @Test public void exectueShouldNotEmitManualEventsWithNoTerminalAuthenticationState() throws QueueException {
+    @Test public void executeShouldNotEmitManualEventsWithNoTerminalAuthenticationState() {
         ChargeEventEntity firstEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
                 .withTimestamp(ZonedDateTime.now().plusMinutes(1))
                 .withCharge(chargeEntity)

--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -8,14 +8,19 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.CardDetailsEntity;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
+import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.pact.ChargeEventEntityFixture;
+import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.StateTransition;
 import uk.gov.pay.connector.queue.StateTransitionQueue;
 
@@ -29,9 +34,11 @@ import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.AdditionalMatchers.geq;
 import static org.mockito.AdditionalMatchers.leq;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -43,6 +50,8 @@ public class HistoricalEventEmitterWorkerTest {
     EmittedEventDao emittedEventDao;
     @Mock
     StateTransitionQueue stateTransitionQueue;
+    @Mock
+    EventQueue eventQueue;
 
     @InjectMocks
     HistoricalEventEmitterWorker worker;
@@ -50,7 +59,12 @@ public class HistoricalEventEmitterWorkerTest {
 
     @Before
     public void setUp() {
-        chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        CardDetailsEntity cardDetails = mock(CardDetailsEntity.class);
+        when(cardDetails.getLastDigitsCardNumber()).thenReturn(LastDigitsCardNumber.of("1234"));
+        chargeEntity = ChargeEntityFixture
+                .aValidChargeEntity()
+                .withCardDetails(cardDetails)
+                .build();
         ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
                 .withTimestamp(chargeEntity.getCreatedDate())
                 .withCharge(chargeEntity)
@@ -119,7 +133,7 @@ public class HistoricalEventEmitterWorkerTest {
         ChargeEventEntity secondChargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
                 .withTimestamp(ZonedDateTime.now().plusMinutes(1))
                 .withCharge(chargeEntity)
-                .withChargeStatus(ChargeStatus.AUTHORISATION_SUCCESS)
+                .withChargeStatus(ChargeStatus.CAPTURED)
                 .build();
 
         chargeEntity.getEvents().add(secondChargeEventEntity);
@@ -137,5 +151,47 @@ public class HistoricalEventEmitterWorkerTest {
         ArgumentCaptor<Event> daoArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         verify(emittedEventDao, times(1)).recordEmission(daoArgumentCaptor.capture());
         assertThat(daoArgumentCaptor.getAllValues().get(0).getEventType(), is("PAYMENT_CREATED"));
+    }
+
+    @Test
+    public void executeShouldEmitManualEventsWithTerminalAuthenticationState() throws QueueException {
+        ChargeEventEntity firstEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now().plusMinutes(1))
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.ENTERING_CARD_DETAILS)
+                .build();
+
+        ChargeEventEntity secondEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now().plusMinutes(2))
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.AUTHORISATION_SUCCESS)
+                .build();
+
+        chargeEntity.getEvents().add(firstEvent);
+        chargeEntity.getEvents().add(secondEvent);
+
+        when(chargeDao.findMaxId()).thenReturn(1L);
+        when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
+
+        worker.execute(1L, OptionalLong.empty());
+
+        verify(eventQueue).emitEvent(any(PaymentDetailsEntered.class));
+    }
+
+    @Test public void exectueShouldNotEmitManualEventsWithNoTerminalAuthenticationState() throws QueueException {
+        ChargeEventEntity firstEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now().plusMinutes(1))
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.ENTERING_CARD_DETAILS)
+                .build();
+
+        chargeEntity.getEvents().add(firstEvent);
+
+        when(chargeDao.findMaxId()).thenReturn(1L);
+        when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
+
+        worker.execute(1L, OptionalLong.empty());
+
+        verifyZeroInteractions(eventQueue);
     }
 }


### PR DESCRIPTION
* determine if a charge state transition should have reached a state
providing user details
* build `PaymentDetailsEntered` event and emit

Depends on collected `ChargeEventEntity` list in https://github.com/alphagov/pay-connector/pull/1557]

- [x]  hook into processing of charge 
- [x]  test emit behaviour based on different charge events provided