### PR TITLE
PP-5757 Don't log generic gateway errors at error level

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -171,7 +171,6 @@ public class CardResource {
             case GATEWAY_ERROR:
                 return serviceErrorResponse(error.getMessage());
             default:
-                logger.error("Charge {}: error {}", chargeId, error.getMessage());
                 return badRequestResponse(error.getMessage());
         }
     }


### PR DESCRIPTION
This log just generates a lot of noise so remove it.
The main logs come from:
- entering a non-sandbox card number for a sandbox account
- entering a sandbox card number that causes an authorisation error
- entering a non-test card number for a worldpay test account
- entering an invalid card number with a valid bin range for a worldpay account
- entering an invalid expiry date for a worldpay account.

There are a few other opaque worldpay errors, but logging them here isn't a good way of telling if there is a problem with our system. We already log all authorisation responses at info level, and have a saved search for authorisation errors due to a payment method being disabled
in worldpay, which is a better way of determining if there is something we should act upon.