### PR TITLE
Pp 5610 remove country length validation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/PrefilledCardHolderDetails.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/PrefilledCardHolderDetails.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.charge.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.Length;
-import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.common.model.domain.PrefilledAddress;
 
 import javax.validation.Valid;
 import java.util.Optional;
@@ -17,7 +17,7 @@ public class PrefilledCardHolderDetails {
 
     @JsonProperty("billing_address")
     @Valid
-    private Address address;
+    private PrefilledAddress address;
 
     public Optional<String> getCardHolderName() {
         return Optional.ofNullable(cardHolderName);
@@ -27,11 +27,11 @@ public class PrefilledCardHolderDetails {
         this.cardHolderName = cardHolderName;
     }
 
-    public Optional<Address> getAddress() {
+    public Optional<PrefilledAddress> getAddress() {
         return Optional.ofNullable(address);
     }
 
-    public void setAddress(Address address) {
+    public void setAddress(PrefilledAddress address) {
         this.address = address;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -42,6 +42,7 @@ import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeEx
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
+import uk.gov.pay.connector.common.model.domain.PrefilledAddress;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.events.EventQueue;
 import uk.gov.pay.connector.events.model.Event;
@@ -225,7 +226,7 @@ public class ChargeService {
     private CardDetailsEntity createCardDetailsEntity(PrefilledCardHolderDetails prefilledCardHolderDetails) {
         CardDetailsEntity cardDetailsEntity = new CardDetailsEntity();
         prefilledCardHolderDetails.getCardHolderName().ifPresent(cardDetailsEntity::setCardHolderName);
-        prefilledCardHolderDetails.getAddress().map(AddressEntity::new).ifPresent(cardDetailsEntity::setBillingAddress);
+        prefilledCardHolderDetails.getAddress().map(PrefilledAddress::toAddress).map(AddressEntity::new).ifPresent(cardDetailsEntity::setBillingAddress);
         return cardDetailsEntity;
     }
 

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/Address.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/Address.java
@@ -1,21 +1,15 @@
 package uk.gov.pay.connector.common.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import org.hibernate.validator.constraints.Length;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Address {
 
-    @Length(max = 255, message = "Field [line1] can have a size between 0 and 255")
     private String line1;
-    @Length(max = 255, message = "Field [line2] can have a size between 0 and 255")
     private String line2;
-    @Length(max = 25, message = "Field [postcode] can have a size between 0 and 25")
     private String postcode;
-    @Length(max = 255, message = "Field [city] can have a size between 0 and 255")
     private String city;
     private String county;
-    @Length(min = 2, max = 2, message = "Field [country] can have an exact size of 2")
     private String country;
 
     public Address() {

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PrefilledAddress.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PrefilledAddress.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.connector.common.model.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Size;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PrefilledAddress {
+
+    @Size(max = 255, message = "Field [line1] can have a size between 0 and 255")
+    private final String line1;
+    @Size(max = 255, message = "Field [line2] can have a size between 0 and 255")
+    private final String line2;
+    @Size(max = 25, message = "Field [postcode] can have a size between 0 and 25")
+    private final String postcode;
+    @Size(max = 255, message = "Field [city] can have a size between 0 and 255")
+    private final String city;
+    @Size(max = 255, message = "Field [county] can have a size between 0 and 255")
+    private final String county;
+    private final String country;
+
+    @JsonCreator
+    public PrefilledAddress(@JsonProperty("line1") String line1,
+                            @JsonProperty("line2") String line2,
+                            @JsonProperty("postcode") String postcode,
+                            @JsonProperty("city") String city,
+                            @JsonProperty("county") String county,
+                            @JsonProperty("country") String country) {
+        this.line1 = line1;
+        this.line2 = line2;
+        this.postcode = postcode;
+        this.city = city;
+        this.county = county;
+        this.country = normalizeCountry(country);
+    }
+
+    public Address toAddress() {
+        return new Address(line1, line2, postcode, city, county, country);
+    }
+
+    private String normalizeCountry(String country) {
+        if (country == null || country.length() != 2) {
+            return null;
+        }
+        return country;
+    }
+
+    public String getLine1() {
+        return line1;
+    }
+
+    public String getLine2() {
+        return line2;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getCounty() {
+        return county;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PrefilledAddress that = (PrefilledAddress) o;
+        return Objects.equals(line1, that.line1) &&
+                Objects.equals(line2, that.line2) &&
+                Objects.equals(postcode, that.postcode) &&
+                Objects.equals(city, that.city) &&
+                Objects.equals(county, that.county) &&
+                Objects.equals(country, that.country);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(line1, line2, postcode, city, county, country);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PrefilledAddressTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PrefilledAddressTest.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.common.model.domain;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class PrefilledAddressTest {
+    
+    @Test
+    public void shouldSetCountryWhenProvidedValueIsTwoCharactersLong() {
+        var address = createPrefilledAdddressWithCountryOf("GB");
+        assertThat(address.getCountry(), is("GB"));
+    }
+
+    @Test
+    public void shouldSetCountryToNullWhenCountryNotSupplied() {
+        var address = createPrefilledAdddressWithCountryOf(null);
+        assertThat(address.getCountry(), is(nullValue()));
+    }
+    
+    @Test
+    public void shouldSetCountryToNullWhenProvidedCountryTooShort() {
+        var address = createPrefilledAdddressWithCountryOf("G");
+        assertThat(address.getCountry(), is(nullValue()));
+    }
+
+    @Test
+    public void shouldSetCountryToNullWhenProvidedCountryTooLong() {
+        var address = createPrefilledAdddressWithCountryOf("GBR");
+        assertThat(address.getCountry(), is(nullValue()));
+    }
+    
+    
+    private PrefilledAddress createPrefilledAdddressWithCountryOf(String country) {
+        return new PrefilledAddress("line1", "line2", "postcode", "city", "county", country);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
@@ -532,6 +532,45 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
     }
 
     @Test
+    public void shouldReturn201AndNoCountryWhenSuppliedCountryIsTooLong() {
+        String cardholderName = "Joe Bogs";
+        String line1 = "Line 1";
+        String postCode = "AB1 CD2";
+        String countryThatIsTooLong = "GBR";
+
+        String postBody = toJson(Map.of(
+                JSON_AMOUNT_KEY, AMOUNT,
+                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
+                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
+                JSON_RETURN_URL_KEY, RETURN_URL,
+                JSON_PREFILLED_CARDHOLDER_DETAILS_KEY, Map.of(
+                        JSON_CARDHOLDER_NAME_KEY, cardholderName,
+                        JSON_BILLING_ADDRESS_KEY, Map.of(
+                                JSON_ADDRESS_LINE_1_KEY, line1,
+                                JSON_ADDRESS_POST_CODE_KEY, postCode,
+                                JSON_ADDRESS_LINE_COUNTRY_CODE, countryThatIsTooLong
+                        )
+                )
+        ));
+
+        connectorRestApiClient.postCreateCharge(postBody)
+                .statusCode(Status.CREATED.getStatusCode())
+                .contentType(JSON)
+                .body(JSON_CHARGE_KEY, is(notNullValue()))
+                .body(JSON_AMOUNT_KEY, isNumber(AMOUNT))
+                .body(JSON_REFERENCE_KEY, is(JSON_REFERENCE_VALUE))
+                .body(JSON_DESCRIPTION_KEY, is(JSON_DESCRIPTION_VALUE))
+                .body(JSON_PROVIDER_KEY, is(PROVIDER_NAME))
+                .body(JSON_RETURN_URL_KEY, is(RETURN_URL))
+                .body("card_details." + JSON_CARDHOLDER_NAME_KEY, is(cardholderName))
+                .body("card_details.billing_address." + JSON_ADDRESS_LINE_1_KEY, is(line1))
+                .body("card_details.billing_address." + JSON_ADDRESS_LINE_2_KEY, is(nullValue()))
+                .body("card_details.billing_address." + JSON_ADDRESS_POST_CODE_KEY, is(postCode))
+                .body("card_details.billing_address." + JSON_ADDRESS_LINE_CITY, is(nullValue()))
+                .body("card_details.billing_address." + JSON_ADDRESS_LINE_COUNTRY_CODE, is(nullValue()));
+    }
+
+    @Test
     public void shouldReturn201WithNoCardDetailsWhenPrefilledCardHolderDetailsFieldsAreNotPresent() {
         String postBody = toJson(Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiCreateResourceIT.java
@@ -387,39 +387,6 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturn422WhenPrefilledCardHolderDetailsFieldsAreLongerThanMaximum() {
-        String postBody = toJson(Map.of(
-                JSON_AMOUNT_KEY, AMOUNT,
-                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
-                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
-                JSON_RETURN_URL_KEY, RETURN_URL,
-                JSON_PREFILLED_CARDHOLDER_DETAILS_KEY, Map.of(
-                        JSON_CARDHOLDER_NAME_KEY, randomAlphanumeric(256),
-                        JSON_BILLING_ADDRESS_KEY, Map.of(
-                                JSON_ADDRESS_LINE_1_KEY, randomAlphanumeric(256),
-                                JSON_ADDRESS_LINE_2_KEY, randomAlphanumeric(256),
-                                JSON_ADDRESS_LINE_CITY, randomAlphanumeric(256),
-                                JSON_ADDRESS_POST_CODE_KEY, randomAlphanumeric(26),
-                                JSON_ADDRESS_LINE_COUNTRY_CODE, randomAlphanumeric(3)
-                        )
-                )
-        ));
-
-        connectorRestApiClient.postCreateCharge(postBody)
-                .statusCode(422)
-                .contentType(JSON)
-                .header("Location", is(nullValue()))
-                .body(JSON_CHARGE_KEY, is(nullValue()))
-                .body(JSON_MESSAGE_KEY, containsInAnyOrder(
-                        "Field [line1] can have a size between 0 and 255",
-                        "Field [line2] can have a size between 0 and 255",
-                        "Field [postcode] can have a size between 0 and 25",
-                        "Field [country] can have an exact size of 2",
-                        "Field [city] can have a size between 0 and 255",
-                        "Field [cardholder_name] can have a size between 0 and 255"));
-    }
-
-    @Test
     public void shouldReturn201WhenPrefilledCardHolderDetailsFieldsAreMaximum() {
         String line1 = randomAlphanumeric(255);
         String city = randomAlphanumeric(255);


### PR DESCRIPTION
     The requirements when setting country for an address of a
    `PrefilledCardHolderDetails` is different to when setting the card payment
    details via frontend. It is believed frontend can send 3 character long
    countries representing a territory and which should already have been
    validated, whilst pre-filled could originate from unvalidated user input
    and should set anything that is not a
    3166-1 alpha-2 code to null so that the default GB will be used.
    
    This introduces a new class 'PrefilledAddress'. If the length of the country
    is greater than two then it is dismissed and null used instead; this is
    the behaviour described in our api documentation. This validation can be
    improved upon to look whether the two characters represent a valid
    3166-1 alpha-2 code but to preserve existing logic (where we only check
    for two characters) we will consider that later.
    
    We considered subclassing `Address` and modifying the behavior for `country`
    but since the valdiation using
    `Address` from Frontend does not use javax.validation we decided to
    create a new class so that it is clear the validation annotations do not
    apply in all cases; also there was some debate whether an address for
    prefilled and non-prefilled are strictly an is-a relationship.
