### PR TITLE
PP-5585 Payment intent auth tests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -12,19 +12,22 @@ public class StripePaymentIntentRequest extends StripeRequest {
     private final String amount;
     private final String paymentMethodId;
     private final String transferGroup;
-    private String frontendUrl;
-    private String chargeExternalId;
+    private final String frontendUrl;
+    private final String chargeExternalId;
+    private final String description;
 
 
     public StripePaymentIntentRequest(
             GatewayAccountEntity gatewayAccount, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig, 
-            String amount, String paymentMethodId, String transferGroup, String frontendUrl, String chargeExternalId) {
+            String amount, String paymentMethodId, String transferGroup, String frontendUrl, String chargeExternalId,
+            String description) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
         this.amount = amount;
         this.paymentMethodId = paymentMethodId;
         this.transferGroup = transferGroup;
         this.frontendUrl = frontendUrl;
         this.chargeExternalId = chargeExternalId;
+        this.description = description;
     }
 
     public static StripePaymentIntentRequest of(
@@ -41,7 +44,8 @@ public class StripePaymentIntentRequest extends StripeRequest {
                 paymentMethodId,
                 request.getChargeExternalId(),
                 frontendUrl,
-                request.getChargeExternalId()
+                request.getChargeExternalId(),
+                request.getDescription()
         );
     }
     
@@ -63,6 +67,7 @@ public class StripePaymentIntentRequest extends StripeRequest {
                 "confirmation_method", "automatic",
                 "capture_method", "manual",
                 "currency", "GBP",
+                "description", description,
                 "transfer_group", transferGroup,
                 "on_behalf_of", stripeConnectAccountId,
                 "confirm", "true",

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -39,6 +39,7 @@ public class StripePaymentIntentRequestTest {
     private String paymentMethodId = "123abc";
     private String frontendUrl = "frontendUrl";
     private Long amount = 100L;
+    private String description = "description";
 
     @Before
     public void setUp() {
@@ -46,6 +47,7 @@ public class StripePaymentIntentRequestTest {
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);
         when(charge.getAmount()).thenReturn(amount);
+        when(charge.getDescription()).thenReturn(description);
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
@@ -67,6 +69,7 @@ public class StripePaymentIntentRequestTest {
         assertThat(payload, containsString("transfer_group=" + chargeExternalId));
         assertThat(payload, containsString("on_behalf_of=" + stripeConnectAccountId));
         assertThat(payload, containsString("confirm=true"));
+        assertThat(payload, containsString("description=" + description));
         assertThat(payload, containsString("return_url=" + frontendUrl + "%2Fcard_details%2F" + chargeExternalId + "%2F3ds_required_in"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -27,6 +27,8 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_FULL_CHARGE_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TRANSFER_RESPONSE;
 
@@ -84,6 +86,11 @@ public class StripeMockClient {
         String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE);
         setupResponse(payload, "/v1/charges", 400);
     }
+    
+    public void mockAuthorisationFailedWithPaymentIntents() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_AUTHORISATION_FAILED_RESPONSE);
+        setupResponse(payload, "/v1/payment_methods", 400);
+    }
 
     public void mockCreateSourceWithThreeDSecureRequired() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE)
@@ -132,5 +139,15 @@ public class StripeMockClient {
     public void mockGetPaymentIntent(String paymentIntentId) {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/payment_intents/" + paymentIntentId, 200);
+    }
+
+    public void mockCreatePaymentIntent() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE);
+        setupResponse(payload, "/v1/payment_intents", 200);
+    }
+    
+    public void mockCreatePaymentMethod() {
+        String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE);
+        setupResponse(payload, "/v1/payment_methods", 200);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -129,6 +129,9 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_CREATE_3DS_SOURCES_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_3ds_sources_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_capture_success_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
+    public static final String STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_method_success_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE_DESTINATION_CHARGE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response_destination_charge.json";
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
     public static final String STRIPE_ERROR_RESPONSE_GENERAL = TEMPLATE_BASE_NAME + "/stripe/error_response_general.json";

--- a/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json
@@ -1,0 +1,58 @@
+{
+  "id": "pi_123",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/charges?payment_intent=pi_123"
+  },
+  "client_secret": "secret",
+  "confirmation_method": "automatic",
+  "created": 1568141588,
+  "currency": "gbp",
+  "customer": null,
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": {
+    "redirect_to_url": {
+      "return_url": "http://localhost:9000/card_details/charge_id/3ds_required_in",
+      "url": "https://hooks.stripe.com/3d_secure_2/hosted?payment_intent=payment_intent_id&payment_intent_client_secret=fssfbbd"
+    },
+    "type": "redirect_to_url"
+  },
+  "on_behalf_of": "acct_123",
+  "payment_method": "pm_123",
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "requires_action",
+  "transfer_data": null,
+  "transfer_group": "tgroup"
+}

--- a/src/test/resources/templates/stripe/create_payment_intent_success_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_success_response.json
@@ -1,0 +1,52 @@
+{
+  "id": "pi_1FHESeEZsufgnuO08A2FUSPy",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/charges?payment_intent=pi_1FHESeEZsufgnuO08A2FUSPy"
+  },
+  "client_secret": "secret",
+  "confirmation_method": "automatic",
+  "created": 1568141588,
+  "currency": "gbp",
+  "customer": null,
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": null,
+  "on_behalf_of": "acct_1EVFduJTPZ7tq2xO",
+  "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "requires_capture",
+  "transfer_data": null,
+  "transfer_group": "bc3rl3m7po6do0mt7r11kbt588"
+}

--- a/src/test/resources/templates/stripe/create_payment_method_success_response.json
+++ b/src/test/resources/templates/stripe/create_payment_method_success_response.json
@@ -1,0 +1,42 @@
+{
+  "id": "pm_1FHEP1EZsufgnuO0Y22yNAKu",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": null,
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": null,
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": "unchecked"
+    },
+    "country": "IE",
+    "exp_month": 12,
+    "exp_year": 2019,
+    "fingerprint": "fmWpgbuponWIBkZ3",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "3220",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1568141363,
+  "customer": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "type": "card"
+}


### PR DESCRIPTION
Add high level tests for payment intent auth flow. I have somewhat duplicated existing tests, although I am not checking exact content of the payloads in the integration test as we have unit tests for the various types of `StripeRequest`  - e.g. https://github.com/alphagov/pay-connector/blob/master/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java

Also adds sending `description` as part of payment intent creation - this is not user facing but is useful for us when viewing payments in Stripe.