### PR TITLE
PP-5757 Only log error on PSP status code of 500+

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderTest.java
@@ -55,10 +55,10 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotAuthoriseIfPaymentProviderReturnsNon200HttpStatusCode() throws Exception {
         try {
-            mockPaymentProviderResponse(400, errorAuthResponse());
+            mockPaymentProviderResponse(500, errorAuthResponse());
             provider.authorise(buildTestAuthorisationRequest());
         } catch (GatewayException.GatewayErrorException e) {
-            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_ERROR));
+            assertEquals(e.toGatewayError(), new GatewayError("Non-success HTTP status code 500 from gateway", ErrorType.GATEWAY_ERROR));
         }
     }
 
@@ -82,10 +82,10 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
     @Test
     public void shouldNotCancelIfPaymentProviderReturnsNon200HttpStatusCode() throws Exception {
         try {
-            mockPaymentProviderResponse(400, errorCancelResponse());
+            mockPaymentProviderResponse(500, errorCancelResponse());
             provider.cancel(buildTestCancelRequest());
         } catch (GatewayException.GatewayErrorException e) {
-            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_ERROR));
+            assertEquals(e.toGatewayError(), new GatewayError("Non-success HTTP status code 500 from gateway", ErrorType.GATEWAY_ERROR));
         }
     }
 
@@ -117,10 +117,10 @@ public class EpdqPaymentProviderTest extends BaseEpdqPaymentProviderTest {
 
     @Test
     public void shouldNotRefundIfPaymentProviderReturnsNon200HttpStatusCode() {
-        mockPaymentProviderResponse(400, errorRefundResponse());
+        mockPaymentProviderResponse(500, errorRefundResponse());
         GatewayRefundResponse response = provider.refund(buildTestRefundRequest());
         assertThat(response.isSuccessful(), is(false));
         assertThat(response.getError().isPresent(), is(true));
-        assertEquals(response.getError().get(), new GatewayError("Unexpected HTTP status code 400 from gateway", ErrorType.GATEWAY_ERROR));
+        assertEquals(response.getError().get(), new GatewayError("Non-success HTTP status code 500 from gateway", ErrorType.GATEWAY_ERROR));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -396,12 +396,22 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
     }
 
     @Test
-    public void shouldErrorIfAuthorisationIsUnsuccessful() throws Exception {
+    public void shouldErrorIfWorldpayReturns401() throws Exception {
         mockWorldpayErrorResponse(401);
         try {
             provider.authorise(getCardAuthorisationRequest());
         } catch (GatewayException.GatewayErrorException e) {
-            assertEquals(e.toGatewayError(), new GatewayError("Unexpected HTTP status code 401 from gateway", ErrorType.GATEWAY_ERROR));
+            assertEquals(e.toGatewayError(), new GatewayError("Non-success HTTP status code 401 from gateway", ErrorType.GATEWAY_ERROR));
+        }
+    }
+    
+    @Test
+    public void shouldErrorIfWorldpayReturns500() throws Exception {
+        mockWorldpayErrorResponse(500);
+        try {
+            provider.authorise(getCardAuthorisationRequest());
+        } catch (GatewayException.GatewayErrorException e) {
+            assertEquals(e.toGatewayError(), new GatewayError("Non-success HTTP status code 500 from gateway", ErrorType.GATEWAY_ERROR));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresIT.java
@@ -100,7 +100,7 @@ public class GatewayAuthFailuresIT {
     public void shouldFailAuthWhenUnexpectedHttpStatusCodeFromGateway() {
         gatewayStub.respondWithUnexpectedResponseCodeWhenCardAuth();
 
-        String errorMessage = "Unexpected HTTP status code 999 from gateway";
+        String errorMessage = "Non-success HTTP status code 999 from gateway";
         String cardAuthUrl = "/v1/frontend/charges/{chargeId}/cards".replace("{chargeId}", chargeTestRecord.getExternalChargeId());
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
 


### PR DESCRIPTION
The GatewayClient was logging every non-success status code as an error. Some PSPs use these codes to indicate BAU info - e.g. Stripe declines a card with a 402 response. So only log an error at this point if we get a 500 or 'more'.
