### PR TITLE
PP-5585 Stripe capture with payment intents

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripePaymentIntent {
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("charges")
+    private ChargesCollection chargesCollection;
+
+    public ChargesCollection getChargesCollection() {
+        return chargesCollection;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class ChargesCollection {
+
+        @JsonProperty("data")
+        private List<StripeCharge> charges;
+
+        public List<StripeCharge> getCharges() {
+            return charges;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequest.java
@@ -8,33 +8,15 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import java.util.Collections;
 import java.util.List;
 
-public class StripeCaptureRequest extends StripeRequest {
-
-    private String stripeChargeId;
-
-    private StripeCaptureRequest(
+public abstract class StripeCaptureRequest extends StripeRequest {
+    protected StripeCaptureRequest(
             GatewayAccountEntity gatewayAccount,
-            String stripeChargeId,
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig
     ) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
-        this.stripeChargeId = stripeChargeId;
     }
     
-    public static StripeCaptureRequest of(CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
-        return new StripeCaptureRequest(
-                request.getGatewayAccount(),
-                request.getTransactionId(),
-                request.getExternalId(),
-                stripeGatewayConfig
-        );
-    }
-
-    protected String urlPath() {
-        return "/v1/charges/" + stripeChargeId + "/capture";
-    }
-
     @Override
     protected List<String> expansionFields() {
         return Collections.singletonList("balance_transaction");

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeChargeCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeChargeCaptureRequest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Collections;
+import java.util.List;
+
+public class StripeChargeCaptureRequest extends StripeCaptureRequest {
+    private final String stripeIdentifier;
+    
+    private StripeChargeCaptureRequest(
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig,
+            String stripeIdentifier
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeIdentifier = stripeIdentifier;
+    }
+    
+    public static StripeCaptureRequest of(CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        
+        
+        return new StripeChargeCaptureRequest(
+                request.getGatewayAccount(),
+                request.getExternalId(),
+                stripeGatewayConfig,
+                request.getTransactionId()
+        );
+    }
+
+    @Override
+    protected String urlPath() {
+        return "/v1/charges/" + stripeIdentifier + "/capture";
+    }
+
+    @Override
+    protected List<String> expansionFields() {
+        return Collections.singletonList("balance_transaction");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCaptureRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentCaptureRequest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Collections;
+import java.util.List;
+
+public class StripePaymentIntentCaptureRequest extends StripeCaptureRequest {
+    private final String stripeIdentifier;
+
+    private StripePaymentIntentCaptureRequest(
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig,
+            String stripeIdentifier
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeIdentifier = stripeIdentifier;
+    }
+
+    public static StripeCaptureRequest of(CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+
+
+        return new StripePaymentIntentCaptureRequest(
+                request.getGatewayAccount(),
+                request.getExternalId(),
+                stripeGatewayConfig,
+                request.getTransactionId()
+        );
+    }
+
+    @Override
+    protected List<String> expansionFields() {
+        return Collections.singletonList("charges.data.balance_transaction");
+    }
+
+    @Override
+    protected String urlPath() {
+        return "/v1/payment_intents/" + stripeIdentifier + "/capture";
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
@@ -56,7 +56,7 @@ public class StripeCaptureRequestTest {
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
 
-        stripeCaptureRequest = StripeCaptureRequest.of(captureGatewayRequest, stripeGatewayConfig);
+        stripeCaptureRequest = StripeChargeCaptureRequest.of(captureGatewayRequest, stripeGatewayConfig);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -127,6 +127,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_3ds_required_response.json";
     public static final String STRIPE_CREATE_3DS_SOURCES_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_3ds_sources_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_capture_success_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE_DESTINATION_CHARGE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response_destination_charge.json";
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
     public static final String STRIPE_ERROR_RESPONSE_GENERAL = TEMPLATE_BASE_NAME + "/stripe/error_response_general.json";

--- a/src/test/resources/templates/stripe/payment_intent_capture_success_response.json
+++ b/src/test/resources/templates/stripe/payment_intent_capture_success_response.json
@@ -1,0 +1,18 @@
+{
+  "id": "pi_1FEy5AEZsufgnuO0f99RWRRn",
+  "object": "payment_intent",
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+      {
+        "id": "ch_123456",
+        "object": "charge",
+        "captured": true,
+        "balance_transaction": {
+          "fee": 50
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
We need to switch over to using Stripe payment intents to process
payments with Stripe, in order to be 3DS2 compliant. In order to
do this in a backwards compatible way we need the capturing with
stripe to work with charges created both via the charges api and
the payment intents api.
This PR uses the fact that stripe namespaces all their ids with
a prefix indicating the resource type (so a payment intent always
has a prefix 'pi_...') so that we can capture the charge
appropriately.
This PR should not affect existing payment flow at all, and will
need to be tested more thoroughly once changes to authorisation
have been implemented.