### PR TITLE
PP-5402 Bug Fix Nested Metadata

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -754,22 +754,10 @@ public class ChargeService {
         telephoneJSON.put("authorised_date", telephoneChargeRequest.getAuthorisedDate());
         telephoneJSON.put("processor_id", telephoneChargeRequest.getProcessorId());
         telephoneJSON.put("auth_code", telephoneChargeRequest.getAuthCode());
-        
-        HashMap<String, Object> paymentOutcome = new HashMap<>();
-        paymentOutcome.put("status", telephoneChargeRequest.getPaymentOutcome().getStatus());
-        
-        if(telephoneChargeRequest.getPaymentOutcome().getCode() != null) {
-            paymentOutcome.put("code", telephoneChargeRequest.getPaymentOutcome().getCode());
-        }
-
-        if(telephoneChargeRequest.getPaymentOutcome().getSupplemental() != null) {
-            HashMap<String, Object> supplemental = new HashMap<>();
-            supplemental.put("error_code", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorCode());
-            supplemental.put("error_message", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorMessage());
-            paymentOutcome.put("supplemental", supplemental);
-        }
-        
-        telephoneJSON.put("payment_outcome", paymentOutcome);
+        telephoneJSON.put("status", telephoneChargeRequest.getPaymentOutcome().getStatus());
+        telephoneJSON.put("code", telephoneChargeRequest.getPaymentOutcome().getCode());
+        telephoneJSON.put("error_code", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorCode());
+        telephoneJSON.put("error_message", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorMessage());
         telephoneJSON.put("telephone_number", telephoneChargeRequest.getTelephoneNumber());
         
         return new ExternalMetadata(telephoneJSON);

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -286,40 +286,34 @@ public class ChargeService {
                 .withChargeId("dummypaymentid123notpersisted");
                 
         chargeEntity.getExternalMetadata().ifPresent(externalMetadata -> {
-
-            final Map<String, Object> paymentOutcomeMap = ((Map) externalMetadata.getMetadata().get("payment_outcome"));
-
+            
             final PaymentOutcome paymentOutcome = new PaymentOutcome(
-                    paymentOutcomeMap.get("status").toString()
+                    externalMetadata.getMetadata().get("status").toString()
             );
+            
+            final Supplemental supplemental = new Supplemental();
             
             ExternalTransactionState state;
             
-            if (paymentOutcomeMap.get("status").toString().equals("success")) {
+            if (externalMetadata.getMetadata().get("status").toString().equals("success")) {
                 state = new ExternalTransactionState(
-                        paymentOutcomeMap.get("status").toString(),
+                        externalMetadata.getMetadata().get("status").toString(),
                         true  
                 );
             } else {
                 state = new ExternalTransactionState(
-                        paymentOutcomeMap.get("status").toString(),
+                        externalMetadata.getMetadata().get("status").toString(),
                         true,
-                        paymentOutcomeMap.get("code").toString(),
+                        externalMetadata.getMetadata().get("code").toString(),
                         "error message"
                 );
-                paymentOutcome.setCode(paymentOutcomeMap.get("code").toString());
+                paymentOutcome.setCode(externalMetadata.getMetadata().get("code").toString());
             }
 
-            if (paymentOutcomeMap.containsKey("supplemental")) {
+            if (externalMetadata.getMetadata().get("error_code") != null || externalMetadata.getMetadata().get("error_message") != null) {
                 paymentOutcome.setSupplemental(new Supplemental(
-                        ((Map) paymentOutcomeMap
-                                .get("supplemental"))
-                                .get("error_code")
-                                .toString(),
-                        ((Map) paymentOutcomeMap
-                                .get("supplemental"))
-                                .get("error_message")
-                                .toString()
+                        (String) externalMetadata.getMetadata().get("error_code"),
+                        (String) externalMetadata.getMetadata().get("error_message")
                 ));
             }
             
@@ -755,10 +749,16 @@ public class ChargeService {
         telephoneJSON.put("processor_id", telephoneChargeRequest.getProcessorId());
         telephoneJSON.put("auth_code", telephoneChargeRequest.getAuthCode());
         telephoneJSON.put("status", telephoneChargeRequest.getPaymentOutcome().getStatus());
-        telephoneJSON.put("code", telephoneChargeRequest.getPaymentOutcome().getCode());
-        telephoneJSON.put("error_code", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorCode());
-        telephoneJSON.put("error_message", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorMessage());
         telephoneJSON.put("telephone_number", telephoneChargeRequest.getTelephoneNumber());
+        
+        if(telephoneChargeRequest.getPaymentOutcome().getCode() != null) {
+            telephoneJSON.put("code", telephoneChargeRequest.getPaymentOutcome().getCode());
+        }
+        
+        if(telephoneChargeRequest.getPaymentOutcome().getSupplemental() != null) {
+            telephoneJSON.put("error_code", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorCode());
+            telephoneJSON.put("error_message", telephoneChargeRequest.getPaymentOutcome().getSupplemental().getErrorMessage());
+        }
         
         return new ExternalMetadata(telephoneJSON);
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -291,8 +291,6 @@ public class ChargeService {
                     externalMetadata.getMetadata().get("status").toString()
             );
             
-            final Supplemental supplemental = new Supplemental();
-            
             ExternalTransactionState state;
             
             if (externalMetadata.getMetadata().get("status").toString().equals("success")) {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -183,14 +183,13 @@ public class ChargeServiceTest {
         
         ExternalMetadata externalMetadata = new ExternalMetadata(
                 Map.of(
-                "created_date", "2018-02-21T16:04:25Z",
-                "authorised_date", "2018-02-21T16:05:33Z",
-                "processor_id", "1PROC",
-                "auth_code", "666",
-                "telephone_number", "+447700900796",
-                "payment_outcome", Map.of(
+                        "created_date", "2018-02-21T16:04:25Z", 
+                        "authorised_date", "2018-02-21T16:05:33Z", 
+                        "processor_id", "1PROC", 
+                        "auth_code", "666", 
+                        "telephone_number", "+447700900796", 
                         "status", "success"
-                ))
+                )
         );
 
         CardDetailsEntity cardDetails = new CardDetailsEntity(
@@ -510,9 +509,7 @@ public class ChargeServiceTest {
                 "processor_id", "1PROC",
                 "auth_code", "666",
                 "telephone_number", "+447700900796",
-                "payment_outcome", Map.of(
-                        "status", "success"
-                ));
+                "status", "success");
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .withPaymentOutcome(paymentOutcome)
@@ -557,14 +554,11 @@ public class ChargeServiceTest {
                 "processor_id", "1PROC",
                 "auth_code", "666",
                 "telephone_number", "+447700900796",
-                "payment_outcome", Map.of(
-                        "status", "failed",
-                        "code", "P0010",
-                        "supplemental", Map.of(
-                                "error_code", "ECKOH01234",
-                                "error_message", "textual message describing error code"
-                        )
-                ));
+                "status", "failed",
+                "code", "P0010",
+                "error_code", "ECKOH01234",
+                "error_message", "textual message describing error code"
+        );
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .withPaymentOutcome(paymentOutcome)
@@ -609,14 +603,11 @@ public class ChargeServiceTest {
                 "processor_id", "1PROC",
                 "auth_code", "666",
                 "telephone_number", "+447700900796",
-                "payment_outcome", Map.of(
-                        "status", "failed",
-                        "code", "P0050",
-                        "supplemental", Map.of(
-                                "error_code", "ECKOH01234",
-                                "error_message", "textual message describing error code"
-                        )
-                ));
+                "status", "failed",
+                "code", "P0010",
+                "error_code", "ECKOH01234",
+                "error_message", "textual message describing error code"
+        );
 
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .withPaymentOutcome(paymentOutcome)

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -604,7 +604,7 @@ public class ChargeServiceTest {
                 "auth_code", "666",
                 "telephone_number", "+447700900796",
                 "status", "failed",
-                "code", "P0010",
+                "code", "P0050",
                 "error_code", "ECKOH01234",
                 "error_message", "textual message describing error code"
         );


### PR DESCRIPTION
## WHAT YOU DID

External metadata should not be storing nested objects. I've refactored populateResponseBuilder and storeExtraFieldsInMetaData to store it as name-value pairs instead. All tests have been appropriately modified.