### PR TITLE
bau: Remove extra persistence id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Transaction.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Transaction.java
@@ -75,8 +75,6 @@ public class Transaction implements Nettable {
     private ZonedDateTime createdDate;
     private SupportedLanguage language;
     private boolean delayedCapture;
-
-    @Id
     private TransactionType transactionType;
     private String cardBrand;
     private String cardBrandLabel;


### PR DESCRIPTION
There is already an `@Id` annotation on the chargeId