### PR TITLE
PP-5204 Handle low value Stripe payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.stripe.request;
 
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
@@ -34,6 +35,17 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 stripeChargeId,
                 request.getRefundExternalId(),
                 request.getChargeExternalId(),
+                stripeGatewayConfig
+        );
+    }
+
+    public static StripeTransferInRequest of(Long amount, CaptureGatewayRequest request, String stripeChargeId, StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeTransferInRequest(
+                amount.toString(),
+                request.getGatewayAccount(),
+                stripeChargeId,
+                request.getExternalId(),
+                request.getExternalId(),
                 stripeGatewayConfig
         );
     }


### PR DESCRIPTION
For reasons too complicated to explain we capture Stripe payments
by first capturing the full amount to the Pay platform account, then
transferring the balance (total - fee) to the connect account.
In the case where fee > amount, we actually need to recoup the
(fee - amount) from the connect accoun in order to break even.
If fee = amount we do nothing.
