### PR TITLE
PP-5605: update version of status that's used to compare with ledger

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
@@ -104,7 +104,7 @@ public class ParityCheckWorker {
 
     private ParityCheckStatus getChargeParityCheckStatus(ChargeEntity charge) {
         var transaction = ledgerService.getTransaction(charge.getExternalId());
-        var externalChargeState = ChargeStatus.fromString(charge.getStatus()).toExternal().getStatus();
+        var externalChargeState = ChargeStatus.fromString(charge.getStatus()).toExternal().getStatusV2();
 
         return getParityCheckStatus(transaction, externalChargeState);
     }

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -85,9 +85,10 @@ public class ParityCheckWorkerTest {
     @Test
     public void executeRecordsParityStatusForChargeAndRefundsExistingInLedger() {
         chargeEntity.getRefunds().add(aValidRefundEntity().build());
+        chargeEntity.setStatus(ChargeStatus.EXPIRED);
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().withStatus("timedout").build()));
         when(ledgerService.getTransaction(chargeEntity.getRefunds().get(0).getExternalId()))
                 .thenReturn(Optional.of(aValidLedgerTransaction().withStatus("submitted").build()));
 


### PR DESCRIPTION
* version always returns v2 status, so that's what should be used when comparing
** update test to replicate the failure behaviour
** update to the status version