### PR TITLE
PP-5757: Emails shouldn't be sent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -33,8 +33,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.Runtime.getRuntime;
+import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode.OPTIONAL;
 
 
 public class UserNotificationService {
@@ -69,32 +71,34 @@ public class UserNotificationService {
     }
 
     private Future<Optional<String>> sendEmail(EmailNotificationType emailNotificationType, ChargeEntity chargeEntity, HashMap<String, String> personalisation) {
-        boolean isEmailEnabled = Optional.ofNullable(chargeEntity.getGatewayAccount().getEmailNotifications().get(emailNotificationType))
+        GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
+        boolean isEmailEnabled = ofNullable(gatewayAccount.getEmailNotifications().get(emailNotificationType))
                 .map(EmailNotificationEntity::isEnabled)
                 .orElse(false);
-        if (emailNotifyGloballyEnabled && isEmailEnabled) {
-            String emailAddress = chargeEntity.getEmail();
-            Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
-            return executorService.submit(() -> {
-                try {
-                    NotifyClientSettings notifyClientSettings = getNotifyClientSettings(emailNotificationType, chargeEntity);
-                    logger.info("Sending {} email, charge_external_id={}", emailNotificationType, chargeEntity.getExternalId());
-                    SendEmailResponse response = notifyClientSettings.getClient()
-                            .sendEmail(notifyClientSettings.getTemplateId(), emailAddress, personalisation, null);
-                    return Optional.of(response.getNotificationId().toString());
-                } catch (NotificationClientException e) {
-                    logger.error("Failed to send " + emailNotificationType + " email - charge_external_id=" + chargeEntity.getExternalId(), e);
-                    metricRegistry.counter("notify-operations.failures").inc();
-                    return Optional.empty();
-                } finally {
-                    responseTimeStopwatch.stop();
-                    metricRegistry.histogram("notify-operations.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
-                }
-            });
+        
+        if (!emailNotifyGloballyEnabled || !isEmailEnabled ||
+                gatewayAccount.getEmailCollectionMode().equals(OPTIONAL) && ofNullable(chargeEntity.getEmail()).isEmpty()) {
+            return CompletableFuture.completedFuture(Optional.empty());
         }
-        return CompletableFuture.completedFuture(Optional.empty());
-    }
 
+        Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
+        return executorService.submit(() -> {
+            try {
+                NotifyClientSettings notifyClientSettings = getNotifyClientSettings(emailNotificationType, chargeEntity);
+                logger.info("Sending {} email, charge_external_id={}", emailNotificationType, chargeEntity.getExternalId());
+                SendEmailResponse response = notifyClientSettings.getClient()
+                        .sendEmail(notifyClientSettings.getTemplateId(), chargeEntity.getEmail(), personalisation, null);
+                return Optional.of(response.getNotificationId().toString());
+            } catch (NotificationClientException e) {
+                logger.error("Failed to send " + emailNotificationType + " email - charge_external_id=" + chargeEntity.getExternalId(), e);
+                metricRegistry.counter("notify-operations.failures").inc();
+                return Optional.empty();
+            } finally {
+                responseTimeStopwatch.stop();
+                metricRegistry.histogram("notify-operations.response_time").update(responseTimeStopwatch.elapsed(TimeUnit.MILLISECONDS));
+            }
+        });
+    }
 
     private NotifyClientSettings getNotifyClientSettings(EmailNotificationType emailNotificationType, ChargeEntity chargeEntity) {
         // todo introduce type for notify settings instead of Map
@@ -132,6 +136,7 @@ public class UserNotificationService {
             return new NotifyClientSettings(notifyClientFactory.getInstance(), payTemplateId);
         }
     }
+    
     private static boolean hasCustomTemplateAndApiKey(Map<String, String> notifySettings, String customTemplateId) {
         return notifySettings != null  && (notifySettings.containsKey(customTemplateId) && isNotBlank(notifySettings.get("api_token")));
     }

--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -36,6 +36,7 @@ import static java.lang.Runtime.getRuntime;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode.OFF;
 import static uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode.OPTIONAL;
 
 
@@ -76,7 +77,7 @@ public class UserNotificationService {
                 .map(EmailNotificationEntity::isEnabled)
                 .orElse(false);
         
-        if (!emailNotifyGloballyEnabled || !isEmailEnabled ||
+        if (!emailNotifyGloballyEnabled || !isEmailEnabled || gatewayAccount.getEmailCollectionMode().equals(OFF) ||
                 gatewayAccount.getEmailCollectionMode().equals(OPTIONAL) && ofNullable(chargeEntity.getEmail()).isEmpty()) {
             return CompletableFuture.completedFuture(Optional.empty());
         }

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.connector.usernotification.service;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.setup.Environment;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.converters.Nullable;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.ExecutorServiceConfig;
+import uk.gov.pay.connector.app.NotifyConfiguration;
+import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
+import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.SendEmailResponse;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.defaultGatewayAccountEntity;
+
+@RunWith(JUnitParamsRunner.class)
+public class UserNotificationServiceEmailCollectionModeTest {
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private ConnectorConfiguration connectorConfig;
+    
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private NotifyClientFactory notifyClientFactory;
+
+    @Mock
+    private NotificationClient notificationClient;
+
+    @Mock
+    private SendEmailResponse mockNotificationCreatedResponse;
+    
+    private UserNotificationService userNotificationService;
+    
+    @Before
+    public void setUp() {
+        NotifyConfiguration notifyConfiguration = mock(NotifyConfiguration.class);
+        when(connectorConfig.getNotifyConfiguration()).thenReturn(notifyConfiguration);
+        when(notifyConfiguration.getEmailTemplateId()).thenReturn("some-template");
+        when(notifyConfiguration.getRefundIssuedEmailTemplateId()).thenReturn("another-template");
+        when(notifyConfiguration.isEmailNotifyEnabled()).thenReturn(true);
+
+        when(notifyClientFactory.getInstance()).thenReturn(notificationClient);
+
+        ExecutorServiceConfig mockExecutorConfiguration = mock(ExecutorServiceConfig.class);
+        when(connectorConfig.getExecutorServiceConfig()).thenReturn(mockExecutorConfiguration);
+        when(mockExecutorConfiguration.getThreadsPerCpu()).thenReturn(2);
+
+        MetricRegistry metricRegistry = mock(MetricRegistry.class);
+        when(environment.metrics()).thenReturn(metricRegistry);
+        when(metricRegistry.histogram(anyString())).thenReturn(mock(Histogram.class));
+
+        when(mockNotificationCreatedResponse.getNotificationId()).thenReturn(UUID.randomUUID());
+        
+        userNotificationService = new UserNotificationService(notifyClientFactory, connectorConfig, environment);
+    }
+    
+    @Test
+    @Parameters({
+            "OPTIONAL, email@example.com, true",
+            "OPTIONAL, null, false",
+    })
+    public void determineSendingEmailEmailCollectionModes(String emailCollectionMode, 
+                                                          @Nullable String emailAddress, 
+                                                          boolean shouldEmailBeSent) throws Exception {
+
+        when(notificationClient.sendEmail(anyString(), anyString(), anyMap(), isNull())).thenReturn(mockNotificationCreatedResponse);
+
+        var gatewayAccount = defaultGatewayAccountEntity();
+        gatewayAccount.setEmailCollectionMode(EmailCollectionMode.fromString(emailCollectionMode));
+        var chargeEntity = aValidChargeEntity().withEmail(emailAddress).withGatewayAccountEntity(gatewayAccount).build();
+        userNotificationService.sendPaymentConfirmedEmail(chargeEntity).get(1000, TimeUnit.SECONDS);
+
+        verify(notificationClient, times(shouldEmailBeSent? 1 : 0)).sendEmail(anyString(), anyString(), anyMap(), isNull());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceEmailCollectionModeTest.java
@@ -84,8 +84,10 @@ public class UserNotificationServiceEmailCollectionModeTest {
     @Parameters({
             "OPTIONAL, email@example.com, true",
             "OPTIONAL, null, false",
+            "OFF, null, false",
+            "OFF, email@example.com, false",
     })
-    public void determineSendingEmailEmailCollectionModes(String emailCollectionMode, 
+    public void determineSendingEmailForEmailCollectionModes(String emailCollectionMode, 
                                                           @Nullable String emailAddress, 
                                                           boolean shouldEmailBeSent) throws Exception {
 

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
@@ -48,8 +48,8 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -208,7 +208,7 @@ public class UserNotificationServiceTest {
         Future<Optional<String>> idF = userNotificationService.sendPaymentConfirmedEmail(ChargeEntityFixture.aValidChargeEntity().build());
         idF.get(1000, TimeUnit.SECONDS);
 
-        verifyZeroInteractions(mockNotifyClient);
+        verifyNoInteractions(mockNotifyClient);
     }
 
     @Test
@@ -219,7 +219,7 @@ public class UserNotificationServiceTest {
         Future<Optional<String>> idF = userNotificationService.sendRefundIssuedEmail(RefundEntityFixture.aValidRefundEntity().build());
         idF.get(1000, TimeUnit.SECONDS);
 
-        verifyZeroInteractions(mockNotifyClient);
+        verifyNoInteractions(mockNotifyClient);
     }
 
     @Test
@@ -231,7 +231,7 @@ public class UserNotificationServiceTest {
 
         userNotificationService = new UserNotificationService(mockNotifyClientFactory, mockConfig, mockEnvironment);
         userNotificationService.sendPaymentConfirmedEmail(chargeEntity);
-        verifyZeroInteractions(mockNotifyClient);
+        verifyNoInteractions(mockNotifyClient);
     }
 
     @Test
@@ -254,7 +254,7 @@ public class UserNotificationServiceTest {
                 .setEnabled(false);
 
         userNotificationService.sendRefundIssuedEmail(refundEntity);
-        verifyZeroInteractions(mockNotifyClient);
+        verifyNoInteractions(mockNotifyClient);
     }
 
     @Test


### PR DESCRIPTION
If the email collection mode is OPTIONAL and there is no email associated with
the charge.

This fixes https://pay-sentry.cloudapps.digital/sentry/connector/issues/85/

Also adding tests for where email collection mode is OFF as it would be possible for a charge to have an email address whilst the email
collection mode is OFF. This can happen if the collection mode was MANDATORY, a
charge was created (but not yet captured) and the service turned the email
collection mode to OFF.