### PR TITLE
PP-5547 Fix comparison of payment provider when creating worldpay jwt

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
@@ -33,7 +33,7 @@ public class Worldpay3dsFlexJwtService {
      * >Worldpay DDC Documentation</a>
      */
     public String generateDdcToken(GatewayAccount gatewayAccount, ZonedDateTime chargeCreatedTime) {
-        if (!gatewayAccount.getGatewayName().equals(PaymentGatewayName.WORLDPAY.toString())) {
+        if (!gatewayAccount.getGatewayName().equals(PaymentGatewayName.WORLDPAY.getName())) {
             throw new Worldpay3dsFlexDdcJwtPaymentProviderException(gatewayAccount.getId());
         }
 

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -96,7 +96,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
     private void setUpChargeAndAccount(String gatewayAccountId, PaymentGatewayName paymentProvider, Map<String, String> credentials, String chargeId) {
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(gatewayAccountId)
-                .withPaymentGateway(paymentProvider.toString())
+                .withPaymentGateway(paymentProvider.getName())
                 .withCredentials(credentials)
                 .build());
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -39,7 +39,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 "organisational_unit_id", "myOrg",
                 "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
         );
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), validCredentials);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), validCredentials);
         int paymentCreationTimeEpochSeconds19August2029 = 1881821916;
         int expectedTokenExpirationTimeEpochSeconds = paymentCreationTimeEpochSeconds19August2029 + tokenExpiryDurationSeconds;
         var paymentCreationZonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochSecond((long) paymentCreationTimeEpochSeconds19August2029), UTC);
@@ -65,7 +65,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 "organisational_unit_id", "myOrg",
                 "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
         );
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), credentialsMissingIssuer);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), credentialsMissingIssuer);
 
         expectedException.expect(Worldpay3dsFlexDdcJwtCredentialsException.class);
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex DDC JWT for account 1 because the " +
@@ -80,7 +80,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 "issuer", "me",
                 "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
         );
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), credentialsMissingOrgId);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), credentialsMissingOrgId);
 
         expectedException.expect(Worldpay3dsFlexDdcJwtCredentialsException.class);
         expectedException.expectMessage(
@@ -96,7 +96,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 "issuer", "me",
                 "organisational_unit_id", "myOrg"
         );
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.toString(), credentialsMissingJwtMacId);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), credentialsMissingJwtMacId);
 
         expectedException.expect(Worldpay3dsFlexDdcJwtCredentialsException.class);
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex DDC JWT for account 1 because the " +
@@ -112,7 +112,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 "organisational_unit_id", "myOrg",
                 "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
         );
-        var gatewayAccount = new GatewayAccount(1L, SMARTPAY.toString(), validCredentials);
+        var gatewayAccount = new GatewayAccount(1L, SMARTPAY.getName(), validCredentials);
 
         expectedException.expect(Worldpay3dsFlexDdcJwtPaymentProviderException.class);
         expectedException.expectMessage("Cannot provide a Worldpay 3ds flex DDC JWT for account 1 because the " +


### PR DESCRIPTION
Was using `.toString()` which returns a capitalized version of the name,
it should use `getName()`.