### PR TITLE
PP-5670: Specify the consumer when running contract test

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -1,10 +1,6 @@
 package uk.gov.pay.connector.pact;
 
-import au.com.dius.pact.provider.junit.PactRunner;
-import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.State;
-import au.com.dius.pact.provider.junit.loader.PactBroker;
-import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
 import au.com.dius.pact.provider.junit.target.HttpTarget;
 import au.com.dius.pact.provider.junit.target.Target;
 import au.com.dius.pact.provider.junit.target.TestTarget;
@@ -15,7 +11,6 @@ import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.runner.RunWith;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
@@ -46,12 +41,7 @@ import static uk.gov.pay.connector.rules.AppWithPostgresRule.WIREMOCK_PORT;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 
-@RunWith(PactRunner.class)
-@Provider("connector")
-@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
-        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
-        consumers = {"selfservice", "publicapi"})
-public class TransactionsApiContractTest {
+public class ContractTest {
 
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule(ConfigOverride.config("captureProcessConfig.backgroundProcessingEnabled", "false"));

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTestSuite.java
@@ -1,15 +1,41 @@
 package uk.gov.pay.connector.pact;
 
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.TestSuite;
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.runners.AllTests;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@RunWith(Suite.class)
+import java.util.Map;
 
-@Suite.SuiteClasses({
-        QueueMessageContractTest.class,
-        TransactionsApiContractTest.class,
-        FrontendContractTest.class
-})
+import static java.lang.String.format;
+
+@RunWith(AllTests.class)
 public class ContractTestSuite {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContractTestSuite.class);
+
+    private static Map<String, JUnit4TestAdapter> map = Map.of(
+            "frontend", new JUnit4TestAdapter(FrontendContractTest.class),
+            "ledger", new JUnit4TestAdapter(QueueMessageContractTest.class),
+            "publicapi", new JUnit4TestAdapter(PublicApiContractTest.class),
+            "selfservice", new JUnit4TestAdapter(SelfServiceContractTest.class));
+
+    public static TestSuite suite() {
+        String consumer = System.getProperty("CONSUMER");
+        TestSuite suite = new TestSuite();
+        
+        if (consumer == null || consumer.isBlank()) {
+            LOGGER.info("Running all contract tests.");
+            map.forEach((key, value) -> suite.addTest(value));
+        } else if (map.containsKey(consumer)) {
+            LOGGER.info("Running {}-connector contract tests only.", consumer);
+            suite.addTest(map.get(consumer));
+        } else {
+            throw new RuntimeException(format("Error running provider contract tests. ${CONSUMER} system property was %s.", consumer));
+        }
+        
+        return suite;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/PublicApiContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/PublicApiContractTest.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.pact;
+
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("connector")
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"publicapi"})
+public class PublicApiContractTest extends ContractTest {
+}

--- a/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.pact;
+
+import au.com.dius.pact.provider.junit.PactRunner;
+import au.com.dius.pact.provider.junit.Provider;
+import au.com.dius.pact.provider.junit.loader.PactBroker;
+import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import org.junit.runner.RunWith;
+
+@RunWith(PactRunner.class)
+@Provider("connector")
+@PactBroker(scheme = "https", host = "pact-broker-test.cloudapps.digital", tags = {"${PACT_CONSUMER_TAG}", "test"},
+        authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
+        consumers = {"selfservice"})
+public class SelfServiceContractTest extends ContractTest {
+}


### PR DESCRIPTION
Currently when a consumer build is kicked off, the provider contract test will
run in its entirety. For example, in a frontend build, the connector provider
contract tests will run as well. However, what is run is:

frontend->connector
ledger->connector
publicapi->connector
selfservice->connector

We really only want to run frontend->connector in this case.

This commit will allow a dynamic creation of the test suite to run based on a
CONSUMER system property. This will mean shorter run times when a provider
contract test is run as part of a specific consumer build.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
