### PR TITLE
PP-5613 Enforce ExternalMetadata Validation when saving ChargeEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -43,6 +43,7 @@ import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import javax.validation.Valid;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -139,6 +140,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     @Column(name = "external_metadata", columnDefinition = "jsonb")
     @Convert(converter = ExternalMetadataConverter.class)
+    @Valid
     private ExternalMetadata externalMetadata;
 
     @Column(name = "parity_check_status")


### PR DESCRIPTION
We evaluate the `@ValidExternalMetadata` when accepting a create charge
request via an end-point however this is not evaluated when attempting
to persist a `ChargeEntity`. This means it is possible to create an
invalid instance of `ExternalMetadata` within Connector and then persist
it to the charges table. This change adds the `@Valid` annotation to the
`externalMetadata` attribute of `ChargeEntity` so that any JPA actions
to update or persist the entity will evaluate the validation, rolling
back the transaction if it fails.