### PR TITLE
BAU: Add Sandbox Visa prepaid unknown credit or debit unknown card

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -18,6 +18,7 @@ public class SandboxCardNumbers {
     private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD = "5200828282828210";
     private static final String GOOD_NON_CORPORATE_NON_PREPAID = "4000020000000000";
     private static final String GOOD_MASTERCARD_CREDIT_CARD = "5101110000000004";
+    private static final String GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD = "4000000000000010";
     private static final String DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER = "0002";
     private static final String DECLINED_CARD_NUMBER = "4000000000000002";
     private static final String CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0127";
@@ -38,6 +39,7 @@ public class SandboxCardNumbers {
             "6011000990139424",
             "36148900647913",
             GOOD_MASTERCARD_CREDIT_CARD,
+            GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD,
             GOOD_WALLET_LAST_DIGITS_CARD_NUMBER,
             GOOD_CARD_PREPAID_NON_CORPORATE,
             GOOD_NON_CORPORATE_NON_PREPAID);


### PR DESCRIPTION
Add the test card number 4000000000000010, which card ID says is a Visa card for which it is unknown whether it is prepaid and for which it is unknown whether it is a credit or debit card but which is not a corporate card, to sandbox to assist services’ testing.