### PR TITLE
PP-5672 Make refunds backwards compatible

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequest.java
@@ -25,14 +25,11 @@ public class StripeRefundRequest extends StripeRequest {
     }
     
     public static StripeRefundRequest of(RefundGatewayRequest request, String stripeChargeId, StripeGatewayConfig stripeGatewayConfig) {
-        String chargeId = Optional.ofNullable(stripeChargeId)
-                .orElse(request.getTransactionId());
-        
         return new StripeRefundRequest(              
                 request.getAmount(),
                 request.getGatewayAccount(),
                 request.getRefundExternalId(),
-                chargeId,
+                stripeChargeId,
                 stripeGatewayConfig
         );
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import javax.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -29,13 +30,10 @@ public class StripeTransferInRequest extends StripeTransferRequest {
     }
 
     public static StripeTransferInRequest of(RefundGatewayRequest request, String stripeChargeId, StripeGatewayConfig stripeGatewayConfig) {
-        String chargeId = Optional.ofNullable(stripeChargeId)
-                .orElse(request.getTransactionId());
-        
         return new StripeTransferInRequest(
                 request.getAmount(),
                 request.getGatewayAccount(),
-                chargeId,
+                stripeChargeId,
                 request.getRefundExternalId(),
                 request.getChargeExternalId(),
                 stripeGatewayConfig

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -76,7 +76,26 @@ public class StripeRefundHandlerTest {
     }
 
     @Test
-    public void shouldRefundSuccessfully() throws Exception {
+    public void shouldRefundSuccessfully_usingPaymentIntentId() throws Exception {
+        RefundEntity refundEntity = RefundEntityFixture
+                .aValidRefundEntity()
+                .withAmount(100L)
+                .withChargeTransactionId("pi_123")
+                .withGatewayAccountEntity(gatewayAccount)
+                .build();
+        refundRequest = RefundGatewayRequest.valueOf(refundEntity);
+        mockTransferSuccess();
+        mockRefundSuccess();
+
+        final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
+
+        assertNotNull(refund);
+        assertTrue(refund.isSuccessful());
+        assertThat(refund.state(), is(GatewayRefundResponse.RefundState.COMPLETE));
+        assertThat(refund.getReference().get(), is("re_1DRiccHj08j21DRiccHj08j2_test"));
+    }
+@Test
+    public void shouldRefundSuccessfully_usingChargeId() throws Exception {
         mockTransferSuccess();
         mockRefundSuccess();
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -44,7 +44,6 @@ public class StripeRefundRequestTest {
     public void setUp() {
         when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
 
-        when(charge.getGatewayTransactionId()).thenReturn(stripeChargeId);
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
 
         when(refund.getAmount()).thenReturn(refundAmount);
@@ -56,7 +55,7 @@ public class StripeRefundRequestTest {
 
         final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
 
-        stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, null, stripeGatewayConfig);
+        stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, stripeChargeId, stripeGatewayConfig);
     }
     @Test
     public void createsCorrectRefundUrl() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -50,7 +50,6 @@ public class StripeTransferInRequestTest {
 
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);
-        when(charge.getGatewayTransactionId()).thenReturn(stripeChargeId);
 
         when(refund.getAmount()).thenReturn(refundAmount);
         when(refund.getExternalId()).thenReturn(refundExternalId);
@@ -62,7 +61,7 @@ public class StripeTransferInRequestTest {
 
         final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
 
-        stripeTransferInRequest = StripeTransferInRequest.of(refundGatewayRequest, null, stripeGatewayConfig);
+        stripeTransferInRequest = StripeTransferInRequest.of(refundGatewayRequest, stripeChargeId, stripeGatewayConfig);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -21,6 +21,7 @@ public class RefundEntityFixture {
     private String reference = "reference";
     public static String userExternalId = "AA213FD51B3801043FBC";
     private String externalId = "someExternalId";
+    private String transactionId = "123456";
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
 
     public static RefundEntityFixture aValidRefundEntity() {
@@ -74,7 +75,9 @@ public class RefundEntityFixture {
     }
 
     private ChargeEntity buildChargeEntity() {
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withTransactionId("1234abc").build();
+        return aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withTransactionId(transactionId).build();
     }
 
     public RefundEntityFixture withCharge(ChargeEntity charge) {
@@ -84,6 +87,11 @@ public class RefundEntityFixture {
 
     public RefundEntityFixture withExternalId(String externalId) {
         this.externalId = externalId;
+        return this;
+    }
+    
+    public RefundEntityFixture withChargeTransactionId(String transactionId) {
+        this.transactionId = transactionId;
         return this;
     }
 }


### PR DESCRIPTION
Reinstate logic to do refund either using payment intent id or
just the charge id based on form of id.
