### PR TITLE
PP-5549 Persist 3DS flex challenge data

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Auth3dsDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Auth3dsDetailsEntity.java
@@ -17,6 +17,18 @@ public class Auth3dsDetailsEntity {
 
     @Column(name = "md_3ds")
     private String md;
+    
+    @Column(name = "worldpay_challenge_acs_url_3ds")
+    private String worldpayChallengeAcsUrl;
+    
+    @Column(name = "worldpay_challenge_transaction_id_3ds")
+    private String worldpayChallengeTransactionId;
+    
+    @Column(name = "worldpay_challenge_payload_3ds")
+    private String worldpayChallengePayload;
+    
+    @Column(name = "version_3ds")
+    private String threeDsVersion;
 
     public String getPaRequest() {
         return paRequest;
@@ -49,4 +61,38 @@ public class Auth3dsDetailsEntity {
     public String getMd() {
         return md;
     }
+
+    public String getWorldpayChallengeAcsUrl() {
+        return worldpayChallengeAcsUrl;
+    }
+
+    public void setWorldpayChallengeAcsUrl(String worldpayChallengeAcsUrl) {
+        this.worldpayChallengeAcsUrl = worldpayChallengeAcsUrl;
+    }
+
+    public String getWorldpayChallengeTransactionId() {
+        return worldpayChallengeTransactionId;
+    }
+
+    public void setWorldpayChallengeTransactionId(String worldpayChallengeTransactionId) {
+        this.worldpayChallengeTransactionId = worldpayChallengeTransactionId;
+    }
+
+    public String getWorldpayChallengePayload() {
+        return worldpayChallengePayload;
+    }
+
+    public void setWorldpayChallengePayload(String worldpayChallengePayload) {
+        this.worldpayChallengePayload = worldpayChallengePayload;
+    }
+
+    public String getThreeDsVersion() {
+        return threeDsVersion;
+    }
+
+    public void setThreeDsVersion(String threeDsVersion) {
+        this.threeDsVersion = threeDsVersion;
+    }
+    
+    
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -62,6 +62,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCE
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_CREATED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_STARTED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.model.domain.Auth3dsDetailsEntityFixture.anAuth3dsDetailsEntity;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 
 public class ChargeDaoIT extends DaoITestBase {
@@ -897,11 +898,27 @@ public class ChargeDaoIT extends DaoITestBase {
 
         String paRequest = "3dsPaRequest";
         String issuerUrl = "https://issuer.example.com/3ds";
-        ChargeEntity chargeEntity = aValidChargeEntity()
-                .withId(null)
-                .withGatewayAccountEntity(gatewayAccount)
+        String htmlOut = "<body><div>Some HTML</div></body>";
+        String md = "some-md";
+        String worldpayChallengeAcsUrl = "http://example.com/some-challenge";
+        String worldpayChallengeTransactionId = "a-transaction-id";
+        String worldpayChallengePayload = "{\"payload\": {\"key1\":\"value\"}}";
+        String threeDsVersion = "2.0";
+
+        var auth3dsDetailsEntity = anAuth3dsDetailsEntity()
                 .withPaRequest(paRequest)
                 .withIssuerUrl(issuerUrl)
+                .withHtmlOut(htmlOut)
+                .withMd(md)
+                .withWorldpayChallengeAcsUrl(worldpayChallengeAcsUrl)
+                .withWorldpayChallengeTransactionId(worldpayChallengeTransactionId)
+                .withWorldpayChallengePayload(worldpayChallengePayload)
+                .withThreeDsVersion(threeDsVersion)
+                .build();
+        var chargeEntity = aValidChargeEntity()
+                .withId(null)
+                .withGatewayAccountEntity(gatewayAccount)
+                .withAuth3dsDetailsEntity(auth3dsDetailsEntity)
                 .build();
 
         assertThat(chargeEntity.getId(), is(nullValue()));
@@ -912,6 +929,12 @@ public class ChargeDaoIT extends DaoITestBase {
 
         assertThat(charge.get().get3dsDetails().getPaRequest(), is(paRequest));
         assertThat(charge.get().get3dsDetails().getIssuerUrl(), is(issuerUrl));
+        assertThat(charge.get().get3dsDetails().getHtmlOut(), is(htmlOut));
+        assertThat(charge.get().get3dsDetails().getMd(), is(md));
+        assertThat(charge.get().get3dsDetails().getWorldpayChallengeAcsUrl(), is(worldpayChallengeAcsUrl));
+        assertThat(charge.get().get3dsDetails().getWorldpayChallengeTransactionId(), is(worldpayChallengeTransactionId));
+        assertThat(charge.get().get3dsDetails().getWorldpayChallengePayload(), is(worldpayChallengePayload));
+        assertThat(charge.get().get3dsDetails().getThreeDsVersion(), is(threeDsVersion));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/Auth3dsDetailsEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/Auth3dsDetailsEntityFixture.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
+
+public final class Auth3dsDetailsEntityFixture {
+    private String paRequest;
+    private String issuerUrl;
+    private String htmlOut;
+    private String md;
+    private String worldpayChallengeAcsUrl;
+    private String worldpayChallengeTransactionId;
+    private String worldpayChallengePayload;
+    private String threeDsVersion;
+
+    private Auth3dsDetailsEntityFixture() {
+    }
+
+    public static Auth3dsDetailsEntityFixture anAuth3dsDetailsEntity() {
+        return new Auth3dsDetailsEntityFixture();
+    }
+
+    public Auth3dsDetailsEntityFixture withPaRequest(String paRequest) {
+        this.paRequest = paRequest;
+        return this;
+    }
+
+    public Auth3dsDetailsEntityFixture withIssuerUrl(String issuerUrl) {
+        this.issuerUrl = issuerUrl;
+        return this;
+    }
+
+    public Auth3dsDetailsEntityFixture withHtmlOut(String htmlOut) {
+        this.htmlOut = htmlOut;
+        return this;
+    }
+
+    public Auth3dsDetailsEntityFixture withMd(String md) {
+        this.md = md;
+        return this;
+    }
+
+    public Auth3dsDetailsEntityFixture withWorldpayChallengeAcsUrl(String worldpayChallengeAcsUrl) {
+        this.worldpayChallengeAcsUrl = worldpayChallengeAcsUrl;
+        return this;
+    }
+
+    public Auth3dsDetailsEntityFixture withWorldpayChallengeTransactionId(String worldpayChallengeTransactionId) {
+        this.worldpayChallengeTransactionId = worldpayChallengeTransactionId;
+        return this;
+    }
+
+    public Auth3dsDetailsEntityFixture withWorldpayChallengePayload(String worldpayChallengePayload) {
+        this.worldpayChallengePayload = worldpayChallengePayload;
+        return this;
+    }
+
+    public Auth3dsDetailsEntityFixture withThreeDsVersion(String threeDsVersion) {
+        this.threeDsVersion = threeDsVersion;
+        return this;
+    }
+
+    public Auth3dsDetailsEntity build() {
+        Auth3dsDetailsEntity auth3dsDetailsEntity = new Auth3dsDetailsEntity();
+        auth3dsDetailsEntity.setPaRequest(paRequest);
+        auth3dsDetailsEntity.setIssuerUrl(issuerUrl);
+        auth3dsDetailsEntity.setHtmlOut(htmlOut);
+        auth3dsDetailsEntity.setMd(md);
+        auth3dsDetailsEntity.setWorldpayChallengeAcsUrl(worldpayChallengeAcsUrl);
+        auth3dsDetailsEntity.setWorldpayChallengeTransactionId(worldpayChallengeTransactionId);
+        auth3dsDetailsEntity.setWorldpayChallengePayload(worldpayChallengePayload);
+        auth3dsDetailsEntity.setThreeDsVersion(threeDsVersion);
+        return auth3dsDetailsEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/ChargeEntityFixture.java
@@ -42,8 +42,7 @@ public class ChargeEntityFixture {
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
     private List<ChargeEventEntity> events = new ArrayList<>();
     private List<RefundEntity> refunds = new ArrayList<>();
-    private String paRequest;
-    private String issuerUrl;
+    private Auth3dsDetailsEntity auth3dsDetailsEntity;
     private String providerSessionId;
     private SupportedLanguage language = SupportedLanguage.ENGLISH;
     private boolean delayedCapture = false;
@@ -68,13 +67,8 @@ public class ChargeEntityFixture {
         chargeEntity.getEvents().addAll(events);
         chargeEntity.getRefunds().addAll(refunds);
         chargeEntity.setProviderSessionId(providerSessionId);
-        if (paRequest != null && issuerUrl != null) {
-            Auth3dsDetailsEntity auth3dsDetailsEntity = new Auth3dsDetailsEntity();
-            auth3dsDetailsEntity.setIssuerUrl(issuerUrl);
-            auth3dsDetailsEntity.setPaRequest(paRequest);
+        chargeEntity.set3dsDetails(auth3dsDetailsEntity);
 
-            chargeEntity.set3dsDetails(auth3dsDetailsEntity);
-        }
         if (this.fee != null) {
             FeeEntity fee = new FeeEntity(chargeEntity, this.fee);
             chargeEntity.setFee(fee);
@@ -152,13 +146,8 @@ public class ChargeEntityFixture {
         return this;
     }
 
-    public ChargeEntityFixture withPaRequest(String paRequest) {
-        this.paRequest = paRequest;
-        return this;
-    }
-
-    public ChargeEntityFixture withIssuerUrl(String issuerUrl) {
-        this.issuerUrl = issuerUrl;
+    public ChargeEntityFixture withAuth3dsDetailsEntity(Auth3dsDetailsEntity auth3dsDetailsEntity) {
+        this.auth3dsDetailsEntity = auth3dsDetailsEntity;
         return this;
     }
 


### PR DESCRIPTION
Add new columns to Auth3dsDetailsEntity so they can be persisted to and read from the database.

Modify test to check that all fields in Auth3dsDetailsEntity are successfully persisted to the database.