### PR TITLE
PP-5662 Send debit/credit card type to ledger

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -32,31 +32,26 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private final String wallet;
     private final Long totalAmount;
 
-    private PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardType, String cardBrand,
-                                              String cardBrandLabel, String gatewayTransactionId, String firstDigitsCardNumber,
-                                              String lastDigitsCardNumber, String cardholderName, String expiryDate,
-                                              String addressLine1, String addressLine2, String addressPostcode,
-                                              String addressCity, String addressCounty, String addressCountry,
-                                              String wallet, Long totalAmount) {
+    private PaymentDetailsEnteredEventDetails(Builder builder) {
 
-        this.corporateSurcharge = corporateSurcharge;
-        this.email = email;
-        this.cardType = cardType;
-        this.cardBrand = cardBrand;
-        this.cardBrandLabel = cardBrandLabel;
-        this.gatewayTransactionId = gatewayTransactionId;
-        this.firstDigitsCardNumber = firstDigitsCardNumber;
-        this.lastDigitsCardNumber = lastDigitsCardNumber;
-        this.cardholderName = cardholderName;
-        this.expiryDate = expiryDate;
-        this.addressLine1 = addressLine1;
-        this.addressLine2 = addressLine2;
-        this.addressPostcode = addressPostcode;
-        this.addressCity = addressCity;
-        this.addressCounty = addressCounty;
-        this.addressCountry = addressCountry;
-        this.wallet = wallet;
-        this.totalAmount = totalAmount;
+        this.corporateSurcharge = builder.corporateSurcharge;
+        this.email = builder.email;
+        this.cardType = builder.cardType;
+        this.cardBrand = builder.cardBrand;
+        this.cardBrandLabel = builder.cardBrandLabel;
+        this.gatewayTransactionId = builder.gatewayTransactionId;
+        this.firstDigitsCardNumber = builder.firstDigitsCardNumber;
+        this.lastDigitsCardNumber = builder.lastDigitsCardNumber;
+        this.cardholderName = builder.cardholderName;
+        this.expiryDate = builder.expiryDate;
+        this.addressLine1 = builder.addressLine1;
+        this.addressLine2 = builder.addressLine2;
+        this.addressPostcode = builder.addressPostcode;
+        this.addressCity = builder.addressCity;
+        this.addressCounty = builder.addressCounty;
+        this.addressCountry = builder.addressCountry;
+        this.wallet = builder.wallet;
+        this.totalAmount = builder.totalAmount;
     }
 
     public static PaymentDetailsEnteredEventDetails from(ChargeEntity charge) {
@@ -306,9 +301,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         }
 
         PaymentDetailsEnteredEventDetails build() {
-            return new PaymentDetailsEnteredEventDetails(corporateSurcharge, email, cardType, cardBrand, cardBrandLabel, gatewayTransactionId,
-                    firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode, addressCity,
-                    addressCounty, addressCountry, wallet, totalAmount);
+            return new PaymentDetailsEnteredEventDetails(this);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -15,6 +15,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     private final Long corporateSurcharge;
     private final String email;
+    private final String cardType;
     private final String cardBrand;
     private final String cardBrandLabel;
     private final String firstDigitsCardNumber;
@@ -31,7 +32,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private final String wallet;
     private final Long totalAmount;
 
-    private PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardBrand,
+    private PaymentDetailsEnteredEventDetails(Long corporateSurcharge, String email, String cardType, String cardBrand,
                                               String cardBrandLabel, String gatewayTransactionId, String firstDigitsCardNumber,
                                               String lastDigitsCardNumber, String cardholderName, String expiryDate,
                                               String addressLine1, String addressLine2, String addressPostcode,
@@ -40,6 +41,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
         this.corporateSurcharge = corporateSurcharge;
         this.email = email;
+        this.cardType = cardType;
         this.cardBrand = cardBrand;
         this.cardBrandLabel = cardBrandLabel;
         this.gatewayTransactionId = gatewayTransactionId;
@@ -67,7 +69,8 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         
         Optional.ofNullable(charge.getCardDetails()).ifPresent(
                 cardDetails -> 
-                    builder.withCardBrand(cardDetails.getCardBrand())
+                    builder.withCardType(Optional.ofNullable(cardDetails.getCardType()).map(Enum::toString).orElse(null))
+                            .withCardBrand(cardDetails.getCardBrand())
                             .withCardBrandLabel(cardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null))
                             .withFirstDigitsCardNumber(Optional.ofNullable(cardDetails.getFirstDigitsCardNumber())
                                     .map(FirstDigitsCardNumber::toString)
@@ -95,6 +98,10 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getCardType() {
+        return cardType;
     }
 
     public String getCardBrand() {
@@ -164,6 +171,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         PaymentDetailsEnteredEventDetails that = (PaymentDetailsEnteredEventDetails) o;
         return Objects.equals(corporateSurcharge, that.corporateSurcharge) &&
                 Objects.equals(email, that.email) &&
+                Objects.equals(cardType, that.cardType) &&
                 Objects.equals(cardBrand, that.cardBrand) &&
                 Objects.equals(firstDigitsCardNumber, that.firstDigitsCardNumber) &&
                 Objects.equals(lastDigitsCardNumber, that.lastDigitsCardNumber) &&
@@ -182,7 +190,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     @Override
     public int hashCode() {
-        return Objects.hash(corporateSurcharge, email, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
+        return Objects.hash(corporateSurcharge, email, cardType, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
                 gatewayTransactionId, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode,
                 addressCounty, addressCountry, wallet, totalAmount);
     }
@@ -190,6 +198,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private static class Builder {
         private Long corporateSurcharge;
         private String email;
+        private String cardType;
         private String cardBrand;
         private String cardBrandLabel;
         private String gatewayTransactionId;
@@ -216,11 +225,16 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
             return this;
         }
 
+        Builder withCardType(String cardType) {
+            this.cardType = cardType;
+            return this;
+        }
+
         Builder withCardBrand(String cardBrand) {
             this.cardBrand = cardBrand;
             return this;
         }
-        
+
         Builder withCardBrandLabel(String cardBrandLabel) { 
             this.cardBrandLabel = cardBrandLabel;
             return this;
@@ -292,7 +306,9 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         }
 
         PaymentDetailsEnteredEventDetails build() {
-            return new PaymentDetailsEnteredEventDetails(corporateSurcharge, email, cardBrand, cardBrandLabel, gatewayTransactionId, firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode, addressCity, addressCounty, addressCountry, wallet, totalAmount);
+            return new PaymentDetailsEnteredEventDetails(corporateSurcharge, email, cardType, cardBrand, cardBrandLabel, gatewayTransactionId,
+                    firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode, addressCity,
+                    addressCounty, addressCountry, wallet, totalAmount);
         }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.wallets.WalletType;
 
@@ -64,6 +65,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasJsonPath("$.event_details.corporate_surcharge", equalTo(10)));
         assertThat(actual, hasJsonPath("$.event_details.total_amount", equalTo(110)));
         assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
+        assertThat(actual, hasJsonPath("$.event_details.card_type", equalTo("DEBIT")));
         assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
         assertThat(actual, hasJsonPath("$.event_details.card_brand_label", equalTo("Visa")));
         assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(validTransactionId)));
@@ -83,7 +85,7 @@ public class PaymentDetailsEnteredTest {
     @Test
     public void whenNotAllTheDataIsAvailable() throws JsonProcessingException {
         ChargeEntity chargeEntity = chargeEntityFixture
-                .withCardDetails(anAuthCardDetails().withAddress(null).withCardNo("4242").getCardDetailsEntity())
+                .withCardDetails(anAuthCardDetails().withAddress(null).withCardNo("4242").withCardType(PayersCardType.CREDIT_OR_DEBIT).getCardDetailsEntity())
                 .withWalletType(null)
                 .withCorporateSurcharge(null)
                 .build();
@@ -100,6 +102,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasNoJsonPath("$.event_details.corporate_surcharge"));
         assertThat(actual, hasJsonPath("$.event_details.total_amount", equalTo(100)));
         assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
+        assertThat(actual, hasNoJsonPath("$.event_details.card_type"));
         assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
         assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(validTransactionId)));
         assertThat(actual, hasNoJsonPath("$.event_details.first_digits_card_number"));

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -8,8 +8,8 @@ import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
+import uk.gov.pay.connector.gateway.model.PayersCardType;
 
 public final class AuthCardDetailsFixture {
     private String cardNo = "4242424242424242";
@@ -107,10 +107,12 @@ public final class AuthCardDetailsFixture {
             cardDetailsEntity.setBillingAddress(new AddressEntity(address));
         }
 
-        CardBrandLabelEntity cardType = new CardBrandLabelEntity();
-        cardType.setBrand("visa");
-        cardType.setLabel("Visa");
-        cardDetailsEntity.setCardTypeDetails(cardType);
+        cardDetailsEntity.setCardType(PayersCardType.toCardType(payersCardType));
+
+        CardBrandLabelEntity cardTypeDetails = new CardBrandLabelEntity();
+        cardTypeDetails.setBrand("visa");
+        cardTypeDetails.setLabel("Visa");
+        cardDetailsEntity.setCardTypeDetails(cardTypeDetails);
 
         return cardDetailsEntity;
     }


### PR DESCRIPTION
When emitting a `PaymentDetailsEntered` event to ledger, send the card type (as `"card_type"`) in the event details. The value will be either `"DEBIT"` or `"CREDIT"` or nothing at all (if we can’t be
certain).