### PR TITLE
PP-5546 Add card type to frontend pact state

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
@@ -8,7 +8,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
         QueueMessageContractTest.class,
         TransactionsApiContractTest.class,
-        WalletApiContractTest.class
+        FrontendContractTest.class
 })
 public class ContractTestSuite {
 

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -19,7 +19,6 @@ import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import java.time.ZonedDateTime;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
@@ -29,7 +28,7 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 @PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test", "staging", "production"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"frontend"})
-public class WalletApiContractTest {
+public class FrontendContractTest {
 
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
@@ -50,7 +49,7 @@ public class WalletApiContractTest {
     }
 
     @State("a sandbox account exists with a charge with id testChargeId that is in state ENTERING_CARD_DETAILS.")
-    public void aChangeExistsAwaitingAuthorisation() {
+    public void aChargeExistsAwaitingAuthorisation() {
         long gatewayAccountId = 666L;
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, gatewayAccountId);
 

--- a/src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java
+++ b/src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.pact.util;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
+import java.util.Collections;
+
 public class GatewayAccountUtil {
 
     public static void setUpGatewayAccount(DatabaseTestHelper dbHelper, long accountId) {
@@ -15,6 +17,7 @@ public class GatewayAccountUtil {
                     .withDescription("aDescription")
                     .withAnalyticsId("8b02c7e542e74423aa9e6d0f0628fd58")
                     .withServiceName("a cool service")
+                    .withCardTypeEntities(Collections.singletonList(dbHelper.getVisaDebitCard()))
                     .insert();
         } else {
             dbHelper.deleteAllChargesOnAccount(accountId);


### PR DESCRIPTION
Add a card type so that frontend consumer pact tests can test the structure of card types in charge responses.

Rename WalletApiContractTest to FrontendContractTest as it will run all contract tests with consumer 'frontend'.