### PR TITLE
PP-5619 Add `used` to `TokenEntity`

### DIFF
--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
@@ -40,6 +40,9 @@ public class TokenEntity extends AbstractVersionedEntity {
     @JoinColumn(name = "charge_id", nullable = false)
     private ChargeEntity chargeEntity;
 
+    @Column(name = "used")
+    private boolean used;
+
     public TokenEntity() {
         // for JPA
     }
@@ -49,7 +52,8 @@ public class TokenEntity extends AbstractVersionedEntity {
         tokenEntity.setChargeEntity(chargeEntity);
         tokenEntity.setCreatedDate(chargeEntity.getCreatedDate());
         tokenEntity.setToken(UUID.randomUUID().toString());
-        
+        tokenEntity.setUsed(false);
+
         return tokenEntity;
     }
 
@@ -83,5 +87,13 @@ public class TokenEntity extends AbstractVersionedEntity {
 
     public void setChargeEntity(ChargeEntity chargeEntity) {
         this.chargeEntity = chargeEntity;
+    }
+
+    public boolean isUsed() {
+        return used;
+    }
+
+    public void setUsed(boolean used) {
+        this.used = used;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -503,6 +503,7 @@ public class ChargeServiceTest {
         TokenEntity tokenEntity = tokenEntityArgumentCaptor.getValue();
         assertThat(tokenEntity.getChargeEntity().getId(), is(CHARGE_ENTITY_ID));
         assertThat(tokenEntity.getToken(), is(notNullValue()));
+        assertThat(tokenEntity.isUsed(), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
@@ -70,6 +70,7 @@ public class TokenDaoJpaIT extends DaoITestBase {
         tokenEntity.setId(nextLong());
         tokenEntity.setToken(tokenId);
         tokenEntity.setChargeEntity(chargeEntity);
+        tokenEntity.setUsed(false);
         tokenDao.persist(tokenEntity);
 
         Optional<TokenEntity> tokenOptional = tokenDao.findByChargeId(defaultTestCharge.getChargeId());
@@ -81,6 +82,7 @@ public class TokenDaoJpaIT extends DaoITestBase {
         assertThat(token.getId(), is(notNullValue()));
         assertThat(token.getToken(), is(tokenId));
         assertThat(token.getChargeEntity().getId(), is(defaultTestCharge.getChargeId()));
+        assertThat(token.isUsed(), is(false));
     }
 
     @Test
@@ -90,7 +92,7 @@ public class TokenDaoJpaIT extends DaoITestBase {
     }
 
     @Test
-    public void findByTokenId_shouldFindToken() {
+    public void findByTokenId_shouldFindUnusedToken() {
 
         String tokenId = "qwerty";
         databaseTestHelper.addToken(defaultTestCharge.getChargeId(), tokenId);
@@ -100,6 +102,21 @@ public class TokenDaoJpaIT extends DaoITestBase {
         assertThat(entity.getId(), is(notNullValue()));
         assertThat(entity.getChargeEntity().getId(), is(defaultTestCharge.getChargeId()));
         assertThat(entity.getToken(), is(tokenId));
+        assertThat(entity.isUsed(), is(false));
+    }
+
+    @Test
+    public void findByTokenId_shouldFindUsedToken() {
+
+        String tokenId = "qwerty";
+        databaseTestHelper.addToken(defaultTestCharge.getChargeId(), tokenId, true);
+
+        TokenEntity entity = tokenDao.findByTokenId(tokenId).get();
+
+        assertThat(entity.getId(), is(notNullValue()));
+        assertThat(entity.getChargeEntity().getId(), is(defaultTestCharge.getChargeId()));
+        assertThat(entity.getToken(), is(tokenId));
+        assertThat(entity.isUsed(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -400,11 +400,16 @@ public class DatabaseTestHelper {
     }
 
     public void addToken(Long chargeId, String tokenId) {
+        addToken(chargeId, tokenId, false);
+    }
+
+    public void addToken(Long chargeId, String tokenId, boolean used) {
         jdbi.withHandle(handle ->
                 handle
-                        .createStatement("INSERT INTO tokens(charge_id, secure_redirect_token) VALUES (:charge_id, :secure_redirect_token)")
+                        .createStatement("INSERT INTO tokens(charge_id, secure_redirect_token, used) VALUES (:charge_id, :secure_redirect_token, :used)")
                         .bind("charge_id", chargeId)
                         .bind("secure_redirect_token", tokenId)
+                        .bind("used", used)
                         .execute()
         );
     }


### PR DESCRIPTION
     PP-5619 Add `used` to `TokenEntity`
    
    `used` is set to `false` when creating new tokens. Update tests to
    check.
    
    We use a primitive boolean for the field in the `TokenEntity`. When JPA loads
    an existing token from the databse with a null value in the `used` column, this
    will get mapped to `false` (we have tested this), which is what we want.
    
    with @AlexBishop1
