### PR TITLE
PP-5520 Delay state transition process w/ blocking queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
+++ b/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
@@ -10,10 +10,12 @@ import uk.gov.pay.connector.queue.StateTransitionQueue;
 
 import javax.inject.Inject;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 public class StateTransitionEmitterProcess {
     private static final Logger LOGGER = LoggerFactory.getLogger(StateTransitionEmitterProcess.class);
 
+    private final long STATE_TRANSITION_PROCESS_DELAY_IN_MILLISECONDS = 100;
     private final StateTransitionQueue stateTransitionQueue;
     private final EventQueue eventQueue;
     private final EventFactory eventFactory;
@@ -29,8 +31,8 @@ public class StateTransitionEmitterProcess {
         this.eventFactory = eventFactory;
     }
 
-    public void handleStateTransitionMessages() {
-        Optional.ofNullable(stateTransitionQueue.poll())
+    public void handleStateTransitionMessages() throws InterruptedException {
+        Optional.ofNullable(stateTransitionQueue.poll(STATE_TRANSITION_PROCESS_DELAY_IN_MILLISECONDS, TimeUnit.MILLISECONDS))
                 .ifPresent(this::emitEvents);
     }
 

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
@@ -1,16 +1,20 @@
 package uk.gov.pay.connector.queue;
 
-import java.util.Queue;
 import java.util.concurrent.DelayQueue;
+import java.util.concurrent.TimeUnit;
 
 public class StateTransitionQueue {
-    private final Queue<StateTransition> queue = new DelayQueue<>();
-    
+    private final DelayQueue<StateTransition> queue = new DelayQueue<>();
+
     public boolean offer(StateTransition stateTransition) {
         return queue.offer(stateTransition);
     }
-    
-    public StateTransition poll() {
-        return queue.poll();
+
+    public StateTransition poll(long timeout, TimeUnit unit) throws InterruptedException {
+        return queue.poll(timeout, unit);
+    }
+
+    public StateTransition poll() throws InterruptedException {
+        return poll(0L, TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
@@ -1,10 +1,11 @@
 package uk.gov.pay.connector.queue;
 
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.TimeUnit;
 
 public class StateTransitionQueue {
-    private final DelayQueue<StateTransition> queue = new DelayQueue<>();
+    private final BlockingQueue<StateTransition> queue = new DelayQueue<>();
 
     public boolean offer(StateTransition stateTransition) {
         return queue.offer(stateTransition);

--- a/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.events.StateTransitionEmitterProcess;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 
 import javax.inject.Inject;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -60,10 +61,7 @@ public class QueueMessageReceiver implements Managed {
                 TimeUnit.SECONDS);
 
         stateTransitionMessageExecutorService.scheduleWithFixedDelay(
-                this::stateTransitionMessageReceiver,
-                0,
-                100,
-                TimeUnit.MILLISECONDS);
+                this::stateTransitionMessageReceiver, 1, 1, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/QueueMessageReceiver.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.events.StateTransitionEmitterProcess;
 import uk.gov.pay.connector.paymentprocessor.service.CardCaptureProcess;
 
 import javax.inject.Inject;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 


### PR DESCRIPTION
State transition events are currently rate limited by a scheduled
executor service waiting delaying polling by 100ms. This ensures
Connector is not constantly polling but doesn't allow the in-memory
queue to be cleared effectively given many state transitions.

* Use the blocking queue poll timeout interface to wait for a `Delayed`
entry to become visible -- this includes the delay if there is nothing
to process but lets the emitter process all elements if there is backlog
* Just use an executor service as there is no scheduling required
