### PR TITLE
PP-5757 Don't log error when notification has already been processed

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/exception/InvalidStateTransitionException.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/InvalidStateTransitionException.java
@@ -5,8 +5,22 @@ import uk.gov.pay.connector.events.model.Event;
 import static java.lang.String.format;
 
 public class InvalidStateTransitionException extends IllegalStateException {
+    
+    private final String currentState;
+    
+    private final String targetState;
+
+    public String getCurrentState() {
+        return currentState;
+    }
+
+    public String getTargetState() {
+        return targetState;
+    }
 
     public InvalidStateTransitionException(String currentState, String targetState, Event event) {
         super(format("Charge state transition [%s] -> [%s] not allowed [event={}]", currentState, targetState, event));
+        this.currentState = currentState;
+        this.targetState = targetState;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -28,8 +28,12 @@ public class ChargeNotificationProcessor {
         try {
             chargeService.transitionChargeState(chargeEntity, newStatus, gatewayEventDate);
         } catch (InvalidStateTransitionException e) {
-            logger.error("{} ({}) notification '{}' could not be used to update charge: {}",
-                    gatewayAccount.getGatewayName(), gatewayAccount.getId(), transactionId, e.getMessage());
+            // don't log an error if we're trying to transition to the same state as this can happen if we've already
+            // processed the notification
+            if (!e.getCurrentState().equals(e.getTargetState())) {
+                logger.error("{} ({}) notification '{}' could not be used to update charge: {}",
+                        gatewayAccount.getGatewayName(), gatewayAccount.getId(), transactionId, e.getMessage());
+            }
             return;
         }
 


### PR DESCRIPTION
We log an error if we fail to transition a charge when processing a notification. We've seen a number of errors logged when we try to transition the charge into a state it's already in. In this case we've already processed the notification so it's fine to do nothing and log nothing.

We're still logging an error if we can't transition to a different state, however we should review if we see errors like this whether they are actually errors.