### PR TITLE
PP-5757 Don't log attempt to cancel charge in not allowed state as error

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -159,7 +159,7 @@ public class ChargeCancelService {
                 throw new ConflictRuntimeException(chargeEntity.getExternalId());
             }
 
-            logger.error("Charge is not in one of the legal states. charge_external_id={}, status={}, legal_states={}",
+            logger.info("Charge is not in one of the legal states. charge_external_id={}, status={}, legal_states={}",
                     chargeEntity.getExternalId(), chargeEntity.getStatus(), getLegalStatusNames(statusFlow.getTerminatableStatuses()));
 
             throw new IllegalStateRuntimeException(chargeEntity.getExternalId());

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -281,7 +281,7 @@ public class ChargeExpiryService {
                     throw new ConflictRuntimeException(chargeEntity.getExternalId());
                 }
 
-                logger.error("Charge is not in one of the legal states. charge_external_id={}, status={}, legal_states={}",
+                logger.warn("Charge is not in one of the legal states. charge_external_id={}, status={}, legal_states={}",
                         chargeId, chargeEntity.getStatus(), getLegalStatusNames(EXPIRE_FLOW.getTerminatableStatuses()));
 
                 throw new IllegalStateRuntimeException(chargeId);


### PR DESCRIPTION
For attempts to cancel a charge that isn't in a legal state, we will send an error response which is either relayed to the service in the public API response, or handled by frontend. This is not an error, so log as INFO.

For an attempt to expire a charge not in a valid state, this ideally shouldn't happen as we should only attempt to expire charges in valid states, but there could be some race involved here. In which case it might be indicative that our expiry process isn't ideal but not an error we need to immediately act on. So log this at WARN level.
