### PR TITLE
PP-5666: update payment created message for pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -57,6 +57,7 @@ public class QueueMessageContractTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withExternalMetadata(new ExternalMetadata(ImmutableMap.of("key", "value")))
                 .withCorporateSurcharge(55L)
+                .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
                 .build();
 
         PaymentCreated paymentCreatedEvent = new PaymentCreated(


### PR DESCRIPTION
The https://github.com/alphagov/pay-connector/pull/1829 change
adds additional data to PaymentCreated message.

Change:
* update pact provider to reflect the change to the message