### PR TITLE
PP-5402-ChargeDAO Find ChargeEntity by providerId-1

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -54,6 +54,16 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setParameter("externalId", externalId)
                 .getResultList().stream().findFirst();
     }
+    
+    public Optional<ChargeEntity> findByProviderSessionId(String providerSessionId) {
+        String query = "SELECT c FROM ChargeEntity c " + 
+                "WHERE c.providerSessionId = :providerSessionId";
+        
+        return entityManager.get()
+                .createQuery(query, ChargeEntity.class)
+                .setParameter("providerSessionId", providerSessionId)
+                .getResultList().stream().findFirst();
+    }
 
     public Optional<ChargeEntity> findByTokenId(String tokenId) {
         String query = "SELECT te.chargeEntity FROM TokenEntity te WHERE te.token=:tokenId";

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -1605,6 +1605,15 @@ public class ChargeDaoIT extends DaoITestBase {
 
         assertThat(chargeDao.findMaxId(), is(defaultTestCharge.getChargeId()));
     }
+    
+    @Test
+    public void findChargeByProviderId() {
+        
+        insertTestCharge();
+        Optional<ChargeEntity> chargeEntity = chargeDao.findByProviderSessionId("providerId");
+        assertThat(chargeEntity.isPresent(), is(true));
+        
+    }
 
     private void insertTestAccount() {
         this.defaultTestAccount = DatabaseFixtures

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -470,6 +470,7 @@ public class  DatabaseFixtures {
         Long chargeId = RandomUtils.nextLong();
         private String description = "Test description";
         String email = "alice.111@mail.test";
+        String providerId = "providerId";
         String externalChargeId = RandomIdGenerator.newId();
         long amount = 101L;
         ChargeStatus chargeStatus = ChargeStatus.CREATED;
@@ -512,6 +513,11 @@ public class  DatabaseFixtures {
 
         public TestCharge withEmail(String email) {
             this.email = email;
+            return this;
+        }
+
+        public TestCharge withProviderId(String providerId) {
+            this.providerId = providerId;
             return this;
         }
 
@@ -574,6 +580,7 @@ public class  DatabaseFixtures {
                     .withLanguage(language)
                     .withDelayedCapture(false)
                     .withEmail(email)
+                    .withProviderId(providerId)
                     .withCorporateSurcharge(corporateCardSurcharge)
                     .build());
             

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -24,6 +24,7 @@ public class AddChargeParams {
     private final ZonedDateTime createdDate;
     private final long version;
     private final String email;
+    private final String providerId;
     private final SupportedLanguage language;
     private final boolean delayedCapture;
     private final Long corporateSurcharge;
@@ -42,6 +43,7 @@ public class AddChargeParams {
         createdDate = builder.createdDate;
         version = builder.version;
         email = builder.email;
+        providerId = builder.providerId;
         language = builder.language;
         delayedCapture = builder.delayedCapture;
         corporateSurcharge = builder.corporateSurcharge;
@@ -96,6 +98,10 @@ public class AddChargeParams {
         return email;
     }
 
+    public String getProviderId() {
+        return providerId;
+    }
+
     public SupportedLanguage getLanguage() {
         return language;
     }
@@ -125,6 +131,7 @@ public class AddChargeParams {
         private ZonedDateTime createdDate = now();
         private long version = 1;
         private String email = "test@example.com";
+        private String providerId = "providerId";
         private SupportedLanguage language = SupportedLanguage.ENGLISH;
         private boolean delayedCapture = false;
         private Long corporateSurcharge;
@@ -196,6 +203,12 @@ public class AddChargeParams {
             this.email = email;
             return this;
         }
+
+
+        public AddChargeParamsBuilder withProviderId(String providerId) {
+            this.providerId = providerId;
+            return this;
+        }        
 
         public AddChargeParamsBuilder withLanguage(SupportedLanguage language) {
             this.language = language;

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -152,12 +152,13 @@ public class DatabaseTestHelper {
                                 "        reference,\n" +
                                 "        version,\n" +
                                 "        email,\n" +
+                                "        provider_session_id,\n" +
                                 "        language,\n" +
                                 "        delayed_capture,\n" +
                                 "        corporate_surcharge,\n" +
                                 "        external_metadata\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
                         addChargeParams.getChargeId(),
                         addChargeParams.getExternalChargeId(),
                         addChargeParams.getAmount(),
@@ -170,6 +171,7 @@ public class DatabaseTestHelper {
                         addChargeParams.getReference().toString(),
                         addChargeParams.getVersion(),
                         addChargeParams.getEmail(),
+                        addChargeParams.getProviderId(),
                         addChargeParams.getLanguage().toString(),
                         addChargeParams.isDelayedCapture(),
                         addChargeParams.getCorporateSurcharge(),


### PR DESCRIPTION
## What you did
This PR adds a method in the ChargeDAO which allows us to search for a ChargeEntity by its providerID. This is so for idempotency regarding telephone payments. 

## How to test

I have added a test in the ChargeDAOIT and modified the test charge so it adds a provider_session_id also.
