### PR TITLE
PP-5402 - Renames Builder method and directly tests @NotNull error message

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
@@ -64,23 +64,23 @@ public class TelephoneChargeCreateRequest {
         // To enable Jackson serialisation we need a default constructor
     }
     
-    public TelephoneChargeCreateRequest(ChargeBuilder chargeBuilder) {
-        this.amount = chargeBuilder.amount;
-        this.reference = chargeBuilder.reference;
-        this.description = chargeBuilder.description;
-        this.createdDate = chargeBuilder.createdDate;
-        this.authorisedDate = chargeBuilder.authorisedDate;
-        this.processorId = chargeBuilder.processorId;
-        this.providerId = chargeBuilder.providerId;
-        this.authCode = chargeBuilder.authCode;
-        this.paymentOutcome = chargeBuilder.paymentOutcome;
-        this.cardType = chargeBuilder.cardType;
-        this.nameOnCard = chargeBuilder.nameOnCard;
-        this.emailAddress = chargeBuilder.emailAddress;
-        this.cardExpiry = chargeBuilder.cardExpiry;
-        this.lastFourDigits = chargeBuilder.lastFourDigits;
-        this.firstSixDigits = chargeBuilder.firstSixDigits;
-        this.telephoneNumber = chargeBuilder.telephoneNumber;
+    public TelephoneChargeCreateRequest(Builder builder) {
+        this.amount = builder.amount;
+        this.reference = builder.reference;
+        this.description = builder.description;
+        this.createdDate = builder.createdDate;
+        this.authorisedDate = builder.authorisedDate;
+        this.processorId = builder.processorId;
+        this.providerId = builder.providerId;
+        this.authCode = builder.authCode;
+        this.paymentOutcome = builder.paymentOutcome;
+        this.cardType = builder.cardType;
+        this.nameOnCard = builder.nameOnCard;
+        this.emailAddress = builder.emailAddress;
+        this.cardExpiry = builder.cardExpiry;
+        this.lastFourDigits = builder.lastFourDigits;
+        this.firstSixDigits = builder.firstSixDigits;
+        this.telephoneNumber = builder.telephoneNumber;
     }
     
     public Long getAmount() {
@@ -147,7 +147,7 @@ public class TelephoneChargeCreateRequest {
         return telephoneNumber;
     }
     
-    public static class ChargeBuilder {
+    public static class Builder {
         private Long amount;
 
         private String reference;
@@ -180,82 +180,82 @@ public class TelephoneChargeCreateRequest {
 
         private String telephoneNumber;
         
-        public ChargeBuilder amount(Long amount) {
+        public Builder withAmount(Long amount) {
             this.amount = amount;
             return this;
         }
 
-        public ChargeBuilder reference(String reference) {
+        public Builder withReference(String reference) {
             this.reference = reference;
             return this;
         }
         
-        public ChargeBuilder description(String description) {
+        public Builder withDescription(String description) {
             this.description = description;
             return this;
         }
         
-        public ChargeBuilder createdDate(String createdDate) {
+        public Builder withCreatedDate(String createdDate) {
             this.createdDate = createdDate;
             return this;
         }
         
-        public ChargeBuilder authorisedDate(String authorisedDate) {
+        public Builder withAuthorisedDate(String authorisedDate) {
             this.authorisedDate = authorisedDate;
             return this;
         }
         
-        public ChargeBuilder processorId(String processorId) {
+        public Builder withProcessorId(String processorId) {
             this.processorId = processorId;
             return this;
         }
         
-        public ChargeBuilder providerId(String providerId) {
+        public Builder withProviderId(String providerId) {
             this.providerId = providerId;
             return this;
         }
         
-        public ChargeBuilder authCode(String authCode) {
+        public Builder withAuthCode(String authCode) {
             this.authCode = authCode;
             return this;
         }
         
-        public ChargeBuilder paymentOutcome(PaymentOutcome paymentOutcome) {
+        public Builder withPaymentOutcome(PaymentOutcome paymentOutcome) {
             this.paymentOutcome = paymentOutcome;
             return this;
         }
         
-        public ChargeBuilder cardType(String cardType) {
+        public Builder withCardType(String cardType) {
             this.cardType = cardType;
             return this;
         }
         
-        public ChargeBuilder nameOnCard(String nameOnCard) {
+        public Builder withNameOnCard(String nameOnCard) {
             this.nameOnCard = nameOnCard;
             return this;
         }
         
-        public ChargeBuilder emailAddress(String emailAddress) {
+        public Builder withEmailAddress(String emailAddress) {
             this.emailAddress = emailAddress;
             return this;
         }
         
-        public ChargeBuilder cardExpiry(String cardExpiry) {
+        public Builder withCardExpiry(String cardExpiry) {
             this.cardExpiry = cardExpiry;
             return this;
         }
         
-        public ChargeBuilder lastFourDigits(String lastFourDigits) {
+        public Builder withLastFourDigits(String lastFourDigits) {
             this.lastFourDigits = lastFourDigits;
             return this;
         }
         
-        public ChargeBuilder firstSixDigits(String firstSixDigits) {
+        public Builder withFirstSixDigits(String firstSixDigits) {
             this.firstSixDigits = firstSixDigits;
             return this;
         }
         
-        public ChargeBuilder telephoneNumber(String telephoneNumber) {
+        public Builder withTelephoneNumber(String telephoneNumber) {
             this.telephoneNumber = telephoneNumber;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -108,7 +108,7 @@ public class ChargeServiceTest {
     private static final int MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS = 10;
 
     private ChargeCreateRequestBuilder requestBuilder;
-    private TelephoneChargeCreateRequest.ChargeBuilder telephoneRequestBuilder;
+    private TelephoneChargeCreateRequest.Builder telephoneRequestBuilder;
     
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -158,22 +158,22 @@ public class ChargeServiceTest {
                 .withDescription("This is a description")
                 .withReference("Pay reference");
 
-        telephoneRequestBuilder = new TelephoneChargeCreateRequest.ChargeBuilder()
-                .amount(100L)
-                .reference("Some reference")
-                .description("Some description")
-                .createdDate("2018-02-21T16:04:25Z")
-                .authorisedDate("2018-02-21T16:05:33Z")
-                .processorId("1PROC")
-                .providerId("1PROV")
-                .authCode("666")
-                .nameOnCard("Jane Doe")
-                .emailAddress("jane.doe@example.com")
-                .telephoneNumber("+447700900796")
-                .cardType("visa")
-                .cardExpiry("01/19")
-                .lastFourDigits("1234")
-                .firstSixDigits("123456");
+        telephoneRequestBuilder = new TelephoneChargeCreateRequest.Builder()
+                .withAmount(100L)
+                .withReference("Some reference")
+                .withDescription("Some description")
+                .withCreatedDate("2018-02-21T16:04:25Z")
+                .withAuthorisedDate("2018-02-21T16:05:33Z")
+                .withProcessorId("1PROC")
+                .withProviderId("1PROV")
+                .withAuthCode("666")
+                .withNameOnCard("Jane Doe")
+                .withEmailAddress("jane.doe@example.com")
+                .withTelephoneNumber("+447700900796")
+                .withCardType("visa")
+                .withCardExpiry("01/19")
+                .withLastFourDigits("1234")
+                .withFirstSixDigits("123456");
 
         gatewayAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), TEST);
         gatewayAccount.setId(GATEWAY_ACCOUNT_ID);
@@ -490,7 +490,7 @@ public class ChargeServiceTest {
                 ));
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
@@ -542,7 +542,7 @@ public class ChargeServiceTest {
                 ));
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
@@ -594,7 +594,7 @@ public class ChargeServiceTest {
                 ));
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
@@ -630,8 +630,8 @@ public class ChargeServiceTest {
         PaymentOutcome paymentOutcome = new PaymentOutcome("success");
         
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .providerId("new")
-                .paymentOutcome(paymentOutcome)
+                .withProviderId("new")
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(telephoneChargeCreateRequest);
@@ -649,7 +649,7 @@ public class ChargeServiceTest {
         PaymentOutcome paymentOutcome = new PaymentOutcome("success");
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
         
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
@@ -687,7 +687,7 @@ public class ChargeServiceTest {
         PaymentOutcome paymentOutcome = new PaymentOutcome("success");
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         ChargeResponse chargeResponse = service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID).get();
@@ -721,7 +721,7 @@ public class ChargeServiceTest {
         PaymentOutcome paymentOutcome = new PaymentOutcome("failed", "P0010", supplemental);
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         ChargeResponse chargeResponse = service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID).get();

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidatorTest.java
@@ -86,6 +86,6 @@ public class CardExpiryValidatorTest {
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
 
         assertThat(constraintViolations.size(), isNumber(1));
-        assertThat(constraintViolations.iterator().next().getMessage().equals("Field [card_expiry] must have valid MM/YY"), is(false));
+        assertThat(constraintViolations.iterator().next().getMessage(), is("Field [card_expiry] cannot be null"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidatorTest.java
@@ -17,7 +17,7 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class CardExpiryValidatorTest {
     
-    private static TelephoneChargeCreateRequest.ChargeBuilder telephoneRequestBuilder = new TelephoneChargeCreateRequest.ChargeBuilder();
+    private static TelephoneChargeCreateRequest.Builder telephoneRequestBuilder = new TelephoneChargeCreateRequest.Builder();
 
     private static Validator validator;
 
@@ -27,22 +27,22 @@ public class CardExpiryValidatorTest {
         validator = factory.getValidator();
         
         telephoneRequestBuilder
-                .amount(1200L)
-                .description("Some description")
-                .reference("Some reference")
-                .processorId("1PROC")
-                .providerId("1PROV")
-                .lastFourDigits("1234")
-                .firstSixDigits("123456")
-                .cardType("visa")
-                .paymentOutcome(new PaymentOutcome("success"));
+                .withAmount(1200L)
+                .withDescription("Some description")
+                .withReference("Some reference")
+                .withProcessorId("1PROC")
+                .withProviderId("1PROV")
+                .withLastFourDigits("1234")
+                .withFirstSixDigits("123456")
+                .withCardType("visa")
+                .withPaymentOutcome(new PaymentOutcome("success"));
     }
 
     @Test
     public void failsValidationForInvalidMonth00() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .cardExpiry("00/99")
+                .withCardExpiry("00/99")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -55,7 +55,7 @@ public class CardExpiryValidatorTest {
     public void failsValidationForInvalidMonth99() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .cardExpiry("99/99")
+                .withCardExpiry("99/99")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -68,7 +68,7 @@ public class CardExpiryValidatorTest {
     public void passesValidationForValidCardExpiry() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .cardExpiry("01/99")
+                .withCardExpiry("01/99")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -80,7 +80,7 @@ public class CardExpiryValidatorTest {
     public void passesValidationForNullCardExpiry() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .cardExpiry(null)
+                .withCardExpiry(null)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidatorTest.java
@@ -30,17 +30,11 @@ public class CardExpiryValidatorTest {
                 .amount(1200L)
                 .description("Some description")
                 .reference("Some reference")
-                .createdDate("2018-02-21T16:04:25Z")
-                .authorisedDate("2018-02-21T16:05:33Z")
-                .authCode("666")
                 .processorId("1PROC")
                 .providerId("1PROV")
                 .lastFourDigits("1234")
                 .firstSixDigits("123456")
                 .cardType("visa")
-                .nameOnCard("Jane Doe")
-                .emailAddress("jane_doe@example.com")
-                .telephoneNumber("+447700900796")
                 .paymentOutcome(new PaymentOutcome("success"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardFirstSixDigitsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardFirstSixDigitsValidatorTest.java
@@ -29,22 +29,16 @@ public class CardFirstSixDigitsValidatorTest {
                 .amount(1200L)
                 .description("Some description")
                 .reference("Some reference")
-                .createdDate("2018-02-21T16:04:25Z")
-                .authorisedDate("2018-02-21T16:05:33Z")
-                .authCode("666")
                 .processorId("1PROC")
                 .providerId("1PROV")
                 .cardExpiry("01/99")
                 .lastFourDigits("1234")
                 .cardType("visa")
-                .nameOnCard("Jane Doe")
-                .emailAddress("jane_doe@example.com")
-                .telephoneNumber("+447700900796")
                 .paymentOutcome(new PaymentOutcome("success"));
     }
 
     @Test
-    public void failsValidationForFiveDigitsGiven() {
+    public void failsValidationForFiveDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .firstSixDigits("12345")
@@ -57,7 +51,7 @@ public class CardFirstSixDigitsValidatorTest {
     }
 
     @Test
-    public void failsValidationForSevenDigitsGiven() {
+    public void failsValidationForSevenDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .firstSixDigits("1234567")
@@ -70,7 +64,7 @@ public class CardFirstSixDigitsValidatorTest {
     }
 
     @Test
-    public void passesValidationForSixDigitsGiven() {
+    public void passesValidationForSixDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .firstSixDigits("123456")

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardFirstSixDigitsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardFirstSixDigitsValidatorTest.java
@@ -17,7 +17,7 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class CardFirstSixDigitsValidatorTest {
     
-    private static TelephoneChargeCreateRequest.ChargeBuilder telephoneRequestBuilder = new TelephoneChargeCreateRequest.ChargeBuilder();
+    private static TelephoneChargeCreateRequest.Builder telephoneRequestBuilder = new TelephoneChargeCreateRequest.Builder();
 
     private static Validator validator;
 
@@ -26,22 +26,22 @@ public class CardFirstSixDigitsValidatorTest {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
         telephoneRequestBuilder
-                .amount(1200L)
-                .description("Some description")
-                .reference("Some reference")
-                .processorId("1PROC")
-                .providerId("1PROV")
-                .cardExpiry("01/99")
-                .lastFourDigits("1234")
-                .cardType("visa")
-                .paymentOutcome(new PaymentOutcome("success"));
+                .withAmount(1200L)
+                .withDescription("Some description")
+                .withReference("Some reference")
+                .withProcessorId("1PROC")
+                .withProviderId("1PROV")
+                .withCardExpiry("01/99")
+                .withLastFourDigits("1234")
+                .withCardType("visa")
+                .withPaymentOutcome(new PaymentOutcome("success"));
     }
 
     @Test
     public void failsValidationForFiveDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .firstSixDigits("12345")
+                .withFirstSixDigits("12345")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -54,7 +54,7 @@ public class CardFirstSixDigitsValidatorTest {
     public void failsValidationForSevenDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .firstSixDigits("1234567")
+                .withFirstSixDigits("1234567")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -67,7 +67,7 @@ public class CardFirstSixDigitsValidatorTest {
     public void passesValidationForSixDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .firstSixDigits("123456")
+                .withFirstSixDigits("123456")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -79,7 +79,7 @@ public class CardFirstSixDigitsValidatorTest {
     public void passesValidationForNullDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .firstSixDigits(null)
+                .withFirstSixDigits(null)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardFirstSixDigitsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardFirstSixDigitsValidatorTest.java
@@ -85,6 +85,6 @@ public class CardFirstSixDigitsValidatorTest {
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
 
         assertThat(constraintViolations.size(), isNumber(1));
-        assertThat(constraintViolations.iterator().next().getMessage().equals("Field [first_six_digits] must be exactly 6 digits"), is(false));
+        assertThat(constraintViolations.iterator().next().getMessage(), is("Field [first_six_digits] cannot be null"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardLastFourDigitsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardLastFourDigitsValidatorTest.java
@@ -86,6 +86,6 @@ public class CardLastFourDigitsValidatorTest {
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
 
         assertThat(constraintViolations.size(), isNumber(1));
-        assertThat(constraintViolations.iterator().next().getMessage().equals("Field [last_four_digits] must be exactly 4 digits"), is(false));
+        assertThat(constraintViolations.iterator().next().getMessage(), is("Field [last_four_digits] cannot be null"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardLastFourDigitsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardLastFourDigitsValidatorTest.java
@@ -30,22 +30,16 @@ public class CardLastFourDigitsValidatorTest {
                 .amount(1200L)
                 .description("Some description")
                 .reference("Some reference")
-                .createdDate("2018-02-21T16:04:25Z")
-                .authorisedDate("2018-02-21T16:05:33Z")
-                .authCode("666")
                 .processorId("1PROC")
                 .providerId("1PROV")
                 .cardExpiry("01/99")
                 .firstSixDigits("123456")
                 .cardType("visa")
-                .nameOnCard("Jane Doe")
-                .emailAddress("jane_doe@example.com")
-                .telephoneNumber("+447700900796")
                 .paymentOutcome(new PaymentOutcome("success"));
     }
 
     @Test
-    public void failsValidationForThreeDigitsGiven() {
+    public void failsValidationForThreeDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .lastFourDigits("123")
@@ -58,7 +52,7 @@ public class CardLastFourDigitsValidatorTest {
     }
 
     @Test
-    public void failsValidationForFiveDigitsGiven() {
+    public void failsValidationForFiveDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .lastFourDigits("12345")
@@ -71,7 +65,7 @@ public class CardLastFourDigitsValidatorTest {
     }
 
     @Test
-    public void passesValidationForFourDigitsGiven() {
+    public void passesValidationForFourDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .lastFourDigits("1234")

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardLastFourDigitsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardLastFourDigitsValidatorTest.java
@@ -17,7 +17,7 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class CardLastFourDigitsValidatorTest {
     
-    private static TelephoneChargeCreateRequest.ChargeBuilder telephoneRequestBuilder = new TelephoneChargeCreateRequest.ChargeBuilder();
+    private static TelephoneChargeCreateRequest.Builder telephoneRequestBuilder = new TelephoneChargeCreateRequest.Builder();
 
     private static Validator validator;
 
@@ -27,22 +27,22 @@ public class CardLastFourDigitsValidatorTest {
         validator = factory.getValidator();
         
         telephoneRequestBuilder
-                .amount(1200L)
-                .description("Some description")
-                .reference("Some reference")
-                .processorId("1PROC")
-                .providerId("1PROV")
-                .cardExpiry("01/99")
-                .firstSixDigits("123456")
-                .cardType("visa")
-                .paymentOutcome(new PaymentOutcome("success"));
+                .withAmount(1200L)
+                .withDescription("Some description")
+                .withReference("Some reference")
+                .withProcessorId("1PROC")
+                .withProviderId("1PROV")
+                .withCardExpiry("01/99")
+                .withFirstSixDigits("123456")
+                .withCardType("visa")
+                .withPaymentOutcome(new PaymentOutcome("success"));
     }
 
     @Test
     public void failsValidationForThreeDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .lastFourDigits("123")
+                .withLastFourDigits("123")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -55,7 +55,7 @@ public class CardLastFourDigitsValidatorTest {
     public void failsValidationForFiveDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .lastFourDigits("12345")
+                .withLastFourDigits("12345")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -68,7 +68,7 @@ public class CardLastFourDigitsValidatorTest {
     public void passesValidationForFourDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .lastFourDigits("1234")
+                .withLastFourDigits("1234")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -80,7 +80,7 @@ public class CardLastFourDigitsValidatorTest {
     public void passesValidationForNullDigits() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .lastFourDigits(null)
+                .withLastFourDigits(null)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardTypeValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardTypeValidatorTest.java
@@ -17,7 +17,7 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class CardTypeValidatorTest {
     
-    private static TelephoneChargeCreateRequest.ChargeBuilder telephoneRequestBuilder = new TelephoneChargeCreateRequest.ChargeBuilder();
+    private static TelephoneChargeCreateRequest.Builder telephoneRequestBuilder = new TelephoneChargeCreateRequest.Builder();
     
     private static Validator validator; 
     
@@ -26,22 +26,22 @@ public class CardTypeValidatorTest {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
         telephoneRequestBuilder
-                .amount(1200L)
-                .description("Some description")
-                .reference("Some reference")
-                .processorId("1PROC")
-                .providerId("1PROV")
-                .cardExpiry("01/99")
-                .lastFourDigits("1234")
-                .firstSixDigits("123456")
-                .paymentOutcome(new PaymentOutcome("success"));
+                .withAmount(1200L)
+                .withDescription("Some description")
+                .withReference("Some reference")
+                .withProcessorId("1PROC")
+                .withProviderId("1PROV")
+                .withCardExpiry("01/99")
+                .withLastFourDigits("1234")
+                .withFirstSixDigits("123456")
+                .withPaymentOutcome(new PaymentOutcome("success"));
     }
     
     @Test
     public void failsValidationForInvalidCardType() {
         
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .cardType("bad-card")
+                .withCardType("bad-card")
                 .build();
         
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -54,7 +54,7 @@ public class CardTypeValidatorTest {
     public void passesValidationForValidCardType() {
         
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .cardType("visa")
+                .withCardType("visa")
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -66,7 +66,7 @@ public class CardTypeValidatorTest {
     public void passesValidationForNullCardType() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .cardType(null)
+                .withCardType(null)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardTypeValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardTypeValidatorTest.java
@@ -72,6 +72,6 @@ public class CardTypeValidatorTest {
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
 
         assertThat(constraintViolations.size(), isNumber(1));
-        assertThat(constraintViolations.iterator().next().getMessage().equals("Field [card_type] must be either master-card, visa, maestro, diners-club or american-express"), is(false));
+        assertThat(constraintViolations.iterator().next().getMessage(), is("Field [card_type] cannot be null"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardTypeValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/CardTypeValidatorTest.java
@@ -29,17 +29,11 @@ public class CardTypeValidatorTest {
                 .amount(1200L)
                 .description("Some description")
                 .reference("Some reference")
-                .createdDate("2018-02-21T16:04:25Z")
-                .authorisedDate("2018-02-21T16:05:33Z")
-                .authCode("666")
                 .processorId("1PROC")
                 .providerId("1PROV")
                 .cardExpiry("01/99")
                 .lastFourDigits("1234")
                 .firstSixDigits("123456")
-                .nameOnCard("Jane Doe")
-                .emailAddress("jane_doe@example.com")
-                .telephoneNumber("+447700900796")
                 .paymentOutcome(new PaymentOutcome("success"));
     }
     

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/PaymentOutcomeValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/PaymentOutcomeValidatorTest.java
@@ -30,18 +30,12 @@ public class PaymentOutcomeValidatorTest {
                 .amount(1200L)
                 .description("Some description")
                 .reference("Some reference")
-                .createdDate("2018-02-21T16:04:25Z")
-                .authorisedDate("2018-02-21T16:05:33Z")
-                .authCode("666")
                 .processorId("1PROC")
                 .providerId("1PROV")
                 .cardExpiry("01/99")
                 .cardType("visa")
                 .lastFourDigits("1234")
-                .firstSixDigits("123456")
-                .nameOnCard("Jane Doe")
-                .emailAddress("jane_doe@example.com")
-                .telephoneNumber("+447700900796");
+                .firstSixDigits("123456");
                 
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/PaymentOutcomeValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/PaymentOutcomeValidatorTest.java
@@ -139,6 +139,6 @@ public class PaymentOutcomeValidatorTest {
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
 
         assertThat(constraintViolations.size(), isNumber(1));
-        assertThat(constraintViolations.iterator().next().getMessage().equals("Field [payment_outcome] must include a valid status and error code"), is(false));
+        assertThat(constraintViolations.iterator().next().getMessage(), is("Field [payment_outcome] cannot be null"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/validation/telephone/PaymentOutcomeValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/validation/telephone/PaymentOutcomeValidatorTest.java
@@ -18,7 +18,7 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 public class PaymentOutcomeValidatorTest {
     
-    private static TelephoneChargeCreateRequest.ChargeBuilder telephoneRequestBuilder = new TelephoneChargeCreateRequest.ChargeBuilder();
+    private static TelephoneChargeCreateRequest.Builder telephoneRequestBuilder = new TelephoneChargeCreateRequest.Builder();
 
     private static Validator validator;
 
@@ -27,15 +27,15 @@ public class PaymentOutcomeValidatorTest {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
         telephoneRequestBuilder
-                .amount(1200L)
-                .description("Some description")
-                .reference("Some reference")
-                .processorId("1PROC")
-                .providerId("1PROV")
-                .cardExpiry("01/99")
-                .cardType("visa")
-                .lastFourDigits("1234")
-                .firstSixDigits("123456");
+                .withAmount(1200L)
+                .withDescription("Some description")
+                .withReference("Some reference")
+                .withProcessorId("1PROC")
+                .withProviderId("1PROV")
+                .withCardExpiry("01/99")
+                .withCardType("visa")
+                .withLastFourDigits("1234")
+                .withFirstSixDigits("123456");
                 
     }
 
@@ -43,7 +43,7 @@ public class PaymentOutcomeValidatorTest {
     public void failsValidationForInvalidPaymentOutcomeStatus() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(new PaymentOutcome("invalid"))
+                .withPaymentOutcome(new PaymentOutcome("invalid"))
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -65,7 +65,7 @@ public class PaymentOutcomeValidatorTest {
         );
         
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -87,7 +87,7 @@ public class PaymentOutcomeValidatorTest {
         );
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -109,7 +109,7 @@ public class PaymentOutcomeValidatorTest {
         );
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(paymentOutcome)
+                .withPaymentOutcome(paymentOutcome)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -121,7 +121,7 @@ public class PaymentOutcomeValidatorTest {
     public void passesValidationForPaymentOutcomeStatusOfSuccess() {
         
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(new PaymentOutcome("success"))
+                .withPaymentOutcome(new PaymentOutcome("success"))
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);
@@ -133,7 +133,7 @@ public class PaymentOutcomeValidatorTest {
     public void passesValidationForNullPaymentOutcome() {
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
-                .paymentOutcome(null)
+                .withPaymentOutcome(null)
                 .build();
 
         Set<ConstraintViolation<TelephoneChargeCreateRequest>> constraintViolations = validator.validate(telephoneChargeCreateRequest);


### PR DESCRIPTION
## WHAT YOU DID
This PR renames TelephoneCreateChargeRequest.ChargeBuilder to TelephoneCreateChargeRequest.ChargeBuilder.

This also ensures that only required fields are sent for the validator in the unit tests.

This also removes the previous assertion for testing null values in the unit validator tests to instead check the error message is equal to "Field [...] cannot be null."
