### PR TITLE
PP-5749: Configure timestamp format

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -11,6 +11,7 @@ server:
       - type: console
         layout:
           type: access-json
+          timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
           customFieldNames:
             timestamp: "@timestamp"
             userAgent: "user_agent"

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -11,8 +11,16 @@ server:
       - type: console
         layout:
           type: access-json
+          timestampFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
           customFieldNames:
             timestamp: "@timestamp"
+            userAgent: "user_agent"
+            requestTime: "response_time"
+            uri: "url"
+            protocol: "http_version"
+            status: "status_code"
+            contentLength: "content_length"
+            remoteAddress: "remote_address"
           additionalFields:
             container: "connector"
             "@version": 1


### PR DESCRIPTION
Turns out json logs weren't showing in splunk as a result of https://github.com/alphagov/pay-connector/pull/1838. Think this is because the default timestamp format is the epoch millisecond, which caused the lambda to not parse the log line correctly.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
