### PR TITLE
PP-5605: additional state validation of transaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
@@ -2,5 +2,6 @@ package uk.gov.pay.connector.charge.model.domain;
 
 public enum ParityCheckStatus {
     EXISTS_IN_LEDGER,
-    MISSING_IN_LEDGER
+    MISSING_IN_LEDGER,
+    DATA_MISMATCH
 }

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
@@ -21,6 +21,7 @@ public class LedgerTransaction {
     private Long fee;
     private Long netAmount;
     private String createdDate;
+    private TransactionState state;
 
     public Long getAmount() {
         return amount;
@@ -64,5 +65,13 @@ public class LedgerTransaction {
 
     public String getTransactionId() {
         return transactionId;
+    }
+
+    public TransactionState getState() {
+        return state;
+    }
+
+    public void setState(TransactionState transactionState) {
+        this.state = transactionState;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paritycheck/TransactionState.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/TransactionState.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.paritycheck;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TransactionState {
+    private String status;
+
+    public TransactionState(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -15,4 +15,9 @@ public class LedgerTransactionFixture {
         ledgerTransaction.setState(new TransactionState(status));
         return ledgerTransaction;
     }
+
+    public LedgerTransactionFixture withStatus(String status) {
+        this.status = status;
+        return this;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.paritycheck.LedgerTransaction;
+import uk.gov.pay.connector.paritycheck.TransactionState;
+
+public class LedgerTransactionFixture {
+    private String status = "created";
+
+    public static LedgerTransactionFixture aValidLedgerTransaction() {
+        return new LedgerTransactionFixture();
+    }
+
+    public LedgerTransaction build() {
+        var ledgerTransaction = new LedgerTransaction();
+        ledgerTransaction.setState(new TransactionState(status));
+        return ledgerTransaction;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -20,7 +20,6 @@ import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.pact.ChargeEventEntityFixture;
 import uk.gov.pay.connector.paritycheck.LedgerService;
-import uk.gov.pay.connector.paritycheck.LedgerTransaction;
 import uk.gov.pay.connector.queue.StateTransition;
 import uk.gov.pay.connector.queue.StateTransitionQueue;
 import uk.gov.pay.connector.refund.dao.RefundDao;
@@ -36,6 +35,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -78,7 +78,7 @@ public class ParityCheckWorkerTest {
     public void executeRecordsParityStatusForChargesExistingInLedger() {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(new LedgerTransaction()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
 
         worker.execute(1L, OptionalLong.empty());
 
@@ -93,8 +93,8 @@ public class ParityCheckWorkerTest {
         chargeEntity.getRefunds().add(aValidRefundEntity().build());
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(new LedgerTransaction()));
-        when(ledgerService.getTransaction(chargeEntity.getRefunds().get(0).getExternalId())).thenReturn(Optional.of(new LedgerTransaction()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
+        when(ledgerService.getTransaction(chargeEntity.getRefunds().get(0).getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
 
         worker.execute(1L, OptionalLong.empty());
 


### PR DESCRIPTION
* the parity checker will validate both the existence and state of the transactions (if they exist)

I didn't add logging what's exactly wrong with a transaction - my attempt didn't look good and it gives limited benefit, so I decided to scrap it.