### PR TITLE
PP-5757 Increase ePDQ capture timeout even more

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -73,8 +73,8 @@ epdq:
     live: ${GDS_CONNECTOR_EPDQ_LIVE_URL}
   credentials: ['username','password','merchant_id','sha_in_passphrase','sha_out_passphrase']
 
-  # The Jersey Client timeouts are set to the same values as for Worldpay initially until we gather more metrics
-  # to be in a position to tweak more appropriately.
+  # ePDQ can take a long time to respond to requests, often 3s or more and sometimes a lot longer, so we have quite
+  # generous timeouts for all operations.
   jerseyClientOverrides:
     auth:
       readTimeout: 20000ms
@@ -83,7 +83,7 @@ epdq:
     refund:
       readTimeout: 20000ms
     capture:
-      readTimeout: 3000ms
+      readTimeout: 20000ms
 
 stripe:
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}


### PR DESCRIPTION
We've seen great results by increasing this from 1s to 3s, but there are requests that come close to 3s to respond.

Increase the timeout to 20s in line with the other requests (auth/cancel/refund) to give it lots of headroom. This should mean that we should rarely or never have to retry requests, meaning our capture queue size won't always be huge and is more indicative of the volume of payments rather that just being full of ePDQ payments retrying.

This will also provide a better experience for services, as they will be able to refund immediately in most cases rather than having to wait a day or 2 until we get a notification from ePDQ to tell us the payment was successfully captured.