### PR TITLE
PP-5585 Switch to authorise using payment intents

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -3,37 +3,57 @@ package uk.gov.pay.connector.gateway.stripe;
 import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeCharge;
+import uk.gov.pay.connector.gateway.stripe.response.StripeParamsFor3ds;
+import uk.gov.pay.connector.gateway.stripe.response.StripePaymentIntentResponse;
 
+import java.util.Objects;
 import java.util.Optional;
-
-import static java.lang.String.format;
 
 public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
 
-    private StripeCharge jsonResponse;
+    private final String transactionId;
+    private final AuthoriseStatus authoriseStatus;
+    private final String redirectUrl;
 
-    public StripeAuthorisationResponse(StripeCharge jsonResponse) {
-        this.jsonResponse = jsonResponse;
+    private StripeAuthorisationResponse(String transactionId, AuthoriseStatus authoriseStatus, String redirectUrl) {
+        if (Objects.isNull(authoriseStatus )) {
+            throw new IllegalArgumentException("Authorise status cannot be null");
+        }
+        this.transactionId = transactionId;
+        this.authoriseStatus = authoriseStatus;
+        this.redirectUrl = redirectUrl;
+    }
+
+    public static StripeAuthorisationResponse of(StripePaymentIntentResponse stripePaymentIntent) {
+        return new StripeAuthorisationResponse(
+                stripePaymentIntent.getId(),
+                stripePaymentIntent.getAuthoriseStatus().orElse(null),
+                stripePaymentIntent.getRedirectUrl().orElse(null)
+        );
+    }
+
+    public static StripeAuthorisationResponse of(StripeCharge stripeCharge) {
+        return new StripeAuthorisationResponse(
+                stripeCharge.getId(),
+                stripeCharge.getAuthorisationStatus().orElse(null),
+                null
+        );
     }
 
     @Override
     public String getTransactionId() {
-        return jsonResponse.getId();
+        return transactionId;
     }
 
     @Override
     public AuthoriseStatus authoriseStatus() {
-        String stripeStatus = jsonResponse.getStatus();
-        switch (stripeStatus) {
-            case "succeeded": 
-                return AuthoriseStatus.AUTHORISED;
-            default: throw new IllegalArgumentException(format("Cannot map stripe status of %s to an %s", stripeStatus, AuthoriseStatus.class.getName()));
-        }
+        return authoriseStatus;
     }
 
     @Override
-    public Optional<? extends GatewayParamsFor3ds> getGatewayParamsFor3ds() {
-        return Optional.empty();
+    public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+        return Optional.ofNullable(redirectUrl)
+                .map(StripeParamsFor3ds::new);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -156,7 +156,7 @@ public class StripePaymentProvider implements PaymentProvider {
             throws GenericGatewayException, GatewayConnectionTimeoutException, GatewayErrorException {
         String jsonResponse = client.postRequestFor(StripeAuthoriseRequest.of(sourceId, request, stripeGatewayConfig)).getEntity();
         final StripeCharge createChargeResponse = jsonObjectMapper.getObject(jsonResponse, StripeCharge.class);
-        return new StripeAuthorisationResponse(createChargeResponse);
+        return StripeAuthorisationResponse.of(createChargeResponse);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import java.util.Optional;
 
@@ -34,9 +35,13 @@ public class StripeCharge {
         }
 
     }
-    
-    
-    
+
+    public Optional<BaseAuthoriseResponse.AuthoriseStatus> getAuthorisationStatus() {
+        return Optional.ofNullable(status)
+                .filter("succeeded"::equals)
+                .map(s -> BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
+    }
+
     public String getId() {
         return id;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -11,34 +11,40 @@ public class StripePaymentIntentRequest extends StripeRequest {
 
     private final String amount;
     private final String paymentMethodId;
+    private final String transferGroup;
+    private String frontendUrl;
+    private String chargeExternalId;
 
-    private StripePaymentIntentRequest(
-            GatewayAccountEntity gatewayAccount,
-            String idempotencyKey,
-            StripeGatewayConfig stripeGatewayConfig,
-            String amount,
-            String paymentMethodId
-    ) {
+
+    public StripePaymentIntentRequest(
+            GatewayAccountEntity gatewayAccount, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig, 
+            String amount, String paymentMethodId, String transferGroup, String frontendUrl, String chargeExternalId) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
         this.amount = amount;
         this.paymentMethodId = paymentMethodId;
+        this.transferGroup = transferGroup;
+        this.frontendUrl = frontendUrl;
+        this.chargeExternalId = chargeExternalId;
     }
 
     public static StripePaymentIntentRequest of(
             CardAuthorisationGatewayRequest request,
             String paymentMethodId,
-            StripeGatewayConfig stripeGatewayConfig
+            StripeGatewayConfig stripeGatewayConfig,
+            String frontendUrl
     ) {
         return new StripePaymentIntentRequest(
                 request.getGatewayAccount(),
                 request.getChargeExternalId(),
                 stripeGatewayConfig,
                 request.getAmount(),
-                paymentMethodId
+                paymentMethodId,
+                request.getChargeExternalId(),
+                frontendUrl,
+                request.getChargeExternalId()
         );
     }
-
-
+    
     @Override
     protected String urlPath() {
         return "/v1/payment_intents";
@@ -56,7 +62,12 @@ public class StripePaymentIntentRequest extends StripeRequest {
                 "amount", amount,
                 "confirmation_method", "automatic",
                 "capture_method", "manual",
-                "currency", "GBP");
+                "currency", "GBP",
+                "transfer_group", transferGroup,
+                "on_behalf_of", stripeConnectAccountId,
+                "confirm", "true",
+                "return_url", String.format("%s/card_details/%s/3ds_required_in", frontendUrl, chargeExternalId)
+        );
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Map;
+
+public class StripePaymentMethodRequest extends StripeRequest {
+    private String cvc;
+    private String expiryMonth;
+    private String expiryYear;
+    private String cardNo;
+
+    public StripePaymentMethodRequest(
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey, StripeGatewayConfig stripeGatewayConfig,
+            String cvc, String expiryMonth, String expiryYear, String cardNo)
+    {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.cvc = cvc;
+        this.expiryMonth = expiryMonth;
+        this.expiryYear = expiryYear;
+        this.cardNo = cardNo;
+    }
+    
+    public static StripePaymentMethodRequest of(CardAuthorisationGatewayRequest request, StripeGatewayConfig config) {
+        return new StripePaymentMethodRequest(
+                request.getGatewayAccount(),
+                request.getChargeExternalId(),
+                config,
+                request.getAuthCardDetails().getCvc(),
+                request.getAuthCardDetails().expiryMonth(),
+                request.getAuthCardDetails().expiryYear(),
+                request.getAuthCardDetails().getCardNo()
+        );
+    }
+
+    @Override
+    protected Map<String, String> params() {
+        return Map.of(
+                "card[cvc]", cvc,
+                "card[exp_month]", expiryMonth,
+                "card[exp_year]", expiryYear,
+                "card[number]", cardNo,
+                "type", "card");
+    }
+
+    @Override
+    protected String urlPath() {
+        return "/v1/payment_methods";
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return OrderRequestType.AUTHORISE;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -1,28 +1,27 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.message.BasicNameValuePair;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class StripePaymentMethodRequest extends StripeRequest {
-    private String cvc;
-    private String expiryMonth;
-    private String expiryYear;
-    private String cardNo;
-
+    private final AuthCardDetails authCardDetails;
+    
     public StripePaymentMethodRequest(
             GatewayAccountEntity gatewayAccount,
-            String idempotencyKey, StripeGatewayConfig stripeGatewayConfig,
-            String cvc, String expiryMonth, String expiryYear, String cardNo)
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig,
+            AuthCardDetails authCardDetails)
     {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
-        this.cvc = cvc;
-        this.expiryMonth = expiryMonth;
-        this.expiryYear = expiryYear;
-        this.cardNo = cardNo;
+        this.authCardDetails = authCardDetails;
     }
     
     public static StripePaymentMethodRequest of(CardAuthorisationGatewayRequest request, StripeGatewayConfig config) {
@@ -30,21 +29,31 @@ public class StripePaymentMethodRequest extends StripeRequest {
                 request.getGatewayAccount(),
                 request.getChargeExternalId(),
                 config,
-                request.getAuthCardDetails().getCvc(),
-                request.getAuthCardDetails().expiryMonth(),
-                request.getAuthCardDetails().expiryYear(),
-                request.getAuthCardDetails().getCardNo()
+                request.getAuthCardDetails()
         );
     }
 
     @Override
     protected Map<String, String> params() {
-        return Map.of(
-                "card[cvc]", cvc,
-                "card[exp_month]", expiryMonth,
-                "card[exp_year]", expiryYear,
-                "card[number]", cardNo,
-                "type", "card");
+        Map<String, String> localParams = new HashMap<>();
+        localParams.put("card[exp_month]", authCardDetails.expiryMonth());
+        localParams.put("card[exp_year]", authCardDetails.expiryYear());
+        localParams.put("card[number]", authCardDetails.getCardNo());
+        localParams.put("card[cvc]", authCardDetails.getCvc());
+        localParams.put("card[name]", authCardDetails.getCardHolder());
+        localParams.put("type", "card");
+
+        authCardDetails.getAddress().ifPresent(address -> {
+            localParams.put("card[address_line1]", address.getLine1());
+            if (StringUtils.isNotBlank(address.getLine2())) {
+                localParams.put("card[address_line2]", address.getLine2());
+            }
+            localParams.put("card[address_city]", address.getCity());
+            localParams.put("card[address_country]", address.getCountry());
+            localParams.put("card[address_zip]", address.getPostcode());
+        });
+        
+        return Map.copyOf(localParams);
     }
 
     @Override
@@ -55,5 +64,10 @@ public class StripePaymentMethodRequest extends StripeRequest {
     @Override
     protected OrderRequestType orderRequestType() {
         return OrderRequestType.AUTHORISE;
+    }
+
+    @Override
+    protected String idempotencyKeyType() {
+        return "payment_method";
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentIntentResponse.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+
+import java.util.Map;
+import java.util.Optional;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripePaymentIntentResponse {
+    private static Map<String, BaseAuthoriseResponse.AuthoriseStatus> statusMap = Map.of(
+            "requires_capture", BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED,
+            "requires_action", BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS
+            
+    );
+    
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("next_action")
+    private NextAction nextAction;
+    
+    private String status;
+
+    public String getId() {
+        return id;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Optional<String> getRedirectUrl() {
+        return Optional.ofNullable(nextAction)
+                .map(NextAction::getRedirectToUrl)
+                .map(m -> m.get("url"));
+                
+    }
+
+    public NextAction getNextAction() {
+        return nextAction;
+    }
+    
+    public Optional<BaseAuthoriseResponse.AuthoriseStatus> getAuthoriseStatus() {
+        return Optional.ofNullable(statusMap.get(status));
+
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class NextAction {
+        @JsonProperty("redirect_to_url")
+        Map<String, String> redirectToUrl;
+
+        public Map<String, String> getRedirectToUrl() {
+            return redirectToUrl;
+        }
+
+        @Override
+        public String toString() {
+            return "NextAction{" +
+                    "redirectToUrl=" + redirectToUrl +
+                    '}';
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "StripePaymentIntentResponse{" +
+                "id='" + id + '\'' +
+                ", nextAction=" + nextAction +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentMethodResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/StripePaymentMethodResponse.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gateway.stripe.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StripePaymentMethodResponse {
+    @JsonProperty("id")
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripePaymentIntentRequestTest {
+    private final String stripeConnectAccountId = "stripeConnectAccountId";
+    private final String chargeExternalId = "payChargeExternalId";
+    private final String stripeBaseUrl = "stripeUrl";
+
+    private StripePaymentIntentRequest stripePaymentIntentRequest;
+
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+    private String paymentMethodId = "123abc";
+    private String frontendUrl = "frontendUrl";
+    private Long amount = 100L;
+
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+        when(charge.getExternalId()).thenReturn(chargeExternalId);
+        when(charge.getAmount()).thenReturn(amount);
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+
+        stripePaymentIntentRequest = StripePaymentIntentRequest.of(authorisationGatewayRequest, paymentMethodId, stripeGatewayConfig, frontendUrl);
+    }
+
+    @Test
+    public void shouldHaveCorrectParametersWithAddress() {
+        
+        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+        assertThat(payload, containsString("payment_method=" + paymentMethodId));
+        assertThat(payload, containsString("amount=" + amount));
+        assertThat(payload, containsString("confirmation_method=automatic"));
+        assertThat(payload, containsString("capture_method=manual"));
+        assertThat(payload, containsString("currency=GBP"));
+        assertThat(payload, containsString("transfer_group=" + chargeExternalId));
+        assertThat(payload, containsString("on_behalf_of=" + stripeConnectAccountId));
+        assertThat(payload, containsString("confirm=true"));
+        assertThat(payload, containsString("return_url=" + frontendUrl + "%2Fcard_details%2F" + chargeExternalId + "%2F3ds_required_in"));
+    }
+
+    @Test
+    public void createsCorrectIdempotencyKey() {
+        assertThat(
+                stripePaymentIntentRequest.getHeaders().get("Idempotency-Key"),
+                is("payment_intent" + chargeExternalId));
+    }
+
+    @Test
+    public void shouldCreateCorrectUrl() {
+        assertThat(stripePaymentIntentRequest.getUrl(), is(URI.create(stripeBaseUrl + "/v1/payment_intents")));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -1,0 +1,129 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripePaymentMethodRequestTest {
+    private final String stripeConnectAccountId = "stripeConnectAccountId";
+    private final String chargeExternalId = "payChargeExternalId";
+    private final String stripeBaseUrl = "stripeUrl";
+    private final String cardNo = "4242424242424242";
+    private final String cardHolder = "Jones";
+    private final String line1 = "line1";
+    private final String line2 = "line2";
+    private final String city = "city";
+    private final String country = "UK";
+    private final String postcode = "W21WE";
+    private String cvc = "123";
+    private String endMonth = "12";
+    private String endYear = "19";
+
+    private StripePaymentMethodRequest stripePaymentMethodRequest;
+
+    @Mock
+    ChargeEntity charge;
+    @Mock
+    GatewayAccountEntity gatewayAccount;
+    @Mock
+    StripeAuthTokens stripeAuthTokens;
+    @Mock
+    StripeGatewayConfig stripeGatewayConfig;
+    private AuthCardDetails authCardDetails;
+
+    @Before
+    public void setUp() {
+        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
+        when(charge.getExternalId()).thenReturn(chargeExternalId);
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+        when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
+
+        authCardDetails = new AuthCardDetails();
+        authCardDetails.setCardNo(cardNo);
+        authCardDetails.setCardHolder(cardHolder);
+        authCardDetails.setCvc(cvc);
+        authCardDetails.setEndDate(endMonth + "/" + endYear);
+
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+
+
+        stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
+    }
+    
+    @Test
+    public void shouldHaveCorrectParametersWithAddress() {
+        Address address = new Address();
+        address.setLine1(line1);
+        address.setLine2(line2);
+        address.setCity(city);
+        address.setCountry(country);
+        address.setPostcode(postcode);
+        authCardDetails.setAddress(address);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+
+        stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
+
+        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
+        assertThat(payload, containsString("card%5Bnumber%5D=" + cardNo));
+        assertThat(payload, containsString("card%5Bname%5D=" + cardHolder));
+        assertThat(payload, containsString("card%5Bexp_year%5D=" + endYear));
+        assertThat(payload, containsString("card%5Bexp_month%5D=" + endMonth));
+        assertThat(payload, containsString("card%5Baddress_line1%5D=" + line1));
+        assertThat(payload, containsString("card%5Baddress_line2%5D=" + line2));
+        assertThat(payload, containsString("card%5Baddress_city%5D=" + city));
+        assertThat(payload, containsString("card%5Baddress_country%5D=" + country));
+        assertThat(payload, containsString("card%5Baddress_zip%5D=" + postcode));
+    }
+
+    @Test
+    public void shouldHaveCorrectParametersWithoutAddress() {
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+        stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
+        
+        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+        assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
+        assertThat(payload, containsString("card%5Bnumber%5D=" + cardNo));
+        assertThat(payload, containsString("card%5Bname%5D=" + cardHolder));
+        assertThat(payload, containsString("card%5Bexp_year%5D=" + endYear));
+        assertThat(payload, containsString("card%5Bexp_month%5D=" + endMonth));
+        assertThat(payload, not(containsString("card%5Baddress_line1%5D=" + line1)));
+        assertThat(payload, not(containsString("card%5Baddress_line2%5D=" + line2)));
+        assertThat(payload, not(containsString("card%5Baddress_city%5D=" + city)));
+        assertThat(payload, not(containsString("card%5Baddress_country%5D=" + country)));
+        assertThat(payload, not(containsString("card%5Baddress_zip%5D=" + postcode)));
+    }
+
+    @Test
+    public void createsCorrectIdempotencyKey() {
+        assertThat(
+                stripePaymentMethodRequest.getHeaders().get("Idempotency-Key"),
+                is("payment_method" + chargeExternalId));
+    }
+
+    @Test
+    public void shouldCreateCorrectUrl() {
+        assertThat(stripePaymentMethodRequest.getUrl(), is(URI.create(stripeBaseUrl + "/v1/payment_methods")));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
@@ -338,6 +338,7 @@ public class StripeResourceAuthorizeIT {
                 .withAccountId(accountId)
                 .withPaymentGateway(paymentProvider)
                 .withCredentials(credentials)
+                .withIntegrationVersion3ds(1)
                 .build());
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/SupportForLiveAndTestStripeTokensIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/SupportForLiveAndTestStripeTokensIT.java
@@ -73,6 +73,7 @@ public class SupportForLiveAndTestStripeTokensIT {
                 .withPaymentGateway(paymentProvider)
                 .withCredentials(credentials)
                 .withProviderUrlType(Type.fromString(accountType))
+                .withIntegrationVersion3ds(1)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 


### PR DESCRIPTION
Introduce logic to decide whether to authorise payment using payment intents or charges API, based on the `integrationVersion3DS` of the gateway account. This will allow us to switch on payment intents authorisation for selected accounts in production to test payment flow end to end, and ensure backwards compatibility. I have tried to leave alone as much of the code as possible as post switch we will delete all the charge API based code.

There are no tests for the new code path yet. I would like to get this out in the wild and test it with IRL with a single gateway account, and then come back to this and make any adjustments, and add unit tests for the new path. Feel free to tell me this is a bad idea.