### PR TITLE
PP-5605: update the query to retrieve charges with parity check status

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -266,13 +266,11 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .getSingleResult();
     }
 
-    public List<ChargeEntity> findByParityCheckStatus(ParityCheckStatus parityCheckStatus, int page, int size) {
-        int firstResult = (page - 1) * size;
-
+    public List<ChargeEntity> findByParityCheckStatus(ParityCheckStatus parityCheckStatus, int size, Long lastProcessedId) {
         return entityManager.get()
-                .createQuery("SELECT c FROM ChargeEntity c WHERE c.parityCheckStatus = :parityCheckStatus ORDER BY c.id", ChargeEntity.class)
+                .createQuery("SELECT c FROM ChargeEntity c WHERE c.id > :lastProcessedId AND c.parityCheckStatus = :parityCheckStatus ORDER BY c.id", ChargeEntity.class)
                 .setParameter("parityCheckStatus", parityCheckStatus)
-                .setFirstResult(firstResult)
+                .setParameter("lastProcessedId", lastProcessedId)
                 .setMaxResults(size)
                 .getResultList();
     }

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
@@ -71,16 +71,16 @@ public class ParityCheckWorker {
 
     private void checkParityForParityCheckStatus(Optional<String> parityCheckStatus) {
         ParityCheckStatus parityStatus = ParityCheckStatus.valueOf(parityCheckStatus.get());
-        int page = 1;
+        Long lastProcessedId = 0L;
 
         logger.info("Starting for status {}", parityCheckStatus.get());
         while (true) {
-            List<ChargeEntity> charges = chargeDao.findByParityCheckStatus(parityStatus, page, PAGE_SIZE);
+            List<ChargeEntity> charges = chargeDao.findByParityCheckStatus(parityStatus, PAGE_SIZE, lastProcessedId);
 
             if (!charges.isEmpty()) {
-                logger.info("Processing charges [page {}, no.of.charges {}] by parity check status", page, charges.size());
+                logger.info("Processing charges [last processed id {}, no.of.charges {}] by parity check status", lastProcessedId, charges.size());
                 charges.forEach(c -> checkParityFor(c, false));
-                page++;
+                lastProcessedId = charges.get(charges.size() - 1).getId();
             } else {
                 break;
             }

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -1653,7 +1653,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER)
                 .insert();
 
-        var charges = chargeDao.findByParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER, 1, 1);
+        var charges = chargeDao.findByParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER, 1, 0L);
 
         assertThat(charges.size(), is(1));
         assertThat(charges.get(0).getParityCheckStatus(), is(ParityCheckStatus.MISSING_IN_LEDGER));

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -199,13 +199,13 @@ public class ParityCheckWorkerTest {
 
     @Test
     public void executeForParityCheckStatusShouldEmitEventsOnlyForStatus() {
-        when(chargeDao.findByParityCheckStatus(ParityCheckStatus.DATA_MISMATCH, 2, 100)).thenReturn(List.of());
-        when(chargeDao.findByParityCheckStatus(ParityCheckStatus.DATA_MISMATCH, 1, 100)).thenReturn(List.of(chargeEntity));
+        when(chargeDao.findByParityCheckStatus(ParityCheckStatus.DATA_MISMATCH, 100, chargeEntity.getId())).thenReturn(List.of());
+        when(chargeDao.findByParityCheckStatus(ParityCheckStatus.DATA_MISMATCH, 100, 0L)).thenReturn(List.of(chargeEntity));
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.empty());
 
         worker.execute(0L, Optional.empty(), doNotReprocessValidRecords, Optional.of("DATA_MISMATCH"));
 
-        verify(chargeDao, times(2)).findByParityCheckStatus(eq(ParityCheckStatus.DATA_MISMATCH), anyInt(), anyInt());
+        verify(chargeDao, times(2)).findByParityCheckStatus(eq(ParityCheckStatus.DATA_MISMATCH), anyInt(), any());
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.MISSING_IN_LEDGER);
         verify(ledgerService, times(1)).getTransaction(any());
         verify(stateTransitionService, times(1)).offerStateTransition(any(), any());


### PR DESCRIPTION
* we cannot use standard way of pagination (max result size + offset) because we update the charge
status, so we actually shouldn't be updating the offset.
* in the updated solution we still use max result, but we pass the id of the last processed charge to
indicate the offset