### PR TITLE
PP-5402 Replaces default error message with external charge state

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -771,7 +771,7 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getChargeId(), is("dummypaymentid123notpersisted"));
         assertThat(chargeResponse.getState().getStatus(), is("failed"));
         assertThat(chargeResponse.getState().isFinished(), is(true));
-        assertThat(chargeResponse.getState().getMessage(), is("error message"));
+        assertThat(chargeResponse.getState().getMessage(), is("Payment method rejected"));
         assertThat(chargeResponse.getState().getCode(), is("P0010"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
@@ -186,6 +186,43 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
     }
 
     @Test
+    public void createTelephoneChargeForFailedStatusP0030() {
+        postBody.replace("payment_outcome",
+                Map.of(
+                        "status", "failed",
+                        "code", "P0030",
+                        "supplemental", Map.of(
+                                "error_code", "ECKOH01234",
+                                "error_message", "textual message describing error code"
+                        )
+                )
+        );
+
+        connectorRestApiClient
+                .postCreateTelephoneCharge(toJson(postBody))
+                .statusCode(201)
+                .contentType(JSON)
+                .body("amount", isNumber(12000))
+                .body("reference", is("MRPC12345"))
+                .body("description", is("New passport application"))
+                .body("processor_id", is("183f2j8923j8"))
+                .body("provider_id", is("17498-8412u9-1273891239"))
+                .body("payment_outcome.status", is("failed"))
+                .body("payment_outcome.code", is("P0030"))
+                .body("payment_outcome.supplemental.error_code", is("ECKOH01234"))
+                .body("payment_outcome.supplemental.error_message", is("textual message describing error code"))
+                .body("card_details.card_brand", is("master-card"))
+                .body("card_details.expiry_date", is("02/19"))
+                .body("card_details.last_digits_card_number", is("1234"))
+                .body("card_details.first_digits_card_number", is("123456"))
+                .body("charge_id", is("dummypaymentid123notpersisted"))
+                .body("state.status", is("failed"))
+                .body("state.code", is("P0030"))
+                .body("state.finished", is(true))
+                .body("state.message", is("Payment was cancelled by the user"));
+    }
+
+    @Test
     public void shouldReturnResponseForAlreadyExistingTelephoneCharge() {
         connectorRestApiClient
                 .postCreateTelephoneCharge(toJson(postBody))

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
@@ -145,7 +145,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("state.status", is("failed"))
                 .body("state.code", is("P0010"))
                 .body("state.finished", is(true))
-                .body("state.message", is("error message"));
+                .body("state.message", is("Payment method rejected"));
     }
 
     @Test
@@ -182,7 +182,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("state.status", is("failed"))
                 .body("state.code", is("P0050"))
                 .body("state.finished", is(true))
-                .body("state.message", is("error message"));
+                .body("state.message", is("Payment provider returned an error"));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
At the moment we return a dummy value of "error message" for state.message when payment_outcome.code is one of P0010, P0030, P0050. This PR returns the relevant messages associated with these error codes from ExternalChargeState.

## How to test

ChargeServiceTest and ChargesApiTelephonePaymentResourceIT