### PR TITLE
PP-5585 Refactor stripe cancel

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeChargeCancelRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeChargeCancelRequest.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Map;
+
+public class StripeChargeCancelRequest extends StripeRequest {
+    private final String stripeChargeId;
+    
+    private StripeChargeCancelRequest(GatewayAccountEntity gatewayAccount, String stripeChargeId, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.stripeChargeId = stripeChargeId;
+    }
+
+    public static StripeChargeCancelRequest of(CancelGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeChargeCancelRequest(
+                request.getGatewayAccount(),
+                request.getTransactionId(),
+                request.getExternalChargeId(),
+                stripeGatewayConfig
+        );
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return OrderRequestType.CANCEL;
+    }
+
+    @Override
+    protected Map<String, String> params() {
+        return Map.of("charge", stripeChargeId);
+    }
+
+    protected String urlPath() {
+        return "/v1/refunds";
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -1,64 +1,63 @@
 package uk.gov.pay.connector.gateway.stripe;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.handler.StripeCancelHandler;
+import uk.gov.pay.connector.gateway.stripe.request.StripeChargeCancelRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.util.JsonObjectMapper;
-
-import java.net.URI;
-import java.util.Map;
 
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeCancelHandlerTest {
-
-    private StripeCancelHandler stripeCancelHandler;
-    private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
-
     @Mock
     private GatewayClient client;
     @Mock
     private StripeGatewayConfig stripeGatewayConfig;
+    
+    @InjectMocks
+    private StripeCancelHandler stripeCancelHandler;
+    
+    private ChargeEntity chargeEntity;
 
     @Before
     public void setup() {
-        stripeCancelHandler = new StripeCancelHandler(client, stripeGatewayConfig);
-        when(stripeGatewayConfig.getAuthTokens()).thenReturn(mock(StripeAuthTokens.class));
+        final String transactionId = "ch_1231231123123";
+        chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(buildGatewayAccountEntity())
+                .withTransactionId(transactionId)
+                .withAmount(10000L)
+                .build();
+
     }
 
     @Test
     public void shouldCancelPaymentSuccessfully() throws Exception {
-        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        CancelGatewayRequest request = CancelGatewayRequest.valueOf(charge);
+        CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
         final GatewayResponse<BaseCancelResponse> response = stripeCancelHandler.cancel(request);
         assertThat(response.isSuccessful(), is(true));
     }
@@ -66,10 +65,9 @@ public class StripeCancelHandlerTest {
     @Test
     public void shouldHandle4xxFromStripeGateway() throws Exception {
         GatewayErrorException exception = new GatewayErrorException("Unexpected HTTP status code 402 from gateway", load(STRIPE_ERROR_RESPONSE), SC_BAD_REQUEST);
-        when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(exception);
+        when(client.postRequestFor(any(StripeChargeCancelRequest.class))).thenThrow(exception);
 
-        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        CancelGatewayRequest request = CancelGatewayRequest.valueOf(charge);
+        CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
         assertThat(gatewayResponse.isFailed(), is(true));
@@ -81,10 +79,9 @@ public class StripeCancelHandlerTest {
     @Test
     public void shouldHandle5xxFromStripeGateway() throws Exception {
         GatewayErrorException exception = new GatewayErrorException("Problem with Stripe servers", "stripe server error", SC_SERVICE_UNAVAILABLE);
-        when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(exception);
+        when(client.postRequestFor(any(StripeChargeCancelRequest.class))).thenThrow(exception);
 
-        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        CancelGatewayRequest request = CancelGatewayRequest.valueOf(charge);
+        CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
         assertThat(gatewayResponse.isFailed(), is(true));
@@ -96,12 +93,21 @@ public class StripeCancelHandlerTest {
     @Test
     public void shouldHandleGatewayException() throws Exception {
         GatewayConnectionTimeoutException gatewayException = new GatewayConnectionTimeoutException("couldn't connect to https://stripe.url");
-        when(client.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), any(Map.class))).thenThrow(gatewayException);
+        when(client.postRequestFor(any(StripeChargeCancelRequest.class))).thenThrow(gatewayException);
 
-        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity().build();
-        CancelGatewayRequest request = CancelGatewayRequest.valueOf(charge);
+        CancelGatewayRequest request = CancelGatewayRequest.valueOf(chargeEntity);
 
         final GatewayResponse<BaseCancelResponse> gatewayResponse = stripeCancelHandler.cancel(request);
         assertThat(gatewayResponse.isFailed(), is(true));
+    }
+
+    private GatewayAccountEntity buildGatewayAccountEntity() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("stripe");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
     }
 }


### PR DESCRIPTION
Change stripe cancel to use Stripe*Request pattern. This will make it easier to change to handle cancelling payment intents.
