### PR TITLE
PP-5757 Log the correct id when we process a Smartpay notification

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
@@ -79,7 +79,7 @@ public class SmartpayNotificationService {
 
         if (interpretedStatus instanceof MappedChargeStatus) {
             chargeNotificationProcessor.invoke(
-                    notification.getPspReference(),
+                    notification.getOriginalReference(),
                     charge,
                     interpretedStatus.getChargeStatus(),
                     notification.getEventDate()

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
@@ -70,7 +70,7 @@ public class SmartpayNotificationServiceTest {
         notificationService.handleNotificationFor(payload);
 
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
-        verify(mockChargeNotificationProcessor).invoke(pspReference, mockCharge, CAPTURED,
+        verify(mockChargeNotificationProcessor).invoke(originalReference, mockCharge, CAPTURED,
                 ZonedDateTime.parse("2015-10-08T13:48:30+02:00"));  // from notification-capture.json
     }
 


### PR DESCRIPTION
We were logging the "pspReference", but this is a unique reference for the operation, rather than the Smartpay's reference for the charge. This is unhelpful as we don't have an easy way to relate it back to the charge. Instead, log the "originalReference" which is Smartpay's reference for the charge.
