### PR TITLE
PP-5402-Modify domain objects and JSON serialization/deserialization classes-2

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -43,6 +43,15 @@ public class CardDetailsEntity {
 
     public CardDetailsEntity() {
     }
+    
+    // For telephone payments
+    public CardDetailsEntity(LastDigitsCardNumber lastDigitsCardNumber, FirstDigitsCardNumber firstDigitsCardNumber, String cardHolderName, String expiryDate, String cardBrand) {
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
+        this.cardHolderName = cardHolderName;
+        this.expiryDate = expiryDate;
+        this.cardBrand = cardBrand;
+    }
 
     public CardDetailsEntity(FirstDigitsCardNumber firstDigitsCardNumber, LastDigitsCardNumber lastDigitsCardNumber, String cardHolderName, String expiryDate, String cardBrand, AddressEntity billingAddress) {
         this.lastDigitsCardNumber = lastDigitsCardNumber;

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -258,8 +258,16 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         return Optional.ofNullable(externalMetadata);
     }
 
+    public void setExternalMetadata(ExternalMetadata externalMetadata) {
+        this.externalMetadata = externalMetadata;
+    }
+
     public void setExternalId(String externalId) {
         this.externalId = externalId;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public void setStatus(ChargeStatus targetStatus) {

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -150,6 +150,31 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                         boolean delayedCapture, ExternalMetadata externalMetadata) {
         this(amount, UNDEFINED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture, externalMetadata);
     }
+    
+    // For telephone payments
+    public ChargeEntity(Long amount,
+                        ServicePaymentReference reference,
+                        String description,
+                        ChargeStatus status,
+                        String email, 
+                        CardDetailsEntity cardDetails, 
+                        ExternalMetadata externalMetadata,
+                        GatewayAccountEntity gatewayAccount,
+                        String providerSessionId, 
+                        SupportedLanguage language) {
+        this.amount = amount;
+        this.reference = reference;
+        this.description = description;
+        this.status = status.getValue();
+        this.email = email;
+        this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+        this.cardDetails = cardDetails;
+        this.externalMetadata = externalMetadata;
+        this.gatewayAccount = gatewayAccount;
+        this.externalId = RandomIdGenerator.newId();
+        this.providerSessionId = providerSessionId;
+        this.language = language;
+    }
 
     // Only the ChargeEntityFixture should directly call this constructor
     public ChargeEntity(Long amount, ChargeStatus status, String returnUrl, String description, ServicePaymentReference reference,

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -151,7 +151,6 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         this(amount, UNDEFINED, returnUrl, description, reference, gatewayAccount, email, ZonedDateTime.now(ZoneId.of("UTC")), language, delayedCapture, externalMetadata);
     }
     
-    // For telephone payments
     public ChargeEntity(Long amount,
                         ServicePaymentReference reference,
                         String description,
@@ -258,18 +257,10 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         return Optional.ofNullable(externalMetadata);
     }
 
-    public void setExternalMetadata(ExternalMetadata externalMetadata) {
-        this.externalMetadata = externalMetadata;
-    }
-
     public void setExternalId(String externalId) {
         this.externalId = externalId;
     }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
+    
     public void setStatus(ChargeStatus targetStatus) {
         setStatus(targetStatus, new UnspecifiedEvent());
     }

--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/PaymentOutcome.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/PaymentOutcome.java
@@ -10,6 +10,15 @@ public class PaymentOutcome {
 
     public PaymentOutcome() {
     }
+    
+    public PaymentOutcome(String status) {
+        this.status = status;
+    }
+    
+    public PaymentOutcome(String status, String code) {
+        this.status = status;
+        this.code = code;
+    }
 
     public PaymentOutcome(String status, String code, Supplemental supplemental) {
         // For testing deserialization

--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/State.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/State.java
@@ -13,6 +13,12 @@ public class State {
     public State() {
         // For Jackson serialization
     }
+    
+    public State(String status, Boolean finished, String message) {
+        this.status = status;
+        this.finished = finished;
+        this.message = message;
+    }
 
     public State(String status, Boolean finished, String message, String code) {
         this.status = status;

--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class TelephoneChargeCreateRequest {
     
-    private int amount;
+    private Long amount;
     
     private String reference;
     
@@ -61,7 +61,7 @@ public class TelephoneChargeCreateRequest {
         this.telephoneNumber = chargeBuilder.telephoneNumber;
     }
     
-    public int getAmount() {
+    public Long getAmount() {
         return amount;
     }
 
@@ -126,7 +126,7 @@ public class TelephoneChargeCreateRequest {
     }
     
     public static class ChargeBuilder {
-        private int amount;
+        private Long amount;
 
         private String reference;
 
@@ -158,7 +158,7 @@ public class TelephoneChargeCreateRequest {
 
         private String telephoneNumber;
         
-        public ChargeBuilder amount(int amount) {
+        public ChargeBuilder amount(Long amount) {
             this.amount = amount;
             return this;
         }

--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class TelephoneChargeResponse {
 
-    private int amount;
+    private Long amount;
 
     private String reference;
 
@@ -67,7 +67,7 @@ public class TelephoneChargeResponse {
         this.state = chargeBuilder.state;
     }
     
-    public int getAmount() {
+    public Long getAmount() {
         return amount;
     }
 
@@ -138,7 +138,7 @@ public class TelephoneChargeResponse {
     }
     
     public static class ChargeBuilder {
-        private int amount;
+        private Long amount;
         private String reference;
         private String description;
         private String createdDate;
@@ -157,7 +157,7 @@ public class TelephoneChargeResponse {
         private String paymentId;
         private State state;
 
-        public ChargeBuilder amount(int amount) {
+        public ChargeBuilder amount(Long amount) {
             this.amount = amount;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/charge/model/TelephonePaymentJSONTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/TelephonePaymentJSONTest.java
@@ -25,7 +25,7 @@ public class TelephonePaymentJSONTest {
         final Supplemental supplemental = new Supplemental("ECKOH01234", "textual message describing error code");
         final PaymentOutcome paymentOutcome = new PaymentOutcome("success", "P0010", supplemental);
         final TelephoneChargeCreateRequest createTelephonePaymentRequest = new TelephoneChargeCreateRequest.ChargeBuilder()
-                .amount(12000)
+                .amount(12000L)
                 .reference("MRPC12345")
                 .description("New passport application")
                 .createdDate("2018-02-21T16:04:25Z")
@@ -55,7 +55,7 @@ public class TelephonePaymentJSONTest {
         final State state = new State("success", true, "created", "P0010");
 
         final TelephoneChargeResponse createTelephoneChargeResponse = new TelephoneChargeResponse.ChargeBuilder()
-                .amount(12000)
+                .amount(12000L)
                 .reference("MRPC12345")
                 .description("New passport application")
                 .createdDate("2018-02-21T16:04:25Z")


### PR DESCRIPTION
## WHAT YOU DID

This PR modifies the TelephoneChargeRequest, TelephoneChargeResponse, ChargeEntity, CardDetailsEntity, PaymentOutcome and State by adding constructors, setters and changing from primitive type integer to the object type of Long.

This also modifies the TelephonePaymentJSONTest to pass in Long instead of int.

We can map amount, reference, description, status, email and cardDetails from the JSON into the ChargeEntity fields so we will need a constructor to take these. Any other remaining fields in the JSON will have to go into ExternalMetadata.

For constructing the TelephonePaymentResponse we need 2 constructors for State. This is because for success we don't want to return a code but with failure we do.

Since the Supplemental object in the JSON is optional then we need 2 constructors in PaymentOutcome to handle this (e.g. one that takes it one that doesn't). Since status in PaymentOutcome is always required in the JSON and since code won't be provided with status success we need a PaymentOutcome constructor that just takes in status.

Please review https://github.com/alphagov/pay-connector/pull/1610 before merging this PR in.
