### PR TITLE
PP-5585 Add `integration_version_3ds` column to Charges

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1198,4 +1198,11 @@
                               defaultNullValue="1"/>
     </changeSet>
 
+    <changeSet id="add integration_version_3ds column to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="integration_version_3ds" type="smallint">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- Adds `integration_version_3ds` column to charges table as Stripe needs to use different path to capture charges for authorised using current 3DS version (in-flight payments) and 3DS2.
   - For charges authorised with 3DS, stripe capture url is `/v1/charges/[stripeChargeId]/capture`
   - For charges authorised with 3DS2, stripe capture url is `v1/payment_intents/[stripePaymentIntentId]/capture`