### PR TITLE
PP-5757: Increase epdq capture timeout

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -83,7 +83,7 @@ epdq:
     refund:
       readTimeout: 2000ms
     capture:
-      readTimeout: 1000ms
+      readTimeout: 3000ms
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}


### PR DESCRIPTION
We have been getting a lot of timeout exceptions when capturing epdq payments -
683 events on 25/10/2019 for example. Hopefully this will go away if we increase the timeout slightly.