### PR TITLE
[PP-5704] update column not to be insertable or updatable by persistance provider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
@@ -29,6 +29,8 @@ public class ChargeEventDao extends JpaDao<ChargeEventEntity> {
         ChargeEventEntity chargeEventEntity = ChargeEventEntity.from(chargeEntity, ChargeStatus.fromString(chargeEntity.getStatus()),
                 Optional.ofNullable(gatewayEventDate));
         this.persist(chargeEventEntity);
+        this.flush();
+        this.forceRefresh(chargeEventEntity);
         return chargeEventEntity;
     }
 

--- a/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
@@ -27,7 +27,7 @@ public class ChargeEventDao extends JpaDao<ChargeEventEntity> {
 
     public ChargeEventEntity persistChargeEventOf(ChargeEntity chargeEntity, ZonedDateTime gatewayEventDate) {
         ChargeEventEntity chargeEventEntity = ChargeEventEntity.from(chargeEntity, ChargeStatus.fromString(chargeEntity.getStatus()),
-                ZonedDateTime.now(), Optional.ofNullable(gatewayEventDate));
+                Optional.ofNullable(gatewayEventDate));
         this.persist(chargeEventEntity);
         return chargeEventEntity;
     }

--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/domain/ChargeEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/domain/ChargeEventEntity.java
@@ -42,17 +42,18 @@ public class ChargeEventEntity extends AbstractVersionedEntity {
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime gatewayEventDate;
 
-    @Convert(converter = UTCDateTimeConverter.class)
+    @Column(insertable = false, updatable = false)
+    @Convert(converter = LocalDateTimeConverter.class)
     private ZonedDateTime updated;
 
     protected ChargeEventEntity() {
     }
 
-    public ChargeEventEntity(ChargeEntity chargeEntity, ChargeStatus chargeStatus, ZonedDateTime updated, Optional<ZonedDateTime> gatewayEventDate) {
+    public ChargeEventEntity(ChargeEntity chargeEntity, ChargeStatus chargeStatus, Optional<ZonedDateTime> updated, Optional<ZonedDateTime> gatewayEventDate) {
         this.chargeEntity = chargeEntity;
         this.status = chargeStatus;
         this.gatewayEventDate = gatewayEventDate.orElse(null);
-        this.updated = updated;
+        this.updated = updated.orElse(null);
     }
 
     public Long getId() {
@@ -79,7 +80,7 @@ public class ChargeEventEntity extends AbstractVersionedEntity {
         return chargeEntity;
     }
 
-    public static ChargeEventEntity from(ChargeEntity chargeEntity, ChargeStatus chargeStatus, ZonedDateTime updated, Optional<ZonedDateTime> gatewayEventDate) {
-        return new ChargeEventEntity(chargeEntity, chargeStatus, updated, gatewayEventDate);
+    public static ChargeEventEntity from(ChargeEntity chargeEntity, ChargeStatus chargeStatus, Optional<ZonedDateTime> gatewayEventDate) {
+        return new ChargeEventEntity(chargeEntity, chargeStatus, Optional.empty(), gatewayEventDate);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/domain/LocalDateTimeConverter.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/domain/LocalDateTimeConverter.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.chargeevent.model.domain;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+@Converter
+public class LocalDateTimeConverter implements AttributeConverter<ZonedDateTime, Timestamp> {
+    @Override
+    public Timestamp convertToDatabaseColumn(ZonedDateTime dateTime) {
+        if (dateTime == null) {
+            return null;
+        }
+        else {
+            return Timestamp.valueOf(dateTime.toLocalDateTime());
+        }
+    }
+
+    @Override
+    public ZonedDateTime convertToEntityAttribute(Timestamp s) {
+        if (s == null) {
+            return null;
+        } else {
+            return s.toLocalDateTime().atZone(ZoneId.of("UTC"));
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/common/dao/JpaDao.java
+++ b/src/main/java/uk/gov/pay/connector/common/dao/JpaDao.java
@@ -19,6 +19,10 @@ public abstract class JpaDao<T> {
         entityManager.get().persist(object);
     }
 
+    public void flush() {
+        entityManager.get().flush();
+    }
+
     public void remove(final T object) {
         entityManager.get().remove(object);
     }

--- a/src/test/java/uk/gov/pay/connector/chargeevent/model/domain/LocalDateTimeConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/chargeevent/model/domain/LocalDateTimeConverterTest.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.chargeevent.model.domain;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class LocalDateTimeConverterTest {
+
+    private LocalDateTimeConverter localDateTimeConverter;
+    
+    @Before
+    public void setUp(){
+        localDateTimeConverter = new LocalDateTimeConverter();
+    }
+
+    @Test
+    public void convertsToUTC() {
+        ZonedDateTime dateTime = ZonedDateTime.parse("2019-10-10T10:55:56Z");
+
+        Timestamp convertedTimestamp = localDateTimeConverter.convertToDatabaseColumn(dateTime);
+        
+        assertThat(convertedTimestamp.toString(), is("2019-10-10 10:55:56.0"));
+    }
+
+    @Test
+    public void convertsFromUTC() {
+        Timestamp timestamp = Timestamp.valueOf("2019-10-10 10:55:56");
+
+        ZonedDateTime convertedDateTime = localDateTimeConverter.convertToEntityAttribute(timestamp);
+        
+        assertThat(convertedDateTime.toString(), is("2019-10-10T10:55:56Z[UTC]"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -33,9 +33,9 @@ public class PaymentDetailsEnteredTest {
         ZonedDateTime latestDateTime = ZonedDateTime.parse(time);
 
         List<ChargeEventEntity> list = List.of(
-                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, latestDateTime.minusHours(3), Optional.empty()),
-                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_SUCCESS, latestDateTime, Optional.empty()),
-                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.ENTERING_CARD_DETAILS, latestDateTime.minusHours(1), Optional.empty())
+                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, Optional.of(latestDateTime.minusHours(3)), Optional.empty()),
+                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_SUCCESS, Optional.of(latestDateTime), Optional.empty()),
+                new ChargeEventEntity(new ChargeEntity(), ChargeStatus.ENTERING_CARD_DETAILS, Optional.of(latestDateTime.minusHours(1)), Optional.empty())
         );
 
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()

--- a/src/test/java/uk/gov/pay/connector/it/dao/DaoITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DaoITestBase.java
@@ -40,6 +40,12 @@ abstract public class DaoITestBase {
         properties.put("javax.persistence.jdbc.user", postgres.getUsername());
         properties.put("javax.persistence.jdbc.password", postgres.getPassword());
 
+        properties.put("eclipselink.logging.level", "WARNING");
+        properties.put("eclipselink.logging.level.sql", "WARNING");
+        properties.put("eclipselink.query-results-cache", "false");
+        properties.put("eclipselink.cache.shared.default", "false");
+        properties.put("eclipselink.ddl-generation.output-mode", "database");
+
         JpaPersistModule jpaModule = new JpaPersistModule("ConnectorUnit");
         jpaModule.properties(properties);
 

--- a/src/test/java/uk/gov/pay/connector/pact/ChargeEventEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ChargeEventEntityFixture.java
@@ -12,7 +12,7 @@ import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidCharge
 
 public class ChargeEventEntityFixture {
     private ChargeStatus chargeStatus = ChargeStatus.CAPTURED;
-    private ZonedDateTime updated = ZonedDateTime.now();
+    private Optional<ZonedDateTime> updated = Optional.of(ZonedDateTime.now());
     private ZonedDateTime gatewayEventDate;
     private Long id = RandomUtils.nextLong();
     private ChargeEntity charge = aValidChargeEntity()
@@ -46,7 +46,7 @@ public class ChargeEventEntityFixture {
     }
 
     public ChargeEventEntityFixture withTimestamp(ZonedDateTime updated) {
-        this.updated = updated;
+        this.updated = Optional.of(updated);
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -38,15 +38,15 @@ public abstract class CardServiceTest {
                 .withId(chargeId)
                 .withStatus(status)
                 .withEvents(List.of(
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, ZonedDateTime.now().minusHours(3), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_SUCCESS, ZonedDateTime.now(), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.ENTERING_CARD_DETAILS, ZonedDateTime.now().minusHours(2), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_TIMEOUT, ZonedDateTime.now().minusHours(1), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_ERROR, ZonedDateTime.now().minusHours(1), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_3DS_REQUIRED, ZonedDateTime.now().minusHours(1), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_CANCELLED, ZonedDateTime.now().minusHours(1), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_REJECTED, ZonedDateTime.now().minusHours(1), Optional.empty()),
-                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR, ZonedDateTime.now().minusHours(1), Optional.empty())
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, Optional.of(ZonedDateTime.now().minusHours(3)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_SUCCESS, Optional.of(ZonedDateTime.now()), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.ENTERING_CARD_DETAILS, Optional.of(ZonedDateTime.now().minusHours(2)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_TIMEOUT, Optional.of(ZonedDateTime.now().minusHours(1)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_ERROR, Optional.of(ZonedDateTime.now().minusHours(1)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_3DS_REQUIRED, Optional.of(ZonedDateTime.now().minusHours(1)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_CANCELLED, Optional.of(ZonedDateTime.now().minusHours(1)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_REJECTED, Optional.of(ZonedDateTime.now().minusHours(1)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR, Optional.of(ZonedDateTime.now().minusHours(1)), Optional.empty())
                 ))
                 .build();
         entity.setCardDetails(new CardDetailsEntity());

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -8,8 +8,8 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.util.BooleanColumnMapper;
 import org.skife.jdbi.v2.util.StringColumnMapper;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
-import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
+import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.exception.ExternalMetadataConverterException;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -20,6 +20,7 @@ import uk.gov.pay.connector.wallets.WalletType;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -614,8 +615,11 @@ public class DatabaseTestHelper {
 
     public void addEvent(Long chargeId, String chargeStatus, ZonedDateTime updated) {
         jdbi.withHandle(
-                h -> h.update("INSERT INTO charge_events(charge_id,status,updated) values(?,?,?)",
-                        chargeId, chargeStatus, Timestamp.from(updated.toInstant()))
+                h -> {
+                    ZonedDateTime utcValue = updated.withZoneSameInstant(ZoneId.of("UTC"));
+                    return h.update("INSERT INTO charge_events(charge_id,status,updated) values(?,?,?)",
+                            chargeId, chargeStatus, Timestamp.valueOf(utcValue.toLocalDateTime()));
+                }
         );
     }
 


### PR DESCRIPTION
Currently the connector nodes generate timestamps that are later put in the db.
This can sometimes cause the problem, when the nodes have different values of time.
In order to mitigate the problem we're going to let db set the timestamp values for
ChargeEvents.
The way we currently handle timestamps is causing some problems in the local environment (if
the timezone is different than UTC).
The long term solution should be to convert all timestamps (at the moment all of them are without
a timzone info) to timestamps with timezone.
The fix put in this PR allows connector to read the timestamp data as UTC regardless the timezone
the app runs in (the explaination can be found here:
https://stackoverflow.com/questions/41618165/how-to-specify-utc-timezone-for-spring-boot-jpa-timestamp).

Changes (tl;dr):
* ChargeEventEntity.updated column changed to non-insertable and non-updatable (db sets the value)
  * replaced its converter to be able to read the value as UTC regardless the jvm timezone
* update countChargesForImmediateCapture (used for metrics only) dao method to pass the cutoff date in UTC
* update DatabaseHelper.addEvent to insert timestamp in UTC