### PR TITLE
PP-5407 Derive intermediate ready state for transition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
@@ -10,10 +10,13 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
+import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.EventFactory;
+import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.queue.PaymentStateTransition;
+import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.StateTransitionQueue;
 
 import javax.inject.Inject;
@@ -22,28 +25,31 @@ import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.stream.Collectors;
-import uk.gov.pay.connector.events.EventQueue;
-import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
-import uk.gov.pay.connector.queue.QueueException;
 
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ABORTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCEL_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_READY;
 import static uk.gov.pay.connector.filters.RestClientLoggingFilter.HEADER_REQUEST_ID;
 
 public class HistoricalEventEmitterWorker {
     private static final Logger logger = LoggerFactory.getLogger(HistoricalEventEmitterWorker.class);
-
     private final ChargeDao chargeDao;
     private final EmittedEventDao emittedEventDao;
     private StateTransitionQueue stateTransitionQueue;
     private final EventQueue eventQueue;
+    
     private final List<ChargeStatus> TERMINAL_AUTHENTICATION_STATES = List.of(
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_SUBMITTED,
@@ -55,7 +61,15 @@ public class HistoricalEventEmitterWorker {
             AUTHORISATION_TIMEOUT,
             AUTHORISATION_CANCELLED
     );
+    private static final List<ChargeStatus> INTERMEDIATE_READY_STATES = List.of(AUTHORISATION_3DS_READY,
+            AUTHORISATION_READY,
+            CAPTURE_READY,
+            EXPIRE_CANCEL_READY,
+            SYSTEM_CANCEL_READY,
+            USER_CANCEL_READY);
+    
     private long maxId;
+    private PaymentGatewayStateTransitions paymentGatewayStateTransitions;
 
     @Inject
     public HistoricalEventEmitterWorker(ChargeDao chargeDao, EmittedEventDao emittedEventDao,
@@ -64,6 +78,7 @@ public class HistoricalEventEmitterWorker {
         this.emittedEventDao = emittedEventDao;
         this.stateTransitionQueue = stateTransitionQueue;
         this.eventQueue = eventQueue;
+        this.paymentGatewayStateTransitions = PaymentGatewayStateTransitions.getInstance();
     }
 
     public void execute(Long startId, OptionalLong maybeMaxId) {
@@ -125,13 +140,38 @@ public class HistoricalEventEmitterWorker {
         }
     }
 
-    private void processSingleChargeStateTransitionEvent(long currentId, ChargeStatus fromChargeState, ChargeEventEntity chargeEventEntity) {
-        PaymentGatewayStateTransitions.getInstance()
-                .getEventForTransition(fromChargeState, chargeEventEntity.getStatus())
-                .ifPresent(eventType -> {
-                    PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventType);
-                    offerPaymentStateTransitionEvents(currentId, chargeEventEntity, transition);
-                });
+    private void processSingleChargeStateTransitionEvent(long currentId, ChargeStatus fromChargeState,
+                                                         ChargeEventEntity chargeEventEntity) {
+        Optional<Class<Event>> eventForTransition = getEventForTransition(fromChargeState, chargeEventEntity);
+
+        eventForTransition.ifPresent(eventType -> {
+            PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventType);
+            offerPaymentStateTransitionEvents(currentId, chargeEventEntity, transition);
+        });
+    }
+
+    private Optional<Class<Event>> getEventForTransition(ChargeStatus fromChargeStatus,
+                                                         ChargeEventEntity chargeEventEntity) {
+        Optional<Class<Event>> eventForTransition = paymentGatewayStateTransitions
+                .getEventForTransition(fromChargeStatus, chargeEventEntity.getStatus());
+
+        if (eventForTransition.isEmpty()) {
+            Optional<ChargeStatus> intermediateChargeStatus = paymentGatewayStateTransitions
+                    .getIntermediateChargeStatus(fromChargeStatus, chargeEventEntity.getStatus());
+
+            if (intermediateChargeStatus.isPresent() && INTERMEDIATE_READY_STATES.contains(intermediateChargeStatus.get())) {
+                eventForTransition = paymentGatewayStateTransitions
+                        .getEventForTransition(intermediateChargeStatus.get(), chargeEventEntity.getStatus());
+            } else {
+                logger.info("Historical Event emitter for Charge [{}] and Event [{}] - Couldn't derive event for transition from [{}] to [{}]",
+                        chargeEventEntity.getChargeEntity().getId(),
+                        chargeEventEntity.getId(),
+                        fromChargeStatus,
+                        chargeEventEntity.getStatus()
+                );
+            }
+        }
+        return eventForTransition;
     }
 
     private void offerPaymentStateTransitionEvents(long currentId, ChargeEventEntity chargeEventEntity, PaymentStateTransition transition) {
@@ -140,7 +180,7 @@ public class HistoricalEventEmitterWorker {
         final boolean emittedBefore = emittedEventDao.hasBeenEmittedBefore(event);
 
         if (emittedBefore) {
-            logger.info("[{}/{}] - found - charge event [{}] emitted before", currentId, maxId, chargeEventEntity.getId(), transition.getStateTransitionEventClass());
+            logger.info("[{}/{}] - found - charge event [{}] emitted before", currentId, maxId, chargeEventEntity.getId());
         } else {
             logger.info("[{}/{}] - found - emitting {} for charge event [{}] ", currentId, maxId, event, chargeEventEntity.getId());
             stateTransitionQueue.offer(transition);

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -1,14 +1,17 @@
 package uk.gov.pay.connector.common.model.domain;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.UnspecifiedEvent;
 import uk.gov.pay.connector.events.model.charge.CaptureAbandonedAfterTooManyRetries;
 import uk.gov.pay.connector.events.model.charge.CaptureErrored;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
-import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.charge.PaymentExpired;
-import uk.gov.pay.connector.events.model.UnspecifiedEvent;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -19,14 +22,38 @@ import java.util.Set;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ABORTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUBMITTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCEL_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCEL_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCEL_SUBMITTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_SUBMITTED;
 
+@RunWith(JUnitParamsRunner.class)
 public class PaymentGatewayStateTransitionsTest {
     PaymentGatewayStateTransitions transitions = PaymentGatewayStateTransitions.getInstance();
 
@@ -70,5 +97,55 @@ public class PaymentGatewayStateTransitionsTest {
     public void getEventTransitionFor_returnsEmptyForUnmodelledEvent() {
         Optional<Class<Event>> eventClassType = transitions.getEventForTransition(CAPTURE_APPROVED, CAPTURE_READY);
         assertThat(eventClassType, is(Optional.empty()));
+    }
+
+    private Object[] intermediateStatesForTransitions() {
+        return new Object[]{
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_3DS_REQUIRED},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_ABORTED},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_CANCELLED},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_ERROR},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_REJECTED},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_SUBMITTED},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_SUCCESS},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_TIMEOUT},
+                new Object[]{AUTHORISATION_READY, ENTERING_CARD_DETAILS, AUTHORISATION_UNEXPECTED_ERROR},
+
+                new Object[]{AUTHORISATION_3DS_READY, AUTHORISATION_3DS_REQUIRED, AUTHORISATION_ERROR},
+                new Object[]{AUTHORISATION_3DS_READY, AUTHORISATION_3DS_REQUIRED, AUTHORISATION_REJECTED},
+                new Object[]{AUTHORISATION_3DS_READY, AUTHORISATION_3DS_REQUIRED, AUTHORISATION_SUCCESS},
+
+                new Object[]{EXPIRE_CANCEL_READY, AUTHORISATION_3DS_REQUIRED, EXPIRED},
+
+                new Object[]{CAPTURE_READY, AUTHORISATION_SUCCESS, CAPTURE_APPROVED_RETRY},
+                new Object[]{CAPTURE_READY, AUTHORISATION_SUCCESS, CAPTURE_ERROR},
+                new Object[]{CAPTURE_READY, AUTHORISATION_SUCCESS, CAPTURE_SUBMITTED},
+                new Object[]{CAPTURE_READY, AUTHORISATION_SUCCESS, CAPTURED},
+                new Object[]{CAPTURE_READY, CAPTURE_APPROVED, CAPTURE_APPROVED_RETRY},
+                new Object[]{CAPTURE_READY, CAPTURE_APPROVED, CAPTURE_ERROR},
+                new Object[]{CAPTURE_READY, CAPTURE_APPROVED, CAPTURE_SUBMITTED},
+                new Object[]{CAPTURE_READY, CAPTURE_APPROVED, CAPTURED},
+                new Object[]{CAPTURE_READY, CAPTURE_APPROVED_RETRY, CAPTURE_SUBMITTED},
+
+                new Object[]{USER_CANCEL_READY, AUTHORISATION_SUCCESS, USER_CANCEL_ERROR},
+                new Object[]{USER_CANCEL_READY, AUTHORISATION_SUCCESS, USER_CANCELLED},
+                new Object[]{USER_CANCEL_READY, AUTHORISATION_SUCCESS, USER_CANCEL_SUBMITTED},
+
+                new Object[]{SYSTEM_CANCEL_READY, AUTHORISATION_SUCCESS, SYSTEM_CANCEL_SUBMITTED},
+                new Object[]{SYSTEM_CANCEL_READY, AUTHORISATION_SUCCESS, SYSTEM_CANCELLED},
+                new Object[]{SYSTEM_CANCEL_READY, AUTHORISATION_SUCCESS, SYSTEM_CANCEL_ERROR},
+                new Object[]{SYSTEM_CANCEL_READY, AWAITING_CAPTURE_REQUEST, SYSTEM_CANCEL_SUBMITTED},
+                new Object[]{SYSTEM_CANCEL_READY, AWAITING_CAPTURE_REQUEST, SYSTEM_CANCELLED},
+                new Object[]{SYSTEM_CANCEL_READY, AWAITING_CAPTURE_REQUEST, SYSTEM_CANCEL_ERROR},
+        };
+    }
+
+    @Test
+    @Parameters(method = "intermediateStatesForTransitions")
+    public void getIntermediateChargeStatusShouldDeriveStatusCorrectly(ChargeStatus expectedIntermediateStatus,
+                                                                       ChargeStatus fromStatus,
+                                                                       ChargeStatus toStatus) {
+        Optional<ChargeStatus> actualStatus = transitions.getIntermediateChargeStatus(fromStatus, toStatus);
+        assertThat(actualStatus.get(), is(expectedIntermediateStatus));
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- HistoricalEventEmitter uses ChargeEvents ordering to derive state transition events. But PaymentGatewayStateTransitions for ongoing operations differs as transitions are based on `READY` state.
- HistoricalEventEmitter now derives intermediate `READY` state (if a transition is not available) between two statuses and uses derived intermediate state to offer state transition event