### PR TITLE
PP-5757 Allow CAPTURE SUBMITTED to CAPTURE ERROR transition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -160,6 +160,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(CAPTURE_READY, CAPTURE_APPROVED_RETRY, ModelledEvent.none());
         graph.putEdgeValue(CAPTURE_READY, CAPTURED, ModelledEvent.of(CaptureConfirmed.class));
 
+        graph.putEdgeValue(CAPTURE_SUBMITTED, CAPTURE_ERROR, ModelledEvent.of(CaptureErrored.class));
         graph.putEdgeValue(CAPTURE_SUBMITTED, CAPTURED, ModelledEvent.of(CaptureConfirmed.class));
 
         graph.putEdgeValue(EXPIRE_CANCEL_READY, EXPIRE_CANCEL_SUBMITTED, ModelledEvent.of(CancelByExpirationSubmitted.class));


### PR DESCRIPTION
We can receive Smartpay notifications informing us that a capture didn't succeed. Currently, as this state transition is disallowed we do nothing to the charge when we receive this notification. The charge therefore remains stuck in the "CAPTURE SUBMITTED" state.

This also means that a ticket is not created in Zendesk to inform us of the capture error, which should be the case.