### PR TITLE
PP-5702 telephone payments with success to be in CAPTURE SUBMITTED state

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -80,7 +80,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
@@ -179,7 +178,7 @@ public class ChargeService {
 
     private ChargeStatus internalChargeStatus(String code) {
         if (code == null) {
-            return AUTHORISATION_SUCCESS;
+            return CAPTURE_SUBMITTED;
         } else if ("P0010".equals(code)) {
             return AUTHORISATION_REJECTED;
         } else {

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -132,7 +132,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRE_CANCEL_READY, ModelledEvent.none());
-        graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_SUCCESS, ModelledEvent.of(AuthorisationSucceeded.class));
+        graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, CAPTURE_SUBMITTED, ModelledEvent.of(CaptureSubmitted.class));
         graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
         graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_CANCELLED, ModelledEvent.of(AuthorisationCancelled.class));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -541,7 +541,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getAmount(), is(100L));
         assertThat(createdChargeEntity.getReference(), is(ServicePaymentReference.of("Some reference")));
         assertThat(createdChargeEntity.getDescription(), is("Some description"));
-        assertThat(createdChargeEntity.getStatus(), is("AUTHORISATION SUCCESS"));
+        assertThat(createdChargeEntity.getStatus(), is("CAPTURE SUBMITTED"));
         assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
         assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneId.of("UTC")))));
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -6,12 +6,11 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.UnspecifiedEvent;
-import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
 import uk.gov.pay.connector.events.model.charge.AuthorisationCancelled;
 import uk.gov.pay.connector.events.model.charge.AuthorisationRejected;
-import uk.gov.pay.connector.events.model.charge.AuthorisationSucceeded;
 import uk.gov.pay.connector.events.model.charge.CaptureAbandonedAfterTooManyRetries;
 import uk.gov.pay.connector.events.model.charge.CaptureErrored;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
@@ -165,8 +164,8 @@ public class PaymentGatewayStateTransitionsTest {
 
     @Test
     public void getEventTransitionForPaymentNotificationCreated_returnsEventForModelledTypedEvent() {
-        Optional<Class<Event>> eventClassType = transitions.getEventForTransition(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_SUCCESS);
-        assertThat(eventClassType.get(), is(AuthorisationSucceeded.class));
+        Optional<Class<Event>> eventClassType = transitions.getEventForTransition(PAYMENT_NOTIFICATION_CREATED, CAPTURE_SUBMITTED);
+        assertThat(eventClassType.get(), is(CaptureSubmitted.class));
 
         eventClassType = transitions.getEventForTransition(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_REJECTED);
         assertThat(eventClassType.get(), is(AuthorisationRejected.class));

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
@@ -19,7 +19,7 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.PAYMENT_NOTIFICATION_CREATED;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
@@ -129,7 +129,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
         List<Map<String, Object>> chargeEvents = testHelper.getChargeEvents(chargeId);
 
         assertThat(chargeEvents, hasEvent(PAYMENT_NOTIFICATION_CREATED));
-        assertThat(chargeEvents, hasEvent(AUTHORISATION_SUCCESS));
+        assertThat(chargeEvents, hasEvent(CAPTURE_SUBMITTED));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- change telephone payments success state from AUTHORISATION_SUCCESS to CAPTURE_SUBMITTED as this reflects the true state of the transaction
- update relevant tests
