### PR TITLE
Pp 5585 accept payment intent notifications

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
+import uk.gov.pay.connector.gateway.stripe.json.StripePaymentIntent;
 import uk.gov.pay.connector.gateway.stripe.json.StripeSourcesResponse;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
 import uk.gov.pay.connector.paymentprocessor.service.Card3dsResponseAuthService;
@@ -25,6 +26,8 @@ import java.util.Optional;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED;
+import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.PAYMENT_INTENT_PAYMENT_FAILED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_CANCELED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_CHARGEABLE;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_FAILED;
@@ -33,7 +36,16 @@ public class StripeNotificationService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final List<StripeNotificationType> sourceTypes = ImmutableList.of(SOURCE_CANCELED, SOURCE_CHARGEABLE, SOURCE_FAILED);
+    private final List<StripeNotificationType> sourceTypes = ImmutableList.of(
+            SOURCE_CANCELED,
+            SOURCE_CHARGEABLE,
+            SOURCE_FAILED
+    );
+    
+    private final List<StripeNotificationType> paymentIntentTypes = ImmutableList.of(
+            PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED, 
+            PAYMENT_INTENT_PAYMENT_FAILED
+    );
     private final List<ChargeStatus> threeDSAuthorisableStates = ImmutableList.of(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_3DS_READY);
 
     private final ChargeService chargeService;
@@ -72,6 +84,53 @@ public class StripeNotificationService {
 
         if (isASourceNotification(notification)) {
             processSourceNotification(notification);
+        } else if (isAPaymentIntentNotification(notification)) {
+            processPaymentIntentNotification(notification);
+        }
+    }
+
+    private void processPaymentIntentNotification(StripeNotification notification) {
+        try {
+            StripePaymentIntent paymentIntent = toPaymentIntent(notification.getObject());
+
+            if (isBlank(paymentIntent.getId())) {
+                logger.error("{} payment intent notification [{}] failed verification because it has no transaction ID", PAYMENT_GATEWAY_NAME, notification);
+                return;
+            }
+            
+            Optional<ChargeEntity> maybeCharge = chargeService.findByProviderAndTransactionId(PAYMENT_GATEWAY_NAME, paymentIntent.getId());
+
+            if (!maybeCharge.isPresent()) {
+                logger.error("{} notification for payment intent [{}] could not be verified (associated charge entity not found)",
+                        PAYMENT_GATEWAY_NAME, paymentIntent.getId());
+                return;
+            }
+
+            ChargeEntity charge = maybeCharge.get();
+
+
+            if (PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED.getType().equals(notification.getType()) &&
+                    !paymentIntent.getAmountCapturable().equals(charge.getAmount())) {
+                logger.error("{} notification for payment intent [{}] does not have amount capturable equal to original charge {}",
+                        PAYMENT_GATEWAY_NAME, paymentIntent.getId(), charge.getExternalId());
+                return;
+            }
+
+
+            if (isChargeIn3DSRequiredOrReadyState(ChargeStatus.fromString(charge.getStatus()))) {
+                executePost3DSAuthorisation(charge, notification.getType());
+            }
+
+        } catch (StripeParseException e) {
+            logger.error("{} notification parsing for payment intent object failed: {}", PAYMENT_GATEWAY_NAME, e);
+        }
+    }
+
+    private StripePaymentIntent toPaymentIntent(String payload) throws StripeParseException {
+        try {
+            return objectMapper.readValue(payload, StripePaymentIntent.class);
+        } catch (Exception e) {
+            throw new StripeParseException(e.getMessage());
         }
     }
 
@@ -101,7 +160,7 @@ public class StripeNotificationService {
             ChargeEntity charge = maybeCharge.get();
 
             if (isChargeIn3DSRequiredOrReadyState(ChargeStatus.fromString(charge.getStatus()))) {
-                authorise3DSSource(charge, notification.getType());
+                executePost3DSAuthorisation(charge, notification.getType());
             }
 
         } catch (StripeParseException e) {
@@ -109,7 +168,7 @@ public class StripeNotificationService {
         }
     }
 
