### PR TITLE
PP-5635: create EmittedEventBackfillService for backfilling missing events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventEntity.java
@@ -73,4 +73,8 @@ public class EmittedEventEntity {
     public ZonedDateTime getEmittedDate() {
         return emittedDate;
     }
+
+    public void setEmittedDate(ZonedDateTime emittedDate) {
+        this.emittedDate = emittedDate;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
@@ -1,0 +1,85 @@
+package uk.gov.pay.connector.events;
+
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.events.dao.EmittedEventDao;
+import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.queue.StateTransitionService;
+import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
+
+import javax.inject.Inject;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static java.time.ZonedDateTime.now;
+
+public class EmittedEventsBackfillService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final EmittedEventDao emittedEventDao;
+    private final ChargeService chargeService;
+    private final HistoricalEventEmitter historicalEventEmitter;
+    private RefundDao refundDao;
+    private final EmittedEventSweepConfig sweepConfig;
+    private static final boolean shouldForceEmission = true;
+
+    @Inject
+    public EmittedEventsBackfillService(EmittedEventDao emittedEventDao, ChargeService chargeService, RefundDao refundDao,
+                                        EventService eventService, StateTransitionService stateTransitionService,
+                                        ConnectorConfiguration configuration) {
+        this.emittedEventDao = emittedEventDao;
+        this.chargeService = chargeService;
+        this.refundDao = refundDao;
+        this.sweepConfig = configuration.getEmittedEventSweepConfig();
+        this.historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, refundDao, shouldForceEmission,
+                eventService, stateTransitionService);
+    }
+
+    public void backfillNotEmittedEvents() {
+        List<EmittedEventEntity> notEmittedEventsToProcess =
+                emittedEventDao.findNotEmittedEventsOlderThan(getCutoffDateForProcessingNotEmittedEvents());
+        String oldestEventDate = notEmittedEventsToProcess.stream()
+                .map(EmittedEventEntity::getEventDate).min(ZonedDateTime::compareTo)
+                .map(ZonedDateTime::toString).orElse("none");
+
+        logger.info("Number of not emitted events to process: [{}]; oldestDate={}",
+                notEmittedEventsToProcess.size(), oldestEventDate);
+
+        notEmittedEventsToProcess.forEach(this::backfillEvent);
+    }
+
+    @Transactional
+    public void backfillEvent(EmittedEventEntity event) {
+        try {
+            Optional<ChargeEntity> charge;
+
+            if (ResourceType.valueOf(event.getResourceType().toUpperCase()).equals(ResourceType.PAYMENT)) {
+                charge = Optional.of(chargeService.findChargeById(event.getResourceExternalId()));
+            } else {
+                charge = refundDao.findByExternalId(event.getResourceExternalId()).map(RefundEntity::getChargeEntity);
+            }
+
+            charge.ifPresent(c -> MDC.put("chargeId", c.getExternalId()));
+            charge.ifPresent(historicalEventEmitter::processPaymentAndRefundEvents);
+            event.setEmittedDate(ZonedDateTime.now(ZoneId.of("UTC")));
+        } finally {
+            MDC.remove("chargeId");
+        }
+    }
+
+    private ZonedDateTime getCutoffDateForProcessingNotEmittedEvents() {
+        int notEmittedEventMaxAgeInSeconds = sweepConfig.getNotEmittedEventMaxAgeInSeconds();
+        return now().minusSeconds(notEmittedEventMaxAgeInSeconds);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
@@ -88,6 +88,11 @@ public class HistoricalEventEmitter {
         this.stateTransitionService = stateTransitionService;
     }
 
+    public void processPaymentAndRefundEvents(ChargeEntity charge) {
+        processPaymentEvents(charge);
+        processRefundEvents(charge);
+    }
+
     public void processPaymentEvents(ChargeEntity charge) {
         List<ChargeEventEntity> chargeEventEntities = getSortedChargeEvents(charge);
 

--- a/src/test/java/uk/gov/pay/connector/events/EmittedEventFixture.java
+++ b/src/test/java/uk/gov/pay/connector/events/EmittedEventFixture.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.events;
+
+import java.time.ZonedDateTime;
+
+public class EmittedEventFixture {
+    private String resourceType = "payment";
+    private String resourceExternalId = "some-external-id";
+    private String eventType = "PaymentCreated";
+    private ZonedDateTime eventDate = ZonedDateTime.parse("2019-09-20T10:00Z");
+    private ZonedDateTime emittedDate;
+
+    public static EmittedEventFixture anEmittedEventEntity() {
+        return new EmittedEventFixture();
+    }
+
+    public EmittedEventEntity build() {
+        return new EmittedEventEntity(resourceType, resourceExternalId, eventType,
+                eventDate, emittedDate);
+    }
+
+    public EmittedEventFixture withEmittedDate(ZonedDateTime emittedDate) {
+        this.emittedDate = emittedDate;
+        return this;
+    }
+
+    public EmittedEventFixture withEventDate(ZonedDateTime eventDate) {
+        this.eventDate = eventDate;
+        return this;
+    }
+
+    public EmittedEventFixture withEventType(String eventType) {
+        this.eventType = eventType;
+        return this;
+    }
+
+    public EmittedEventFixture withResourceExternalId(String resourceExternalId) {
+        this.resourceExternalId = resourceExternalId;
+        return this;
+    }
+
+    public EmittedEventFixture withResourceType(String resourceType) {
+        this.resourceType = resourceType;
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
@@ -1,0 +1,152 @@
+package uk.gov.pay.connector.events;
+
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.dao.EmittedEventDao;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.pact.ChargeEventEntityFixture;
+import uk.gov.pay.connector.queue.StateTransitionService;
+import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.events.EmittedEventFixture.anEmittedEventEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EmittedEventsBackfillServiceTest {
+    @Mock
+    private EmittedEventDao emittedEventDao;
+    @Mock
+    private ChargeService chargeService;
+    @Mock
+    private RefundDao refundDao;
+    @Mock
+    private EventService eventService;
+    @Mock
+    private StateTransitionService stateTransitionService;
+    @Mock
+    private ConnectorConfiguration connectorConfiguration;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    private Appender<ILoggingEvent> mockAppender;
+    private EmittedEventsBackfillService emittedEventsBackfillService;
+    private ChargeEntity chargeEntity;
+    private RefundEntity refundEntity;
+
+    @Before
+    public void setUp() {
+        var sweepConfig = mock(EmittedEventSweepConfig.class);
+        when(sweepConfig.getNotEmittedEventMaxAgeInSeconds()).thenReturn(1800);
+        when(connectorConfiguration.getEmittedEventSweepConfig()).thenReturn(sweepConfig);
+        Logger root = (Logger) LoggerFactory.getLogger(EmittedEventsBackfillService.class);
+        mockAppender = mock(Appender.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+        emittedEventsBackfillService = new EmittedEventsBackfillService(emittedEventDao, chargeService, refundDao,
+                eventService, stateTransitionService, connectorConfiguration);
+        chargeEntity = ChargeEntityFixture
+                .aValidChargeEntity()
+                .build();
+        ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(chargeEntity.getCreatedDate())
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.CREATED)
+                .build();
+        chargeEntity.getEvents().add(chargeEventEntity);
+        refundEntity = mock(RefundEntity.class);
+        when(refundEntity.getChargeEntity()).thenReturn(chargeEntity);
+    }
+    
+    @Test
+    public void logsMessageWhenNoEmittedEventsSatisfyingCriteria() {
+        when(emittedEventDao.findNotEmittedEventsOlderThan(any())).thenReturn(List.of());
+        
+        emittedEventsBackfillService.backfillNotEmittedEvents();
+        
+        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any());
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Number of not emitted events to process: [0]; oldestDate=none"));
+    }
+
+    @Test
+    public void backfillsEventsWhenEmittedPaymentEventSatisfyingCriteria() {
+        var emittedEvent = anEmittedEventEntity().withResourceExternalId(chargeEntity.getExternalId()).build();
+        when(emittedEventDao.findNotEmittedEventsOlderThan(any())).thenReturn(List.of(emittedEvent));
+        when(chargeService.findChargeById(chargeEntity.getExternalId())).thenReturn(chargeEntity);
+
+        emittedEventsBackfillService.backfillNotEmittedEvents();
+
+        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Number of not emitted events to process: [1]; oldestDate=2019-09-20T10:00Z"));
+    }
+
+    @Test
+    public void backfillsEventsWhenEmittedRefundEventSatisfyingCriteria() {
+        var emittedEvent = anEmittedEventEntity().withResourceType("refund")
+                .withResourceExternalId(chargeEntity.getExternalId()).build();
+        when(emittedEventDao.findNotEmittedEventsOlderThan(any())).thenReturn(List.of(emittedEvent));
+        when(refundDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(refundEntity));
+
+        emittedEventsBackfillService.backfillNotEmittedEvents();
+
+        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Number of not emitted events to process: [1]; oldestDate=2019-09-20T10:00Z"));
+    }
+
+    @Test
+    public void backfillsEventsWhenEmittedEventsSatisfyingCriteria() {
+        var emittedPaymentEvent = anEmittedEventEntity().withResourceExternalId(chargeEntity.getExternalId()).build();
+        var emittedRefundEvent = anEmittedEventEntity().withResourceType("refund")
+                .withEventDate(ZonedDateTime.parse("2019-09-20T09:00Z"))
+                .withResourceExternalId(chargeEntity.getExternalId())
+                .build();
+        when(emittedEventDao.findNotEmittedEventsOlderThan(any())).thenReturn(List.of(emittedPaymentEvent, emittedRefundEvent));
+        when(refundDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(refundEntity));
+        when(chargeService.findChargeById(chargeEntity.getExternalId())).thenReturn(chargeEntity);
+
+        emittedEventsBackfillService.backfillNotEmittedEvents();
+
+        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any());
+        verify(stateTransitionService, times(2)).offerStateTransition(any(), any());
+        verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
+        List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
+        assertThat(loggingEvents.get(0).getFormattedMessage(), is("Number of not emitted events to process: [2]; oldestDate=2019-09-20T09:00Z"));
+    }
+}


### PR DESCRIPTION
Context:
In order to make sure we emit all the events even when connector
shuts down in an ungraceful way, we need to track events and reprocess them when they haven't been emitted.

Changes:
* add processPaymentAndRefundEvents to historcal event emitter (wrapper method for otherwise
two separate methods)
* created service that
  * retrieves not emitted events from emitted events table
  * for each emitted event retrieves relevant charge and invokes charge backfill (for both payment and refund)
  * sets emittedDate to now (to mark an event as processed)

Possible improvements:
If there are multiple events for the same charge it would invoke the backfill for each of those events.
We could possibly store charge ids and verify wheteher the charge has been already processed in given run