### PR TITLE
PP-5520 Schedule multiple state transition threads

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
+++ b/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 public class StateTransitionEmitterProcess {
     private static final Logger LOGGER = LoggerFactory.getLogger(StateTransitionEmitterProcess.class);
 
-    private final long STATE_TRANSITION_PROCESS_DELAY_IN_MILLISECONDS = 100;
+    private final long STATE_TRANSITION_PROCESS_DELAY_IN_MILLISECONDS = 1000;
     private final StateTransitionQueue stateTransitionQueue;
     private final EventQueue eventQueue;
     private final EventFactory eventFactory;


### PR DESCRIPTION
* thread pool size is fixed to an environment variable
* only one thread was being scheduled for execution with a `Callable`
* loop through thread pool size and schedule all threads for execution