### PR TITLE
PP-5552 Emit refund availability update on payment creation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -40,6 +40,7 @@ public class EventFactory {
             RefundCreatedByUser.class,
             RefundCreatedByService.class,
             RefundError.class,
+            PaymentCreated.class,
             CaptureSubmitted.class,
             CaptureConfirmed.class
     );

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -215,6 +215,7 @@ public class EventFactoryTest {
         Long chargeEventEntityId = 100L;
         ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture
                 .aValidChargeEventEntity()
+                .withCharge(charge)
                 .withId(chargeEventEntityId)
                 .build();
         when(chargeEventDao.findById(ChargeEventEntity.class, chargeEventEntityId)).thenReturn(
@@ -224,11 +225,15 @@ public class EventFactoryTest {
         
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
-        assertThat(events.size(), is(1));
+        assertThat(events.size(), is(2));
         PaymentCreated event = (PaymentCreated) events.get(0); 
         Assert.assertThat(event, instanceOf(PaymentCreated.class));
         Assert.assertThat(event.getEventDetails(), instanceOf(PaymentCreatedEventDetails.class));
         Assert.assertThat(event.getResourceExternalId(), Is.is(chargeEventEntity.getChargeEntity().getExternalId()));
+
+        RefundAvailabilityUpdated event2 = (RefundAvailabilityUpdated) events.get(1);
+        Assert.assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
+        Assert.assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
@@ -748,7 +748,6 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
         Thread.sleep(100);
         List<Message> messages = readMessagesFromEventQueue();
         
-        assertThat(messages.size(), is(1));
         final Message message = messages.get(0);
         ZonedDateTime eventTimestamp = ZonedDateTime.parse(
                 new JsonParser()


### PR DESCRIPTION
In order for ledger to know the refund availability of a payment throughout the whole lifecycle of the payment, we need to emit this on creation as well as at other points affecting refund availability.
