### PR TITLE
PP-5714: Configure connector to use json logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <eclipselink.version>2.7.4</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <jackson.version>2.10.0</jackson.version>
-        <pay-java-commons.version>1.0.20191010084537</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20191016090650</pay-java-commons.version>
         <surefire.version>3.0.0-M3</surefire.version>
         <javax.persistence.version>2.2.1</javax.persistence.version>
         <jooq.version>3.12.1</jooq.version>
@@ -39,6 +39,11 @@
         </repository>
     </repositories>
     <dependencies>
+        <dependency>
+            <groupId>uk.gov.pay</groupId>
+            <artifactId>logging</artifactId>
+            <version>${pay-java-commons.version}</version>
+        </dependency>
         <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>utils</artifactId>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -62,6 +62,7 @@ import uk.gov.pay.connector.usernotification.resource.EmailNotificationResource;
 import uk.gov.pay.connector.util.DependentResourceWaitCommand;
 import uk.gov.pay.connector.util.JsonMappingExceptionMapper;
 import uk.gov.pay.connector.webhook.resource.NotificationResource;
+import uk.gov.pay.logging.LogstashConsoleAppenderFactory;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -93,6 +94,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
         bootstrap.addCommand(new DependentResourceWaitCommand());
         bootstrap.addCommand(new RenderStateTransitionGraphCommand());
+        bootstrap.getObjectMapper().getSubtypeResolver().registerSubtypes(LogstashConsoleAppenderFactory.class);
     }
 
     @Override

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -10,11 +10,11 @@ server:
 logging:
   level: INFO
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] [chargeID=%X{chargeId:-(none)}] - %msg%n"
+      customFields:
+        container: "connector"
     - type: sentry
       threshold: ERROR
       dsn: ${SENTRY_DSN:-https://example.com@dummy/1}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -10,11 +10,11 @@ server:
 logging:
   level: INFO
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      customFields:
+        container: "connector"
 
 worldpay:
   urls:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -10,11 +10,11 @@ server:
 logging:
   level: INFO
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      customFields:
+        container: "connector"
 
 worldpay:
   urls:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -10,11 +10,11 @@ server:
 logging:
   level: INFO
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      customFields:
+        container: "connector"
 
 worldpay:
   urls:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-  level: WARN
+  level: INFO
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] - %msg%n"
+      customFields:
+        container: "connector"
 
 links:
   frontendUrl: http://Frontend/

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -8,13 +8,13 @@ server:
   registerDefaultExceptionMappers: false
 
 logging:
-  level: WARN
+  level: INFO
   appenders:
-    - type: console
+    - type: logstash-console
       threshold: ALL
-      timeZone: UTC
       target: stdout
-      logFormat: "[%d{yyyy-MM-dd HH:mm:ss.SSS}] [thread=%thread] [level=%-5level] [logger=%logger{15}] [requestID=%X{X-Request-Id:-(none)}] [chargeID=%X{chargeId:-(none)}] - %msg%n"
+      customFields:
+        container: "connector"
 
 links:
   frontendUrl: http://Frontend/


### PR DESCRIPTION
This won't break any splunk searches as the search terms used by searches relating to connector are still valid. These are `account="*prod*"`, `service="*docker*"`, and piping search results to `rex field=_raw`.