### PR TITLE
PP-5785 Worldpay Notification - Send non 2xx if charge not found

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -89,10 +89,13 @@ public class WorldpayNotificationService {
         Optional<ChargeEntity> optionalChargeEntity = chargeDao.findByProviderAndTransactionId(gatewayName(),
                 notification.getTransactionId());
 
-        if (!optionalChargeEntity.isPresent()) {
-            logger.error("{} notification {} could not be evaluated (associated charge entity not found)",
+        if (optionalChargeEntity.isEmpty()) {
+            logger.info("{} notification {} could not be evaluated (associated charge entity not found)",
                     gatewayName(), notification);
-            return true;
+            // Respond with an error, which will cause worldpay to try to send the notification
+            // again later — this is necessary because sometimes we might receive a notification
+            // for a telephone payment before we know about the payment itself
+            return false;
         }
 
         if (isCaptureNotification(notification)) {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -123,7 +123,7 @@ public class WorldpayNotificationServiceTest {
 
 
     @Test
-    public void ifChargeNotFound_shouldNotInvokeChargeNotificationProcessor() {
+    public void ifChargeNotFound_shouldNotInvokeChargeNotificationProcessorAndReturnFalse() {
         final String payload = sampleWorldpayNotification(
                 transactionId,
                 referenceId,
@@ -135,7 +135,7 @@ public class WorldpayNotificationServiceTest {
         when(mockChargeDao.findByProviderAndTransactionId(WORLDPAY.getName(), transactionId)).thenReturn(Optional.empty());
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
-        assertTrue(result);
+        assertFalse(result);
 
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -21,7 +21,6 @@ import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
@@ -103,15 +102,11 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void shouldNotUpdateStatusToDatabaseIfGatewayAccountIsNotFound() throws Exception {
-        String chargeId = createNewCharge(AUTHORISATION_SUCCESS);
-
+    public void shouldReturnNon2xxStatusIfChargeIsNotFoundForTransaction() throws Exception {
         notifyConnector("unknown-transation-id", "GARBAGE")
-                .statusCode(200)
+                .statusCode(403)
                 .extract().body()
                 .asString();
-
-        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.getValue());
     }
 
     @Test


### PR DESCRIPTION
## WHAT
- Returns non 2xx response for WorldpayNotification and when a charge is not found for Worldpay Transaction ID.
   Currently, we always have a charge (for successful authorisation) associated with worldpay transaction ID and we ignore notifications (send 200 response to worldpay) if charge is not found for corresponding worldpay transaction ID.

   This is an issue with telephone payments, where we can get worldpay CAPTURE notification, before we receive any payload for telphone payment. In such cases, charge related to telephone payment stays in CAPTURE_SUBMITTED state forever and can't be refunded.

   Returning non 2xx response will ensure worldpay retries the notification periodically for upto 7 days and we can receive telephone payment payload & worldpay notification for CAPTURE in any order.

- Also downgraded ERROR level logging to INFO when charge is not found for notification