### PR TITLE
PP-5545: Add additional3DSData element for 3DS2 Flex

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -23,6 +23,7 @@ public class AuthCardDetails implements AuthorisationDetails {
     private PayersCardType payersCardType;
     private PayersCardPrepaidStatus payersCardPrepaidStatus;
     private Boolean corporateCard;
+    private String worldpay3dsFlexDdcResult;
 
     public static AuthCardDetails anAuthCardDetails() {
         return new AuthCardDetails();
@@ -83,6 +84,11 @@ public class AuthCardDetails implements AuthorisationDetails {
         this.payersCardPrepaidStatus = payersCardPrepaidStatus;
     }
 
+    @JsonProperty("worldpay_3ds_flex_ddc_result")
+    public void setWorldpay3dsFlexDdcResult(String worldpay3dsFlexDdcResult) {
+        this.worldpay3dsFlexDdcResult = worldpay3dsFlexDdcResult;
+    }
+
     public String getCardNo() {
         return cardNo;
     }
@@ -135,5 +141,9 @@ public class AuthCardDetails implements AuthorisationDetails {
 
     public PayersCardPrepaidStatus getPayersCardPrepaidStatus() {
         return payersCardPrepaidStatus == null ? PayersCardPrepaidStatus.UNKNOWN : payersCardPrepaidStatus;
+    }
+
+    public Optional<String> getWorldpay3dsFlexDdcResult() {
+        return Optional.ofNullable(worldpay3dsFlexDdcResult);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -116,8 +116,11 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) throws GatewayException {
         GatewayOrder gatewayOrder = buildAuthoriseOrder(request);
-        GatewayClient.Response response = authoriseClient.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
-                request.getGatewayAccount(), gatewayOrder, getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+        GatewayClient.Response response = authoriseClient.postRequestFor(
+                gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                request.getGatewayAccount(), 
+                gatewayOrder, 
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
         return getWorldpayGatewayResponse(response);
     }
 
@@ -128,8 +131,11 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     .map(providerSessionId -> singletonList(new HttpCookie(WORLDPAY_MACHINE_COOKIE_NAME, providerSessionId)))
                     .orElse(emptyList());
             
-            GatewayClient.Response response = authoriseClient.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
-                    request.getGatewayAccount(), build3dsResponseAuthOrder(request), cookies, 
+            GatewayClient.Response response = authoriseClient.postRequestFor(
+                    gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                    request.getGatewayAccount(), 
+                    build3dsResponseAuthOrder(request), 
+                    cookies, 
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
             
             GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getWorldpayGatewayResponse(response);

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -43,6 +43,13 @@
                 </browser>
             </shopper>
             </#if>
+            <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>
+            <additional3DSData
+                dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()}"
+                challengeWindowSize="390x400"
+                challengePreference="noPreference"
+            />
+            </#if>
         </order>
     </submit>
 </paymentService>

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -22,6 +22,7 @@ public final class AuthCardDetailsFixture {
     private PayersCardType payersCardType = PayersCardType.DEBIT;
     private PayersCardPrepaidStatus payersCardPrepaidStatus = PayersCardPrepaidStatus.UNKNOWN;
     private Boolean corporateCard = Boolean.FALSE;
+    private String worldpay3dsFlexDdcResult;
 
     private AuthCardDetailsFixture() {
     }
@@ -84,6 +85,11 @@ public final class AuthCardDetailsFixture {
         this.payersCardPrepaidStatus = payersCardPrepaidStatus;
         return this;
     }
+    
+    public AuthCardDetailsFixture withWorldpay3dsFlexDdcResult(String worldpay3dsFlexDdcResult) {
+        this.worldpay3dsFlexDdcResult = worldpay3dsFlexDdcResult;
+        return this;
+    }
 
     public CardDetailsEntity getCardDetailsEntity() {
         CardDetailsEntity cardDetailsEntity = new CardDetailsEntity();
@@ -116,6 +122,7 @@ public final class AuthCardDetailsFixture {
         authCardDetails.setPayersCardType(payersCardType);
         authCardDetails.setPayersCardPrepaidStatus(payersCardPrepaidStatus);
         authCardDetails.setCorporateCard(corporateCard);
+        authCardDetails.setWorldpay3dsFlexDdcResult(worldpay3dsFlexDdcResult);
         return authCardDetails;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/XPathUtils.java
+++ b/src/test/java/uk/gov/pay/connector/util/XPathUtils.java
@@ -1,0 +1,44 @@
+package uk.gov.pay.connector.util;
+
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathFactory;
+import java.io.IOException;
+import java.io.StringReader;
+
+public class XPathUtils {
+    
+    public static XPathAndDocument getFromXmlString(String xml) throws ParserConfigurationException, IOException, SAXException {
+        InputSource inputXML = new InputSource( new StringReader(xml));
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document document = db.parse(inputXML);
+        XPathFactory xpathFactory = XPathFactory.newInstance();
+        return new XPathAndDocument(xpathFactory.newXPath(), document);
+    }
+
+    public static class XPathAndDocument {
+        
+        private final XPath xpath;
+        private final Document document;
+
+        XPathAndDocument(XPath xpath, Document document) {
+            this.xpath = xpath;
+            this.document = document;
+        }
+
+        public XPath getXpath() {
+            return xpath;
+        }
+
+        public Document getDocument() {
+            return document;
+        }
+    }
+}


### PR DESCRIPTION
Test the `additional3DSData` element exists when the
`worldpay_3ds_flex_ddc_result` property (in AuthCardDetails) is present.

WorldpayPaymentProviderTest looks a bit messy and could use some refactoring but I'll do this in another PR.