### PR TITLE
PP-5757 Improve 3DS Authorisation response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -33,11 +33,6 @@ public class Gateway3DSAuthorisationResponse {
         return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "");
     }
 
-    public boolean isDeclined() {
-        return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.REJECTED ||
-                authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.ERROR;
-    }
-
     public boolean isSuccessful() {
         return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED
                 || authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTH_3DS_READY;

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -112,18 +112,17 @@ public class CardResource {
     @Produces(APPLICATION_JSON)
     public Response authorise3dsCharge(@PathParam("chargeId") String chargeId, Auth3dsDetails auth3DsDetails) {
         Gateway3DSAuthorisationResponse response = card3dsResponseAuthService.process3DSecureAuthorisation(chargeId, auth3DsDetails);
-        return response.isDeclined() ? badRequestResponse("This transaction was declined.") : handleGateway3DSAuthoriseResponse(response);
-    }
-
-    private Response handleGateway3DSAuthoriseResponse(Gateway3DSAuthorisationResponse response) {
+        
         if (response.isSuccessful()) {
             return ResponseUtil.successResponseWithEntity(
                     ImmutableMap.of(
                             "status", response.getMappedChargeStatus().toString()
                     ));
-        } else {
-            return serviceErrorResponse("Failed");
         }
+        if (response.isException()) {
+            return serviceErrorResponse("There was an error when attempting to authorise the transaction.");
+        }
+        return badRequestResponse("This transaction was declined.");
     }
 
     @POST

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsTest.java
@@ -47,7 +47,6 @@ public class EpdqPaymentProvider3dsTest extends BaseEpdqPaymentProviderTest {
         Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertFalse(response.isSuccessful());
-        assertThat(response.isDeclined(), is(true));
         verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "AUTHORISED", REJECTED.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -184,7 +184,7 @@ public class StripePaymentProviderTest {
 
         Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
 
-        assertTrue(response.isDeclined());
+        assertThat(response.isSuccessful(), is(false));
         assertThat(response.getMappedChargeStatus(), is(ChargeStatus.AUTHORISATION_REJECTED));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -277,7 +277,7 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
     public void shouldReturnStatus500_WhenAuthorisationCallThrowsException() {
         String chargeId = createNewCharge(AUTHORISATION_3DS_REQUIRED);
 
-        String expectedErrorMessage = "Failed";
+        String expectedErrorMessage = "There was an error when attempting to authorise the transaction.";
         worldpayMockClient.mockServerFault();
 
         givenSetup()
@@ -296,7 +296,7 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
     public void shouldReturnStatus500_AWorldpayPaResParseError() {
         String chargeId = createNewCharge(AUTHORISATION_3DS_REQUIRED);
 
-        String expectedErrorMessage = "Failed";
+        String expectedErrorMessage = "There was an error when attempting to authorise the transaction.";
         worldpayMockClient.mockAuthorisationPaResParseError();
 
         givenSetup()


### PR DESCRIPTION
We were doing as follows:
- If the authorisation status was AUTHORISED or AUTH_3DS_READY we
returned a 200 response frontend.
- If the authorisation status was REJECTED or ERROR we returned a 400
response to frontend.
- If the authorisation status was anything else, we returned a 500 to frontend, causing it to show the technical difficulties page.

However, this did not account for the CANCELLED status which is a valid outcome for Worldpay 3DS authorisations, which we have observed come back.

Improve this by still returning a 200 for AUTHORISED or AUTH_3DS_READY statuses, and a 500 only for the EXCEPTION status, and a 400 for any other status.

Sentry issue: https://pay-sentry.cloudapps.digital/sentry/connector/issues/109