### PR TITLE
Pp 5547 add end point for worldpay jwt

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -27,6 +27,7 @@ import uk.gov.pay.commons.utils.logging.LoggingFilter;
 import uk.gov.pay.commons.utils.xray.Xray;
 import uk.gov.pay.commons.utils.metrics.DatabaseMetricsService;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
+import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.resource.ChargesFrontendResource;
@@ -108,6 +109,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new JsonMappingExceptionMapper());
         environment.jersey().register(new JsonMappingExceptionMapper());
         environment.jersey().register(new ZeroAmountNotAllowedForGatewayAccountExceptionMapper());
+        environment.jersey().register(new ConflictWebApplicationExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -13,6 +13,8 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.persist.jpa.JpaPersistModule;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.setup.Environment;
+import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
+import uk.gov.pay.connector.charge.util.JwtGenerator;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.epdq.EpdqSha512SignatureGenerator;
@@ -101,6 +103,11 @@ public class ConnectorModule extends AbstractModule {
     @Provides
     public StripeGatewayConfig stripeGatewayConfig(ConnectorConfiguration connectorConfiguration) {
         return connectorConfiguration.getStripeConfig();
+    }
+
+    @Provides
+    public Worldpay3dsFlexJwtService worldpay3dsFlexJwtServiceGenerator() {
+        return new Worldpay3dsFlexJwtService(new JwtGenerator(), configuration.getChargeSweepConfig().getDefaultChargeExpiryThreshold());
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/connector/charge/exception/ConflictWebApplicationException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/ConflictWebApplicationException.java
@@ -1,0 +1,10 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class ConflictWebApplicationException extends WebApplicationException {
+
+    public ConflictWebApplicationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/ConflictWebApplicationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/ConflictWebApplicationExceptionMapper.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.commons.model.ErrorIdentifier.GENERIC;
+
+public class ConflictWebApplicationExceptionMapper implements ExceptionMapper<ConflictWebApplicationException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConflictWebApplicationExceptionMapper.class);
+
+    @Override
+    public Response toResponse(ConflictWebApplicationException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(GENERIC, exception.getMessage());
+
+        return Response.status(409)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexDdcJwtCredentialsException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexDdcJwtCredentialsException.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.charge.exception;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class Worldpay3dsFlexDdcJwtCredentialsException extends ConflictWebApplicationException {
+
+    public Worldpay3dsFlexDdcJwtCredentialsException(Long accountId, Set<String> missingCredentials) {
+        super(format("Cannot generate Worldpay 3ds Flex DDC JWT for account %s because the following credentials are unavailable: %s",
+                accountId,  missingCredentials));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexDdcJwtPaymentProviderException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexDdcJwtPaymentProviderException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.charge.exception;
+
+import static java.lang.String.format;
+
+public class Worldpay3dsFlexDdcJwtPaymentProviderException extends ConflictWebApplicationException {
+
+    public Worldpay3dsFlexDdcJwtPaymentProviderException(Long accountId) {
+        super(format("Cannot provide a Worldpay 3ds flex DDC JWT for account %s because the Payment Provider is not Worldpay.",
+                accountId));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -81,7 +81,8 @@ public class ChargesFrontendResource {
     public Response getWorldpay3dsFlexDdcJwt(@PathParam("chargeId") String chargeId) {
 
         ChargeEntity chargeEntity = chargeService.findChargeById(chargeId);
-        String token = worldpay3dsFlexJwtService.generateDdcToken(GatewayAccount.valueOf(chargeEntity.getGatewayAccount()));
+        GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
+        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, chargeEntity.getCreatedDate());
 
         return Response.ok().entity(Map.of("jwt", token)).build();
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
@@ -14,8 +14,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
-
 public class Worldpay3dsFlexJwtService {
 
     private final JwtGenerator jwtGenerator;
@@ -69,8 +67,8 @@ public class Worldpay3dsFlexJwtService {
     private Map<String, Object> generateDdcClaims(String issuer, String organisationId, ZonedDateTime chargeCreatedTime) {
         return Map.of(
                 "jti", RandomIdGenerator.newId(),
-                "iat", Instant.now().toEpochMilli(),
-                "exp", chargeCreatedTime.plus(tokenExpiryDurationSeconds, SECONDS).toInstant().toEpochMilli(),
+                "iat", Instant.now().getEpochSecond(),
+                "exp", chargeCreatedTime.plusSeconds(tokenExpiryDurationSeconds).toInstant().getEpochSecond(),
                 "iss", issuer,
                 "OrgUnitId", organisationId);
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.charge.service;
+
+import uk.gov.pay.connector.charge.exception.Worldpay3dsFlexDdcJwtCredentialsException;
+import uk.gov.pay.connector.charge.exception.Worldpay3dsFlexDdcJwtPaymentProviderException;
+import uk.gov.pay.connector.charge.util.JwtGenerator;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import javax.inject.Inject;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+public class Worldpay3dsFlexJwtService {
+
+    private final JwtGenerator jwtGenerator;
+
+    @Inject
+    public Worldpay3dsFlexJwtService(JwtGenerator jwtGenerator) {
+        this.jwtGenerator = jwtGenerator;
+    }
+
+    /**
+     * Utility method to create a JWT for Worldpay 3DS Flex DDC based upon the required claims
+     * shown in their documentation.
+     *
+     * @see <a href="https://beta.developer.worldpay.com/docs/wpg/directintegration/3ds2#device-data-collection-ddc-"
+     * >Worldpay DDC Documentation</a>
+     */
+    public String generateDdcToken(GatewayAccount gatewayAccount) {
+        if (!gatewayAccount.getGatewayName().equals(PaymentGatewayName.WORLDPAY.toString())) {
+            throw new Worldpay3dsFlexDdcJwtPaymentProviderException(gatewayAccount.getId());
+        }
+
+        Map<String, String> credentials = gatewayAccount.getCredentials();
+        String issuer = credentials.get("issuer");
+        String organisationId = credentials.get("organisational_unit_id");
+        String jwtMacId = credentials.get("jwt_mac_id");
+
+        Set<String> missingCredentials = new HashSet<>();
+
+        if (issuer == null) {
+            missingCredentials.add("issuer");
+        }
+
+        if (organisationId == null) {
+            missingCredentials.add("organisational_unit_id");
+        }
+
+        if (jwtMacId == null) {
+            missingCredentials.add("jwt_mac_id");
+        }
+
+        if (missingCredentials.size() > 0) {
+            throw new Worldpay3dsFlexDdcJwtCredentialsException(gatewayAccount.getId(), missingCredentials);
+        }
+
+        var claims = generateDdcClaims(issuer, organisationId);
+        return jwtGenerator.createJwt(claims, jwtMacId);
+    }
+
+    private Map<String, Object> generateDdcClaims(String issuer, String organisationId) {
+        return Map.of(
+                "jti", RandomIdGenerator.newId(),
+                "iat", Instant.now().toEpochMilli(),
+                "exp", Instant.now().plus(90, MINUTES).toEpochMilli(),
+                "iss", issuer,
+                "OrgUnitId", organisationId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/JwtGenerator.java
@@ -3,36 +3,13 @@ package uk.gov.pay.connector.charge.util;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.crypto.spec.SecretKeySpec;
-import java.time.Instant;
 import java.util.Map;
-
-import static java.time.temporal.ChronoUnit.MINUTES;
 
 public class JwtGenerator {
 
-    /**
-     * Utility method to create a JWT for Worldpay 3DS Flex DDC based upon the required claims
-     * shown in their documentation.
-     *
-     * @see <a href="https://beta.developer.worldpay.com/docs/wpg/directintegration/3ds2#device-data-collection-ddc-"
-     * >Worldpay DDC Documentation</a>
-     */
-    public String createWorldpay3dsFlexDdcJwt(String issuer, String organisationId, String secret) {
-        Map<String, Object> claims = Map.of(
-                "jti", RandomIdGenerator.newId(),
-                "iat", Instant.now().toEpochMilli(),
-                "exp", Instant.now().plus(90, MINUTES).toEpochMilli(),
-                "iss", issuer,
-                "OrgUnitId", organisationId);
-
-        return createJwt(claims, secret);
-    }
-
-
-    private String createJwt(Map<String, Object> claims, String secret) {
+    public String createJwt(Map<String, Object> claims, String secret) {
         SecretKeySpec secret_key = new SecretKeySpec(secret.getBytes(), "HmacSHA256");
 
         return Jwts.builder()

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.rules.ResourceTestRuleWithCustomExceptionMappersBuilder;
 
 import javax.ws.rs.client.Entity;
@@ -27,13 +28,15 @@ public class ChargesFrontendResourceTest {
     @Mock
     private static ChargeService chargeService;
     @Mock
-    private static  ChargeDao chargeDao;
+    private static ChargeDao chargeDao;
     @Mock
     private static CardTypeDao cardTypeDao;
+    @Mock
+    private static Worldpay3dsFlexJwtService worldpay3dsFlexJwtService;
     
     @ClassRule
     public static ResourceTestRule resources = ResourceTestRuleWithCustomExceptionMappersBuilder.getBuilder()
-            .addResource(new ChargesFrontendResource(chargeDao, chargeService, cardTypeDao))
+            .addResource(new ChargesFrontendResource(chargeDao, chargeService, cardTypeDao, worldpay3dsFlexJwtService))
             .build();
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -35,7 +35,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
 
     
     @Before
-    public void setup() {
+    public void setUp() {
         databaseTestHelper = testContext.getDatabaseTestHelper();
         connectorRestApi = new RestAssuredClient(testContext.getPort());
     }

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -1,0 +1,111 @@
+package uk.gov.pay.connector.charge.resource;
+
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.pay.connector.util.RestAssuredClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
+import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class ChargesFrontendResourceWorldpayJwtIT {
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private DatabaseTestHelper databaseTestHelper;
+    private RestAssuredClient connectorRestApi;
+
+    
+    @Before
+    public void setup() {
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+        connectorRestApi = new RestAssuredClient(testContext.getPort());
+    }
+
+    @Test
+    public void shouldGetCorrectDdcToken() {
+        var chargeId = "myFirstChargeId";
+        var gatewayAccountId = "101";
+        var validCredentials = Map.of(
+                "issuer", "ME",
+                "organisational_unit_id", "My Org",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, validCredentials, chargeId);
+
+        connectorRestApi
+                .withChargeId(chargeId)
+                .getWorldpay3dsFlexDdcJwt()
+                .statusCode(HttpStatus.SC_OK)
+                .body("jwt", is(notNullValue()));
+    }
+
+    @Test
+    public void shouldReturn409WhenCredentialsAreMissingForDdcToken() {
+        var chargeId = "mySecondChargeId";
+        var gatewayAccountId = "202";
+        var credentialsMissingIssuer = Map.of(
+                "organisational_unit_id", "My Org",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, credentialsMissingIssuer, chargeId);
+
+        connectorRestApi
+                .withChargeId(chargeId)
+                .getWorldpay3dsFlexDdcJwt()
+                .statusCode(HttpStatus.SC_CONFLICT)
+                .body("message", is(List.of("Cannot generate Worldpay 3ds Flex DDC JWT for account 202 because the following credentials are unavailable: [issuer]")));
+    }
+
+    @Test
+    public void shouldReturn409WhenThePaymentProviderIsNotWorldpayForDdcToken() {
+        var chargeId = "myThirdChargeId";
+        var gatewayAccountId = "303";
+        var validCredentials = Map.of(
+                "issuer", "ME",
+                "organisational_unit_id", "My Org",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        setUpChargeAndAccount(gatewayAccountId, SMARTPAY, validCredentials, chargeId);
+
+        connectorRestApi
+                .withChargeId(chargeId)
+                .getWorldpay3dsFlexDdcJwt()
+                .statusCode(HttpStatus.SC_CONFLICT)
+                .body("message", is(List.of("Cannot provide a Worldpay 3ds flex DDC JWT for account 303 because the Payment Provider is not Worldpay.")));
+    }
+    
+    private void setUpChargeAndAccount(String gatewayAccountId, PaymentGatewayName paymentProvider, Map<String, String> credentials, String chargeId) {
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(gatewayAccountId)
+                .withPaymentGateway(paymentProvider.toString())
+                .withCredentials(credentials)
+                .build());
+
+        databaseTestHelper.addCharge(
+                anAddChargeParams()
+                        .withGatewayAccountId(gatewayAccountId)
+                        .withExternalChargeId(chargeId)
+                        .build()
+        );
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -1,0 +1,118 @@
+package uk.gov.pay.connector.charge.service;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import uk.gov.pay.connector.charge.exception.Worldpay3dsFlexDdcJwtCredentialsException;
+import uk.gov.pay.connector.charge.exception.Worldpay3dsFlexDdcJwtPaymentProviderException;
+import uk.gov.pay.connector.charge.util.JwtGenerator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+
+public class Worldpay3dsFlexJwtServiceTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final JwtGenerator jwtGenerator = new JwtGenerator();
+    private static Worldpay3dsFlexJwtService worldpay3dsFlexJwtService = new Worldpay3dsFlexJwtService(jwtGenerator);
+
+
+    @Test
+    public void shouldCreateCorrectTokenForWorldpay3dsFlexDdc() {
+        var validCredentials = Map.of(
+                "issuer", "me",
+                "organisational_unit_id", "myOrg",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), validCredentials);
+
+        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount);
+
+        Jws<Claims> jws = Jwts.parser()
+                .setSigningKey(new SecretKeySpec(validCredentials.get("jwt_mac_id").getBytes(), "HmacSHA256"))
+                .parseClaimsJws(token);
+
+        assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
+        assertThat(jws.getHeader().get("typ"), is("JWT"));
+        assertThat(jws.getBody().get("jti"), is (notNullValue()));
+        assertThat(jws.getBody().get("iat"), is (notNullValue()));
+        assertThat(jws.getBody().get("exp"), is (notNullValue()));
+        assertThat(jws.getBody().get("iss"), is(validCredentials.get("issuer")));
+        assertThat(jws.getBody().get("OrgUnitId"), is(validCredentials.get("organisational_unit_id")));
+    }
+
+    @Test
+    public void shouldThrowExceptionForMissingIssuer() {
+        var credentialsMissingIssuer = Map.of(
+                "organisational_unit_id", "myOrg",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), credentialsMissingIssuer);
+
+        expectedException.expect(Worldpay3dsFlexDdcJwtCredentialsException.class);
+        expectedException.expectMessage("Cannot generate Worldpay 3ds Flex DDC JWT for account 1 because the " +
+                "following credentials are unavailable: [issuer]");
+
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount);
+    }
+
+    @Test
+    public void shouldThrowExceptionForMissingOrgId() {
+        var credentialsMissingOrgId = Map.of(
+                "issuer", "me",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), credentialsMissingOrgId);
+
+        expectedException.expect(Worldpay3dsFlexDdcJwtCredentialsException.class);
+        expectedException.expectMessage(
+                "Cannot generate Worldpay 3ds Flex DDC JWT for account 1 because the following credentials are " +
+                        "unavailable: [organisational_unit_id]");
+
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount);
+    }
+
+    @Test
+    public void shouldThrowExceptionForMissingJwtMacId() {
+        var credentialsMissingJwtMacId = Map.of(
+                "issuer", "me",
+                "organisational_unit_id", "myOrg"
+        );
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), credentialsMissingJwtMacId);
+
+        expectedException.expect(Worldpay3dsFlexDdcJwtCredentialsException.class);
+        expectedException.expectMessage("Cannot generate Worldpay 3ds Flex DDC JWT for account 1 because the " +
+                "following credentials are unavailable: [jwt_mac_id]");
+
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount);
+    }
+
+    @Test
+    public void shouldThrowExceptionForNonWorldpayAccount() {
+        var validCredentials = Map.of(
+                "issuer", "me",
+                "organisational_unit_id", "myOrg",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        var gatewayAccount = new GatewayAccount(1L, SMARTPAY.toString(), validCredentials);
+
+        expectedException.expect(Worldpay3dsFlexDdcJwtPaymentProviderException.class);
+        expectedException.expectMessage("Cannot provide a Worldpay 3ds flex DDC JWT for account 1 because the " +
+                "Payment Provider is not Worldpay.");
+
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java
@@ -7,9 +7,9 @@ import io.jsonwebtoken.Jwts;
 import org.junit.Test;
 
 import javax.crypto.spec.SecretKeySpec;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class JwtGeneratorTest {
@@ -17,12 +17,11 @@ public class JwtGeneratorTest {
     private static final JwtGenerator jwtGenerator = new JwtGenerator();
 
     @Test
-    public void shouldCreateCorrectTokenForWorldpay3dsFlexDdc() {
+    public void shouldCreateCorrectToken() {
         String secret = "fa2daee2-1fbb-45ff-4444-52805d5cd9e0";
-        String issuer = "ME";
-        String orgId = "myOrg";
+        Map<String, Object> claims = Map.of("key1", "value1", "key2", "value2");
 
-        String token = jwtGenerator.createWorldpay3dsFlexDdcJwt(issuer, orgId, secret);
+        String token = jwtGenerator.createJwt(claims, secret);
 
         Jws<Claims> jws = Jwts.parser()
                 .setSigningKey(new SecretKeySpec(secret.getBytes(), "HmacSHA256"))
@@ -30,10 +29,7 @@ public class JwtGeneratorTest {
 
         assertThat(jws.getHeader().getAlgorithm(), is("HS256"));
         assertThat(jws.getHeader().get("typ"), is("JWT"));
-        assertThat(jws.getBody().get("jti"), is (notNullValue()));
-        assertThat(jws.getBody().get("iat"), is (notNullValue()));
-        assertThat(jws.getBody().get("exp"), is (notNullValue()));
-        assertThat(jws.getBody().get("iss"), is(issuer));
-        assertThat(jws.getBody().get("OrgUnitId"), is(orgId));
+        assertThat(jws.getBody().get("key1"), is("value1"));
+        assertThat(jws.getBody().get("key2"), is("value2"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.Random;
 
 import static java.time.ZonedDateTime.now;
 
@@ -119,7 +120,7 @@ public class AddChargeParams {
     }
 
     public static final class AddChargeParamsBuilder {
-        private Long chargeId = 1L;
+        private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
         private String gatewayAccountId;
         private long amount = 1000;

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -25,6 +25,10 @@ public class RestAssuredClient {
         this.headers = new HashMap<>();
     }
 
+    public RestAssuredClient(int port) {
+        this(port, null);
+    }
+
     public RestAssuredClient withAccountId(String accountId) {
         this.accountId = accountId;
         return this;
@@ -157,6 +161,14 @@ public class RestAssuredClient {
         return given()
                 .port(port)
                 .get(requestPath)
+                .then();
+    }
+
+    public ValidatableResponse getWorldpay3dsFlexDdcJwt() {
+        return given()
+                .port(port)
+                .get("/v1/frontend/charges/{chargeId}/worldpay/3ds-flex/ddc"
+                .replace("{chargeId}", chargeId))
                 .then();
     }
 


### PR DESCRIPTION
PP-5547 Add end-point to get worldpay 3ds flex ddc jwt
    
    - Add end-point within `ChargesFrontendResource` for getting a worldpay
    3ds flex ddc jwt.
    - Add integration tests for the new end-point in new file named
    `ChargesFrontendResourceWorldpayJwtIT` since `ChargesFrontendResourceIT`
    is very large
    - Introduced a Worldpay3dsFlexJwtService and moved a worldpay method out
    of JwtGenerator (includes tests for the new service).
    - Introduce separate exceptions for when credentials are invalid or the
    payment provider is not Worldpay since we want an alert on the former.
    Both map to a new `ConflictWebApplicationException` class so that we can use a single
    `ConflictWebApplicationExceptionMapper` to generate the 409 response (this can also be
    used elsewhere going forward).