### PR TITLE
PP-5672 Make Stripe refund more robust

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferReversalRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferReversalRequest.java
@@ -1,0 +1,43 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+public class StripeTransferReversalRequest extends StripeRequest {
+    private String transferId;
+
+    protected StripeTransferReversalRequest(
+            GatewayAccountEntity gatewayAccount,
+            String idempotencyKey,
+            StripeGatewayConfig stripeGatewayConfig,
+            String transferId
+    ) {
+        super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
+        this.transferId = transferId;
+    }
+
+    public static StripeTransferReversalRequest of(String transferId, RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeTransferReversalRequest(
+                request.getGatewayAccount(),
+                request.getRefundExternalId(),
+                stripeGatewayConfig,
+                transferId
+        );
+    }
+
+    public String urlPath() {
+        return "/v1/transfers/" + transferId + "/reversals" ;
+    }
+
+    @Override
+    protected OrderRequestType orderRequestType() {
+        return OrderRequestType.REFUND;
+    }
+
+    @Override
+    protected String idempotencyKeyType() {
+        return "reverse_transfer";
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -108,4 +108,9 @@ public class StripeMockClient {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/payment_methods", 200);
     }
+
+    public void mockTransferReversal(String transferid) {
+        String payload = TestTemplateResourceLoader.load(STRIPE_TRANSFER_RESPONSE);
+        setupResponse(payload, "/v1/transfers/" + transferid + "/reversals", 200);
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -131,6 +131,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_capture_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response.json";
+    public static final String STRIPE_PAYMENT_INTENT_WITH_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_with_charge_response.json";
     public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
     public static final String STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_method_success_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE_DESTINATION_CHARGE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response_destination_charge.json";

--- a/src/test/resources/templates/stripe/create_payment_intent_with_charge_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_with_charge_response.json
@@ -1,0 +1,67 @@
+{
+  "id": "pi_123",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+      {
+        "id": "ch_1DRQ842eZvKYlo2CPbf7NNDv_test",
+        "object": "charge",
+        "amount": 100,
+        "amount_refunded": 0,
+        "application": null,
+        "application_fee": null,
+        "balance_transaction": "txn_19XJJ02eZvKYlo2ClwuJ1rbA"
+      }
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/charges?payment_intent=pi_123"
+  },
+  "client_secret": "secret",
+  "confirmation_method": "automatic",
+  "created": 1568141588,
+  "currency": "gbp",
+  "customer": null,
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": {
+    "redirect_to_url": {
+      "return_url": "http://localhost:9000/card_details/charge_id/3ds_required_in",
+      "url": "https://hooks.stripe.com/3d_secure_2/hosted?payment_intent=payment_intent_id&payment_intent_client_secret=fssfbbd"
+    },
+    "type": "redirect_to_url"
+  },
+  "on_behalf_of": "acct_123",
+  "payment_method": "pm_123",
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "requires_action",
+  "transfer_data": null,
+  "transfer_group": "tgroup"
+}

--- a/src/test/resources/templates/stripe/transfer_success_response.json
+++ b/src/test/resources/templates/stripe/transfer_success_response.json
@@ -1,5 +1,5 @@
 {
-  "id": "tr_1EID0pFijUALR7rqVvcSKggr",
+  "id": "transfer_id",
   "object": "transfer",
   "amount": 50
 }


### PR DESCRIPTION
This PR mitigates a problem we have observed in the wild.
The problem is that the following can happen:
- refund request to Stripe succeeds
- transfer request from connected account to platform account fails
- we as GOV.UK Pay are left out of pocket
- from service's point of view refund seems to be an error, yet the
end user has recieved the refund, and the service still recieves the
funds as part of next payout (since it is still credited to their account)

To avoid this, the `StripeRefundHandler` now does the following:
- transfer funds from connect account to platform account (if this
fails, refund fails, and no harm done)
- attempt to refund payment
- if refund step fails, reverse original transfer
- iff reversal fails, log error that will be picked up by Splunk alerting

The general idea is that we try reversable things before non-reversable things,
so that in the case of failure of non-reversible operation we can revert the
whole state without causing confusion.

I have also tidied up the tests somewhat. There were tests claiming to be about
testing specific kinds of failure from Stripe, which were essentially duplicate
since all Stripe failures are being mocked. I have left tests that check the
behaviour of refund handler for main failure modes that the handler can
discriminate between.

Finally, I have removed handling of 'non-payment intents' based payments
as we now only process payments using payment intents API.

