### PR TITLE
PP-5553 Return 500 response if credentials for generating JWT missing

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -28,6 +28,7 @@ import uk.gov.pay.commons.utils.metrics.DatabaseMetricsService;
 import uk.gov.pay.commons.utils.xray.Xray;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
+import uk.gov.pay.connector.charge.exception.InternalServerErrorExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.resource.ChargesFrontendResource;
@@ -112,6 +113,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new JsonMappingExceptionMapper());
         environment.jersey().register(new ZeroAmountNotAllowedForGatewayAccountExceptionMapper());
         environment.jersey().register(new ConflictWebApplicationExceptionMapper());
+        environment.jersey().register(new InternalServerErrorExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/InternalServerErrorException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/InternalServerErrorException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.charge.exception;
+
+public class InternalServerErrorException extends RuntimeException {
+
+    public InternalServerErrorException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/InternalServerErrorExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/InternalServerErrorExceptionMapper.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.commons.model.ErrorIdentifier.GENERIC;
+
+public class InternalServerErrorExceptionMapper implements ExceptionMapper<InternalServerErrorException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InternalServerErrorExceptionMapper.class);
+    
+    @Override
+    public Response toResponse(InternalServerErrorException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(GENERIC, exception.getMessage());
+
+        return Response.status(500)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexJwtCredentialsException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexJwtCredentialsException.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.charge.exception;
 
 import static java.lang.String.format;
 
-public class Worldpay3dsFlexJwtCredentialsException extends ConflictWebApplicationException {
+public class Worldpay3dsFlexJwtCredentialsException extends InternalServerErrorException {
 
     public Worldpay3dsFlexJwtCredentialsException(Long accountId, String missingCredential) {
         super(format("Cannot generate Worldpay 3ds Flex JWT for account %s because the following credential is unavailable: %s",

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -82,7 +82,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
         connectorRestApi
                 .withChargeId(chargeExternalId)
                 .getWorldpay3dsFlexDdcJwt()
-                .statusCode(HttpStatus.SC_CONFLICT)
+                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
                 .body("message", is(List.of("Cannot generate Worldpay 3ds Flex JWT for account 202 because the following credential is unavailable: issuer")));
     }
 
@@ -159,6 +159,32 @@ public class ChargesFrontendResourceWorldpayJwtIT {
                 .statusCode(HttpStatus.SC_OK)
                 .body("$", hasKey("auth_3ds_data"))
                 .body("auth_3ds_data", not(hasKey("worldpayChallengeJwt")));
+    }
+
+    @Test
+    public void shouldReturn500WhenCredentialsAreMissingForChallengeToken() {
+        long chargeId = nextLong();
+        var chargeExternalId = "mySecondChargeId";
+        var gatewayAccountId = "202";
+        var credentialsMissingIssuer = Map.of(
+                "organisational_unit_id", "My Org",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, credentialsMissingIssuer, chargeId, chargeExternalId,
+                ChargeStatus.AUTHORISATION_3DS_REQUIRED);
+
+        databaseTestHelper.updateCharge3dsFlexChallengeDetails(chargeId,
+                "http://example.com",
+                "a-transaction-id",
+                "a-payload",
+                "2.1.0");
+        
+        connectorRestApi
+                .withAccountId(gatewayAccountId)
+                .withChargeId(chargeExternalId)
+                .getFrontendCharge()
+                .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR)
+                .body("message", is(List.of("Cannot generate Worldpay 3ds Flex JWT for account 202 because the following credential is unavailable: issuer")));
     }
 
     private void setUpChargeAndAccount(String gatewayAccountId,


### PR DESCRIPTION
When calling the frontend endpoint to generate a Worldpay 3DS flex DDC JWT or when calling the frontend endpoint to get a charge when it is in a state that will cause the response to contain a calculated JWT, if the required credentials aren't set on the account, return a 500 rather than a 409.