### PR TITLE
PP-5402-Removes dummy PaymentId

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -293,7 +293,7 @@ public class ChargeService {
                 .withProviderId(chargeEntity.getProviderSessionId())
                 .withCardDetails(persistedCard)
                 .withEmail(chargeEntity.getEmail())
-                .withChargeId("dummypaymentid123notpersisted");
+                .withChargeId(chargeEntity.getExternalId());
 
         chargeEntity.getExternalMetadata().ifPresent(externalMetadata -> {
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -808,7 +808,7 @@ public class ChargeServiceTest {
         assertThat(telephoneChargeResponse.get().getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(telephoneChargeResponse.get().getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(telephoneChargeResponse.get().getTelephoneNumber(), is("+447700900796"));
-        assertThat(telephoneChargeResponse.get().getChargeId(), is("dummypaymentid123notpersisted"));
+        assertThat(telephoneChargeResponse.get().getChargeId().length(), is(26));
         assertThat(telephoneChargeResponse.get().getState().getStatus(), is("success"));
         assertThat(telephoneChargeResponse.get().getState().isFinished(), is(true));
     }
@@ -841,7 +841,7 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(chargeResponse.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(chargeResponse.getTelephoneNumber(), is("+447700900796"));
-        assertThat(chargeResponse.getChargeId(), is("dummypaymentid123notpersisted"));
+        assertThat(chargeResponse.getChargeId().length(), is(26));
         assertThat(chargeResponse.getState().getStatus(), is("success"));
         assertThat(chargeResponse.getState().isFinished(), is(true));
     }
@@ -878,7 +878,7 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(chargeResponse.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(chargeResponse.getTelephoneNumber(), is("+447700900796"));
-        assertThat(chargeResponse.getChargeId(), is("dummypaymentid123notpersisted"));
+        assertThat(chargeResponse.getChargeId().length(), is(26));
         assertThat(chargeResponse.getState().getStatus(), is("failed"));
         assertThat(chargeResponse.getState().isFinished(), is(true));
         assertThat(chargeResponse.getState().getMessage(), is("Payment method rejected"));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -110,6 +110,7 @@ public class ChargeServiceTest {
     private static final String[] EXTERNAL_CHARGE_ID = new String[1];
     private static final int RETRIABLE_NUMBER_OF_CAPTURE_ATTEMPTS = 1;
     private static final int MAXIMUM_NUMBER_OF_CAPTURE_ATTEMPTS = 10;
+    private static final List<Map<String, Object>> EMPTY_LINKS = new ArrayList<>();
 
     private ChargeCreateRequestBuilder requestBuilder;
     private TelephoneChargeCreateRequest.Builder telephoneRequestBuilder;
@@ -809,7 +810,7 @@ public class ChargeServiceTest {
         assertThat(telephoneChargeResponse.get().getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(telephoneChargeResponse.get().getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(telephoneChargeResponse.get().getTelephoneNumber(), is("+447700900796"));
-        assertThat(telephoneChargeResponse.get().getDataLinks(), is(new ArrayList<Map<String, Object>>()));
+        assertThat(telephoneChargeResponse.get().getDataLinks(), is(EMPTY_LINKS));
         assertThat(telephoneChargeResponse.get().getDelayedCapture(), is(false));
         assertThat(telephoneChargeResponse.get().getChargeId().length(), is(26));
         assertThat(telephoneChargeResponse.get().getState().getStatus(), is("success"));
@@ -845,7 +846,7 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(chargeResponse.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(chargeResponse.getTelephoneNumber(), is("+447700900796"));
-        assertThat(chargeResponse.getDataLinks(), is(new ArrayList<Map<String, Object>>()));
+        assertThat(chargeResponse.getDataLinks(), is(EMPTY_LINKS));
         assertThat(chargeResponse.getDelayedCapture(), is(false));
         assertThat(chargeResponse.getChargeId().length(), is(26));
         assertThat(chargeResponse.getState().getStatus(), is("success"));
@@ -884,7 +885,7 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(chargeResponse.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(chargeResponse.getTelephoneNumber(), is("+447700900796"));
-        assertThat(chargeResponse.getDataLinks(), is(new ArrayList<Map<String, Object>>()));
+        assertThat(chargeResponse.getDataLinks(), is(EMPTY_LINKS));
         assertThat(chargeResponse.getDelayedCapture(), is(false));
         assertThat(chargeResponse.getChargeId().length(), is(26));
         assertThat(chargeResponse.getState().getStatus(), is("failed"));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -61,6 +61,7 @@ import java.net.URI;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -808,9 +809,12 @@ public class ChargeServiceTest {
         assertThat(telephoneChargeResponse.get().getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(telephoneChargeResponse.get().getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(telephoneChargeResponse.get().getTelephoneNumber(), is("+447700900796"));
+        assertThat(telephoneChargeResponse.get().getDataLinks(), is(new ArrayList<Map<String, Object>>()));
+        assertThat(telephoneChargeResponse.get().getDelayedCapture(), is(false));
         assertThat(telephoneChargeResponse.get().getChargeId().length(), is(26));
         assertThat(telephoneChargeResponse.get().getState().getStatus(), is("success"));
         assertThat(telephoneChargeResponse.get().getState().isFinished(), is(true));
+        
     }
 
     @Test
@@ -841,6 +845,8 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(chargeResponse.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(chargeResponse.getTelephoneNumber(), is("+447700900796"));
+        assertThat(chargeResponse.getDataLinks(), is(new ArrayList<Map<String, Object>>()));
+        assertThat(chargeResponse.getDelayedCapture(), is(false));
         assertThat(chargeResponse.getChargeId().length(), is(26));
         assertThat(chargeResponse.getState().getStatus(), is("success"));
         assertThat(chargeResponse.getState().isFinished(), is(true));
@@ -878,6 +884,8 @@ public class ChargeServiceTest {
         assertThat(chargeResponse.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(chargeResponse.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(chargeResponse.getTelephoneNumber(), is("+447700900796"));
+        assertThat(chargeResponse.getDataLinks(), is(new ArrayList<Map<String, Object>>()));
+        assertThat(chargeResponse.getDelayedCapture(), is(false));
         assertThat(chargeResponse.getChargeId().length(), is(26));
         assertThat(chargeResponse.getState().getStatus(), is("failed"));
         assertThat(chargeResponse.getState().isFinished(), is(true));

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
@@ -77,7 +77,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
                 .body("payment_outcome.status", is("success"))
-                .body("charge_id", is("dummypaymentid123notpersisted"));
+                .body("charge_id.length()", is(26));
     }
     
     @Test
@@ -109,7 +109,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
                 .body("telephone_number", is("+447700900796"))
-                .body("charge_id", is("dummypaymentid123notpersisted"))
+                .body("charge_id.length()", is(26))
                 .body("state.status", is("success"))
                 .body("state.finished", is(true));
     }
@@ -144,7 +144,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.expiry_date", is("02/19"))
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
-                .body("charge_id", is("dummypaymentid123notpersisted"))
+                .body("charge_id.length()", is(26))
                 .body("state.status", is("failed"))
                 .body("state.code", is("P0010"))
                 .body("state.finished", is(true))
@@ -187,7 +187,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.expiry_date", is("02/19"))
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
-                .body("charge_id", is("dummypaymentid123notpersisted"))
+                .body("charge_id.length()", is(26))
                 .body("state.status", is("failed"))
                 .body("state.code", is("P0050"))
                 .body("state.finished", is(true))
@@ -224,7 +224,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.expiry_date", is("02/19"))
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
-                .body("charge_id", is("dummypaymentid123notpersisted"))
+                .body("charge_id.length()", is(26))
                 .body("state.status", is("failed"))
                 .body("state.code", is("P0030"))
                 .body("state.finished", is(true))
@@ -270,7 +270,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
                 .body("telephone_number", is(stringOf50Characters))
-                .body("charge_id", is("dummypaymentid123notpersisted"))
+                .body("charge_id.length()", is(26))
                 .body("state.status", is("failed"))
                 .body("state.code", is("P0030"))
                 .body("state.finished", is(true))
@@ -298,7 +298,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.expiry_date", is("02/19"))
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
-                .body("charge_id", is("dummypaymentid123notpersisted"))
+                .body("charge_id.length()", is(26))
                 .body("state.status", is("success"))
                 .body("state.finished", is(true));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
@@ -77,7 +77,9 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("card_details.last_digits_card_number", is("1234"))
                 .body("card_details.first_digits_card_number", is("123456"))
                 .body("payment_outcome.status", is("success"))
-                .body("charge_id.length()", is(26));
+                .body("charge_id.length()", is(26))
+                .body("state.status", is("success"))
+                .body("state.finished", is(true));
     }
     
     @Test


### PR DESCRIPTION
## WHAT YOU DID
This PR removes the dummy payment id that is returned by Connector which was previously included for testing purposes. Now this has been replaced with the ChargeEntity.external_id which populates payment_id field in publicapi with it.

This PR also modifies the ChargeService tests to test for the junk fields in Connector JSON as well as fixing the createTelephoneChargeForOnlyRequiredFields() test to check for state.

In both ChargeService and ChargesApiTelephonePaymentResourceIT since the chargeId is random we just check for the length.