### PR TITLE
PP-5635: resource for emitted event sweeper

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.command.RenderStateTransitionGraphCommand;
 import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
 import uk.gov.pay.connector.common.exception.UnsupportedOperationExceptionMapper;
 import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
+import uk.gov.pay.connector.events.resource.EmittedEventResource;
 import uk.gov.pay.connector.filters.SchemeRewriteFilter;
 import uk.gov.pay.connector.gateway.smartpay.auth.BasicAuthUser;
 import uk.gov.pay.connector.gateway.smartpay.auth.SmartpayAccountSpecificAuthenticator;
@@ -131,6 +132,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(PerformanceReportResource.class));
         environment.jersey().register(injector.getInstance(SearchRefundsResource.class));
         environment.jersey().register(injector.getInstance(DiscrepancyResource.class));
+        environment.jersey().register(injector.getInstance(EmittedEventResource.class));
 
         environment.jersey().register(ChargeIdMDCLoggingFeature.class);
         

--- a/src/main/java/uk/gov/pay/connector/events/resource/EmittedEventResource.java
+++ b/src/main/java/uk/gov/pay/connector/events/resource/EmittedEventResource.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.events.resource;
+
+import uk.gov.pay.connector.events.EmittedEventsBackfillService;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.status;
+
+@Path("/")
+public class EmittedEventResource {
+
+    private EmittedEventsBackfillService emittedEventsBackfillService;
+
+    @Inject
+    public EmittedEventResource(EmittedEventsBackfillService emittedEventsBackfillService) {
+        this.emittedEventsBackfillService = emittedEventsBackfillService;
+    }
+
+    @POST
+    @Path("/v1/tasks/emitted-events-sweep")
+    @Produces(APPLICATION_JSON)
+    public Response expireCharges() {
+        emittedEventsBackfillService.backfillNotEmittedEvents();
+        return status(OK).build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/resource/EmittedEventResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/resource/EmittedEventResourceTest.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.events.resource;
+
+import io.dropwizard.testing.junit.ResourceTestRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.events.EmittedEventsBackfillService;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EmittedEventResourceTest {
+    private static final EmittedEventsBackfillService emittedEventsBackfillService = mock(EmittedEventsBackfillService.class);
+    
+    @ClassRule
+    public static final ResourceTestRule resources = ResourceTestRule.builder()
+            .addResource(new EmittedEventResource(emittedEventsBackfillService))
+            .build();
+
+    @Test
+    public void shouldReturn200() {
+        Response response = resources
+                .target("/v1/tasks/emitted-events-sweep")
+                .request()
+                .post(Entity.json(""));
+
+        assertThat(response.getStatus(), is(200));
+    }
+}


### PR DESCRIPTION
Context:
In order to make sure we emit all the events even when connector
shuts down in an ungraceful way, we need to track events and reprocess them when they haven't been emitted.

Changes:
* added resource that invokes the emittedEventsBackfillService