### PR TITLE
PP-5681 fix card expiry date mismatch for telephone payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
@@ -18,7 +18,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     private final String lastDigitsCardNumber;
     private final String cardholderName;
     private final String email;
-    private final String cardExpiryDate;
+    private final String expiryDate;
     private final String cardBrand;
     private final Map<String, Object> externalMetadata;
 
@@ -26,7 +26,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     private PaymentNotificationCreatedEventDetails(Long gatewayAccountId, Long amount, String reference,
                                                    String description, String gatewayTransactionId,
                                                    String firstDigitsCardNumber, String lastDigitsCardNumber,
-                                                   String cardholderName, String email, String cardExpiryDate,
+                                                   String cardholderName, String email, String expiryDate,
                                                    String cardBrand, Map<String, Object> externalMetadata) {
         this.gatewayAccountId = gatewayAccountId;
         this.amount = amount;
@@ -37,7 +37,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
         this.lastDigitsCardNumber = lastDigitsCardNumber;
         this.cardholderName = cardholderName;
         this.email = email;
-        this.cardExpiryDate = cardExpiryDate;
+        this.expiryDate = expiryDate;
         this.cardBrand = cardBrand;
         this.externalMetadata = externalMetadata;
     }
@@ -88,7 +88,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                 Objects.equals(lastDigitsCardNumber, that.lastDigitsCardNumber) &&
                 Objects.equals(cardholderName, that.cardholderName) &&
                 Objects.equals(email, that.email) &&
-                Objects.equals(cardExpiryDate, that.cardExpiryDate) &&
+                Objects.equals(expiryDate, that.expiryDate) &&
                 Objects.equals(cardBrand, that.cardBrand) &&
                 Objects.equals(externalMetadata, that.externalMetadata);
     }
@@ -96,7 +96,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     @Override
     public int hashCode() {
         return Objects.hash(gatewayAccountId, amount, reference, description, gatewayTransactionId,
-                firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, email, cardExpiryDate,
+                firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, email, expiryDate,
                 cardBrand, externalMetadata);
     }
 
@@ -136,8 +136,8 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
         return email;
     }
 
-    public String getCardExpiryDate() {
-        return cardExpiryDate;
+    public String getExpiryDate() {
+        return expiryDate;
     }
 
     public String getCardBrand() {

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
@@ -65,7 +65,7 @@ public class PaymentNotificationCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.first_digits_card_number", equalTo("424242")));
         assertThat(actual, hasJsonPath("$.event_details.last_digits_card_number", equalTo("4242")));
         assertThat(actual, hasJsonPath("$.event_details.cardholder_name", equalTo("Mr Test")));
-        assertThat(actual, hasJsonPath("$.event_details.card_expiry_date", equalTo("12/99")));
+        assertThat(actual, hasJsonPath("$.event_details.expiry_date", equalTo("12/99")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.processor_id", equalTo("processorID")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.auth_code", equalTo("012345")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.telephone_number", equalTo("+447700900796")));
@@ -95,7 +95,7 @@ public class PaymentNotificationCreatedTest {
         assertThat(actual, hasNoJsonPath("$.event_details.first_digits_card_number"));
         assertThat(actual, hasNoJsonPath("$.event_details.last_digits_card_number"));
         assertThat(actual, hasNoJsonPath("$.event_details.cardholder_name"));
-        assertThat(actual, hasNoJsonPath("$.event_details.card_expiry_date"));
+        assertThat(actual, hasNoJsonPath("$.event_details.expiry_date"));
         assertThat(actual, hasNoJsonPath("$.event_details.external_metadata.processor_id"));
         assertThat(actual, hasNoJsonPath("$.event_details.external_metadata.auth_code"));
         assertThat(actual, hasNoJsonPath("$.event_details.external_metadata.telephone_number"));


### PR DESCRIPTION
## WHAT YOU DID
- rename event details field to fix the mismatch between connector and ledger
- update relevant tests
