### PR TITLE
PP-5402 Truncate fields stored in external metadata over 50 characters

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -164,7 +164,7 @@ public class ChargeService {
                     telephoneChargeRequest.getProviderId(),
                     SupportedLanguage.ENGLISH
             );
-
+            
             chargeDao.persist(chargeEntity);
             return chargeEntity;
         });
@@ -744,18 +744,24 @@ public class ChargeService {
 
     private ExternalMetadata storeExtraFieldsInMetaData(TelephoneChargeCreateRequest telephoneChargeRequest) {
         HashMap<String, Object> telephoneJSON = new HashMap<>();
-        telephoneJSON.put("processor_id", telephoneChargeRequest.getProcessorId());
+        telephoneJSON.put("processor_id", telephoneChargeRequest.getProcessorId().substring(0, Math.min(telephoneChargeRequest.getProcessorId().length(), 50)));
         telephoneJSON.put("status", telephoneChargeRequest.getPaymentOutcome().getStatus());
-
         telephoneChargeRequest.getCreatedDate().ifPresent(createdDate -> telephoneJSON.put("created_date", createdDate));
         telephoneChargeRequest.getAuthorisedDate().ifPresent(authorisedDate -> telephoneJSON.put("authorised_date", authorisedDate));
-        telephoneChargeRequest.getAuthCode().ifPresent(authCode -> telephoneJSON.put("auth_code", authCode));
-        telephoneChargeRequest.getTelephoneNumber().ifPresent(telephoneNumber -> telephoneJSON.put("telephone_number", telephoneNumber));
-        telephoneChargeRequest.getPaymentOutcome().getCode().ifPresent(code -> telephoneJSON.put("code", code));
+        telephoneChargeRequest.getAuthCode().ifPresent(authCode -> telephoneJSON.put("auth_code", authCode.substring(0, Math.min(authCode.length(), 50))));
+        telephoneChargeRequest.getTelephoneNumber().ifPresent(telephoneNumber -> telephoneJSON.put("telephone_number", telephoneNumber.substring(0, Math.min(telephoneNumber.length(), 50))));
+        telephoneChargeRequest.getPaymentOutcome().getCode().ifPresent(code -> telephoneJSON.put("code", code.substring(0, Math.min(code.length(), 50))));
         telephoneChargeRequest.getPaymentOutcome().getSupplemental().ifPresent(
                 supplemental -> {
-                    supplemental.getErrorCode().ifPresent(errorCode -> telephoneJSON.put("error_code", errorCode));
-                    supplemental.getErrorMessage().ifPresent(errorMessage -> telephoneJSON.put("error_message", errorMessage));
+                    supplemental.getErrorCode().ifPresent(errorCode -> telephoneJSON.put("error_code", errorCode.substring(0, Math.min(errorCode.length(), 50))));
+                    supplemental.getErrorMessage().ifPresent(errorMessage -> {
+                        
+                        if(errorMessage.length() > 50) {
+                            logger.info("Telephone payment error message - processor_id {} is longer than 50 characters and has been truncated and stored. Actual value is {}", telephoneChargeRequest.getProcessorId(), errorMessage);
+                        }
+                        
+                        telephoneJSON.put("error_message", errorMessage.substring(0, Math.min(errorMessage.length(), 50)));
+                    });
                 }
         );
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -744,28 +744,30 @@ public class ChargeService {
 
     private ExternalMetadata storeExtraFieldsInMetaData(TelephoneChargeCreateRequest telephoneChargeRequest) {
         HashMap<String, Object> telephoneJSON = new HashMap<>();
-        telephoneJSON.put("processor_id", telephoneChargeRequest.getProcessorId().substring(0, Math.min(telephoneChargeRequest.getProcessorId().length(), 50)));
+        String processorId = telephoneChargeRequest.getProcessorId();
+        telephoneJSON.put("processor_id", checkAndGetTruncatedValue(processorId, "processor_id", processorId));
         telephoneJSON.put("status", telephoneChargeRequest.getPaymentOutcome().getStatus());
         telephoneChargeRequest.getCreatedDate().ifPresent(createdDate -> telephoneJSON.put("created_date", createdDate));
         telephoneChargeRequest.getAuthorisedDate().ifPresent(authorisedDate -> telephoneJSON.put("authorised_date", authorisedDate));
-        telephoneChargeRequest.getAuthCode().ifPresent(authCode -> telephoneJSON.put("auth_code", authCode.substring(0, Math.min(authCode.length(), 50))));
-        telephoneChargeRequest.getTelephoneNumber().ifPresent(telephoneNumber -> telephoneJSON.put("telephone_number", telephoneNumber.substring(0, Math.min(telephoneNumber.length(), 50))));
-        telephoneChargeRequest.getPaymentOutcome().getCode().ifPresent(code -> telephoneJSON.put("code", code.substring(0, Math.min(code.length(), 50))));
+        telephoneChargeRequest.getAuthCode().ifPresent(authCode -> telephoneJSON.put("auth_code", checkAndGetTruncatedValue(processorId, "auth_code", authCode)));
+        telephoneChargeRequest.getTelephoneNumber().ifPresent(telephoneNumber -> telephoneJSON.put("telephone_number", checkAndGetTruncatedValue(processorId, "telephone_number", telephoneNumber)));
+        telephoneChargeRequest.getPaymentOutcome().getCode().ifPresent(code -> telephoneJSON.put("code", code));
         telephoneChargeRequest.getPaymentOutcome().getSupplemental().ifPresent(
                 supplemental -> {
-                    supplemental.getErrorCode().ifPresent(errorCode -> telephoneJSON.put("error_code", errorCode.substring(0, Math.min(errorCode.length(), 50))));
-                    supplemental.getErrorMessage().ifPresent(errorMessage -> {
-                        
-                        if(errorMessage.length() > 50) {
-                            logger.info("Telephone payment error message - processor_id {} is longer than 50 characters and has been truncated and stored. Actual value is {}", telephoneChargeRequest.getProcessorId(), errorMessage);
-                        }
-                        
-                        telephoneJSON.put("error_message", errorMessage.substring(0, Math.min(errorMessage.length(), 50)));
-                    });
+                    supplemental.getErrorCode().ifPresent(errorCode -> telephoneJSON.put("error_code", checkAndGetTruncatedValue(processorId, "error_code", errorCode)));
+                    supplemental.getErrorMessage().ifPresent(errorMessage -> telephoneJSON.put("error_message", checkAndGetTruncatedValue(processorId, "error_message", errorMessage)));
                 }
         );
 
         return new ExternalMetadata(telephoneJSON);
+    }
+    
+    private String checkAndGetTruncatedValue(String processorId, String field, String value) {
+        if (value.length() > 50) {
+            logger.info("Telephone payment {} - {} field is longer than 50 characters and has been truncated and stored. Actual value is {}", processorId, field, value);
+            return value.substring(0, 50);
+        }
+        return value;
     }
 
     private void checkIfZeroAmountAllowed(Long amount, GatewayAccountEntity gatewayAccount) {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.charge.service;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang.StringUtils;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -58,6 +59,7 @@ import uk.gov.pay.connector.wallets.WalletType;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.List;
@@ -645,7 +647,116 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
+    
+    @Test
+    public void shouldCreateATelephoneChargeAndTruncateMetaDataOver50Characters() {
+        String stringGreaterThan50 = StringUtils.repeat("*", 51);
+        String stringOf50 = StringUtils.repeat("*", 50);
 
+        Supplemental supplemental = new Supplemental(stringGreaterThan50, stringGreaterThan50);
+        PaymentOutcome paymentOutcome = new PaymentOutcome("failed", "P0050", supplemental);
+
+        Map<String, Object> metadata = Map.of(
+                "created_date", "2018-02-21T16:04:25Z",
+                "authorised_date", "2018-02-21T16:05:33Z",
+                "processor_id", stringOf50,
+                "auth_code", stringOf50,
+                "telephone_number", stringOf50,
+                "status", "failed",
+                "code", "P0050",
+                "error_code", stringOf50,
+                "error_message", stringOf50
+        );
+
+        TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
+                .withPaymentOutcome(paymentOutcome)
+                .withProcessorId(stringGreaterThan50)
+                .withAuthCode(stringGreaterThan50)
+                .withTelephoneNumber(stringGreaterThan50)
+                .build();
+
+        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+
+        ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
+        assertThat(createdChargeEntity.getId(), is(CHARGE_ENTITY_ID));
+
+        assertThat(createdChargeEntity.getGatewayAccount().getId(), is(GATEWAY_ACCOUNT_ID));
+        assertThat(createdChargeEntity.getExternalId(), is(EXTERNAL_CHARGE_ID[0]));
+        assertThat(createdChargeEntity.getGatewayAccount().getCredentials(), is(emptyMap()));
+        assertThat(createdChargeEntity.getGatewayAccount().getGatewayName(), is("sandbox"));
+        assertThat(createdChargeEntity.getAmount(), is(100L));
+        assertThat(createdChargeEntity.getReference(), is(ServicePaymentReference.of("Some reference")));
+        assertThat(createdChargeEntity.getDescription(), is("Some description"));
+        assertThat(createdChargeEntity.getStatus(), is("AUTHORISATION ERROR"));
+        assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
+        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, ZonedDateTime.now(ZoneId.of("UTC")))));
+        assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
+        assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
+        assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
+        assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
+        assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
+        assertThat(createdChargeEntity.getProviderSessionId(), is("1PROV"));
+        assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
+        assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
+    }
+
+    @Test
+    public void shouldCreateATelephoneChargeAndNotTruncateMetaDataOf50Characters() {
+        String stringOf50 = StringUtils.repeat("*", 50);
+
+        Supplemental supplemental = new Supplemental(stringOf50, stringOf50);
+        PaymentOutcome paymentOutcome = new PaymentOutcome("failed", "P0050", supplemental);
+
+        Map<String, Object> metadata = Map.of(
+                "created_date", "2018-02-21T16:04:25Z",
+                "authorised_date", "2018-02-21T16:05:33Z",
+                "processor_id", stringOf50,
+                "auth_code", stringOf50,
+                "telephone_number", stringOf50,
+                "status", "failed",
+                "code", "P0050",
+                "error_code", stringOf50,
+                "error_message", stringOf50
+        );
+
+        TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
+                .withPaymentOutcome(paymentOutcome)
+                .withProcessorId(stringOf50)
+                .withAuthCode(stringOf50)
+                .withTelephoneNumber(stringOf50)
+                .build();
+
+        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+
+        ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
+        assertThat(createdChargeEntity.getId(), is(CHARGE_ENTITY_ID));
+
+        assertThat(createdChargeEntity.getGatewayAccount().getId(), is(GATEWAY_ACCOUNT_ID));
+        assertThat(createdChargeEntity.getExternalId(), is(EXTERNAL_CHARGE_ID[0]));
+        assertThat(createdChargeEntity.getGatewayAccount().getCredentials(), is(emptyMap()));
+        assertThat(createdChargeEntity.getGatewayAccount().getGatewayName(), is("sandbox"));
+        assertThat(createdChargeEntity.getAmount(), is(100L));
+        assertThat(createdChargeEntity.getReference(), is(ServicePaymentReference.of("Some reference")));
+        assertThat(createdChargeEntity.getDescription(), is("Some description"));
+        assertThat(createdChargeEntity.getStatus(), is("AUTHORISATION ERROR"));
+        assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
+        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, ZonedDateTime.now(ZoneId.of("UTC")))));
+        assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
+        assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
+        assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
+        assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
+        assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
+        assertThat(createdChargeEntity.getProviderSessionId(), is("1PROV"));
+        assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
+        assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
+    }
+    
     @Test
     public void shouldNotFindCharge() {
         PaymentOutcome paymentOutcome = new PaymentOutcome("success");


### PR DESCRIPTION
## WHAT YOU DID
Context for why this PR is needed is found here [PP-5613 Enforce ExternalMetadata Validation when saving ChargeEntity](https://github.com/alphagov/pay-connector/pull/1680). 

This PR modifies storeExtraFieldsInMetaData in ChargeServe to ensure that any fields stored in metadata over 50 characters are truncated to 50. Anything that is 50 characters or below are kept the same.

## How to test

See ChargeServiceTest and ChargesApiTelephonePaymentResourceIT.