### PR TITLE
PP-5659: Add `live` details to PaymentCreated and PaymentNotificationCreated

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -16,11 +16,13 @@ public class PaymentCreatedEventDetails extends EventDetails {
     private final String paymentProvider;
     private final String language;
     private final boolean delayedCapture;
+    private final boolean live;
     private final Map<String, Object> externalMetadata;
 
     public PaymentCreatedEventDetails(Long amount, String description, String reference, String returnUrl,
                                       Long gatewayAccountId, String paymentProvider, String language,
-                                      boolean delayedCapture, Map<String, Object> externalMetadata) {
+                                      boolean delayedCapture, boolean live,
+                                      Map<String, Object> externalMetadata) {
         this.amount = amount;
         this.description = description;
         this.reference = reference;
@@ -29,6 +31,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
         this.paymentProvider = paymentProvider;
         this.language = language;
         this.delayedCapture = delayedCapture;
+        this.live = live;
         this.externalMetadata = externalMetadata;
     }
 
@@ -42,6 +45,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 charge.getGatewayAccount().getGatewayName(),
                 charge.getLanguage().toString(),
                 charge.isDelayedCapture(),
+                charge.getGatewayAccount().isLive(),
                 charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null));
     }
 
@@ -76,6 +80,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
     public boolean isDelayedCapture() {
         return delayedCapture;
     }
+    
+    public boolean isLive() { 
+        return live;
+    }
 
     public Map<String, Object> getExternalMetadata() {
         return externalMetadata;
@@ -94,12 +102,13 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 Objects.equals(paymentProvider, that.paymentProvider) &&
                 Objects.equals(language, that.language) &&
                 Objects.equals(delayedCapture, that.delayedCapture) &&
+                Objects.equals(live, that.live) &&
                 Objects.equals(externalMetadata, that.externalMetadata);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(amount, description, reference, returnUrl, gatewayAccountId, paymentProvider, language,
-                delayedCapture, externalMetadata);
+                delayedCapture, live, externalMetadata);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
@@ -20,6 +20,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     private final String email;
     private final String expiryDate;
     private final String cardBrand;
+    private final boolean live;
     private final Map<String, Object> externalMetadata;
 
 
@@ -27,7 +28,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                                                    String description, String gatewayTransactionId,
                                                    String firstDigitsCardNumber, String lastDigitsCardNumber,
                                                    String cardholderName, String email, String expiryDate,
-                                                   String cardBrand, Map<String, Object> externalMetadata) {
+                                                   String cardBrand, boolean live, Map<String, Object> externalMetadata) {
         this.gatewayAccountId = gatewayAccountId;
         this.amount = amount;
         this.reference = reference;
@@ -39,6 +40,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
         this.email = email;
         this.expiryDate = expiryDate;
         this.cardBrand = cardBrand;
+        this.live = live;
         this.externalMetadata = externalMetadata;
     }
 
@@ -71,6 +73,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                     charge.getEmail(),
                     expiryDate,
                     cardBrand,
+                    charge.getGatewayAccount().isLive(), 
                     charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null));
     }
 
@@ -90,6 +93,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                 Objects.equals(email, that.email) &&
                 Objects.equals(expiryDate, that.expiryDate) &&
                 Objects.equals(cardBrand, that.cardBrand) &&
+                Objects.equals(live, that.live) &&
                 Objects.equals(externalMetadata, that.externalMetadata);
     }
 
@@ -97,7 +101,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     public int hashCode() {
         return Objects.hash(gatewayAccountId, amount, reference, description, gatewayTransactionId,
                 firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, email, expiryDate,
-                cardBrand, externalMetadata);
+                cardBrand, live, externalMetadata);
     }
 
     public Long getGatewayAccountId() {
@@ -142,6 +146,10 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
 
     public String getCardBrand() {
         return cardBrand;
+    }
+    
+    public boolean isLive() { 
+        return live;
     }
 
     public Map<String, Object> getExternalMetadata() {

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -161,7 +161,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
     private PaymentCreated aPaymentCreatedEvent() {
         PaymentCreatedEventDetails eventDetails = new PaymentCreatedEventDetails(
                 1L, "desc", "ref", "return_url",
-                100L, "someProvider", "en", false, null);
+                100L, "someProvider", "en", false, false, null);
         return new PaymentCreated("my-resource-external-id", eventDetails, ZonedDateTime.parse("2019-01-01T14:00:00Z"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -64,6 +64,7 @@ public class PaymentCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
         assertThat(actual, hasJsonPath("$.event_details.description", equalTo("new passport")));
         assertThat(actual, hasJsonPath("$.event_details.reference", equalTo("myref")));
+        assertThat(actual, hasJsonPath("$.event_details.live", equalTo(false)));
         assertThat(actual, hasJsonPath("$.event_details.return_url", equalTo("http://example.com")));
         assertThat(actual, hasJsonPath("$.event_details.gateway_account_id", equalTo(chargeEntity.getGatewayAccount().getId().toString())));
         assertThat(actual, hasJsonPath("$.event_details.payment_provider", equalTo(chargeEntity.getGatewayAccount().getGatewayName())));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
@@ -58,6 +58,7 @@ public class PaymentNotificationCreatedTest {
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
 
         assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
+        assertThat(actual, hasJsonPath("$.event_details.live", equalTo(false)));
         assertThat(actual, hasJsonPath("$.event_details.description", equalTo("This is a description")));
         assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
         assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));
@@ -85,6 +86,7 @@ public class PaymentNotificationCreatedTest {
         assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_NOTIFICATION_CREATED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.event_details.live", equalTo(false)));
 
         assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
         assertThat(actual, hasJsonPath("$.event_details.description", equalTo("This is a description")));


### PR DESCRIPTION
Add `live` attribute based on gateway accounts live status.

Depends on https://github.com/alphagov/pay-ledger/pull/322