### PR TITLE
PP-5666: add pre-filled card details to payment created event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ bin
 .DS_Store
 /pacts/pacts.json
 /pacts/
+
+# state transition output
+states.dot

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -35,6 +35,7 @@ import uk.gov.pay.connector.events.model.charge.UnexpectedGatewayErrorDuringAuth
 import uk.gov.pay.connector.events.model.charge.UserApprovedForCapture;
 import uk.gov.pay.connector.events.model.charge.UserApprovedForCaptureAwaitingServiceApproval;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -207,6 +208,10 @@ public class PaymentGatewayStateTransitions {
                         return null;
                     }
                 });
+    }
+
+    public <T extends Event> List<ChargeStatus> getNextStatus(ChargeStatus fromStatus) {
+        return new ArrayList<>(graph.successors(fromStatus));
     }
     
     public static List<Class> getAllEventsResultingInTerminalState() {

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -1,13 +1,36 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import com.google.common.collect.ImmutableList;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
+import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ABORTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUBMITTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 
 public class PaymentCreatedEventDetails extends EventDetails {
+
+    private static List<ChargeStatus> postAuthorisationReadyStates = ImmutableList.of(
+            AUTHORISATION_ABORTED, AUTHORISATION_SUCCESS, AUTHORISATION_REJECTED, AUTHORISATION_ERROR,
+            AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR, AUTHORISATION_3DS_REQUIRED, AUTHORISATION_CANCELLED,
+            AUTHORISATION_SUBMITTED
+    );
+
     private final Long amount;
     private final String description;
     private final String reference;
@@ -18,6 +41,14 @@ public class PaymentCreatedEventDetails extends EventDetails {
     private final boolean delayedCapture;
     private final boolean live;
     private final Map<String, Object> externalMetadata;
+    private final String email;
+    private final String cardholderName;
+    private final String addressLine1;
+    private final String addressLine2;
+    private final String addressPostcode;
+    private final String addressCity;
+    private final String addressCounty;
+    private final String addressCountry;
 
     public PaymentCreatedEventDetails(Builder builder) {
         this.amount = builder.amount;
@@ -30,10 +61,18 @@ public class PaymentCreatedEventDetails extends EventDetails {
         this.delayedCapture = builder.delayedCapture;
         this.live = builder.live;
         this.externalMetadata = builder.externalMetadata;
+        this.email = builder.email;
+        this.cardholderName = builder.cardholderName;
+        this.addressLine1 = builder.addressLine1;
+        this.addressLine2 = builder.addressLine2;
+        this.addressPostcode = builder.addressPostcode;
+        this.addressCity = builder.addressCity;
+        this.addressCounty = builder.addressCounty;
+        this.addressCountry = builder.addressCountry;
     }
 
     public static PaymentCreatedEventDetails from(ChargeEntity charge) {
-        return new Builder()
+        var builder = new Builder()
                 .withAmount(charge.getAmount())
                 .withDescription(charge.getDescription())
                 .withReference(charge.getReference().toString())
@@ -44,7 +83,35 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 .withDelayedCapture(charge.isDelayedCapture())
                 .withLive(charge.getGatewayAccount().isLive())
                 .withExternalMetadata(charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null))
-                .build();
+                .withEmail(charge.getEmail());
+
+        if (isInCreatedState(charge) || hasNotGoneThroughAuthorisation(charge)) {
+            addCardDetailsIfExist(charge, builder);
+        }
+
+        return builder.build();
+    }
+
+    private static boolean isInCreatedState(ChargeEntity charge) {
+        return ChargeStatus.CREATED.equals(ChargeStatus.fromString(charge.getStatus()));
+    }
+
+    private static boolean hasNotGoneThroughAuthorisation(ChargeEntity charge) {
+        return charge.getEvents().stream()
+                .map(ChargeEventEntity::getStatus)
+                .noneMatch(status -> postAuthorisationReadyStates.contains(status));
+    }
+
+    private static void addCardDetailsIfExist(ChargeEntity charge, Builder builder) {
+        Optional.ofNullable(charge.getCardDetails()).ifPresent(
+                cardDetails ->
+                        builder.withCardholderName(cardDetails.getCardHolderName())
+                                .withAddressLine1(cardDetails.getBillingAddress().map(AddressEntity::getLine1).orElse(null))
+                                .withAddressLine2(cardDetails.getBillingAddress().map(AddressEntity::getLine2).orElse(null))
+                                .withAddressCity(cardDetails.getBillingAddress().map(AddressEntity::getCity).orElse(null))
+                                .withAddressCountry(cardDetails.getBillingAddress().map(AddressEntity::getCountry).orElse(null))
+                                .withAddressCounty(cardDetails.getBillingAddress().map(AddressEntity::getCounty).orElse(null))
+                                .withAddressPostcode(cardDetails.getBillingAddress().map(AddressEntity::getPostcode).orElse(null)));
     }
 
     public Long getAmount() {
@@ -87,6 +154,38 @@ public class PaymentCreatedEventDetails extends EventDetails {
         return externalMetadata;
     }
 
+    public String getEmail() {
+        return email;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public String getAddressLine1() {
+        return addressLine1;
+    }
+
+    public String getAddressLine2() {
+        return addressLine2;
+    }
+
+    public String getAddressPostcode() {
+        return addressPostcode;
+    }
+
+    public String getAddressCity() {
+        return addressCity;
+    }
+
+    public String getAddressCounty() {
+        return addressCounty;
+    }
+
+    public String getAddressCountry() {
+        return addressCountry;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -101,7 +200,15 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 Objects.equals(language, that.language) &&
                 Objects.equals(delayedCapture, that.delayedCapture) &&
                 Objects.equals(live, that.live) &&
-                Objects.equals(externalMetadata, that.externalMetadata);
+                Objects.equals(externalMetadata, that.externalMetadata) &&
+                Objects.equals(email, that.email) &&
+                Objects.equals(cardholderName, that.cardholderName) &&
+                Objects.equals(addressLine1, that.addressLine1) &&
+                Objects.equals(addressLine2, that.addressLine2) &&
+                Objects.equals(addressPostcode, that.addressPostcode) &&
+                Objects.equals(addressCity, that.addressCity) &&
+                Objects.equals(addressCounty, that.addressCounty) &&
+                Objects.equals(addressCountry, that.addressCountry);
     }
 
     @Override
@@ -121,6 +228,14 @@ public class PaymentCreatedEventDetails extends EventDetails {
         private boolean delayedCapture;
         private boolean live;
         private Map<String, Object> externalMetadata;
+        private String email;
+        private String cardholderName;
+        private String addressLine1;
+        private String addressLine2;
+        private String addressPostcode;
+        private String addressCity;
+        private String addressCounty;
+        private String addressCountry;
 
         public PaymentCreatedEventDetails build() {
             return new PaymentCreatedEventDetails(this);
@@ -173,6 +288,46 @@ public class PaymentCreatedEventDetails extends EventDetails {
 
         public Builder withExternalMetadata(Map<String, Object> externalMetadata) {
             this.externalMetadata = externalMetadata;
+            return this;
+        }
+
+        public Builder withEmail(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public Builder withCardholderName(String cardholderName) {
+            this.cardholderName = cardholderName;
+            return this;
+        }
+
+        public Builder withAddressLine1(String addressLine1) {
+            this.addressLine1 = addressLine1;
+            return this;
+        }
+
+        public Builder withAddressLine2(String addressLine2) {
+            this.addressLine2 = addressLine2;
+            return this;
+        }
+
+        public Builder withAddressPostcode(String addressPostcode) {
+            this.addressPostcode = addressPostcode;
+            return this;
+        }
+
+        public Builder withAddressCity(String addressCity) {
+            this.addressCity = addressCity;
+            return this;
+        }
+
+        public Builder withAddressCounty(String addressCounty) {
+            this.addressCounty = addressCounty;
+            return this;
+        }
+
+        public Builder withAddressCountry(String addressCountry) {
+            this.addressCountry = addressCountry;
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -25,7 +25,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
+import static org.hamcrest.core.IsIterableContaining.hasItems;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
@@ -175,5 +176,18 @@ public class PaymentGatewayStateTransitionsTest {
 
         eventClassType = transitions.getEventForTransition(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_CANCELLED);
         assertThat(eventClassType.get(), is(AuthorisationCancelled.class));
+    }
+
+    @Test
+    public void getNextStatus_returnsAListOfFollowingStatuses() {
+        assertThat(transitions.getNextStatus(AUTHORISATION_READY), hasItems(AUTHORISATION_ABORTED,
+                AUTHORISATION_SUCCESS,
+                AUTHORISATION_REJECTED,
+                AUTHORISATION_ERROR,
+                AUTHORISATION_TIMEOUT,
+                AUTHORISATION_UNEXPECTED_ERROR,
+                AUTHORISATION_3DS_REQUIRED,
+                AUTHORISATION_CANCELLED,
+                AUTHORISATION_SUBMITTED));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -1,25 +1,35 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import org.junit.Before;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.model.domain.ChargeEntityFixture;
 
 import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
+@RunWith(JUnitParamsRunner.class)
 public class PaymentCreatedTest {
 
     private final String paymentId = "jweojfewjoifewj";
     private final String time = "2018-03-12T16:25:01.123456Z";
 
-    private final ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+    private final ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
             .withCreatedDate(ZonedDateTime.parse(time))
             .withExternalId(paymentId)
             .withDescription("new passport")
@@ -27,40 +37,109 @@ public class PaymentCreatedTest {
             .withReturnUrl("http://example.com")
             .withAmount(100L)
             .withCorporateSurcharge(77L)
-            .withExternalMetadata(new ExternalMetadata(ImmutableMap.of("key1", "value1", "key2", "value2")))
-            .build();
+            .withEmail(null)
+            .withExternalMetadata(new ExternalMetadata(ImmutableMap.of("key1", "value1", "key2", "value2")));
+    private ChargeEntity chargeEntity;
 
-    private final PaymentCreated paymentCreatedEvent = PaymentCreated.from(chargeEntity);
-    private String actual;
-
-
-    @Before
-    public void setup() throws Exception {
-        actual = paymentCreatedEvent.toJsonString();
+    private String preparePaymentCreatedEvent() throws JsonProcessingException {
+        chargeEntity = chargeEntityFixture.build();
+        var paymentCreatedEvent = PaymentCreated.from(chargeEntity);
+        return paymentCreatedEvent.toJsonString();
     }
 
     @Test
-    public void serializesTimeWithMicrosecondPrecision() {
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+    public void serializesPayloadForCreatedWithoutCardDetails() throws JsonProcessingException {
+        var paymentCreatedEvent = preparePaymentCreatedEvent();
+
+        assertBasePaymentCreatedDetails(paymentCreatedEvent);
+        assertDoesNotContainCardDetails(paymentCreatedEvent);
+        assertThat(paymentCreatedEvent, hasNoJsonPath("$.event_details.email"));
     }
 
     @Test
-    public void serializesPaymentCreatedEventType() {
+    public void serializesPayloadForCreatedWithCardDetailsAndEmail() throws JsonProcessingException {
+        chargeEntityFixture
+                .withEmail("test@email.gov.uk")
+                .withCardDetails(anAuthCardDetails().getCardDetailsEntity());
+
+        var paymentCreatedEvent = preparePaymentCreatedEvent();
+
+        assertBasePaymentCreatedDetails(paymentCreatedEvent);
+        assertContainsCardDetails(paymentCreatedEvent);
+        assertThat(paymentCreatedEvent, hasJsonPath("$.event_details.email", equalTo("test@email.gov.uk")));
+    }
+
+    @Test
+    public void serializesPayloadForNonCreatedWithCardDetails() throws JsonProcessingException {
+        chargeEntityFixture
+                .withStatus(ChargeStatus.SYSTEM_CANCELLED)
+                .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
+                .withEvents(List.of(
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, Optional.of(ZonedDateTime.now().minusHours(3)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.SYSTEM_CANCELLED, Optional.of(ZonedDateTime.now().minusHours(3)), Optional.empty())
+                ));
+
+        var paymentCreatedEvent = preparePaymentCreatedEvent();
+
+        assertBasePaymentCreatedDetails(paymentCreatedEvent);
+        assertContainsCardDetails(paymentCreatedEvent);
+        assertThat(paymentCreatedEvent, hasNoJsonPath("$.event_details.email"));
+    }
+
+    @Test
+    @Parameters(method = "eventStatuses")
+    public void serializesPayloadForNonCreatedWithoutCardDetailsWhenContainsChargeEvent(ChargeStatus status) throws JsonProcessingException {
+        chargeEntityFixture
+                .withStatus(ChargeStatus.SYSTEM_CANCELLED)
+                .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
+                .withEvents(List.of(
+                        new ChargeEventEntity(new ChargeEntity(), ChargeStatus.CREATED, Optional.of(ZonedDateTime.now().minusHours(3)), Optional.empty()),
+                        new ChargeEventEntity(new ChargeEntity(), status, Optional.of(ZonedDateTime.now().minusHours(3)), Optional.empty())
+                ));
+
+        var paymentCreatedEvent = preparePaymentCreatedEvent();
+
+        assertBasePaymentCreatedDetails(paymentCreatedEvent);
+        assertDoesNotContainCardDetails(paymentCreatedEvent);
+        assertThat(paymentCreatedEvent, hasNoJsonPath("$.event_details.email"));
+    }
+
+    private Object[] eventStatuses() {
+        return new Object[]{
+                new Object[]{ChargeStatus.AUTHORISATION_ABORTED},
+                new Object[]{ChargeStatus.AUTHORISATION_SUCCESS},
+                new Object[]{ChargeStatus.AUTHORISATION_REJECTED},
+                new Object[]{ChargeStatus.AUTHORISATION_ERROR},
+                new Object[]{ChargeStatus.AUTHORISATION_TIMEOUT},
+                new Object[]{ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR},
+                new Object[]{ChargeStatus.AUTHORISATION_3DS_REQUIRED},
+                new Object[]{ChargeStatus.AUTHORISATION_CANCELLED},
+                new Object[]{ChargeStatus.AUTHORISATION_SUBMITTED}
+        };
+    }
+
+    private void assertDoesNotContainCardDetails(String actual) {
+        assertThat(actual, hasNoJsonPath("$.event_details.cardholder_name"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_line_1"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_line_2"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_postcode"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_city"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_county"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_country"));
+    }
+
+    private void assertContainsCardDetails(String actual) {
+        assertThat(actual, hasJsonPath("$.event_details.cardholder_name", equalTo("Mr Test")));
+        assertThat(actual, hasJsonPath("$.event_details.address_line1", equalTo("125 Kingsway")));
+        assertThat(actual, hasJsonPath("$.event_details.address_line2", equalTo("Aviation House")));
+        assertThat(actual, hasJsonPath("$.event_details.address_postcode", equalTo("WC2B 6NH")));
+        assertThat(actual, hasJsonPath("$.event_details.address_city", equalTo("London")));
+        assertThat(actual, hasJsonPath("$.event_details.address_county", equalTo("London")));
+        assertThat(actual, hasJsonPath("$.event_details.address_country", equalTo("GB")));
+    }
+
+    private void assertBasePaymentCreatedDetails(String actual) {
         assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_CREATED")));
-    }
-
-    @Test
-    public void serializesPaymentResourceType() {
-        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
-    }
-
-    @Test
-    public void serializesPaymentResourceExternaId() {
-        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
-    }
-
-    @Test
-    public void serializesPayloadFieldstoJsonString() {
         assertThat(actual, hasJsonPath("$.event_details.amount", equalTo(100)));
         assertThat(actual, hasJsonPath("$.event_details.description", equalTo("new passport")));
         assertThat(actual, hasJsonPath("$.event_details.reference", equalTo("myref")));
@@ -72,5 +151,8 @@ public class PaymentCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.delayed_capture", equalTo(chargeEntity.isDelayedCapture())));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.key1", equalTo("value1")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.key2", equalTo("value2")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
+@SuppressWarnings("PMD.UnusedPrivateMethod")
 @RunWith(JUnitParamsRunner.class)
 public class PaymentCreatedTest {
 


### PR DESCRIPTION
Why?
To allow searches on pre-filled data in ledger

Why is it complicated?
* it’s impossible to distinguish the new event from event backfilling
* once user fills the card details the pre-filled data is lost

Why does this approach work?
During the backfill the states happening after AUTHORISATION_READY event
(AUTHORISATION_READY won’t appear in db) will cause PaymentDetailsEntered
to be emitted. So if there is a charge (in whatever state) that doesn’t
have any charge events in the post-AUTHORISATION_READY states
(PaymentGatewayStateTransitions.java#L112-L120) then if we have information
about card details we can freely add it to PaymentCreated event.
In the normal event flow (not a backfill) this conditions should apply too
(there shouldn’t be enough time to transition to the next state (any of the
post-auth-ready ones) and if there is then we’ve lost the pre-filled data
anyway so we shouldn’t add them to the PaymentCreated payload.

Changes:
* updated PaymentDetailsEntered event to include card-details and email
* added relevant unit tests

Todo (in separate PR) - updates to the pact test