### PR TITLE
PP-5445 emit payment notification created events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -250,16 +250,9 @@ public class ChargesApiResource {
             @NotNull @Valid TelephoneChargeCreateRequest telephoneChargeCreateRequest,
             @Context UriInfo uriInfo
     ) {
-        return chargeService.findCharge(
-                telephoneChargeCreateRequest
-        ).map(
-                response -> Response.status(200).entity(response).build()
-        ).orElse(Response
-                .status(201)
-                .entity(chargeService.create(
-                        telephoneChargeCreateRequest,
-                        accountId
-                ).get())
+        return chargeService.findCharge(telephoneChargeCreateRequest)
+                .map(response -> Response.status(200).entity(response).build())
+                .orElse(Response.status(201).entity(chargeService.create(telephoneChargeCreateRequest, accountId).get())
                 .build());
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -86,6 +86,8 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPR
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.PAYMENT_NOTIFICATION_CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.UNDEFINED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
 import static uk.gov.pay.connector.common.model.domain.NumbersInStringsSanitizer.sanitize;
 
@@ -156,7 +158,7 @@ public class ChargeService {
                     telephoneChargeRequest.getAmount(),
                     ServicePaymentReference.of(telephoneChargeRequest.getReference()),
                     telephoneChargeRequest.getDescription(),
-                    internalChargeStatus(telephoneChargeRequest.getPaymentOutcome().getCode().orElse(null)),
+                    UNDEFINED,
                     telephoneChargeRequest.getEmailAddress().orElse(null),
                     cardDetails,
                     storeExtraFieldsInMetaData(telephoneChargeRequest),
@@ -166,6 +168,9 @@ public class ChargeService {
             );
             
             chargeDao.persist(chargeEntity);
+            transitionChargeState(chargeEntity, PAYMENT_NOTIFICATION_CREATED);
+            transitionChargeState(chargeEntity, internalChargeStatus(telephoneChargeRequest.getPaymentOutcome().getCode().orElse(null)));
+            chargeDao.merge(chargeEntity);
             return chargeEntity;
         });
     }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
@@ -43,11 +43,35 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     }
 
     public static PaymentNotificationCreatedEventDetails from(ChargeEntity charge) {
-        return new PaymentNotificationCreatedEventDetails(charge.getGatewayAccount().getId(), charge.getAmount(),
-                charge.getReference().toString(), charge.getDescription(), charge.getGatewayTransactionId(),
-                charge.getCardDetails().getFirstDigitsCardNumber().toString(), charge.getCardDetails().getLastDigitsCardNumber().toString(),
-                charge.getCardDetails().getCardHolderName(), charge.getEmail(), charge.getCardDetails().getExpiryDate(), charge.getCardDetails().getCardBrand(),
-                charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null));
+            String firstDigitsCardNumber = null;
+            String lastDigitsCardNumber = null;
+            String cardHolderName = null;
+            String expiryDate = null;
+            String cardBrand = null;
+
+            if (charge.getCardDetails() != null) {
+                if (charge.getCardDetails().getLastDigitsCardNumber() != null) {
+                    lastDigitsCardNumber = charge.getCardDetails().getLastDigitsCardNumber().toString();
+                }
+                if (charge.getCardDetails().getFirstDigitsCardNumber() != null) {
+                    firstDigitsCardNumber = charge.getCardDetails().getFirstDigitsCardNumber().toString();
+                }
+                cardHolderName = charge.getCardDetails().getCardHolderName();
+                expiryDate = charge.getCardDetails().getExpiryDate();
+                cardBrand = charge.getCardDetails().getCardBrand();
+            }
+            return new PaymentNotificationCreatedEventDetails(charge.getGatewayAccount().getId(),
+                    charge.getAmount(),
+                    charge.getReference().toString(),
+                    charge.getDescription(),
+                    charge.getGatewayTransactionId(),
+                    firstDigitsCardNumber,
+                    lastDigitsCardNumber,
+                    cardHolderName,
+                    charge.getEmail(),
+                    expiryDate,
+                    cardBrand,
+                    charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null));
     }
 
     @Override
@@ -74,5 +98,53 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
         return Objects.hash(gatewayAccountId, amount, reference, description, gatewayTransactionId,
                 firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, email, cardExpiryDate,
                 cardBrand, externalMetadata);
