### PR TITLE
PP-5749: Configure dropwizard server to log in json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
     </repositories>
     <dependencies>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+            <version>${dropwizard.version}</version>
+        </dependency>
+        <dependency>
             <groupId>uk.gov.pay</groupId>
             <artifactId>logging</artifactId>
             <version>${pay-java-commons.version}</version>

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -6,6 +6,16 @@ server:
     - type: http
       port: ${ADMIN_PORT:-0}
   registerDefaultExceptionMappers: false
+  requestLog:
+    appenders:
+      - type: console
+        layout:
+          type: access-json
+          customFieldNames:
+            timestamp: "@timestamp"
+          additionalFields:
+            container: "connector"
+            "@version": 1
 
 logging:
   level: INFO

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -13,6 +13,13 @@ server:
           type: access-json
           customFieldNames:
             timestamp: "@timestamp"
+            userAgent: "user_agent"
+            requestTime: "response_time"
+            uri: "url"
+            protocol: "http_version"
+            status: "status_code"
+            contentLength: "content_length"
+            remoteAddress: "remote_address"
           additionalFields:
             container: "connector"
             "@version": 1

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -6,6 +6,16 @@ server:
     - type: http
       port: 0
   registerDefaultExceptionMappers: false
+  requestLog:
+    appenders:
+      - type: console
+        layout:
+          type: access-json
+          customFieldNames:
+            timestamp: "@timestamp"
+          additionalFields:
+            container: "connector"
+            "@version": 1
 
 logging:
   level: INFO


### PR DESCRIPTION
This configures the server/jetty logger to log as:
```
{
  "container": "connector",
  "status_code": 200,
  "method": "GET",
  "http_version": "HTTP/1.1",
  "url": "/healthcheck",
  "@timestamp": 1571914521986,
  "@version": 1,
  "response_time": 43,
  "content_length": 249,
  "remote_address": "172.29.0.1",
  "user_agent": "curl/7.54.0"
}
```

I did try to configure json logging to use our `uk.gov.pay.logging.LogstashConsoleAppenderFactory`:

```
server:
  requestLog:
    appenders:
      - type: logstash-console
```

but this didn't work, as in, although the server started up fine, there were no
request logs. This appears to be the case as the "console" appender used by the
requestLog uses the `AccessJsonLayout` which logs an `IAccessEvent` (see
https://github.com/dropwizard/dropwizard/blob/master/dropwizard-json-logging/src/main/java/io/dropwizard/logging/json/layout/AccessJsonLayout.java#L20),
whereas our `LogstashConsoleAppenderFactory` logs a `ILoggingEvent` interface
(see
https://github.com/alphagov/pay-java-commons/blob/master/logging/src/main/java/uk/gov/pay/logging/LogstashConsoleAppenderFactory.java#L20).