### PR TITLE
PP-5635: add dao method to retrieve not emitted events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
@@ -66,7 +66,7 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
     public void markEventAsEmitted(Event event) {
         Query query = entityManager.get()
                 .createQuery("UPDATE EmittedEventEntity e" +
-                        " SET e.emittedDate = :emittedDate , e.eventDate = :eventDate " + 
+                        " SET e.emittedDate = :emittedDate , e.eventDate = :eventDate " +
                         " WHERE e.resourceType = :resource_type" +
                         " AND e.resourceExternalId = :resource_external_id" +
                         " AND e.eventType = :event_type" +
@@ -77,7 +77,18 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
                 .setParameter("event_type", event.getEventType())
                 .setParameter("emittedDate", ZonedDateTime.now(ZoneId.of("UTC")))
                 .setParameter("eventDate", event.getTimestamp());
-        
+
         query.executeUpdate();
+    }
+
+    public List<EmittedEventEntity> findNotEmittedEventsOlderThan(ZonedDateTime cutOffDate) {
+        String query = "SELECT e from EmittedEventEntity e " +
+                "WHERE e.eventDate < :cutOffDate " +
+                "AND e.emittedDate is null";
+
+        return entityManager.get()
+                .createQuery(query, EmittedEventEntity.class)
+                .setParameter("cutOffDate", cutOffDate)
+                .getResultList();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -138,6 +138,21 @@ public class EmittedEventDaoIT extends DaoITestBase {
         assertThat(event.get("emitted_date").toString(), is(emittedDateBeforeUpdate));
     }
 
+    @Test
+    public void findNotEmittedEventsOlderThan_shouldReturnEventsWithEmptyEmittedDate() {
+        final PaymentCreated paymentCreatedEvent = aPaymentCreatedEvent();
+        emittedEventDao.recordEmission(paymentCreatedEvent.getResourceType(), paymentCreatedEvent.getResourceExternalId(),
+                paymentCreatedEvent.getEventType(), paymentCreatedEvent.getTimestamp());
+
+        List<EmittedEventEntity> notEmittedEvents = emittedEventDao.findNotEmittedEventsOlderThan(ZonedDateTime.parse("2019-01-01T14:00:01Z"));
+
+        assertThat(notEmittedEvents.size(), is(1));
+        assertThat(notEmittedEvents.get(0).getEmittedDate(), nullValue());
+        assertThat(notEmittedEvents.get(0).getEventType(), is(paymentCreatedEvent.getEventType()));
+        assertThat(notEmittedEvents.get(0).getResourceExternalId(), is(paymentCreatedEvent.getResourceExternalId()));
+        assertThat(notEmittedEvents.get(0).getResourceType(), is(paymentCreatedEvent.getResourceType().getLowercase()));
+    }
+
     private PaymentCreated aPaymentCreatedEvent() {
         PaymentCreatedEventDetails eventDetails = new PaymentCreatedEventDetails(
                 1L, "desc", "ref", "return_url",


### PR DESCRIPTION
Context:
In order to make sure we emit all the events even when connector
shuts down in an ungraceful way, we need to track events that hasn't been emitted.

Changes:
* introduce dao method which retrieves all the events from emitted_events table
that don't have emitted_date set