+    }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getFirstDigitsCardNumber() {
+        return firstDigitsCardNumber;
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getCardExpiryDate() {
+        return cardExpiryDate;
+    }
+
+    public String getCardBrand() {
+        return cardBrand;
+    }
+
+    public Map<String, Object> getExternalMetadata() {
+        return externalMetadata;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.events.model.charge.PaymentEvent;
+import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByService;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
@@ -113,6 +114,8 @@ public class EventFactory {
                 return CaptureSubmitted.from(chargeEvent);
             } else if (eventClass == CaptureConfirmed.class) {
                 return CaptureConfirmed.from(chargeEvent);
+            } else if (eventClass == PaymentNotificationCreated.class) {
+                return PaymentNotificationCreated.from(chargeEvent);
             } else {
                 return eventClass.getConstructor(String.class, ZonedDateTime.class).newInstance(
                         chargeEvent.getChargeEntity().getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreated.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentNotificationCreatedEventDetails;
 
 import java.time.ZonedDateTime;
@@ -7,5 +9,12 @@ import java.time.ZonedDateTime;
 public class PaymentNotificationCreated extends PaymentEvent {
     public PaymentNotificationCreated(String resourceExternalId, PaymentNotificationCreatedEventDetails eventDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static PaymentNotificationCreated from(ChargeEventEntity chargeEvent) {
+        ChargeEntity charge = chargeEvent.getChargeEntity();
+        return new  PaymentNotificationCreated(charge.getExternalId(),
+                PaymentNotificationCreatedEventDetails.from(charge),
+                chargeEvent.getUpdated());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
@@ -1,0 +1,103 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+
+public class PaymentNotificationCreatedTest {
+
+    private final String paymentId = "jweojfewjoifewj";
+    private final String time = "2018-03-12T16:25:01.123456Z";
+    private final String providerId = "validTransactionId";
+
+    private ChargeEntityFixture chargeEntityFixture;
+
+    @Before
+    public void setUp() throws Exception {
+        chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.parse(time))
+                .withStatus(ChargeStatus.PAYMENT_NOTIFICATION_CREATED)
+                .withExternalId(paymentId)
+                .withTransactionId(providerId)
+                .withCardDetails(anAuthCardDetails().withAddress(null).getCardDetailsEntity())
+                .withAmount(100L);
+    }
+
+    @Test
+    public void whenAllTheDataIsAvailable() throws JsonProcessingException {
+        ExternalMetadata externalMetadata = new ExternalMetadata(Map.of(
+                "processor_id", "processorID",
+                "auth_code", "012345",
+                "telephone_number", "+447700900796"));
+        chargeEntityFixture.withExternalMetadata(externalMetadata);
+
+        ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity);
+
+        String actual = PaymentNotificationCreated.from(chargeEvent).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_NOTIFICATION_CREATED")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+
+        assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
+        assertThat(actual, hasJsonPath("$.event_details.description", equalTo("This is a description")));
+        assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
+        assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(providerId)));
+        assertThat(actual, hasJsonPath("$.event_details.first_digits_card_number", equalTo("424242")));
+        assertThat(actual, hasJsonPath("$.event_details.last_digits_card_number", equalTo("4242")));
+        assertThat(actual, hasJsonPath("$.event_details.cardholder_name", equalTo("Mr Test")));
+        assertThat(actual, hasJsonPath("$.event_details.card_expiry_date", equalTo("12/99")));
+        assertThat(actual, hasJsonPath("$.event_details.external_metadata.processor_id", equalTo("processorID")));
+        assertThat(actual, hasJsonPath("$.event_details.external_metadata.auth_code", equalTo("012345")));
+        assertThat(actual, hasJsonPath("$.event_details.external_metadata.telephone_number", equalTo("+447700900796")));
+    }
+
+    @Test
+    public void whenNotAllTheDataIsAvailable() throws JsonProcessingException {
+        chargeEntityFixture
+                .withCardDetails(null)
+                .withExternalMetadata(null);
+        ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity);
+
+        String actual = PaymentNotificationCreated.from(chargeEvent).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_NOTIFICATION_CREATED")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+
+        assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
+        assertThat(actual, hasJsonPath("$.event_details.description", equalTo("This is a description")));
+        assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(providerId)));
+
+        assertThat(actual, hasNoJsonPath("$.event_details.card_brand"));
+        assertThat(actual, hasNoJsonPath("$.event_details.first_digits_card_number"));
+        assertThat(actual, hasNoJsonPath("$.event_details.last_digits_card_number"));
+        assertThat(actual, hasNoJsonPath("$.event_details.cardholder_name"));
+        assertThat(actual, hasNoJsonPath("$.event_details.card_expiry_date"));
+        assertThat(actual, hasNoJsonPath("$.event_details.external_metadata.processor_id"));
+        assertThat(actual, hasNoJsonPath("$.event_details.external_metadata.auth_code"));
+        assertThat(actual, hasNoJsonPath("$.event_details.external_metadata.telephone_number"));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- emit events to ledger when a telephone payment notification is received
- implement PaymentNotificationCreated event and PaymentNotificationCreatedEventDetails
- emit events when charge transformed from UNIDENTIFIED to  PAYMENT_NOTIFICATION_CREATED and when PAYMENT_NOTIFICATION_CREATED transformed to the relevant failed or success (SUBMITTED) state
- add relevant tests
