### PR TITLE
PP-5585 Correct stripe payment method creation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -40,17 +40,17 @@ public class StripePaymentMethodRequest extends StripeRequest {
         localParams.put("card[exp_year]", authCardDetails.expiryYear());
         localParams.put("card[number]", authCardDetails.getCardNo());
         localParams.put("card[cvc]", authCardDetails.getCvc());
-        localParams.put("card[name]", authCardDetails.getCardHolder());
+        localParams.put("billing_details[name]", authCardDetails.getCardHolder());
         localParams.put("type", "card");
 
         authCardDetails.getAddress().ifPresent(address -> {
-            localParams.put("card[address_line1]", address.getLine1());
+            localParams.put("billing_details[address[line1]]", address.getLine1());
             if (StringUtils.isNotBlank(address.getLine2())) {
-                localParams.put("card[address_line2]", address.getLine2());
+                localParams.put("billing_details[address[line2]]", address.getLine2());
             }
-            localParams.put("card[address_city]", address.getCity());
-            localParams.put("card[address_country]", address.getCountry());
-            localParams.put("card[address_zip]", address.getPostcode());
+            localParams.put("billing_details[address[city]]", address.getCity());
+            localParams.put("billing_details[address[country]]", address.getCountry());
+            localParams.put("billing_details[address[postal_code]]", address.getPostcode());
         });
         
         return Map.copyOf(localParams);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -87,14 +87,14 @@ public class StripePaymentMethodRequestTest {
         String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
         assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
         assertThat(payload, containsString("card%5Bnumber%5D=" + cardNo));
-        assertThat(payload, containsString("card%5Bname%5D=" + cardHolder));
+        assertThat(payload, containsString("billing_details%5Bname%5D=" + cardHolder));
         assertThat(payload, containsString("card%5Bexp_year%5D=" + endYear));
         assertThat(payload, containsString("card%5Bexp_month%5D=" + endMonth));
-        assertThat(payload, containsString("card%5Baddress_line1%5D=" + line1));
-        assertThat(payload, containsString("card%5Baddress_line2%5D=" + line2));
-        assertThat(payload, containsString("card%5Baddress_city%5D=" + city));
-        assertThat(payload, containsString("card%5Baddress_country%5D=" + country));
-        assertThat(payload, containsString("card%5Baddress_zip%5D=" + postcode));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bline1%5D%5D=" + line1));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bline2%5D%5D=" + line2));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bcity%5D%5D=" + city));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bcountry%5D%5D=" + country));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bpostal_code%5D%5D=" + postcode));
     }
 
     @Test
@@ -105,14 +105,9 @@ public class StripePaymentMethodRequestTest {
         String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
         assertThat(payload, containsString("card%5Bcvc%5D=" + cvc));
         assertThat(payload, containsString("card%5Bnumber%5D=" + cardNo));
-        assertThat(payload, containsString("card%5Bname%5D=" + cardHolder));
+        assertThat(payload, containsString("billing_details%5Bname%5D=" + cardHolder));
         assertThat(payload, containsString("card%5Bexp_year%5D=" + endYear));
         assertThat(payload, containsString("card%5Bexp_month%5D=" + endMonth));
-        assertThat(payload, not(containsString("card%5Baddress_line1%5D=" + line1)));
-        assertThat(payload, not(containsString("card%5Baddress_line2%5D=" + line2)));
-        assertThat(payload, not(containsString("card%5Baddress_city%5D=" + city)));
-        assertThat(payload, not(containsString("card%5Baddress_country%5D=" + country)));
-        assertThat(payload, not(containsString("card%5Baddress_zip%5D=" + postcode)));
     }
 
     @Test


### PR DESCRIPTION
See https://stripe.com/docs/api/payment_methods/create
for arguments to be provided to a payment method.

Changed to use billing_details fro name and address.