### PR TITLE
PP-5544 Include 3ds_integration_version in gateway account responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -42,13 +42,12 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 @SequenceGenerator(name = "gateway_accounts_gateway_account_id_seq",
         sequenceName = "gateway_accounts_gateway_account_id_seq", allocationSize = 1)
 public class GatewayAccountEntity extends AbstractVersionedEntity {
-    
+
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_accounts_gateway_account_id_seq")
     @JsonIgnore
     private Long id;
 
-    //TODO: Should we rename the columns to be more consistent?
     @Column(name = "payment_provider")
     private String gatewayName;
 
@@ -92,6 +91,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @Column(name = "allow_zero_amount")
     private boolean allowZeroAmount;
+    
+    @Column(name = "integration_version_3ds")
+    private int integrationVersion3ds;
 
     @Column(name = "notify_settings", columnDefinition = "json")
     @Convert(converter = JsonToMapConverter.class)
@@ -120,7 +122,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public GatewayAccountEntity() {
     }
-    
+
     public GatewayAccountEntity(String gatewayName, Map<String, String> credentials, Type type) {
         this.gatewayName = gatewayName;
         this.credentials = credentials;
@@ -188,7 +190,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public EmailCollectionMode getEmailCollectionMode() {
         return emailCollectionMode;
     }
-    
+
     @JsonView(Views.ApiView.class)
     public NotificationCredentials getNotificationCredentials() {
         return notificationCredentials;
@@ -216,28 +218,34 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return allowZeroAmount;
     }
 
-    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_credit_card_surcharge_amount")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public long getCorporateNonPrepaidCreditCardSurchargeAmount() {
         return corporateCreditCardSurchargeAmount;
     }
 
-    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_debit_card_surcharge_amount")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public long getCorporateNonPrepaidDebitCardSurchargeAmount() {
         return corporateDebitCardSurchargeAmount;
     }
 
-    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_prepaid_credit_card_surcharge_amount")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public long getCorporatePrepaidCreditCardSurchargeAmount() {
         return corporatePrepaidCreditCardSurchargeAmount;
     }
 
