### PR TITLE
Remove support for custom CA certificates

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -4,16 +4,6 @@ set -eu
 RUN_MIGRATION=${RUN_MIGRATION:-false}
 RUN_APP=${RUN_APP:-true}
 
-if [ -n "${CERTS_PATH:-}" ]; then
-  i=0
-  truststore_pass=changeit
-  for cert in "$CERTS_PATH"/*; do
-    [ -f "$cert" ] || continue
-    echo "Adding $cert to default truststore"
-    keytool -importcert -noprompt -cacerts -storepass "$truststore_pass" -file "$cert" -alias custom$((i++))
-  done
-fi
-
 java $JAVA_OPTS -jar *-allinone.jar waitOnDependencies *.yaml
 
 if [ "$RUN_MIGRATION" == "true" ]; then

--- a/env.sh
+++ b/env.sh
@@ -7,6 +7,4 @@ then
   set +a  
 fi
 
-export CERTS_PATH=$WORKSPACE/pay-scripts/services/ssl/certs
-
 eval "$@"


### PR DESCRIPTION
We only needed to augment the default Java truststore for local testing with
selfsigned certificates, but this is no longer required.

Remove support for adding custom CA certificates.