### PR TITLE
PP-5757: Downgrade unexpected status code log to WARN

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -70,7 +70,7 @@ public class GatewayClient {
             if (statusCode == OK.getStatusCode()) {
                 return gatewayResponse;
             } else {
-                logger.error("Gateway returned unexpected status code: {}, for gateway url={} with type {} with order request type {}",
+                logger.warn("Gateway returned unexpected status code: {}, for gateway url={} with type {} with order request type {}",
                         statusCode, url, account.getType(), request.getOrderRequestType().toString());
                 incrementFailureCounter(metricRegistry, metricsPrefix);
                 throw new GatewayErrorException("Unexpected HTTP status code " + statusCode + " from gateway", gatewayResponse.getEntity(), statusCode);


### PR DESCRIPTION
Over the past 7 days there were 417 "Gateway returned unexpected status code"
log lines compared with 216,283 "POSTing request for account" log lines. This
is an error rate of 0.19%. This doesn't materially affect the running of the
application so downgrading the log level to WARN.
