### PR TITLE
PP-5658 Emit card brand label with payment details entered event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/cardtype/model/domain/CardBrandLabelEntity.java
+++ b/src/main/java/uk/gov/pay/connector/cardtype/model/domain/CardBrandLabelEntity.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.cardtype.model.domain;
+
+import uk.gov.pay.connector.common.model.domain.UuidAbstractEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "card_types")
+public class CardBrandLabelEntity extends UuidAbstractEntity {
+
+    @Column
+    private String brand;
+
+    @Column
+    private String label;
+    
+    public String getBrand() {
+        return brand;
+    }
+
+    public void setBrand(String brand) {
+        this.brand = brand;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.charge.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
@@ -17,7 +16,6 @@ import javax.persistence.Enumerated;
 import java.util.Objects;
 import javax.persistence.OneToOne;
 import javax.persistence.JoinColumn;
-
 import java.util.Optional;
 
 @Embeddable
@@ -168,8 +166,12 @@ public class CardDetailsEntity {
     public int hashCode() {
         return Objects.hash(firstDigitsCardNumber, lastDigitsCardNumber, cardHolderName, expiryDate, cardBrand, cardType, billingAddress);
     }
+    
+    public Optional<CardTypeEntity> getCardTypeDetails() {
+        return Optional.ofNullable(cardTypeDetails);
+    }
 
-    public CardTypeEntity getCardTypeDetails() {
-        return cardTypeDetails;
+    public void setCardTypeDetails(CardTypeEntity cardTypeDetails) {
+        this.cardTypeDetails = cardTypeDetails;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -3,8 +3,8 @@ package uk.gov.pay.connector.charge.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
-import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 
 import javax.persistence.FetchType;
@@ -44,7 +44,7 @@ public class CardDetailsEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "card_brand", referencedColumnName = "brand", updatable = false, insertable = false)
-    private CardTypeEntity cardTypeDetails;
+    private CardBrandLabelEntity cardTypeDetails;
 
     @Column(name = "card_brand")
     private String cardBrand;
@@ -168,11 +168,11 @@ public class CardDetailsEntity {
         return Objects.hash(firstDigitsCardNumber, lastDigitsCardNumber, cardHolderName, expiryDate, cardBrand, cardType, billingAddress);
     }
     
-    public Optional<CardTypeEntity> getCardTypeDetails() {
+    public Optional<CardBrandLabelEntity> getCardTypeDetails() {
         return Optional.ofNullable(cardTypeDetails);
     }
 
-    public void setCardTypeDetails(CardTypeEntity cardTypeDetails) {
+    public void setCardTypeDetails(CardBrandLabelEntity cardTypeDetails) {
         this.cardTypeDetails = cardTypeDetails;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 
+import javax.persistence.FetchType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Embeddable;
@@ -41,7 +42,7 @@ public class CardDetailsEntity {
     @JsonProperty("expiry_date")
     private String expiryDate;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "card_brand", referencedColumnName = "brand", updatable = false, insertable = false)
     private CardTypeEntity cardTypeDetails;
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -3,7 +3,9 @@ package uk.gov.pay.connector.charge.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
+import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 
 import javax.persistence.Column;
@@ -13,6 +15,9 @@ import javax.persistence.Embedded;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import java.util.Objects;
+import javax.persistence.OneToOne;
+import javax.persistence.JoinColumn;
+
 import java.util.Optional;
 
 @Embeddable
@@ -37,6 +42,10 @@ public class CardDetailsEntity {
     @Column(name = "expiry_date")
     @JsonProperty("expiry_date")
     private String expiryDate;
+
+    @OneToOne
+    @JoinColumn(name = "card_brand", referencedColumnName = "brand", updatable = false, insertable = false)
+    private CardTypeEntity cardTypeDetails;
 
     @Column(name = "card_brand")
     private String cardBrand;
@@ -140,7 +149,7 @@ public class CardDetailsEntity {
         this.cardType = cardType;
         return this;
     }
-
+    
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -158,5 +167,9 @@ public class CardDetailsEntity {
     @Override
     public int hashCode() {
         return Objects.hash(firstDigitsCardNumber, lastDigitsCardNumber, cardHolderName, expiryDate, cardBrand, cardType, billingAddress);
+    }
+
+    public CardTypeEntity getCardTypeDetails() {
+        return cardTypeDetails;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
@@ -15,6 +16,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private final Long corporateSurcharge;
     private final String email;
     private final String cardBrand;
+    private final String cardBrandLabel;
     private final String firstDigitsCardNumber;
     private final String lastDigitsCardNumber;
     private final String gatewayTransactionId;
@@ -30,15 +32,16 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private final Long totalAmount;
 
     private PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardBrand,
-                                             String gatewayTransactionId, String firstDigitsCardNumber,
-                                             String lastDigitsCardNumber, String cardholderName, String expiryDate,
-                                             String addressLine1, String addressLine2, String addressPostcode,
-                                             String addressCity, String addressCounty, String addressCountry,
-                                             String wallet, Long totalAmount) {
+                                              String cardBrandLabel, String gatewayTransactionId, String firstDigitsCardNumber,
+                                              String lastDigitsCardNumber, String cardholderName, String expiryDate,
+                                              String addressLine1, String addressLine2, String addressPostcode,
+                                              String addressCity, String addressCounty, String addressCountry,
+                                              String wallet, Long totalAmount) {
 
         this.corporateSurcharge = corporateSurcharge;
         this.email = email;
         this.cardBrand = cardBrand;
+        this.cardBrandLabel = cardBrandLabel;
         this.gatewayTransactionId = gatewayTransactionId;
         this.firstDigitsCardNumber = firstDigitsCardNumber;
         this.lastDigitsCardNumber = lastDigitsCardNumber;
@@ -65,6 +68,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         Optional.ofNullable(charge.getCardDetails()).ifPresent(
                 cardDetails -> 
                     builder.withCardBrand(cardDetails.getCardBrand())
+                            .withCardBrandLabel(cardDetails.getCardTypeDetails().map(CardTypeEntity::getLabel).orElse(null))
                             .withFirstDigitsCardNumber(Optional.ofNullable(cardDetails.getFirstDigitsCardNumber())
                                     .map(FirstDigitsCardNumber::toString)
                                     .orElse(null)
@@ -95,6 +99,10 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     public String getCardBrand() {
         return cardBrand;
+    }
+    
+    public String getCardBrandLabel() { 
+        return cardBrandLabel; 
     }
 
     public String getFirstDigitsCardNumber() {
@@ -183,6 +191,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         private Long corporateSurcharge;
         private String email;
         private String cardBrand;
+        private String cardBrandLabel;
         private String gatewayTransactionId;
         private String firstDigitsCardNumber;
         private String lastDigitsCardNumber;
@@ -209,6 +218,11 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
         Builder withCardBrand(String cardBrand) {
             this.cardBrand = cardBrand;
+            return this;
+        }
+        
+        Builder withCardBrandLabel(String cardBrandLabel) { 
+            this.cardBrandLabel = cardBrandLabel;
             return this;
         }
 
@@ -278,7 +292,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         }
 
         PaymentDetailsEnteredEventDetails build() {
-            return new PaymentDetailsEnteredEventDetails(corporateSurcharge, email, cardBrand, gatewayTransactionId, firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode, addressCity, addressCounty, addressCountry, wallet, totalAmount);
+            return new PaymentDetailsEnteredEventDetails(corporateSurcharge, email, cardBrand, cardBrandLabel, gatewayTransactionId, firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode, addressCity, addressCounty, addressCountry, wallet, totalAmount);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
-import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
@@ -68,7 +68,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         Optional.ofNullable(charge.getCardDetails()).ifPresent(
                 cardDetails -> 
                     builder.withCardBrand(cardDetails.getCardBrand())
-                            .withCardBrandLabel(cardDetails.getCardTypeDetails().map(CardTypeEntity::getLabel).orElse(null))
+                            .withCardBrandLabel(cardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null))
                             .withFirstDigitsCardNumber(Optional.ofNullable(cardDetails.getFirstDigitsCardNumber())
                                     .map(FirstDigitsCardNumber::toString)
                                     .orElse(null)

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -65,6 +65,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasJsonPath("$.event_details.total_amount", equalTo(110)));
         assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
         assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
+        assertThat(actual, hasJsonPath("$.event_details.card_brand_label", equalTo("Visa")));
         assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(validTransactionId)));
         assertThat(actual, hasJsonPath("$.event_details.first_digits_card_number", equalTo("424242")));
         assertThat(actual, hasJsonPath("$.event_details.last_digits_card_number", equalTo("4242")));

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
 import org.apache.commons.lang3.StringUtils;
-import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
@@ -107,7 +107,7 @@ public final class AuthCardDetailsFixture {
             cardDetailsEntity.setBillingAddress(new AddressEntity(address));
         }
 
-        CardTypeEntity cardType = new CardTypeEntity();
+        CardBrandLabelEntity cardType = new CardBrandLabelEntity();
         cardType.setBrand("visa");
         cardType.setLabel("Visa");
         cardDetailsEntity.setCardTypeDetails(cardType);

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
@@ -105,6 +106,11 @@ public final class AuthCardDetailsFixture {
         if(address != null) {
             cardDetailsEntity.setBillingAddress(new AddressEntity(address));
         }
+
+        CardTypeEntity cardType = new CardTypeEntity();
+        cardType.setBrand("visa");
+        cardType.setLabel("Visa");
+        cardDetailsEntity.setCardTypeDetails(cardType);
 
         return cardDetailsEntity;
     }


### PR DESCRIPTION
Add card brand label to details that are sent to Ledger during payment details entered. 

Join card types to card details on charge entity. This isn't needed anywhere else the charge entity is used but there is no clean abstraction for including database lookup logic anywhere in the event/ event details building process.

* verify that the `card_brand_label` attribute is set on the payment details entered event