### PR TITLE
Pp 5619 only return unused tokens

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -66,7 +66,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
     }
 
     public Optional<ChargeEntity> findByTokenId(String tokenId) {
-        String query = "SELECT te.chargeEntity FROM TokenEntity te WHERE te.token=:tokenId";
+        String query = "SELECT te.chargeEntity FROM TokenEntity te WHERE te.token=:tokenId AND te.used=false";
 
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)

--- a/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
+++ b/src/main/java/uk/gov/pay/connector/token/dao/TokenDao.java
@@ -26,14 +26,6 @@ public class TokenDao extends JpaDao<TokenEntity> {
                 .findFirst();
     }
 
-    public Optional<TokenEntity> findByChargeId(Long chargeId) {
-        return entityManager.get()
-                .createQuery("SELECT t FROM TokenEntity t WHERE t.chargeEntity.id = :chargeId", TokenEntity.class)
-                .setParameter("chargeId", chargeId)
-                .getResultList().stream()
-                .findFirst();
-    }
-    
     public int deleteTokensOlderThanSpecifiedDate(ZonedDateTime cutOffDate) {
         return entityManager.get()
                 .createQuery("DELETE FROM TokenEntity t WHERE t.createdDate < :cutOffDate", TokenEntity.class)

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -1304,7 +1304,7 @@ public class ChargeDaoIT extends DaoITestBase {
     }
 
     @Test
-    public void testFindChargeByTokenId() {
+    public void testFindChargeByUnusedTokenId() {
         TestCharge charge = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -1323,6 +1323,20 @@ public class ChargeDaoIT extends DaoITestBase {
 
         assertThat(chargeOpt.get().getGatewayAccount(), is(notNullValue()));
         assertThat(chargeOpt.get().getGatewayAccount().getId(), is(defaultTestAccount.getAccountId()));
+    }
+
+    @Test
+    public void testFindChargeByUsedTokenId() {
+        TestCharge charge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .insert();
+
+        databaseTestHelper.addToken(charge.getChargeId(), "used-token-id", true);
+
+        Optional<ChargeEntity> chargeOpt = chargeDao.findByTokenId("used-token-id");
+        assertTrue(chargeOpt.isEmpty());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
-import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -56,39 +55,6 @@ public class TokenDaoJpaIT extends DaoITestBase {
         tokenDao.persist(tokenEntity);
 
         assertThat(databaseTestHelper.getChargeTokenId(defaultChargeTestEntity.getId()), is(tokenEntity.getToken()));
-    }
-
-    @Test
-    public void findByChargeId_shouldFindToken() {
-
-        String tokenId = "tokenBB2";
-        final Optional<ChargeEntity> maybeCharge = chargeDao.findByExternalId(defaultTestCharge.externalChargeId);
-        assertThat(maybeCharge.isPresent(), is(true));
-        ChargeEntity chargeEntity = maybeCharge.get();
-        
-        TokenEntity tokenEntity = new TokenEntity();
-        tokenEntity.setId(nextLong());
-        tokenEntity.setToken(tokenId);
-        tokenEntity.setChargeEntity(chargeEntity);
-        tokenEntity.setUsed(false);
-        tokenDao.persist(tokenEntity);
-
-        Optional<TokenEntity> tokenOptional = tokenDao.findByChargeId(defaultTestCharge.getChargeId());
-
-        assertThat(tokenOptional.isPresent(), is(true));
-
-        TokenEntity token = tokenOptional.get();
-
-        assertThat(token.getId(), is(notNullValue()));
-        assertThat(token.getToken(), is(tokenId));
-        assertThat(token.getChargeEntity().getId(), is(defaultTestCharge.getChargeId()));
-        assertThat(token.isUsed(), is(false));
-    }
-
-    @Test
-    public void findByChargeId_shouldNotFindToken() {
-        Long noExistingChargeId = 9876512L;
-        assertThat(tokenDao.findByChargeId(noExistingChargeId).isPresent(), is(false));
     }
 
     @Test


### PR DESCRIPTION
    PP-5619 Only return charges for unused tokens
    
    When searching for a charge by token id only return the charge if the
    token is unused.

    Remove the find token by charge id since it was only being used by its
    own tests.

    
    with @AlexBishop1
