### PR TITLE
PP-5326 Disable zap

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                 }
             }
             steps {
-                runAppE2E("connector", "card,zap")
+                runAppE2E("connector", "card")
             }
         }
       }


### PR DESCRIPTION
We had previously disabled it, but it came back as part of some e2e refactoring. Remove again.