### PR TITLE
PP-5520 Check null card details

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -28,7 +29,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private final String wallet;
     private final Long totalAmount;
 
-    public PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardBrand,
+    private PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardBrand,
                                              String gatewayTransactionId, String firstDigitsCardNumber,
                                              String lastDigitsCardNumber, String cardholderName, String expiryDate,
                                              String addressLine1, String addressLine2, String addressPostcode,
@@ -54,25 +55,34 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     }
 
     public static PaymentDetailsEnteredEventDetails from(ChargeEntity charge) {
-        return new PaymentDetailsEnteredEventDetails(
-                charge.getCorporateSurcharge().orElse(null),
-                charge.getEmail(),
-                charge.getCardDetails().getCardBrand(),
-                charge.getGatewayTransactionId(),
-                Optional.ofNullable(charge.getCardDetails().getFirstDigitsCardNumber()).map(FirstDigitsCardNumber::toString).orElse(null),
-                Optional.ofNullable(charge.getCardDetails().getLastDigitsCardNumber())
-                        .map(LastDigitsCardNumber::toString)
-                        .orElse(null),
-                charge.getCardDetails().getCardHolderName(),
-                charge.getCardDetails().getExpiryDate(),
-                charge.getCardDetails().getBillingAddress().map(a -> a.getLine1()).orElse(null),
-                charge.getCardDetails().getBillingAddress().map(a -> a.getLine2()).orElse(null),
-                charge.getCardDetails().getBillingAddress().map(a -> a.getPostcode()).orElse(null),
-                charge.getCardDetails().getBillingAddress().map(a -> a.getCity()).orElse(null),
-                charge.getCardDetails().getBillingAddress().map(a -> a.getCounty()).orElse(null),
-                charge.getCardDetails().getBillingAddress().map(a -> a.getCountry()).orElse(null),
-                Optional.ofNullable(charge.getWalletType()).map(Enum::toString).orElse(null),
-                CorporateCardSurchargeCalculator.getTotalAmountFor(charge));
+        Builder builder = new Builder()
+                .withEmail(charge.getEmail())
+                .withGatewayTransactionId(charge.getGatewayTransactionId())
+                .withCorporateSurcharge(charge.getCorporateSurcharge().orElse(null))
+                .withTotalAmount(CorporateCardSurchargeCalculator.getTotalAmountFor(charge))
+                .withWallet(Optional.ofNullable(charge.getWalletType()).map(Enum::toString).orElse(null));
+        
+        Optional.ofNullable(charge.getCardDetails()).ifPresent(
+                cardDetails -> 
+                    builder.withCardBrand(cardDetails.getCardBrand())
+                            .withFirstDigitsCardNumber(Optional.ofNullable(cardDetails.getFirstDigitsCardNumber())
+                                    .map(FirstDigitsCardNumber::toString)
+                                    .orElse(null)
+                            )
+                            .withLastDigitsCardNumber(Optional.ofNullable(cardDetails.getLastDigitsCardNumber())
+                                    .map(LastDigitsCardNumber::toString)
+                                    .orElse(null)
+                            )
+                            .withCardholderName(cardDetails.getCardHolderName())
+                            .withExpiryDate(cardDetails.getExpiryDate())
+                            .withAddressLine1(cardDetails.getBillingAddress().map(AddressEntity::getLine1).orElse(null))
+                            .withAddressLine2(cardDetails.getBillingAddress().map(AddressEntity::getLine2).orElse(null))
+                            .withAddressCity(cardDetails.getBillingAddress().map(AddressEntity::getCity).orElse(null))
+                            .withAddressCountry(cardDetails.getBillingAddress().map(AddressEntity::getCountry).orElse(null))
+                            .withAddressCounty(cardDetails.getBillingAddress().map(AddressEntity::getCounty).orElse(null))
+                            .withAddressPostcode(cardDetails.getBillingAddress().map(AddressEntity::getPostcode).orElse(null)));
+                
+        return builder.build();
     }
 
     public Long getCorporateSurcharge() {
@@ -167,5 +177,108 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         return Objects.hash(corporateSurcharge, email, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
                 gatewayTransactionId, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode,
                 addressCounty, addressCountry, wallet, totalAmount);
+    }
+
+    private static class Builder {
+        private Long corporateSurcharge;
+        private String email;
+        private String cardBrand;
+        private String gatewayTransactionId;
+        private String firstDigitsCardNumber;
+        private String lastDigitsCardNumber;
+        private String cardholderName;
+        private String expiryDate;
+        private String addressLine1;
+        private String addressLine2;
+        private String addressPostcode;
+        private String addressCity;
+        private String addressCounty;
+        private String addressCountry;
+        private String wallet;
+        private Long totalAmount;
+
+        Builder withCorporateSurcharge(Long corporateSurcharge) {
+            this.corporateSurcharge = corporateSurcharge;
+            return this;
+        }
+
+        Builder withEmail(String email) {
+            this.email = email;
+            return this;
+        }
+
+        Builder withCardBrand(String cardBrand) {
+            this.cardBrand = cardBrand;
+            return this;
+        }
+
+        Builder withGatewayTransactionId(String gatewayTransactionId) {
+            this.gatewayTransactionId = gatewayTransactionId;
+            return this;
+        }
+
+        Builder withFirstDigitsCardNumber(String firstDigitsCardNumber) {
+            this.firstDigitsCardNumber = firstDigitsCardNumber;
+            return this;
+        }
+
+        Builder withLastDigitsCardNumber(String lastDigitsCardNumber) {
+            this.lastDigitsCardNumber = lastDigitsCardNumber;
+            return this;
+        }
+
+        Builder withCardholderName(String cardholderName) {
+            this.cardholderName = cardholderName;
+            return this;
+        }
+
+        Builder withExpiryDate(String expiryDate) {
+            this.expiryDate = expiryDate;
+            return this;
+        }
+
+        Builder withAddressLine1(String addressLine1) {
+            this.addressLine1 = addressLine1;
+            return this;
+        }
+
+        Builder withAddressLine2(String addressLine2) {
+            this.addressLine2 = addressLine2;
+            return this;
+        }
+
+        Builder withAddressPostcode(String addressPostcode) {
+            this.addressPostcode = addressPostcode;
+            return this;
+        }
+
+        Builder withAddressCity(String addressCity) {
+            this.addressCity = addressCity;
+            return this;
+        }
+
+        Builder withAddressCounty(String addressCounty) {
+            this.addressCounty = addressCounty;
+            return this;
+        }
+
+        Builder withAddressCountry(String addressCountry) {
+            this.addressCountry = addressCountry;
+            return this;
+        }
+
+        Builder withWallet(String wallet) {
+            this.wallet = wallet;
+            return this;
+        }
+
+        Builder withTotalAmount(Long totalAmount) {
+            this.totalAmount = totalAmount;
+            return this;
+        }
+
+        PaymentDetailsEnteredEventDetails build() {
+            return new PaymentDetailsEnteredEventDetails(corporateSurcharge, email, cardBrand, gatewayTransactionId, firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode, addressCity, addressCounty, addressCountry, wallet, totalAmount);
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -247,9 +247,10 @@ public class HistoricalEventEmitterWorkerTest {
         assertThat(argument.getAllValues().get(1).getStateTransitionEventClass(), is(CaptureConfirmed.class));
 
         ArgumentCaptor<Event> daoArgumentCaptor = ArgumentCaptor.forClass(Event.class);
-        verify(emittedEventDao, times(2)).recordEmission(daoArgumentCaptor.capture());
+        verify(emittedEventDao, times(3)).recordEmission(daoArgumentCaptor.capture());
         assertThat(daoArgumentCaptor.getAllValues().get(0).getEventType(), is("CAPTURE_SUBMITTED"));
         assertThat(daoArgumentCaptor.getAllValues().get(1).getEventType(), is("CAPTURE_CONFIRMED"));
+        assertThat(daoArgumentCaptor.getAllValues().get(2).getEventType(), is("PAYMENT_DETAILS_ENTERED"));
     }
 
     @Test


### PR DESCRIPTION
From running historical event emitter we've seen PaymentDetailsEnteredEventDetails creation fail because CardDetails is null. Check this before dereferencing.