### PR TITLE
PP-5587 Refactor HistoricalEventEmitter

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EventService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventService.java
@@ -28,7 +28,7 @@ public class EventService {
             emittedEventDao.recordEmission(event);
         } catch (QueueException e) {
             emittedEventDao.recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp());
-            logger.error("Error emitting {} event: {}", event.getEventType(), e.getMessage());
+            logger.error("Failed to emit event {} due to {} [externalId={}]", event.getEventType(), e.getMessage(), event.getResourceExternalId());
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
@@ -57,4 +57,11 @@ public class StateTransitionService {
                     );
                 });
     }
+
+    @Transactional
+    public void offerStateTransition(StateTransition stateTransition, Event event) {
+        stateTransitionQueue.offer(stateTransition);
+        eventService.recordOfferedEvent(event.getResourceType(), event.getResourceExternalId(),
+                event.getEventType(), event.getTimestamp());
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
@@ -10,11 +10,11 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.events.EventQueue;
+import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.paritycheck.LedgerTransaction;
-import uk.gov.pay.connector.queue.StateTransitionQueue;
+import uk.gov.pay.connector.queue.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
@@ -37,12 +37,12 @@ public class ParityCheckWorker {
 
     @Inject
     public ParityCheckWorker(ChargeDao chargeDao, ChargeService chargeService, LedgerService ledgerService, EmittedEventDao emittedEventDao,
-                             StateTransitionQueue stateTransitionQueue, EventQueue eventQueue, RefundDao refundDao) {
+                             StateTransitionService stateTransitionService, EventService eventService, RefundDao refundDao) {
         this.chargeDao = chargeDao;
         this.chargeService = chargeService;
         this.ledgerService = ledgerService;
-        this.historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, stateTransitionQueue, eventQueue,
-                refundDao, shouldForceEmission);
+        this.historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, refundDao, shouldForceEmission,
+                eventService, stateTransitionService);
     }
 
     public void execute(Long startId, OptionalLong maybeMaxId, boolean doNotReprocessValidRecords) {

--- a/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
@@ -36,6 +36,11 @@ public class RefundHistoryEntityFixture {
                 userExternalId, gatewayTransactionId, chargeExternalId, gatewayAccountId);
     }
 
+    public RefundHistoryEntityFixture withExternalId(String externalId) {
+        this.externalId = externalId;
+        return this;
+    }
+    
     public RefundHistoryEntityFixture withStatus(String status) {
         this.status = status;
         return this;


### PR DESCRIPTION
## WHAT YOU DID
- Refactors `HistoricalEventEmitter` to use `StateTransitionService` & `EventService` to offer & emit events
- `emitted_date` won't be set immediately now for emitted events in HistoricalEventEmitter (except when emitting PaymentDetailsEntered event) and is set when event is polled from StateTransitionQueue