### PR TITLE
PP-5619 Add endpoint to get token with used and charge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenResponse.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenResponse.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.token.model.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+
+import java.util.Objects;
+
+public class TokenResponse {
+
+    @JsonProperty("used")
+    private final boolean used;
+
+    @JsonProperty("charge")
+    private final ChargeEntity charge;
+
+    public TokenResponse(boolean used, ChargeEntity charge) {
+        this.used = used;
+        this.charge = Objects.requireNonNull(charge);
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
+++ b/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.token.dao.TokenDao;
+import uk.gov.pay.connector.token.model.domain.TokenResponse;
 import uk.gov.pay.connector.util.ResponseUtil;
 
 import javax.inject.Inject;
@@ -34,6 +35,18 @@ public class SecurityTokensResource {
     public SecurityTokensResource(TokenDao tokenDao, ChargeDao chargeDao) {
         this.tokenDao = tokenDao;
         this.chargeDao = chargeDao;
+    }
+
+    @GET
+    @Path("/v1/frontend/tokens/{chargeTokenId}")
+    @Produces(APPLICATION_JSON)
+    @JsonView(GatewayAccountEntity.Views.FrontendView.class)
+    public Response getToken(@PathParam("chargeTokenId") String chargeTokenId) {
+        logger.debug("get token {}", chargeTokenId);
+        return tokenDao.findByTokenId(chargeTokenId)
+                .map(tokenEntity -> new TokenResponse(tokenEntity.isUsed(), tokenEntity.getChargeEntity()))
+                .map(ResponseUtil::successResponseWithEntity)
+                .orElseGet(() -> notFoundResponse("Token invalid!"));
     }
 
     @GET

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -657,16 +657,22 @@ public class  DatabaseFixtures {
     public class TestToken {
         TestCharge testCharge;
         String secureRedirectToken = "3c9fee80-977a-4da5-a003-4872a8cf95b6";
+        boolean used = false;
 
         public TestToken withCharge(TestCharge testCharge) {
             this.testCharge = testCharge;
             return this;
         }
 
+        public TestToken withUsed(boolean used) {
+            this.used = used;
+            return this;
+        }
+
         public TestToken insert() {
             if (testCharge == null)
                 throw new IllegalStateException("Test Charge must be provided.");
-            databaseTestHelper.addToken(testCharge.getChargeId(), secureRedirectToken);
+            databaseTestHelper.addToken(testCharge.getChargeId(), secureRedirectToken, used);
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -658,7 +658,7 @@ public class  DatabaseFixtures {
         TestCharge testCharge;
         String secureRedirectToken = "3c9fee80-977a-4da5-a003-4872a8cf95b6";
 
-        public TestToken withTestToken(TestCharge testCharge) {
+        public TestToken withCharge(TestCharge testCharge) {
             this.testCharge = testCharge;
             return this;
         }


### PR DESCRIPTION
Add new `/v1/frontend/tokens/TOKEN_ID` endpoint that gives responses like this:

```json
{
  "used": false,
  "charge": {
    "external_id": "ab0defghi1j23k4l5mn678opqr",
    "amount": …
  }
}
```

Also, make `SecurityTokensResourceIT` use fewer private methods (separate commit).