### PR TITLE
PP-5650 Provider Id correctly stored in gateway_transaction_id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -55,17 +55,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setParameter("externalId", externalId)
                 .getResultList().stream().findFirst();
     }
-
-    public Optional<ChargeEntity> findByProviderSessionId(String providerSessionId) {
-        String query = "SELECT c FROM ChargeEntity c " +
-                "WHERE c.providerSessionId = :providerSessionId";
-
-        return entityManager.get()
-                .createQuery(query, ChargeEntity.class)
-                .setParameter("providerSessionId", providerSessionId)
-                .getResultList().stream().findFirst();
-    }
-
+    
     public Optional<ChargeEntity> findByTokenId(String tokenId) {
         String query = "SELECT te.chargeEntity FROM TokenEntity te WHERE te.token=:tokenId AND te.used=false";
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -167,7 +167,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                         CardDetailsEntity cardDetails,
                         ExternalMetadata externalMetadata,
                         GatewayAccountEntity gatewayAccount,
-                        String providerSessionId,
+                        String gatewayTransactionId,
                         SupportedLanguage language) {
         this.amount = amount;
         this.reference = reference;
@@ -179,7 +179,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         this.externalMetadata = externalMetadata;
         this.gatewayAccount = gatewayAccount;
         this.externalId = RandomIdGenerator.newId();
-        this.providerSessionId = providerSessionId;
+        this.gatewayTransactionId = gatewayTransactionId;
         this.language = language;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -290,7 +290,7 @@ public class ChargeService {
                 .withAmount(chargeEntity.getAmount())
                 .withReference(chargeEntity.getReference())
                 .withDescription(chargeEntity.getDescription())
-                .withProviderId(chargeEntity.getProviderSessionId())
+                .withProviderId(chargeEntity.getGatewayTransactionId())
                 .withCardDetails(persistedCard)
                 .withEmail(chargeEntity.getEmail())
                 .withChargeId(chargeEntity.getExternalId());

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -127,7 +127,7 @@ public class ChargeService {
 
     @Transactional
     public Optional<ChargeResponse> findCharge(TelephoneChargeCreateRequest telephoneChargeRequest) {
-        return chargeDao.findByProviderSessionId(telephoneChargeRequest.getProviderId())
+        return chargeDao.findByGatewayTransactionId(telephoneChargeRequest.getProviderId())
                 .map(charge -> populateResponseBuilderWith(aChargeResponseBuilder(), charge).build());
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -215,8 +215,8 @@ public class ChargeServiceTest {
                 SupportedLanguage.ENGLISH
         );
 
-        when(mockedChargeDao.findByProviderSessionId("1PROV")).thenReturn(Optional.of(returnedChargeEntity));
-        when(mockedChargeDao.findByProviderSessionId("new")).thenReturn(Optional.empty());
+        when(mockedChargeDao.findByGatewayTransactionId("1PROV")).thenReturn(Optional.of(returnedChargeEntity));
+        when(mockedChargeDao.findByGatewayTransactionId("new")).thenReturn(Optional.empty());
 
         // Populate ChargeEntity with ID when persisting
         doAnswer(invocation -> {
@@ -547,7 +547,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
         assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
-        assertThat(createdChargeEntity.getProviderSessionId(), is("1PROV"));
+        assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
@@ -597,7 +597,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
         assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is(nullValue()));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
-        assertThat(createdChargeEntity.getProviderSessionId(), is("1PROV"));
+        assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
@@ -647,7 +647,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
         assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is(nullValue()));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
-        assertThat(createdChargeEntity.getProviderSessionId(), is("1PROV"));
+        assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
@@ -702,7 +702,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
         assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
-        assertThat(createdChargeEntity.getProviderSessionId(), is("1PROV"));
+        assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
@@ -756,7 +756,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
         assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
-        assertThat(createdChargeEntity.getProviderSessionId(), is("1PROV"));
+        assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
@@ -773,7 +773,7 @@ public class ChargeServiceTest {
         Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(telephoneChargeCreateRequest);
 
         ArgumentCaptor<String> chargeEntityArgumentCaptor = forClass(String.class);
-        verify(mockedChargeDao).findByProviderSessionId(chargeEntityArgumentCaptor.capture());
+        verify(mockedChargeDao).findByGatewayTransactionId(chargeEntityArgumentCaptor.capture());
 
         String providerId = chargeEntityArgumentCaptor.getValue();
         assertThat(providerId, is("new"));
@@ -793,7 +793,7 @@ public class ChargeServiceTest {
         Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(telephoneChargeCreateRequest);
 
         ArgumentCaptor<String> chargeEntityArgumentCaptor = forClass(String.class);
-        verify(mockedChargeDao).findByProviderSessionId(chargeEntityArgumentCaptor.capture());
+        verify(mockedChargeDao).findByGatewayTransactionId(chargeEntityArgumentCaptor.capture());
 
         String providerId = chargeEntityArgumentCaptor.getValue();
         assertThat(providerId, is("1PROV"));

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -1634,16 +1634,7 @@ public class ChargeDaoIT extends DaoITestBase {
 
         assertThat(chargeDao.findMaxId(), is(defaultTestCharge.getChargeId()));
     }
-
-    @Test
-    public void findChargeByProviderId() {
-
-        insertTestCharge();
-        Optional<ChargeEntity> chargeEntity = chargeDao.findByProviderSessionId("providerId");
-        assertThat(chargeEntity.isPresent(), is(true));
-
-    }
-
+    
     @Test
     public void findChargesByParityCheckStatus() {
         DatabaseFixtures

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -473,7 +473,6 @@ public class DatabaseFixtures {
         Long chargeId = RandomUtils.nextLong();
         private String description = "Test description";
         String email = "alice.111@mail.test";
-        String providerId = "providerId";
         String externalChargeId = RandomIdGenerator.newId();
         long amount = 101L;
         ChargeStatus chargeStatus = ChargeStatus.CREATED;
@@ -519,12 +518,7 @@ public class DatabaseFixtures {
             this.email = email;
             return this;
         }
-
-        public TestCharge withProviderId(String providerId) {
-            this.providerId = providerId;
-            return this;
-        }
-
+        
         public TestCharge withChargeStatus(ChargeStatus chargeStatus) {
             this.chargeStatus = chargeStatus;
             return this;
@@ -589,7 +583,6 @@ public class DatabaseFixtures {
                     .withLanguage(language)
                     .withDelayedCapture(false)
                     .withEmail(email)
-                    .withProviderId(providerId)
                     .withCorporateSurcharge(corporateCardSurcharge)
                     .withParityCheckStatus(parityCheckStatus)
                     .build());

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -114,14 +114,13 @@ public class DatabaseTestHelper {
                                 "        reference,\n" +
                                 "        version,\n" +
                                 "        email,\n" +
-                                "        provider_session_id,\n" +
                                 "        language,\n" +
                                 "        delayed_capture,\n" +
                                 "        corporate_surcharge,\n" +
                                 "        parity_check_status,\n" +
                                 "        external_metadata\n" +
                                 "    )\n" +
-                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
+                                "   VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\n",
                         addChargeParams.getChargeId(),
                         addChargeParams.getExternalChargeId(),
                         addChargeParams.getAmount(),
@@ -134,7 +133,6 @@ public class DatabaseTestHelper {
                         addChargeParams.getReference().toString(),
                         addChargeParams.getVersion(),
                         addChargeParams.getEmail(),
-                        addChargeParams.getProviderId(),
                         addChargeParams.getLanguage().toString(),
                         addChargeParams.isDelayedCapture(),
                         addChargeParams.getCorporateSurcharge(),


### PR DESCRIPTION
At present the provider_id is incorrectly being stored in the provider_session_id column in Connector database. This PR fixes this and stores provider_id in the gateway_transaction_id field column. 

Since ChargeDAO already has a findByGatewayTransactionId I removed the findByProviderSessionId. ChargeEntity has been refactored to have it stored in gateway_transaction_id, as well as the tests. This also removes adding provider_id in the test charge which I previously added for findByProviderSessionId. Since we don't do this now I've removed that addition to the test charge.