### PR TITLE
PP-5614 Double time allowed to retry pocessing state transition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/StateTransition.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransition.java
@@ -12,7 +12,7 @@ public abstract class StateTransition implements Delayed {
 
     private static final int MAXIMUM_NUMBER_OF_ATTEMPTS = 10;
     private static final int BASE_ATTEMPTS = 1;
-    private static final long DEFAULT_DELAY_DURATION_IN_MILLISECONDS = 100L;
+    private static final long DEFAULT_DELAY_DURATION_IN_MILLISECONDS = 200L;
 
     public StateTransition(Class stateTransitionEventClass) {
         this(stateTransitionEventClass, BASE_ATTEMPTS, DEFAULT_DELAY_DURATION_IN_MILLISECONDS);


### PR DESCRIPTION
We are seeing very occasional failures to process state transitions e.g. https://govuk.zendesk.com/agent/tickets/3793212

After investigating it seems highly likely this is due to the related transaction failing to complete in time. This PR increases time per retry. The reasoning for increasing time rather than number of attempts is that we are primarily concerned with robustness rather than speed. Increasing time will increase chances of correctness without increasing load on the system.
