### PR TITLE
PP-5553 Test that 409 is returned when credentials are missing

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -161,6 +161,32 @@ public class ChargesFrontendResourceWorldpayJwtIT {
                 .body("auth_3ds_data", not(hasKey("worldpayChallengeJwt")));
     }
 
+    @Test
+    public void shouldReturn409WhenCredentialsAreMissingForChallengeToken() {
+        long chargeId = nextLong();
+        var chargeExternalId = "mySecondChargeId";
+        var gatewayAccountId = "202";
+        var credentialsMissingIssuer = Map.of(
+                "organisational_unit_id", "My Org",
+                "jwt_mac_id", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0"
+        );
+        setUpChargeAndAccount(gatewayAccountId, WORLDPAY, credentialsMissingIssuer, chargeId, chargeExternalId,
+                ChargeStatus.AUTHORISATION_3DS_REQUIRED);
+
+        databaseTestHelper.updateCharge3dsFlexChallengeDetails(chargeId,
+                "http://example.com",
+                "a-transaction-id",
+                "a-payload",
+                "2.1.0");
+
+        connectorRestApi
+                .withAccountId(gatewayAccountId)
+                .withChargeId(chargeExternalId)
+                .getFrontendCharge()
+                .statusCode(HttpStatus.SC_CONFLICT)
+                .body("message", is(List.of("Cannot generate Worldpay 3ds Flex JWT for account 202 because the following credential is unavailable: issuer")));
+    }
+
     private void setUpChargeAndAccount(String gatewayAccountId,
                                        PaymentGatewayName paymentProvider,
                                        Map<String, String> credentials,


### PR DESCRIPTION
Test that a 409 response is returned when calling the frontend get charge endpoint, and the charge is in a state where we calculate a challenge JWT but the required credentials are missing.