### PR TITLE
Add logging for payment provider 3ds response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -69,6 +69,12 @@ public class Card3dsResponseAuthService {
     ) {
         Optional<String> transactionId = operationResponse.getTransactionId();
 
+        LOGGER.info("3DS response authorisation for {} - {} .'. about to attempt charge update from {} -> {}",
+                chargeExternalId,
+                operationResponse,
+                oldChargeStatus,
+                operationResponse.getMappedChargeStatus());
+
         ChargeEntity updatedCharge = chargeService.updateChargePost3dsAuthorisation(
                 chargeExternalId,
                 operationResponse.getMappedChargeStatus(),


### PR DESCRIPTION
Add extra logging of the payment provider 3ds response before attempting
to update the charge status. This is to help investigate 3ds errors.

with @alexbishop1
