### PR TITLE
PP-5619 Add end-point to mark token as used

### DIFF
--- a/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
+++ b/src/main/java/uk/gov/pay/connector/token/resource/SecurityTokensResource.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.util.ResponseUtil;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -58,6 +59,20 @@ public class SecurityTokensResource {
         Optional<ChargeEntity> chargeOpt = chargeDao.findByTokenId(chargeTokenId);
         return chargeOpt
                 .map(ResponseUtil::successResponseWithEntity)
+                .orElseGet(() -> notFoundResponse("Token invalid!"));
+    }
+
+    @POST
+    @Path("/v1/frontend/tokens/{chargeTokenId}/used")
+    @Produces(APPLICATION_JSON)
+    @Transactional
+    public Response markTokenUsed(@PathParam("chargeTokenId") String chargeTokenId) {
+        logger.debug("mark token used for token {}", chargeTokenId);
+        return tokenDao.findByTokenId(chargeTokenId)
+                .map(tokenEntity -> {
+                    tokenEntity.setUsed(true);
+                    return noContentResponse();
+                })
                 .orElseGet(() -> notFoundResponse("Token invalid!"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang.math.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.postgresql.util.PGobject;
 import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.util.BooleanColumnMapper;
 import org.skife.jdbi.v2.util.StringColumnMapper;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
@@ -256,6 +257,15 @@ public class DatabaseTestHelper {
                 h.createQuery("SELECT secure_redirect_token from tokens WHERE charge_id = :charge_id ORDER BY id DESC")
                         .bind("charge_id", chargeId)
                         .map(StringColumnMapper.INSTANCE)
+                        .first()
+        );
+    }
+
+    public boolean isChargeTokenUsed(String tokenId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("SELECT used FROM tokens WHERE secure_redirect_token = :token_id")
+                        .bind("token_id", tokenId)
+                        .map(BooleanColumnMapper.PRIMITIVE)
                         .first()
         );
     }
@@ -653,6 +663,7 @@ public class DatabaseTestHelper {
     public void truncateAllData() {
         jdbi.withHandle(h -> h.createStatement("TRUNCATE TABLE gateway_accounts CASCADE").execute());
         jdbi.withHandle(h -> h.createStatement("TRUNCATE TABLE emitted_events CASCADE").execute());
+        jdbi.withHandle(h -> h.createStatement("TRUNCATE TABLE tokens").execute());
     }
 
     public Long getChargeIdByExternalId(String externalChargeId) {


### PR DESCRIPTION
Returns no content for successful invocation.

Update:
When truncating the test database after each test include the `tokens` table explicitly
    since it has no fk link to either `gateway_accounts` or
    `emitted_events`. This was likely causing some intermittent failures on
    the `SecurityTokenResourceIT` tests and was preventing `SecurityTokenResourceIT.shouldDeleteToken` passing for this PR.