### PR TITLE
PP-5587 Record emitted events to DB

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EventService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventService.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.events;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.events.dao.EmittedEventDao;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.queue.QueueException;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+
+public class EventService {
+    private static final Logger logger = LoggerFactory.getLogger(EventService.class);
+
+    private EventQueue eventQueue;
+    private EmittedEventDao emittedEventDao;
+
+    @Inject
+    public EventService(EventQueue eventQueue, EmittedEventDao emittedEventDao) {
+        this.eventQueue = eventQueue;
+        this.emittedEventDao = emittedEventDao;
+    }
+
+    public void emitAndRecordEvent(Event event) {
+        try {
+            eventQueue.emitEvent(event);
+            emittedEventDao.recordEmission(event);
+        } catch (QueueException e) {
+            emittedEventDao.recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp());
+            logger.error("Error emitting {} event: {}", event.getEventType(), e.getMessage());
+        }
+    }
+
+    public void emitAndMarkEventAsEmitted(Event event) throws QueueException {
+        eventQueue.emitEvent(event);
+        emittedEventDao.markEventAsEmitted(event);
+    }
+
+    public void recordOfferedEvent(ResourceType resourceType, String externalId, String eventType, ZonedDateTime eventDate) {
+        emittedEventDao.recordEmission(resourceType, externalId, eventType, eventDate);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
+++ b/src/main/java/uk/gov/pay/connector/events/StateTransitionEmitterProcess.java
@@ -17,19 +17,19 @@ public class StateTransitionEmitterProcess {
 
     private final long STATE_TRANSITION_PROCESS_DELAY_IN_MILLISECONDS = 1000;
     private final StateTransitionQueue stateTransitionQueue;
-    private final EventQueue eventQueue;
     private final EventFactory eventFactory;
+    private EventService eventService;
 
     @Inject
     public StateTransitionEmitterProcess(
             StateTransitionQueue stateTransitionQueue,
-            EventQueue eventQueue,
             EventFactory eventFactory,
-            StateTransitionQueueMetricEmitter stateTransitionQueueMetricEmitter
+            StateTransitionQueueMetricEmitter stateTransitionQueueMetricEmitter,
+            EventService eventService
     ) {
         this.stateTransitionQueue = stateTransitionQueue;
-        this.eventQueue = eventQueue;
         this.eventFactory = eventFactory;
+        this.eventService = eventService;
 
         stateTransitionQueueMetricEmitter.register();
     }
@@ -53,7 +53,7 @@ public class StateTransitionEmitterProcess {
                 eventFactory.createEvents(stateTransition)
                         .forEach(event -> {
                             try {
-                                eventQueue.emitEvent(event);
+                                eventService.emitAndMarkEventAsEmitted(event);
                             } catch (QueueException e) {
                                 handleException(e, stateTransition);
                             }

--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -57,7 +57,7 @@ public abstract class Event {
         return eventTypeForClass(this.getClass());
     }
 
-    static String eventTypeForClass(Class clazz) {
+    public static String eventTypeForClass(Class clazz) {
         return clazz.getSimpleName().replaceAll("([^A-Z0-9]+)([A-Z0-9])", "$1_$2").toUpperCase();
     }
 

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
@@ -1,0 +1,60 @@
+package uk.gov.pay.connector.queue;
+
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.refund.service.RefundStateEventMap;
+
+import javax.inject.Inject;
+
+public class StateTransitionService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private StateTransitionQueue stateTransitionQueue;
+    private EventService eventService;
+
+    @Inject
+    public StateTransitionService(StateTransitionQueue stateTransitionQueue,
+                                  EventService eventService) {
+        this.stateTransitionQueue = stateTransitionQueue;
+        this.eventService = eventService;
+    }
+
+    @Transactional
+    public void offerRefundStateTransition(RefundEntity refundEntity, RefundStatus refundStatus) {
+        Class refundEventClass = RefundStateEventMap.calculateRefundEventClass(refundEntity.getUserExternalId(), refundStatus);
+        RefundStateTransition refundStateTransition = new RefundStateTransition(refundEntity.getExternalId(), refundStatus, refundEventClass);
+        stateTransitionQueue.offer(refundStateTransition);
+
+        eventService.recordOfferedEvent(ResourceType.REFUND,
+                refundEntity.getExternalId(),
+                Event.eventTypeForClass(refundEventClass),
+                null);
+    }
+
+    @Transactional
+    public void offerPaymentStateTransition(String externalId, ChargeStatus fromChargeState, ChargeStatus targetChargeState, ChargeEventEntity chargeEventEntity) {
+        PaymentGatewayStateTransitions.getInstance()
+                .getEventForTransition(fromChargeState, targetChargeState)
+                .ifPresent(eventClass -> {
+                    PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventClass);
+                    stateTransitionQueue.offer(transition);
+                    logger.info("Offered payment state transition to emitter queue [from={}] [to={}] [chargeEventId={}] [chargeId={}]", fromChargeState, targetChargeState, chargeEventEntity.getId(), externalId);
+
+                    eventService.recordOfferedEvent(ResourceType.PAYMENT,
+                            externalId,
+                            Event.eventTypeForClass(eventClass),
+                            chargeEventEntity.getUpdated()
+                    );
+                });
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.events;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.events.dao.EmittedEventDao;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.charge.PaymentCreated;
+import uk.gov.pay.connector.events.model.charge.PaymentEvent;
+import uk.gov.pay.connector.queue.QueueException;
+
+import java.time.ZonedDateTime;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EventServiceTest {
+
+    @Mock
+    EventQueue eventQueue;
+    @Mock
+    EmittedEventDao emittedEventDao;
+
+    @InjectMocks
+    EventService eventService;
+
+    @Test
+    public void emitAndRecordEvent_shouldRecordEmission() throws QueueException {
+        Event event = new PaymentEvent("external-id", ZonedDateTime.now());
+        eventService.emitAndRecordEvent(event);
+
+        verify(emittedEventDao).recordEmission(event);
+        verify(eventQueue).emitEvent(event);
+    }
+
+    @Test
+    public void emitAndRecordEvent_shouldRecordEmissionWithoutEmittedDateForQueueException() throws QueueException {
+        Event event = new PaymentCreated("external-id", null, ZonedDateTime.now());
+        doThrow(QueueException.class).when(eventQueue).emitEvent(event);
+        eventService.emitAndRecordEvent(event);
+
+        verify(eventQueue).emitEvent(event);
+        verify(emittedEventDao, never()).recordEmission(event);
+        verify(emittedEventDao).recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp());
+    }
+
+    @Test
+    public void emitAndMarkEventAsEmitted() throws QueueException {
+        Event event = new PaymentEvent("external-id", ZonedDateTime.now());
+        eventService.emitAndMarkEventAsEmitted(event);
+
+        verify(eventQueue).emitEvent(event);
+        verify(emittedEventDao).markEventAsEmitted(event);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
@@ -17,12 +16,12 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
-import uk.gov.pay.connector.events.EventQueue;
+import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
-import uk.gov.pay.connector.queue.StateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionService;
 import uk.gov.pay.connector.util.AuthUtils;
 
 import java.util.Optional;
@@ -52,16 +51,12 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
-    @Mock
-    private StateTransitionQueue stateTransitionQueue;
-
-    @Mock
-    private EventQueue eventQueue;
-
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
     private ChargeService chargeService;
     private Card3dsResponseAuthService card3dsResponseAuthService;
     private CardExecutorService mockExecutorService = mock(CardExecutorService.class);
+    private EventService mockEventService = mock(EventService.class);;
+    private StateTransitionService mockStateTransitionService = mock(StateTransitionService.class);;
 
     @Before
     public void setUpCardAuthorisationService() {
@@ -72,7 +67,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, stateTransitionQueue, eventQueue);
+                null, mockConfiguration, null, mockStateTransitionService, mockEventService);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);
@@ -197,7 +192,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
             card3dsResponseAuthService.process3DSecureAuthorisation(charge.getExternalId(), AuthUtils.buildAuth3dsDetails());
             fail("Exception not thrown.");
         } catch (OperationAlreadyInProgressRuntimeException e) {
-            ErrorResponse response = (ErrorResponse)e.getResponse().getEntity();
+            ErrorResponse response = (ErrorResponse) e.getResponse().getEntity();
             assertThat(response.getMessages(), contains(format("Authorisation for charge already in progress, %s", charge.getExternalId())));
         }
     }

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.connector.queue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.model.charge.PaymentStarted;
+import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import static java.time.ZonedDateTime.now;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.events.model.ResourceType.PAYMENT;
+import static uk.gov.pay.connector.events.model.ResourceType.REFUND;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StateTransitionServiceTest {
+
+    StateTransitionService stateTransitionService;
+
+    @Mock
+    StateTransitionQueue mockStateTransitionQueue;
+    @Mock
+    EventService mockEventService;
+
+    @Before
+    public void setUp() {
+        stateTransitionService = new StateTransitionService(mockStateTransitionQueue, mockEventService);
+    }
+
+    @Test
+    public void shouldOfferPaymentStateTransitionMessageForAValidStateTransitionIntoNonLockingState() {
+        ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
+        when(chargeEvent.getId()).thenReturn(100L);
+        when(chargeEvent.getUpdated()).thenReturn(now());
+
+        stateTransitionService.offerPaymentStateTransition("external-id", ChargeStatus.CREATED, ENTERING_CARD_DETAILS, chargeEvent);
+        ArgumentCaptor<PaymentStateTransition> paymentStateTransitionArgumentCaptor = ArgumentCaptor.forClass(PaymentStateTransition.class);
+        verify(mockStateTransitionQueue).offer(paymentStateTransitionArgumentCaptor.capture());
+
+        assertThat(paymentStateTransitionArgumentCaptor.getValue().getChargeEventId(), is(100L));
+        assertThat(paymentStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(PaymentStarted.class));
+
+        verify(mockEventService).recordOfferedEvent(PAYMENT, "external-id", "PAYMENT_STARTED", chargeEvent.getUpdated());
+    }
+
+    @Test
+    public void shouldNotOfferStateTransitionMessageForAValidStateTransitionIntoLockingState() {
+        ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
+        stateTransitionService.offerPaymentStateTransition("external-id", ChargeStatus.CREATED, AUTHORISATION_READY, chargeEvent);
+
+        verifyNoMoreInteractions(mockStateTransitionQueue);
+        verifyNoMoreInteractions(mockEventService);
+    }
+
+    @Test
+    public void shouldOfferRefundStateTransitionMessageForAValidStateTransition() {
+        RefundEntity refundEntity = aValidRefundEntity()
+                .withExternalId("external-id")
+                .withStatus(CREATED)
+                .build();
+        
+        stateTransitionService.offerRefundStateTransition(refundEntity, CREATED);
+        
+        ArgumentCaptor<RefundStateTransition> refundStateTransitionArgumentCaptor = ArgumentCaptor.forClass(RefundStateTransition.class);
+        verify(mockStateTransitionQueue).offer(refundStateTransitionArgumentCaptor.capture());
+
+        assertThat(refundStateTransitionArgumentCaptor.getValue().getRefundExternalId(), is(refundEntity.getExternalId()));
+        assertThat(refundStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(RefundCreatedByUser.class));
+
+        verify(mockEventService).recordOfferedEvent(REFUND, "external-id", "REFUND_CREATED_BY_USER", null);
+    }
+}


### PR DESCRIPTION
## WHAT 
- Adds an entry to EmittedEvents table when an event is offered to StateTransitionQueue
- Updates `emitted_date` when event is taken from StateTransitionQueue and is emitted
- Added service `StateTransitionService` which is now resposible for offering events to StateTransitionQueue
- Added service `EventService` that emits event and records into DB as appropriate
- Updated relevant tests and added new tests

This doesn't change the way HistoricalEventEmitter emit and records events.