### PR TITLE
PP-5635: add indices for emitted_events date columns

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1271,4 +1271,10 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add partial index to emitted_events emitted_date column" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_emitted_events_null_emitted_date ON emitted_events (emitted_date) where emitted_date is null;
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Context:
The emitted event sweeper queries emitted_events table to retrieve
not emitted events. It uses event_date and emitted_date to determine
which records should be re-processed (https://github.com/alphagov/pay-connector/pull/1767).
In order to make sure queries are efficient indices on those columns
are required.