### PR TITLE
PP-5587 Provisional event date for emitted events (refunds)

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
@@ -66,7 +66,7 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
     public void markEventAsEmitted(Event event) {
         Query query = entityManager.get()
                 .createQuery("UPDATE EmittedEventEntity e" +
-                        " SET e.emittedDate = :emittedDate " + 
+                        " SET e.emittedDate = :emittedDate , e.eventDate = :eventDate " + 
                         " WHERE e.resourceType = :resource_type" +
                         " AND e.resourceExternalId = :resource_external_id" +
                         " AND e.eventType = :event_type" +
@@ -75,7 +75,8 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
         query.setParameter("resource_type", event.getResourceType().getLowercase())
                 .setParameter("resource_external_id", event.getResourceExternalId())
                 .setParameter("event_type", event.getEventType())
-                .setParameter("emittedDate", ZonedDateTime.now(ZoneId.of("UTC")));
+                .setParameter("emittedDate", ZonedDateTime.now(ZoneId.of("UTC")))
+                .setParameter("eventDate", event.getTimestamp());
         
         query.executeUpdate();
     }

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
@@ -14,6 +14,9 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.refund.service.RefundStateEventMap;
 
 import javax.inject.Inject;
+import java.time.ZoneId;
+
+import static java.time.ZonedDateTime.now;
 
 public class StateTransitionService {
 
@@ -38,7 +41,7 @@ public class StateTransitionService {
         eventService.recordOfferedEvent(ResourceType.REFUND,
                 refundEntity.getExternalId(),
                 Event.eventTypeForClass(refundEventClass),
-                null);
+                now(ZoneId.of("UTC")));
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -9,14 +9,19 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.model.ResourceType;
 import uk.gov.pay.connector.events.model.charge.PaymentStarted;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
+import java.time.ZonedDateTime;
+
 import static java.time.ZonedDateTime.now;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -84,7 +89,18 @@ public class StateTransitionServiceTest {
         assertThat(refundStateTransitionArgumentCaptor.getValue().getRefundExternalId(), is(refundEntity.getExternalId()));
         assertThat(refundStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(RefundCreatedByUser.class));
 
-        verify(mockEventService).recordOfferedEvent(REFUND, "external-id", "REFUND_CREATED_BY_USER", null);
+        ArgumentCaptor<ZonedDateTime> eventDateArgumentCaptor = forClass(ZonedDateTime.class);
+        ArgumentCaptor<ResourceType> resourceTypeCaptor = forClass(ResourceType.class);
+        ArgumentCaptor<String> externalIdCaptor = forClass(String.class);
+        ArgumentCaptor<String> eventTypeCaptor = forClass(String.class);
+
+        verify(mockEventService).recordOfferedEvent(resourceTypeCaptor.capture(), externalIdCaptor.capture(),
+                eventTypeCaptor.capture(), eventDateArgumentCaptor.capture());
+
+        assertThat(resourceTypeCaptor.getValue(), is(REFUND));
+        assertThat(externalIdCaptor.getValue(), is("external-id"));
+        assertThat(eventTypeCaptor.getValue(), is("REFUND_CREATED_BY_USER"));
+        assertThat(eventDateArgumentCaptor.getValue(), is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
At the time of offering `RefundStateTransition` to StateTransitionQueue, DB state is not fully committed. So `refund_history` entry (and `history_start_date`  which is treated as event date) for corresponding refund status won't exists, and  due to this can't set `event_date` for refund event (in `emitted_events`).

- If `event_date` is empty, there won't be an easy way to identify events (by duration) that have been offered to StateTransitionQueue but not been emitted.

Solution

- Set `emitted_events.event_date` to `now()` when offering refund state   transition events to StateTransitionQueue
- Update `event_date` to actual date when emitting event to SQS queue