-    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     @JsonProperty("corporate_prepaid_debit_card_surcharge_amount")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public long getCorporatePrepaidDebitCardSurchargeAmount() {
         return corporatePrepaidDebitCardSurchargeAmount;
+    }
+
+    @JsonProperty("integration_version_3ds")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public int getIntegrationVersion3ds() {
+        return integrationVersion3ds;
     }
 
     public void setNotificationCredentials(NotificationCredentials notificationCredentials) {
@@ -316,7 +324,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public void setCorporateDebitCardSurchargeAmount(long corporateDebitCardSurchargeAmount) {
         this.corporateDebitCardSurchargeAmount = corporateDebitCardSurchargeAmount;
     }
-    
+
     public void setCorporatePrepaidCreditCardSurchargeAmount(long corporatePrepaidCreditCardSurchargeAmount) {
         this.corporatePrepaidCreditCardSurchargeAmount = corporatePrepaidCreditCardSurchargeAmount;
     }
@@ -335,6 +343,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setAllowZeroAmount(boolean allowZeroAmount) {
         this.allowZeroAmount = allowZeroAmount;
+    }
+
+    public void setIntegrationVersion3ds(int integrationVersion3ds) {
+        this.integrationVersion3ds = integrationVersion3ds;
     }
 
     public class Views {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -64,6 +64,9 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("allow_zero_amount")
     private boolean allowZeroAmount;
     
+    @JsonProperty("integration_version_3ds")
+    private int integrationVersion3ds;
+    
     public GatewayAccountResourceDTO() {
     }
 
@@ -82,7 +85,8 @@ public class GatewayAccountResourceDTO {
                                      Map<EmailNotificationType, EmailNotificationEntity> emailNotifications,
                                      EmailCollectionMode emailCollectionMode,
                                      boolean requires3ds,
-                                     boolean allowZeroAmount) {
+                                     boolean allowZeroAmount,
+                                     int integrationVersion3ds) {
         this.accountId = accountId;
         this.paymentProvider = paymentProvider;
         this.type = type;
@@ -99,6 +103,7 @@ public class GatewayAccountResourceDTO {
         this.emailCollectionMode = emailCollectionMode;
         this.requires3ds = requires3ds;
         this.allowZeroAmount = allowZeroAmount;
+        this.integrationVersion3ds = integrationVersion3ds;
     }
 
     public static GatewayAccountResourceDTO fromEntity(GatewayAccountEntity gatewayAccountEntity) {
@@ -118,7 +123,8 @@ public class GatewayAccountResourceDTO {
                 gatewayAccountEntity.getEmailNotifications(),
                 gatewayAccountEntity.getEmailCollectionMode(),
                 gatewayAccountEntity.isRequires3ds(),
-                gatewayAccountEntity.isAllowZeroAmount()
+                gatewayAccountEntity.isAllowZeroAmount(),
+                gatewayAccountEntity.getIntegrationVersion3ds()
         );
     }
 
@@ -192,5 +198,9 @@ public class GatewayAccountResourceDTO {
     
     public boolean isAllowZeroAmount() {
         return allowZeroAmount;
+    }
+
+    public int getIntegrationVersion3ds() {
+        return integrationVersion3ds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -12,6 +12,8 @@ import java.util.Map;
 
 public class GatewayAccountObjectConverter {
 
+    private static final int DEFAULT_INTEGRATION_VERSION_3_DS = 1;
+
     public static GatewayAccountEntity createEntityFrom(GatewayAccountRequest gatewayAccountRequest) {
 
         Map<String, String> credentials = gatewayAccountRequest.getCredentialsAsMap();
@@ -25,6 +27,7 @@ public class GatewayAccountObjectConverter {
         gatewayAccountEntity.setDescription(gatewayAccountRequest.getDescription());
         gatewayAccountEntity.setAnalyticsId(gatewayAccountRequest.getAnalyticsId());
         gatewayAccountEntity.setRequires3ds(gatewayAccountRequest.getRequires3ds());
+        gatewayAccountEntity.setIntegrationVersion3ds(DEFAULT_INTEGRATION_VERSION_3_DS);
 
         gatewayAccountEntity.addNotification(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(gatewayAccountEntity));
         gatewayAccountEntity.addNotification(EmailNotificationType.REFUND_ISSUED, new EmailNotificationEntity(gatewayAccountEntity));

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -33,6 +33,7 @@ public class GatewayAccountResourceDTOTest {
         entity.setEmailCollectionMode(EmailCollectionMode.MANDATORY);
         entity.setRequires3ds(true);
         entity.setAllowZeroAmount(true);
+        entity.setIntegrationVersion3ds(2);
 
         Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
@@ -56,5 +57,6 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.getEmailCollectionMode(), is(entity.getEmailCollectionMode()));
         assertThat(dto.getEmailNotifications().size(), is(1));
         assertThat(dto.getEmailNotifications().get(EmailNotificationType.PAYMENT_CONFIRMED).getTemplateBody(), is("testTemplate"));
+        assertThat(dto.getIntegrationVersion3ds(), is(entity.getIntegrationVersion3ds()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -316,6 +316,7 @@ public class  DatabaseFixtures {
         private long corporateDebitCardSurchargeAmount;
         private long corporatePrepaidCreditCardSurchargeAmount;
         private long corporatePrepaidDebitCardSurchargeAmount;
+        private int integrationVersion3ds = 2;
 
         public long getAccountId() {
             return accountId;
@@ -436,6 +437,11 @@ public class  DatabaseFixtures {
             return this;
         }
         
+        public TestAccount withIntegrationVersion3ds(int integrationVersion3ds) {
+            this.integrationVersion3ds = integrationVersion3ds;
+            return this;
+        }
+        
         public TestAccount insert() {
             databaseTestHelper.addGatewayAccount(
                     String.valueOf(accountId),
@@ -449,7 +455,8 @@ public class  DatabaseFixtures {
                     corporateCreditCardSurchargeAmount,
                     corporateDebitCardSurchargeAmount,
                     corporatePrepaidCreditCardSurchargeAmount,
-                    corporatePrepaidDebitCardSurchargeAmount);
+                    corporatePrepaidDebitCardSurchargeAmount,
+                    integrationVersion3ds);
             for (TestCardType cardType : cardTypes) {
                 databaseTestHelper.addAcceptedCardType(this.getAccountId(), cardType.getId());
             }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -609,6 +609,7 @@ public class ChargesFrontendResourceIT {
                 .body("gateway_account.analytics_id", is(analyticsId))
                 .body("gateway_account.corporate_credit_card_surcharge_amount", isNumber(corporateCreditCardSurchargeAmount))
                 .body("gateway_account.corporate_debit_card_surcharge_amount", isNumber(corporateDebitCardSurchargeAmount))
+                .body("gateway_account.integration_version_3ds", is(2))
                 .body("gateway_account.card_types", is(notNullValue()))
                 .body("gateway_account.card_types", containsInAnyOrder(
                         allOf(

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -76,7 +76,8 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
                 .body("corporate_debit_card_surcharge_amount", is(50))
                 .body("allow_apple_pay", is(true))
                 .body("allow_google_pay", is(false))
-                .body("allow_zero_amount", is(true));
+                .body("allow_zero_amount", is(true))
+                .body("integration_version_3ds", is(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -166,7 +166,8 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .body("corporate_credit_card_surcharge_amount", is(0))
                 .body("allow_google_pay", is(false))
                 .body("allow_apple_pay", is(false))
-                .body("allow_zero_amount", is(false));
+                .body("allow_zero_amount", is(false))
+                .body("integration_version_3ds", is(2));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -47,7 +47,8 @@ public class DatabaseTestHelper {
                                   long corporateCreditCardSurchargeAmount,
                                   long corporateDebitCardSurchargeAmount,
                                   long corporatePrepaidCreditCardSurchargeAmount,
-                                  long corporatePrepaidDebitCardSurchargeAmount) {
+                                  long corporatePrepaidDebitCardSurchargeAmount,
+                                  int integrationVersion3ds) {
         try {
             PGobject jsonObject = new PGobject();
             jsonObject.setType("json");
@@ -68,8 +69,9 @@ public class DatabaseTestHelper {
                                     "                              corporate_credit_card_surcharge_amount,\n" +
                                     "                              corporate_debit_card_surcharge_amount,\n" +
                                     "                              corporate_prepaid_credit_card_surcharge_amount,\n" +
-                                    "                              corporate_prepaid_debit_card_surcharge_amount)\n" +
-                                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                                    "                              corporate_prepaid_debit_card_surcharge_amount," +
+                                    "                              integration_version_3ds)\n" +
+                                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                             Long.valueOf(accountId),
                             paymentGateway,
                             jsonObject,
@@ -81,7 +83,8 @@ public class DatabaseTestHelper {
                             corporateCreditCardSurchargeAmount,
                             corporateDebitCardSurchargeAmount,
                             corporatePrepaidCreditCardSurchargeAmount,
-                            corporatePrepaidDebitCardSurchargeAmount)
+                            corporatePrepaidDebitCardSurchargeAmount,
+                            integrationVersion3ds)
             );
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -89,11 +92,11 @@ public class DatabaseTestHelper {
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider, Map<String, String> credentials) {
-        addGatewayAccount(accountId, paymentProvider, credentials, null, TEST, null, null, EmailCollectionMode.MANDATORY, 0, 0, 0, 0);
+        addGatewayAccount(accountId, paymentProvider, credentials, null, TEST, null, null, EmailCollectionMode.MANDATORY, 0, 0, 0, 0,2);
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider, Map<String, String> credentials, GatewayAccountEntity.Type gatewayAccountType) {
-        addGatewayAccount(accountId, paymentProvider, credentials, null, gatewayAccountType, null, null, EmailCollectionMode.MANDATORY, 0, 0, 0, 0);
+        addGatewayAccount(accountId, paymentProvider, credentials, null, gatewayAccountType, null, null, EmailCollectionMode.MANDATORY, 0, 0, 0, 0, 2);
     }
 
     public void addGatewayAccount(long accountId, String paymentProvider) {
@@ -101,15 +104,15 @@ public class DatabaseTestHelper {
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider) {
-        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, null, null, EmailCollectionMode.MANDATORY, 0, 0, 0, 0);
+        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, null, null, EmailCollectionMode.MANDATORY, 0, 0, 0, 0, 2);
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider, String description, String analyticsId, long corporateCreditCardSurchargeAmount, long corporateDebitCardSurchargeAmount, long corporatePrepaidCreditCardSurchargeAmount, long corporatePrepaidDebitCardSurchargeAmount) {
-        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId, EmailCollectionMode.MANDATORY, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount, corporatePrepaidCreditCardSurchargeAmount, corporatePrepaidDebitCardSurchargeAmount);
+        addGatewayAccount(accountId, paymentProvider, null, "a cool service", TEST, description, analyticsId, EmailCollectionMode.MANDATORY, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount, corporatePrepaidCreditCardSurchargeAmount, corporatePrepaidDebitCardSurchargeAmount, 2);
     }
 
     public void addGatewayAccount(String accountId, String paymentProvider, Map<String, String> credentials, String serviceName, GatewayAccountEntity.Type type, String description, String analyticsId, long corporateCreditCardSurchargeAmount, long corporateDebitCardSurchargeAmount, long corporatePrepaidCreditCardSurchargeAmount, long corporatePrepaidDebitCardSurchargeAmount) {
-        addGatewayAccount(accountId, paymentProvider, credentials, serviceName, type, description, analyticsId, EmailCollectionMode.MANDATORY, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount, corporatePrepaidCreditCardSurchargeAmount, corporatePrepaidDebitCardSurchargeAmount);
+        addGatewayAccount(accountId, paymentProvider, credentials, serviceName, type, description, analyticsId, EmailCollectionMode.MANDATORY, corporateCreditCardSurchargeAmount, corporateDebitCardSurchargeAmount, corporatePrepaidCreditCardSurchargeAmount, corporatePrepaidDebitCardSurchargeAmount, 2);
     }
 
     public void updateGatewayAccountAllowZeroAmount(long gatewayAccountId, boolean allowZeroAmount) {


### PR DESCRIPTION
Modify GatewayAccountEntity so that the value of the integration_version_3ds column is retrieved from and set in the database, giving it a default value of 1.

Include the value in gateway account API responses with the key "3ds_integration_version".