### PR TITLE
PP-5557 Send different 2nd order request for 3DS Flex

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
 
 import javax.ws.rs.core.MediaType;
+import java.util.Optional;
 
 public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     
@@ -83,8 +84,8 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
             this.requires3ds = requires3ds;
         }
 
-        public String getPaResponse3ds() {
-            return paResponse3ds;
+        public Optional<String> getPaResponse3ds() {
+            return Optional.ofNullable(paResponse3ds);
         }
 
         public void setPaResponse3ds(String paResponse3ds) {

--- a/src/main/resources/templates/worldpay/Worldpay3dsResponseAuthOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/Worldpay3dsResponseAuthOrderTemplate.xml
@@ -5,7 +5,11 @@
     <submit>
         <order orderCode="${transactionId?xml}">
             <info3DSecure>
-                <paResponse>${paResponse3ds?xml}</paResponse>
+                <#if paResponse3ds.isPresent()>
+                <paResponse>${paResponse3ds.get()?xml}</paResponse>
+                <#else>
+                <completedAuthentication/>
+                </#if>
             </info3DSecure>
             <session id="${sessionId?xml}"/>
         </order>

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -28,6 +28,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";
     public static final String WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-3ds-response-auth-worldpay-request.xml";
+    public static final String WORLDPAY_VALID_3DS_FLEX_RESPONSE_AUTH_WORLDPAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-3ds-flex-response-auth-worldpay-request.xml";
 
     public static final String WORLDPAY_CAPTURE_SUCCESS_RESPONSE = WORLDPAY_BASE_NAME + "/capture-success-response.xml";
     public static final String WORLDPAY_CAPTURE_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/capture-error-response.xml";

--- a/src/test/resources/templates/worldpay/valid-3ds-flex-response-auth-worldpay-request.xml
+++ b/src/test/resources/templates/worldpay/valid-3ds-flex-response-auth-worldpay-request.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//Worldpay//DTD Worldpay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!">
+            <info3DSecure>
+                <completedAuthentication/>
+            </info3DSecure>
+            <session id="uniqueSessionId"/>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
When a request is made to /v1/frontend/charges/{chargeId}/3ds when 3DS Flex is used for the payment, the request will not contain a paResponse.

In this case, the order request XML payload will now contain a `<completedAuthentication/>` element rather than a `<paRequest></paRequest>` element.