### PR TITLE
PP-5538 Handle out of order Capture events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
@@ -166,7 +166,19 @@ public class HistoricalEventEmitterWorker {
         return charge.getEvents()
                 .stream()
                 .sorted(Comparator.comparing(ChargeEventEntity::getUpdated))
+                .sorted(HistoricalEventEmitterWorker::sortOutOfOrderCaptureEvents)
                 .collect(Collectors.toList());
+    }
+
+    private static int sortOutOfOrderCaptureEvents(ChargeEventEntity lhs, ChargeEventEntity rhs) {
+        // puts CAPTURE_SUBMITTED at top of the events list (after first pass of sorting)
+        // when timestamp for CAPTURED is same or before CAPTURE_SUBMITTED timestamp 
+        if (lhs.getStatus().equals(ChargeStatus.CAPTURE_SUBMITTED)
+                && rhs.getStatus().equals(ChargeStatus.CAPTURED)) {
+            return -1;
+        } else {
+            return 0;
+        }
     }
 
     private void processChargeStateTransitionEvents(long currentId, List<ChargeEventEntity> chargeEventEntities) {


### PR DESCRIPTION
## WHAT YOU DID
- HistoricalEventEmitterWorker: Puts `CAPTURE_SUBMITTED` and `CAPTURED` events in respective order while sorting charge events, and if `CAPTURED` event appears before `CAPTURE_SUBMITTED` due to same timestamp for both events (possible for payment providers - Sandbox and Stripe)