### PR TITLE
PP-5544 Add 3ds_integration_version column

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1181,4 +1181,21 @@
                 columnName="return_url" />
     </changeSet>
 
+    <changeSet id="add integration_version_3ds column to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="integration_version_3ds" type="smallint">
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add default to integration_version_3ds" author="">
+        <addDefaultValue tableName="gateway_accounts" columnName="integration_version_3ds" defaultValue="1"/>
+    </changeSet>
+
+    <changeSet id="update integration_version_3ds to be non-nullable" author="">
+        <addNotNullConstraint tableName="gateway_accounts"
+                              columnName="integration_version_3ds"
+                              defaultNullValue="1"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Add 3ds_integration_version column to the gateway_accounts table.
Current expected values are 1 or 2.

A value of 1 indicates the current 3DS integration should be used.
A value of 2, in the case of Worldpay gateway accounts for now, indicates that the 3DS Flex integration should be used.