### PR TITLE
PP-5549 Handle 3DS Flex challenge response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayParamsFor3dsFlex.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayParamsFor3dsFlex.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import uk.gov.pay.connector.charge.model.domain.Auth3dsDetailsEntity;
+import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+
+public class WorldpayParamsFor3dsFlex implements GatewayParamsFor3ds {
+    
+    private final String challengeAcsUrl;
+    private final String challengeTransactionId;
+    private final String challengePayload;
+    private final String threeDsVersion;
+
+    public WorldpayParamsFor3dsFlex(String challengeAcsUrl,
+                                    String challengeTransactionId,
+                                    String challengePayload,
+                                    String threeDsVersion) {
+        this.challengeAcsUrl = challengeAcsUrl;
+        this.challengeTransactionId = challengeTransactionId;
+        this.challengePayload = challengePayload;
+        this.threeDsVersion = threeDsVersion;
+    }
+
+    @Override
+    public Auth3dsDetailsEntity toAuth3dsDetailsEntity() {
+        var auth3dsDetailsEntity = new Auth3dsDetailsEntity();
+        auth3dsDetailsEntity.setWorldpayChallengeAcsUrl(challengeAcsUrl);
+        auth3dsDetailsEntity.setWorldpayChallengeTransactionId(challengeTransactionId);
+        auth3dsDetailsEntity.setWorldpayChallengePayload(challengePayload);
+        auth3dsDetailsEntity.setThreeDsVersion(threeDsVersion);
+        return auth3dsDetailsEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -26,6 +26,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
+    public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";
     public static final String WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-3ds-response-auth-worldpay-request.xml";
 
     public static final String WORLDPAY_CAPTURE_SUCCESS_RESPONSE = WORLDPAY_BASE_NAME + "/capture-success-response.xml";

--- a/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_FLEX_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_ERROR_RESPONSE;
@@ -118,6 +119,26 @@ public class WorldpayXMLUnmarshallerTest {
         assertThat(response.getGatewayParamsFor3ds().isPresent(), is(true));
         assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getPaRequest(), is("eJxVUsFuwjAM/ZWK80aSUgpFJogNpHEo2hjTzl"));
         assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getIssuerUrl(), is("https://secure-test.worldpay.com/jsp/test/shopper/ThreeDResponseSimulator.jsp"));
+
+        assertThat(response.authoriseStatus(), is(AuthoriseStatus.REQUIRES_3DS));
+    }
+
+    @Test
+    public void shouldUnmarshall3dsFlexResponse() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_3DS_FLEX_RESPONSE);
+        WorldpayOrderStatusResponse response = XMLUnmarshaller.unmarshall(successPayload, WorldpayOrderStatusResponse.class);
+
+        assertNull(response.getLastEvent());
+        assertNull(response.getRefusedReturnCode());
+        assertNull(response.getRefusedReturnCodeDescription());
+        assertNull(response.getErrorCode());
+        assertNull(response.getErrorMessage());
+
+        assertThat(response.getGatewayParamsFor3ds().isPresent(), is(true));
+        assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getWorldpayChallengeAcsUrl(), is("https://worldpay.com"));
+        assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getWorldpayChallengeTransactionId(), is("rUT8fLKDviHXr8aUn3l1"));
+        assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getWorldpayChallengePayload(), is("P.25de9db33221a55eedc6ac352b927a8c3a08d747643c592dd8f8ab7d3..."));
+        assertThat(response.getGatewayParamsFor3ds().get().toAuth3dsDetailsEntity().getThreeDsVersion(), is("2.1.0"));
 
         assertThat(response.authoriseStatus(), is(AuthoriseStatus.REQUIRES_3DS));
     }

--- a/src/test/resources/templates/worldpay/3ds-flex-response.xml
+++ b/src/test/resources/templates/worldpay/3ds-flex-response.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the order-->
+    <reply>
+        <orderStatus orderCode="ExampleOrder1"> <!--The orderCode you supplied in the order-->
+            <challengeRequired>
+                <threeDSChallengeDetails>
+                    <threeDSVersion>2.1.0</threeDSVersion>
+                    <transactionId3DS>rUT8fLKDviHXr8aUn3l1</transactionId3DS>
+                    <acsURL><![CDATA[https://worldpay.com]]></acsURL>
+                    <payload>P.25de9db33221a55eedc6ac352b927a8c3a08d747643c592dd8f8ab7d3...</payload>
+                </threeDSChallengeDetails>
+            </challengeRequired>
+        </orderStatus>
+    </reply>
+</paymentService>


### PR DESCRIPTION
Handle an authorisation response from worldpay which contains a challengeRequiredElement by storing the challenge details and updating the status of the charge to "AUTHORISATION 3DS REQUIRED".

Add tests for handling 3DS flex challenge response including a "contract" test that talks to a real Worldpay gateway