### PR TITLE
PP-5552 Emit refund availability updated events on all terminal trans…

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -34,6 +34,7 @@ import uk.gov.pay.connector.events.model.charge.UnexpectedGatewayErrorDuringAuth
 import uk.gov.pay.connector.events.model.charge.UserApprovedForCapture;
 import uk.gov.pay.connector.events.model.charge.UserApprovedForCaptureAwaitingServiceApproval;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -199,6 +200,17 @@ public class PaymentGatewayStateTransitions {
                         return null;
                     }
                 });
+    }
+    
+    public static List<Class> getAllEventsResultingInTerminalState() {
+        return getInstance().graph.edges()
+                .stream()
+                .filter(endpointPair -> getInstance().graph.successors(endpointPair.nodeV()).isEmpty())
+                .map(getInstance().graph::edgeValue)
+                .flatMap(Optional::stream)
+                .map(me -> (ModelledTypedEvent) me)
+                .map(ModelledTypedEvent::getClazz)
+                .collect(Collectors.toList());
     }
 
     public static boolean isValidTransition(ChargeStatus state, ChargeStatus targetState, Event event) {

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -20,6 +20,7 @@ import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceD
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.EventFactory;
 import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.events.model.charge.CancelByExternalServiceSubmitted;
 import uk.gov.pay.connector.events.model.charge.CaptureAbandonedAfterTooManyRetries;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
@@ -246,13 +247,13 @@ public class EventFactoryTest {
         when(chargeEventDao.findById(ChargeEventEntity.class, chargeEventEntityId)).thenReturn(
                 Optional.of(chargeEventEntity)
         );
-        PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, CaptureAbandonedAfterTooManyRetries.class);
+        PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, CancelByExternalServiceSubmitted.class);
 
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
         assertThat(events.size(), is(1));
-        CaptureAbandonedAfterTooManyRetries event = (CaptureAbandonedAfterTooManyRetries) events.get(0);
-        Assert.assertThat(event, instanceOf(CaptureAbandonedAfterTooManyRetries.class));
+        CancelByExternalServiceSubmitted event = (CancelByExternalServiceSubmitted) events.get(0);
+        Assert.assertThat(event, instanceOf(CancelByExternalServiceSubmitted.class));
         Assert.assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
     }
 
@@ -299,6 +300,31 @@ public class EventFactoryTest {
         assertThat(events.size(), is(2));
         CaptureSubmitted event1 = (CaptureSubmitted) events.get(0);
         Assert.assertThat(event1, instanceOf(CaptureSubmitted.class));
+
+        RefundAvailabilityUpdated event2 = (RefundAvailabilityUpdated) events.get(1);
+        Assert.assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
+        Assert.assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
+    }
+
+    @Test
+    public void shouldCreatedARefundAvailabilityUpdatedEventForEventThatLeadsToTerminalState() throws Exception {
+        Long chargeEventEntityId = 100L;
+        ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture
+                .aValidChargeEventEntity()
+                .withCharge(charge)
+                .withId(chargeEventEntityId)
+                .build();
+        when(chargeEventDao.findById(ChargeEventEntity.class, chargeEventEntityId)).thenReturn(
+                Optional.of(chargeEventEntity)
+        );
+        PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, CaptureAbandonedAfterTooManyRetries.class);
+
+        List<Event> events = eventFactory.createEvents(paymentStateTransition);
+
+        assertThat(events.size(), is(2));
+        CaptureAbandonedAfterTooManyRetries event = (CaptureAbandonedAfterTooManyRetries) events.get(0);
+        Assert.assertThat(event, instanceOf(CaptureAbandonedAfterTooManyRetries.class));
+        Assert.assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
 
         RefundAvailabilityUpdated event2 = (RefundAvailabilityUpdated) events.get(1);
         Assert.assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.PurgeQueueRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
@@ -27,8 +28,8 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
-import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static io.restassured.http.ContentType.JSON;
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -756,7 +757,12 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
                         .get("timestamp")
                         .getAsString()
         );
-        assertThat(message.getBody(), hasJsonPath("$.event_type", equalTo("PAYMENT_CREATED")));
+
+        Optional<JsonObject> createdMessage = messages.stream()
+                .map(m -> new JsonParser().parse(m.getBody()).getAsJsonObject())
+                .filter(e -> e.get("event_type").getAsString().equals("PAYMENT_CREATED"))
+                .findFirst();
+        assertThat(createdMessage.isPresent(), is(true));
         assertThat(eventTimestamp, is(within(200, MILLIS, persistedCreatedDate)));
     }
 


### PR DESCRIPTION
…itions

We need to update refund availability of a payment whenever it reaches
a terminal state. This updates event factory to enable that.