### PR TITLE
PP-5696 Fix Smartpay 3DS

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/Smartpay3dsAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/Smartpay3dsAuthorisationResponse.java
@@ -1,0 +1,64 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.persistence.oxm.annotations.XmlPath;
+import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+
+import java.util.Optional;
+import java.util.StringJoiner;
+
+public class Smartpay3dsAuthorisationResponse extends SmartpayBaseResponse implements BaseAuthoriseResponse {
+
+    private static final String AUTHORISED = "Authorised";
+    private static final String REFUSED = "Refused";
+
+    @XmlPath("soap:Body/ns1:authorise3dResponse/ns1:paymentResult/ns1:resultCode/text()")
+    private String result;
+
+    @XmlPath("soap:Body/ns1:authorise3dResponse/ns1:paymentResult/ns1:pspReference/text()")
+    private String pspReference;
+    
+    @Override
+    public AuthoriseStatus authoriseStatus() {
+        if (result == null) {
+            return AuthoriseStatus.ERROR;
+        }
+        switch (result) {
+            case AUTHORISED:
+                return AuthoriseStatus.AUTHORISED;
+            case REFUSED:
+                return AuthoriseStatus.REJECTED;
+            default:
+                return AuthoriseStatus.ERROR;
+        }
+    }
+
+    @Override
+    public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+        return Optional.empty();
+    }
+
+    @Override
+    public String getTransactionId() {
+        return pspReference;
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner joiner = new StringJoiner(", ", "SmartPay 3DS authorisation response (", ")");
+        if (StringUtils.isNotBlank(getTransactionId())) {
+            joiner.add("pspReference: " + getTransactionId());
+        }
+        if (StringUtils.isNotBlank(result)) {
+            joiner.add("resultCode: " + result);
+        }
+        if (StringUtils.isNotBlank(getErrorCode())) {
+            joiner.add("faultcode: " + getErrorCode());
+        }
+        if (StringUtils.isNotBlank(getErrorMessage())) {
+            joiner.add("faultstring: " + getErrorMessage());
+        }
+        return joiner.toString();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
 import io.dropwizard.setup.Environment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
@@ -45,8 +43,6 @@ import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCreden
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
 public class SmartpayPaymentProvider implements PaymentProvider {
-
-    private final Logger logger = LoggerFactory.getLogger(SmartpayPaymentProvider.class);
 
     private final ExternalRefundAvailabilityCalculator externalRefundAvailabilityCalculator;
     private final GatewayClient client;
@@ -101,13 +97,10 @@ public class SmartpayPaymentProvider implements PaymentProvider {
             GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                     request.getGatewayAccount(), build3dsResponseAuthOrderFor(request),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
-            GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getSmartpayGatewayResponse(response, SmartpayAuthorisationResponse.class);
+            GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getSmartpayGatewayResponse(response, Smartpay3dsAuthorisationResponse.class);
             
             if (!gatewayResponse.getBaseResponse().isPresent())
                 gatewayResponse.throwGatewayError();
-            
-            // TODO added temporarily for debugging as 3D secure is broken for Smartpay - @stephencdaly
-            logger.info("Smartpay 3DS response: " + response.getEntity());
             
             transactionId = Optional.ofNullable(gatewayResponse.getBaseResponse().get().getTransactionId());
             stringifiedResponse = gatewayResponse.toString();

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -24,18 +23,13 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_3DS_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_SUCCESS_RESPONSE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest {
-
-    @Before
-    public void setup() {
-        super.setup();
-        mockSmartpaySuccessfulOrderSubmitResponse();
-    }
 
     @Test
     public void shouldGetPaymentProviderName() {
@@ -49,7 +43,8 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
 
     @Test
     public void shouldSendSuccessfullyAOrderForMerchant() throws Exception {
-
+        mockSmartpaySuccessfulOrderSubmitResponse();
+        
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 
         ChargeEntity chargeEntity = aValidChargeEntity()
@@ -93,6 +88,8 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
 
     @Test
     public void shouldSuccess3DSAuthorisation() {
+        mockSmartpay3dsAuthorisationSuccessfulOrderSubmitResponse();
+        
         GatewayAccountEntity gatewayAccountEntity = aServiceAccount();
         gatewayAccountEntity.setRequires3ds(true);
         ChargeEntity chargeEntity = aValidChargeEntity()
@@ -114,6 +111,10 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
         mockSmartpayResponse(200, successAuthorise3dsrequiredResponse());
     }
 
+    private void mockSmartpay3dsAuthorisationSuccessfulOrderSubmitResponse() {
+        mockSmartpayResponse(200, success3dsAuthoriseResponse());
+    }
+
     private String successAuthorise3dsrequiredResponse() {
         return TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE).replace("{{pspReference}}", "12345678");
     }
@@ -124,6 +125,10 @@ public class SmartpayPaymentProviderTest extends BaseSmartpayPaymentProviderTest
 
     private String successAuthoriseResponse() {
         return TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE).replace("{{pspReference}}", "12345678");
+    }
+
+    private String success3dsAuthoriseResponse() {
+        return TestTemplateResourceLoader.load(SMARTPAY_3DS_AUTHORISATION_SUCCESS_RESPONSE).replace("{{pspReference}}", "12345678");
     }
 
     private String successCaptureResponse() {

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -38,7 +38,6 @@ import uk.gov.pay.connector.util.TestClientFactory;
 import javax.ws.rs.client.Client;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.not;
@@ -249,7 +248,7 @@ public class SmartpayPaymentProviderTest {
         when(gatewayClientFactory.createGatewayClient(any(PaymentGatewayName.class), any(MetricRegistry.class))).thenReturn(gatewayClient);
 
         GatewayConfig gatewayConfig = mock(GatewayConfig.class);
-        when(gatewayConfig.getUrls()).thenReturn(Collections.EMPTY_MAP);
+        when(gatewayConfig.getUrls()).thenReturn(Map.of(TEST.toString(), url));
 
         ConnectorConfiguration configuration = mock(ConnectorConfiguration.class);
         when(configuration.getGatewayConfigFor(PaymentGatewayName.SMARTPAY)).thenReturn(gatewayConfig);

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
@@ -13,7 +13,6 @@ import org.junit.runner.RunWith;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -98,7 +97,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
     public void shouldSuccessWhenAuth3dsRequiredAndAuthorisationSuccess() throws JsonProcessingException {
         databaseTestHelper.enable3dsForGatewayAccount(Long.parseLong(accountId));
         String chargeId = createNewChargeWithNoTransactionId(AUTHORISATION_3DS_REQUIRED);
-        smartpayMockClient.mockAuthorisationSuccess();
+        smartpayMockClient.mock3dsAuthorisationSuccess();
 
         givenSetup()
                 .body(new ObjectMapper().writeValueAsString(get3dsPayload()))
@@ -113,7 +112,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
     public void shouldFailWhenAuth3dsRequiredAndAuthorisationFailure() throws JsonProcessingException {
         databaseTestHelper.enable3dsForGatewayAccount(Long.parseLong(accountId));
         String chargeId = createNewChargeWithNoTransactionId(AUTHORISATION_3DS_REQUIRED);
-        smartpayMockClient.mockAuthorisationFailure();
+        smartpayMockClient.mock3dsAuthorisationFailure();
 
         givenSetup()
                 .body(new ObjectMapper().writeValueAsString(get3dsPayload()))

--- a/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
@@ -3,11 +3,23 @@ package uk.gov.pay.connector.rules;
 import com.github.tomakehurst.wiremock.http.Fault;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.UUID.randomUUID;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.*;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_3DS_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_3DS_AUTHORISATION_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CANCEL_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_REFUND_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_REFUND_SUCCESS_RESPONSE;
 
 public class SmartpayMockClient {
 
@@ -21,6 +33,16 @@ public class SmartpayMockClient {
         mockAuthorisationWithTransactionId(randomUUID().toString());
     }
 
+    public void mock3dsAuthorisationSuccess() {
+        mock3dsAuthorisationWithTransactionId(randomUUID().toString());
+    }
+
+    private void mock3dsAuthorisationWithTransactionId(String transactionId) {
+        String authoriseResponse = TestTemplateResourceLoader.load(SMARTPAY_3DS_AUTHORISATION_SUCCESS_RESPONSE)
+                .replace("{{pspReference}}", transactionId);
+        paymentServiceResponse(authoriseResponse);
+    }
+
     public void mockAuthorisation3dsRequired() {
         String authoriseResponse = TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE)
                 .replace("{{pspReference}}", randomUUID().toString());
@@ -30,6 +52,11 @@ public class SmartpayMockClient {
     public void mockAuthorisationFailure() {
         String authoriseResponse = TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_FAILED_RESPONSE);
         paymentServiceResponse(authoriseResponse);
+    }
+    
+    public void mock3dsAuthorisationFailure() {
+        String authorise3dsResponse = TestTemplateResourceLoader.load(SMARTPAY_3DS_AUTHORISATION_FAILED_RESPONSE);
+        paymentServiceResponse(authorise3dsResponse);
     }
 
     public void mockCaptureSuccess() {

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -56,8 +56,10 @@ public class TestTemplateResourceLoader {
     private static final String SMARTPAY_BASE_NAME = TEMPLATE_BASE_NAME + "/smartpay";
 
     public static final String SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-success-response.xml";
+    public static final String SMARTPAY_3DS_AUTHORISATION_SUCCESS_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-3ds-success-response.xml";
     public static final String SMARTPAY_AUTHORISATION_3DS_REQUIRED_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-3ds-required-response.xml";
     public static final String SMARTPAY_AUTHORISATION_FAILED_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-failed-response.xml";
+    public static final String SMARTPAY_3DS_AUTHORISATION_FAILED_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-3ds-failed-response.xml";
     static final String SMARTPAY_AUTHORISATION_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request.xml";

--- a/src/test/resources/templates/smartpay/authorisation-3ds-failed-response.xml
+++ b/src/test/resources/templates/smartpay/authorisation-3ds-failed-response.xml
@@ -1,0 +1,19 @@
+<ns0:Envelope xmlns:ns0="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns1="http://payment.services.adyen.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <ns0:Body>
+        <ns1:authorise3dResponse>
+            <ns1:paymentResult>
+                <ns1:additionalData xsi:nil="true" />
+                <ns1:authCode xsi:nil="true" />
+                <ns1:dccAmount xsi:nil="true" />
+                <ns1:dccSignature xsi:nil="true" />
+                <ns1:fraudResult xsi:nil="true" />
+                <ns1:issuerUrl xsi:nil="true" />
+                <ns1:md xsi:nil="true" />
+                <ns1:paRequest xsi:nil="true" />
+                <ns1:pspReference>8814436101583280</ns1:pspReference>
+                <ns1:refusalReason>CVC Declined</ns1:refusalReason>
+                <ns1:resultCode>Refused</ns1:resultCode>
+            </ns1:paymentResult>
+        </ns1:authorise3dResponse>
+    </ns0:Body>
+</ns0:Envelope>

--- a/src/test/resources/templates/smartpay/authorisation-3ds-success-response.xml
+++ b/src/test/resources/templates/smartpay/authorisation-3ds-success-response.xml
@@ -1,0 +1,20 @@
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soap:Body>
+        <ns1:authorise3dResponse xmlns:ns1="http://payment.services.adyen.com">
+            <ns1:paymentResult>
+                <additionalData xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <authCode xmlns="http://payment.services.adyen.com">87802</authCode>
+                <dccAmount xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <dccSignature xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <fraudResult xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <issuerUrl xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <md xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <paRequest xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <pspReference xmlns="http://payment.services.adyen.com">{{pspReference}}</pspReference>
+                <refusalReason xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
+                <resultCode xmlns="http://payment.services.adyen.com">Authorised</resultCode>
+            </ns1:paymentResult>
+        </ns1:authorise3dResponse>
+    </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
The root element in the response to a 3DS authorisation request is 'authorise3dResponse', as opposed to 'authoriseResponse' in the response to the first authorisation attempt.

Add a new class to unmarshall the 3DS authorisation response and use this when handling the response.
