### PR TITLE
bau: Log when dropwizard shutdowns in tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardTestApplications.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardTestApplications.java
@@ -6,10 +6,13 @@ import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.ResourceHelpers;
 import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.InjectorLookup;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -29,6 +32,7 @@ import static java.lang.Runtime.getRuntime;
  */
 final class DropwizardTestApplications {
 
+    private static final Logger logger = LoggerFactory.getLogger(DropwizardTestApplications.class);
     private static final Map<Pair<Class<? extends Application>, String>, DropwizardTestSupport> apps = new ConcurrentHashMap<>();
     private static Set<ConfigOverride> configs = Sets.newHashSet();
 
@@ -59,9 +63,13 @@ final class DropwizardTestApplications {
     }
 
     private static void shutdownIfConfigHasChanged(ConfigOverride[] configOverrides) {
-        if (!configs.equals(Sets.newHashSet(configOverrides))) {
+        var newConfigOverrides = Sets.newHashSet(configOverrides);
+        if (!configs.equals(newConfigOverrides)) {
+            logger.info("Shutting down dropwizard as config has changed");
             apps.values().forEach(DropwizardTestSupport::after);
             apps.clear();
+        } else {
+            logger.info("Config was not changed.");
         }
     }
 


### PR DESCRIPTION
Am not sure why SendRefundEmailIT.shouldSendEmailFollowingASuccessfulRefund
occasionally fails. When it does there is a log `Email notifications is
disabled by configuration` which would explain why the test failed but at this
point I'm not sure why dropwizard was started with a wrong config, as
SendRefundEmailIT overrides the `notifyConfig.emailNotifyEnabled` to be `true`.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