-    private void authorise3DSSource(ChargeEntity charge, String notificationEventType) {
+    private void executePost3DSAuthorisation(ChargeEntity charge, String notificationEventType) {
         try {
             final StripeNotificationType type = StripeNotificationType.byType(notificationEventType);
 
@@ -126,14 +185,20 @@ public class StripeNotificationService {
     private boolean isASourceNotification(StripeNotification notification) {
         return sourceTypes.contains(StripeNotificationType.byType(notification.getType()));
     }
+    
+    private boolean isAPaymentIntentNotification(StripeNotification notification) {
+        return paymentIntentTypes.contains(StripeNotificationType.byType(notification.getType()));
+    }
 
     private String getMappedAuth3dsResult(StripeNotificationType type) {
         switch (type) {
             case SOURCE_CHARGEABLE:
+            case PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED:
                 return Auth3dsDetails.Auth3dsResult.AUTHORISED.toString();
             case SOURCE_CANCELED:
                 return Auth3dsDetails.Auth3dsResult.CANCELED.toString();
             case SOURCE_FAILED:
+            case PAYMENT_INTENT_PAYMENT_FAILED:
                 return Auth3dsDetails.Auth3dsResult.DECLINED.toString();
             default:
                 return Auth3dsDetails.Auth3dsResult.ERROR.toString();

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
@@ -7,6 +7,8 @@ public enum StripeNotificationType {
     SOURCE_CANCELED("source.canceled"),
     SOURCE_CHARGEABLE("source.chargeable"),
     SOURCE_FAILED("source.failed"),
+    PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED("payment_intent.amount_capturable_updated"),
+    PAYMENT_INTENT_PAYMENT_FAILED("payment_intent.payment_failed"),
     UNKNOWN("");
 
     private final String type;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -109,6 +109,9 @@ public class StripePaymentProvider implements PaymentProvider {
                 case DECLINED:
                     return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED);
                 case AUTHORISED:
+                    if (request.getTransactionId().get().startsWith("pi_")) {
+                        return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
+                    }
                     return authorise3DSSource(request);
             }
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
@@ -12,9 +12,20 @@ public class StripePaymentIntent {
     
     @JsonProperty("charges")
     private ChargesCollection chargesCollection;
+    
+    @JsonProperty("amount_capturable")
+    private Long amountCapturable;
 
     public ChargesCollection getChargesCollection() {
         return chargesCollection;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public Long getAmountCapturable() {
+        return amountCapturable;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Map;
+
+public class StripePaymentIntentRequest extends StripeRequest {
+
+    private final String amount;
+    private final String paymentMethodId;
+
+    private StripePaymentIntentRequest(
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig,
+            String amount,
+            String paymentMethodId
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.amount = amount;
+        this.paymentMethodId = paymentMethodId;
+    }
+
+    public static StripePaymentIntentRequest of(
+            CardAuthorisationGatewayRequest request,
+            String paymentMethodId,
+            StripeGatewayConfig stripeGatewayConfig
+    ) {
+        return new StripePaymentIntentRequest(
+                request.getGatewayAccount(),
+                request.getChargeExternalId(),
+                stripeGatewayConfig,
+                request.getAmount(),
+                paymentMethodId
+        );
+    }
+
+
+    @Override
+    protected String urlPath() {
+        return "/v1/payment_intents";
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return OrderRequestType.AUTHORISE;
+    }
+
+    @Override
+    protected Map<String, String> params() {
+        return Map.of(
+                "payment_method", paymentMethodId,
+                "amount", amount,
+                "confirmation_method", "automatic",
+                "capture_method", "manual",
+                "currency", "GBP");
+    }
+
+    @Override
+    protected String idempotencyKeyType() {
+        return "payment_intent";
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
@@ -55,7 +55,7 @@ public abstract class StripeRequest implements GatewayClientRequest {
 
     public final Map<String, String> getHeaders() {
         Map<String, String> result = new HashMap<>(Map.copyOf(headers()));
-        Optional.ofNullable(idempotencyKey).ifPresent(idempotencyKey -> result.put("Idempotency-Key", getIdempotencyKeyType() + idempotencyKey));
+        Optional.ofNullable(idempotencyKey).ifPresent(idempotencyKey -> result.put("Idempotency-Key", idempotencyKeyType() + idempotencyKey));
         result.putAll(AuthUtil.getStripeAuthHeader(stripeGatewayConfig, gatewayAccount.isLive()));
 
         return result;
@@ -89,7 +89,7 @@ public abstract class StripeRequest implements GatewayClientRequest {
         return Collections.emptyList();
     }
     
-    protected  String getIdempotencyKeyType() {
+    protected  String idempotencyKeyType() {
         return orderRequestType().toString();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -58,7 +58,7 @@ public class StripeTransferInRequest extends StripeTransferRequest {
     }
 
     @Override
-    protected String getIdempotencyKeyType() {
+    protected String idempotencyKeyType() {
         return "transfer_in";
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -44,7 +44,7 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
     }
 
     @Override
-    protected String getIdempotencyKeyType() {
+    protected String idempotencyKeyType() {
         return "transfer_out";
     }
     

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -139,6 +139,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_TRANSFER_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/transfer_success_response.json";
 
     public static final String STRIPE_NOTIFICATION_3DS_SOURCE = TEMPLATE_BASE_NAME + "/stripe/notification_3ds_source.json";
+    public static final String STRIPE_NOTIFICATION_PAYMENT_INTENT = TEMPLATE_BASE_NAME + "/stripe/notification_payment_intent.json";
 
     public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.xml";
     public static final String SQS_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/error-response.xml";

--- a/src/test/resources/templates/stripe/notification_3ds_source.json
+++ b/src/test/resources/templates/stripe/notification_3ds_source.json
@@ -4,7 +4,7 @@
   "created": 1543339552,
   "data": {
     "object": {
-      "id": "{{sourceId}}",
+      "id": "{{id}}",
       "object": "source",
       "amount": 1000,
       "client_secret": "src_client_secret_E3GrK9qEhos6IcVNoQ2iaHt6",

--- a/src/test/resources/templates/stripe/notification_payment_intent.json
+++ b/src/test/resources/templates/stripe/notification_payment_intent.json
@@ -1,0 +1,31 @@
+{
+  "id": "evt_1FF3RvEZsufgnuO0tnyTrqsL",
+  "type": "{{type}}",
+  "object": "event",
+  "api_version": "2019-02-19",
+  "created": 1567622603,
+  "data": {
+    "object": {
+      "id": "{{id}}",
+      "object": "payment_intent",
+      "amount": 1000,
+      "amount_capturable": 1000,
+      "amount_received": 0,
+      "application": null,
+      "application_fee_amount": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "manual",
+      "charges": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ch_1FF3RuEZsufgnuO0IPT8CY3o",
+            "object": "charge",
+            "amount": 1000
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
   This PR modifies the StripeNotificationService to accept 2 new Stripe
    notifications
    `payment_intent.amount_capturable_updated`- https://stripe.com/docs/api/events/types#event_types-payment_intent.amount_capturable_updated
    `payment_intent.payment_failed` - https://stripe.com/docs/api/events/types#event_types-payment_intent.payment_failed

   If we receive a `amount_capturable_updated` notification we check whether
   the amount capturable matches the amount of the charge, and then
   set the the charge to authorised using the existing `authorise3dsResponse` method
   on the StripePaymentProvider. As with capture, I use the structure of
   Stripe ids to decide whether to process as a payment intent or the old
   way.    
   If we receive a `payment_failed` event then the charge is moved to
   `AUTHORISATION DECLINED`, similarly to how we currently process
   the `source_failed` event.    
   These changes do not look very DRY, but we only need to process both
   source notifications and payment intent notifications for the period
   in which we're releasing this change, after which the source
   notification handling code will be deleted, so for that reason have
   kept two paths quite distinct.