### PR TITLE
PP-5635: configuration for emitted event sweeper

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
+import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
@@ -72,6 +73,9 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     @JsonProperty("chargesSweepConfig")
     private ChargeSweepConfig chargeSweepConfig;
+
+    @NotNull
+    private EmittedEventSweepConfig emittedEventSweepConfig;
 
     @NotNull
     private String graphiteHost;
@@ -208,5 +212,9 @@ public class ConnectorConfiguration extends Configuration {
 
     public RestClientConfig getRestClientConfig() {
         return restClientConfig;
+    }
+
+    public EmittedEventSweepConfig getEmittedEventSweepConfig() {
+        return emittedEventSweepConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/EmittedEventSweepConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/EmittedEventSweepConfig.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.app.config;
+
+import io.dropwizard.Configuration;
+
+public class EmittedEventSweepConfig extends Configuration {
+    
+    private int notEmittedEventMaxAgeInSeconds;
+
+    public int getNotEmittedEventMaxAgeInSeconds() {
+        return notEmittedEventMaxAgeInSeconds;
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -209,6 +209,9 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}
 
+emittedEventSweepConfig:
+  notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
+
 restClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 

--- a/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationIT.java
+++ b/src/test/java/uk/gov/pay/connector/app/ConnectorConfigurationIT.java
@@ -30,6 +30,7 @@ public class ConnectorConfigurationIT {
         assertThat(captureProcessConfig.getMaximumRetries(), is(48));
         assertThat(RULE.getConfiguration().getLedgerBaseUrl(), is(not(emptyString())));
         assertThat(RULE.getConfiguration().getRestClientConfig().isDisabledSecureConnection(), is(true));
+        assertThat(RULE.getConfiguration().getEmittedEventSweepConfig().getNotEmittedEventMaxAgeInSeconds(), is(1800));
     }
 
 }

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -169,6 +169,9 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}
 
+emittedEventSweepConfig:
+  notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
+
 restClientConfig:
   disabledSecureConnection: true
 

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -63,8 +63,8 @@ stripe:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}
     live: ${GDS_CONNECTOR_STRIPE_AUTH_LIVE_TOKEN}
   webhookSigningSecrets:
-      test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
-      live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
+    test: ${GDS_CONNECTOR_STRIPE_WEBHOOK_SIGN_SECRET:-whtest}
+    live: ${GDS_CONNECTOR_STRIPE_WEBHOOK_LIVE_SIGN_SECRET:-whlive}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
@@ -167,6 +167,9 @@ emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}
+
+emittedEventSweepConfig:
+  notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
 restClientConfig:
   disabledSecureConnection: true

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -158,6 +158,9 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}
 
+emittedEventSweepConfig:
+  notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
+
 restClientConfig:
   disabledSecureConnection: true
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -164,6 +164,9 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}
 
+emittedEventSweepConfig:
+  notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
+
 restClientConfig:
   disabledSecureConnection: true
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -161,6 +161,9 @@ chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}
   awaitingCaptureExpiryThreshold: ${AWAITING_DELAY_CAPTURE_EXPIRY_WINDOW:-172800}
 
+emittedEventSweepConfig:
+  notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
+
 restClientConfig:
   disabledSecureConnection: true
 


### PR DESCRIPTION
Context:
In order to make sure we emit all the events even when connector
shuts down in an ungraceful way, we need to track events that hasn't been emitted.

Changes:
* defining config which will determine the max age of not emitted event (sweeper will
process all the events that are older than this value)