### PR TITLE
PP-5547 Add Json Web Token support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <jooq.version>3.11.11</jooq.version>
         <postgresql.version>42.2.6</postgresql.version>
         <commons-lang3.version>3.9</commons-lang3.version>
+        <jjwt.version>0.10.7</jjwt.version>
     </properties>
     <repositories>
         <repository>
@@ -463,6 +464,23 @@
             <artifactId>testcontainers</artifactId>
             <version>1.12.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.charge.util;
+
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.time.Instant;
+import java.util.Map;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+public class JwtGenerator {
+
+    /**
+     * Utility method to create a JWT for Worldpay 3DS Flex DDC based upon the required claims
+     * shown in their documentation.
+     *
+     * @see <a href="https://beta.developer.worldpay.com/docs/wpg/directintegration/3ds2#device-data-collection-ddc-"
+     * >Worldpay DDC Documentation</a>
+     */
+    public String createWorldpay3dsFlexDdcJwt(String issuer, String organisationId, String secret) {
+        Map<String, Object> claims = Map.of(
+                "jti", RandomIdGenerator.newId(),
+                "iat", Instant.now().toEpochMilli(),
+                "exp", Instant.now().plus(90, MINUTES).toEpochMilli(),
+                "iss", issuer,
+                "OrgUnitId", organisationId);
+
+        return createJwt(claims, secret);
+    }
+
+
+    private String createJwt(Map<String, Object> claims, String secret) {
+        SecretKeySpec secret_key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .addClaims(claims)
+                .signWith(secret_key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.charge.util;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import org.junit.Test;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class JwtGeneratorTest {
+
+    private static final JwtGenerator jwtGenerator = new JwtGenerator();
+
+    @Test
+    public void shouldCreateCorrectTokenForWorldpay3dsFlexDdc() {
+        String secret = "fa2daee2-1fbb-45ff-4444-52805d5cd9e0";
+        String issuer = "ME";
+        String orgId = "myOrg";
+
+        String token = jwtGenerator.createWorldpay3dsFlexDdcJwt(issuer, orgId, secret);
+
+        Jws<Claims> jws = Jwts.parser()
+                .setSigningKey(new SecretKeySpec(secret.getBytes(), "HmacSHA256"))
+                .parseClaimsJws(token);
+
+        assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
+        assertThat(jws.getHeader().get("typ"), is("JWT"));
+        assertThat(jws.getBody().get("jti"), is (notNullValue()));
+        assertThat(jws.getBody().get("iat"), is (notNullValue()));
+        assertThat(jws.getBody().get("exp"), is (notNullValue()));
+        assertThat(jws.getBody().get("iss"), is(issuer));
+        assertThat(jws.getBody().get("OrgUnitId"), is(orgId));
+    }
+}


### PR DESCRIPTION
Create a JWTFacade class to offer simple creation of JWTs. This uses
`io.jsonwebtoken` which is listed as a reputable library on `jwt.io`, it
has a simple builder pattern to generate the tokens and an Apach 2.0
licence. It enforces key strength when signing and will not permit the
use of a key considered too weak for the desired algorithm (e.g. for
HSA256 the key must be greater than 256 bits). Since the Worldpay test
token is only 288 bits and we cannot change it, this initial
implementation uses HSA256 to sign the JWT, which is supported by
Worldpay.

This commit includes the first public method on the facade to generate a
Worldpay 3DS Flex DDC token and a unit test to ensure the token, when
decoded includes the correct header and body elements.


## How to test
I've added a unit test but you can independently check this generates valid tokens using https://www.jsonwebtoken.io