### PR TITLE
PP-5585 Refund with payment intents

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripePaymentIntent {
@@ -26,6 +27,11 @@ public class StripePaymentIntent {
 
     public Long getAmountCapturable() {
         return amountCapturable;
+    }
+    
+    public Optional<StripeCharge> getCharge() {
+        return chargesCollection.getCharges().stream()
+                .findFirst();
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+public class StripeGetPaymentIntentRequest extends StripeRequest {
+    private final String paymentIntentId;
+    
+    public StripeGetPaymentIntentRequest(
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig,
+            String paymentIntentId
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.paymentIntentId = paymentIntentId;
+    }
+
+    public static GatewayClientRequest of(
+            RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig
+    ) {
+        return new StripeGetPaymentIntentRequest(
+                request.getGatewayAccount(),
+                request.getRefundExternalId(),
+                stripeGatewayConfig,
+                request.getTransactionId()
+        );
+    }
+
+    @Override
+    protected String urlPath() {
+        return "/v1/payment_intents/" + paymentIntentId;
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return OrderRequestType.REFUND;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class StripeRefundRequest extends StripeRequest {
     private final String stripeChargeId;
@@ -23,12 +24,15 @@ public class StripeRefundRequest extends StripeRequest {
         this.amount = amount;
     }
     
-    public static StripeRefundRequest of(RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+    public static StripeRefundRequest of(RefundGatewayRequest request, String stripeChargeId, StripeGatewayConfig stripeGatewayConfig) {
+        String chargeId = Optional.ofNullable(stripeChargeId)
+                .orElse(request.getTransactionId());
+        
         return new StripeRefundRequest(              
                 request.getAmount(),
                 request.getGatewayAccount(),
                 request.getRefundExternalId(),
-                request.getTransactionId(),
+                chargeId,
                 stripeGatewayConfig
         );
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /***
  * Represents a request to transfer an amount from a Stripe Connect account to 
@@ -27,11 +28,14 @@ public class StripeTransferInRequest extends StripeTransferRequest {
         this.transferGroup = transferGroup;
     }
 
-    public static StripeTransferInRequest of(RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+    public static StripeTransferInRequest of(RefundGatewayRequest request, String stripeChargeId, StripeGatewayConfig stripeGatewayConfig) {
+        String chargeId = Optional.ofNullable(stripeChargeId)
+                .orElse(request.getTransactionId());
+        
         return new StripeTransferInRequest(
                 request.getAmount(),
                 request.getGatewayAccount(),
-                request.getTransactionId(),
+                chargeId,
                 request.getRefundExternalId(),
                 request.getChargeExternalId(),
                 stripeGatewayConfig

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -56,7 +56,7 @@ public class StripeRefundRequestTest {
 
         final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
 
-        stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, stripeGatewayConfig);
+        stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, null, stripeGatewayConfig);
     }
     @Test
     public void createsCorrectRefundUrl() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -62,7 +62,7 @@ public class StripeTransferInRequestTest {
 
         final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
 
-        stripeTransferInRequest = StripeTransferInRequest.of(refundGatewayRequest, stripeGatewayConfig);
+        stripeTransferInRequest = StripeTransferInRequest.of(refundGatewayRequest, null, stripeGatewayConfig);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
@@ -107,6 +107,57 @@ public class StripeRefundIT extends ChargingITestBase {
     }
     
     @Test
+    public void stripeRefundOfPaymentIntent() {
+        var paymentIntentCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withAmount(100L)
+                .withTransactionId("pi_charge_transaction_id")
+                .withTestAccount(defaultTestAccount)
+                .withChargeStatus(CAPTURED)
+                .insert();
+        String platformAccountId = "stripe_platform_account_id";
+        String externalChargeId = paymentIntentCharge.getExternalChargeId();
+        long amount = 10L;
+        
+        stripeMockClient.mockGetPaymentIntent(paymentIntentCharge.getTransactionId());
+        stripeMockClient.mockRefund();
+        stripeMockClient.mockTransferSuccess(null);
+
+        ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", paymentIntentCharge.getAmount());
+        String refundPayload = new Gson().toJson(refundData);
+
+        ValidatableResponse response = given().port(testContext.getPort())
+                .body(refundPayload)
+                .accept(ContentType.JSON)
+                .contentType(ContentType.JSON)
+                .post("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds"
+                        .replace("{accountId}", accountId)
+                        .replace("{chargeId}", externalChargeId))
+                .then()
+                .statusCode(ACCEPTED_202);
+
+        List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(paymentIntentCharge.getChargeId());
+        assertThat(refundsFoundByChargeId.size(), is(1));
+        assertThat(refundsFoundByChargeId.get(0).get("status"), is("REFUNDED"));
+
+        String refundId = response.extract().path("refund_id");
+
+        verify(postRequestedFor(urlEqualTo("/v1/payment_intents/" + paymentIntentCharge.getTransactionId())));
+        
+        verify(postRequestedFor(urlEqualTo("/v1/refunds"))
+                .withHeader("Idempotency-Key", equalTo("refund" + refundId))
+                .withRequestBody(containing("charge=ch_123456"))
+                .withRequestBody(containing("amount=" + amount)));
+
+        verify(postRequestedFor(urlEqualTo("/v1/transfers"))
+                .withHeader("Idempotency-Key", equalTo("transfer_in" + refundId))
+                .withHeader("Stripe-Account", equalTo(stripeAccountId))
+                .withRequestBody(containing("transfer_group=" + paymentIntentCharge.getExternalChargeId()))
+                .withRequestBody(containing("destination=" + platformAccountId)));
+    }
+    
+    @Test
     public void stripeRefund_shouldResultInRefundErrorIfRefundFails() {
         String externalChargeId = defaultTestCharge.getExternalChargeId();
         long amount = 10L;

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -26,6 +26,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_FULL_CHARGE_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TRANSFER_RESPONSE;
 
@@ -126,5 +127,10 @@ public class StripeMockClient {
     public void mockTransferFailure() {
         String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE);
         setupResponse(payload, "/v1/transfers", 400);
+    }
+
+    public void mockGetPaymentIntent(String paymentIntentId) {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE);
+        setupResponse(payload, "/v1/payment_intents/" + paymentIntentId, 200);
     }
 }


### PR DESCRIPTION
When using payment intents to track payment, we set the transaction id
of a charge to be the payment intent id. When it comes to refunding
such a charge, Stripe does not offer an API of the form
```
/v1/payment_intents/{paymentIntentId}/refund
```
or similar, so we have to first get the relevant payment intent from Stripe
then refund the associated charge.