### PR TITLE
PP-5672 Revert Stripe refund logic

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -135,6 +135,7 @@ public class StripeRefundHandlerTest {
 
     @Test
     public void shouldNotRefund_whenStatusCode4xxOnTransfer() throws Exception {
+        mockRefundSuccess();
         mockTransfer4xxResponse();
 
         final GatewayRefundResponse refund = refundHandler.refund(refundRequest);
@@ -148,20 +149,7 @@ public class StripeRefundHandlerTest {
 
     @Test
     public void shouldNotRefund_whenStatusCode5xxOnTransfer() throws Exception {
-        mockTransferResponse5xx();
-
-        GatewayRefundResponse refund = refundHandler.refund(refundRequest);
-
-        assertThat(refund.getError().isPresent(), Is.is(true));
-        assertThat(refund.getError().get().getMessage(), containsString("An internal server error occurred while refunding Transaction id:"));
-        assertThat(refund.getError().get().getErrorType(), Is.is(GATEWAY_ERROR));
-    }
-
-    @Test
-    public void shouldReverseTransfer_ifRefundStepFails() throws Exception {
-        mockTransferSuccess();
         mockRefund5xxResponse();
-        mockTransferReversalSuccess();
 
         GatewayRefundResponse refund = refundHandler.refund(refundRequest);
 
@@ -169,20 +157,7 @@ public class StripeRefundHandlerTest {
         assertThat(refund.getError().get().getMessage(), containsString("An internal server error occurred while refunding Transaction id:"));
         assertThat(refund.getError().get().getErrorType(), Is.is(GATEWAY_ERROR));
     }
-
-    @Test
-    public void shouldNotRefund_ifTransferReversalFails() throws Exception {
-        mockTransferSuccess();
-        mockRefund4xxResponse();
-        mockTransferReversalFailure();
-
-        GatewayRefundResponse refund = refundHandler.refund(refundRequest);
-
-        assertThat(refund.getError().isPresent(), Is.is(true));
-        assertThat(refund.getError().get().getMessage(), containsString("An internal server error occurred while refunding Transaction id:"));
-        assertThat(refund.getError().get().getErrorType(), Is.is(GATEWAY_ERROR));
-    }
-
+    
     private void mockRefundSuccess() throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
         GatewayClient.Response response = mock(GatewayClient.Response.class);
         when(response.getEntity()).thenReturn(load(STRIPE_REFUND_FULL_CHARGE_RESPONSE));

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
@@ -153,9 +153,7 @@ public class StripeRefundIT extends ChargingITestBase {
     public void stripeRefund_shouldResultInRefundErrorIfRefundFails() {
         String externalChargeId = defaultTestCharge.getExternalChargeId();
         long amount = 10L;
-        stripeMockClient.mockTransferSuccess(null);
         stripeMockClient.mockRefundError();
-        stripeMockClient.mockTransferReversal("transfer_id");
 
         ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());
         String refundPayload = new Gson().toJson(refundData);
@@ -179,6 +177,7 @@ public class StripeRefundIT extends ChargingITestBase {
         String externalChargeId = defaultTestCharge.getExternalChargeId();
         long amount = 10L;
         
+        stripeMockClient.mockRefund();
         stripeMockClient.mockTransferFailure();
 
         ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", amount, "refund_amount_available", defaultTestCharge.getAmount());


### PR DESCRIPTION
We have run into issues with the way Stripe refund currently works.
We try to do this
- transfer from connect account
- refund payment from platform account

- if refund fails reverse the transfer

However, it turns out we cannot reverse the transfer easily due to the
indebtedness of our platform account. So revert to the original order -
refund first then transfer. We will still alert on any failures and can
resolve them manually.
