### PR TITLE
PP-5757: Log gateway account username for bad smartpay notifications

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
@@ -42,15 +42,15 @@ public class SmartpayNotificationService {
     }
 
     @Transactional
-    public boolean handleNotificationFor(String payload) {
+    public boolean handleNotificationFor(String payload, String username) {
         List<SmartpayNotification> notifications = parse(payload);
         for (SmartpayNotification notification : notifications) {
-            handle(notification);
+            handle(notification, username);
         }
         return true;
     }
 
-    private void handle(SmartpayNotification notification) {
+    private void handle(SmartpayNotification notification, String username) {
         if (shouldIgnore(notification)) {
             logger.info("{} notification {} ignored", PAYMENT_GATEWAY_NAME, notification);
             return;
@@ -69,8 +69,8 @@ public class SmartpayNotificationService {
                 notification.getOriginalReference());
 
         if (!maybeCharge.isPresent()) {
-            logger.warn("{} notification {} could not be evaluated (associated charge entity not found)",
-                    PAYMENT_GATEWAY_NAME, notification);
+            logger.warn("{} notification {} could not be evaluated (associated charge entity not found). Username associated with gateway account: {}",
+                    PAYMENT_GATEWAY_NAME, notification, username);
             return;
         }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/auth/SmartpayAccountSpecificAuthenticator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/auth/SmartpayAccountSpecificAuthenticator.java
@@ -22,7 +22,6 @@ public class SmartpayAccountSpecificAuthenticator implements Authenticator<Basic
     public SmartpayAccountSpecificAuthenticator(GatewayAccountDao gatewayAccountDao, HashUtil hashUtil) {
         this.gatewayAccountDao = gatewayAccountDao;
         this.hashUtil = hashUtil;
-
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
@@ -15,7 +15,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
+import java.util.Base64;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
@@ -46,11 +48,19 @@ public class NotificationResource {
     @Consumes(APPLICATION_JSON)
     @PermitAll
     @Path("/v1/api/notifications/smartpay")
-    public Response authoriseSmartpayNotifications(String notification) {
-        smartpayNotificationService.handleNotificationFor(notification);
+    public Response authoriseSmartpayNotifications(@HeaderParam("Authorization") String auth, String notification) {
+        smartpayNotificationService.handleNotificationFor(notification, getUsername(auth));
         String response = "[accepted]";
         logger.info("Responding to notification from provider=smartpay with 200 {}", response);
         return Response.ok(response).build();
+    }
+
+    private String getUsername(String auth) {
+        try {
+            return new String(Base64.getDecoder().decode(auth.replace("Basic ", "")), UTF_8).split(":")[0];
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @POST

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
@@ -67,7 +67,7 @@ public class SmartpayNotificationServiceTest {
         final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_CAPTURE,
                 randomId(), originalReference, pspReference);
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
         verify(mockChargeNotificationProcessor).invoke(originalReference, mockCharge, CAPTURED,
@@ -79,7 +79,7 @@ public class SmartpayNotificationServiceTest {
         final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_REFUND,
                 randomId(), originalReference, pspReference);
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
         verify(mockRefundNotificationProcessor).invoke(SMARTPAY,
@@ -91,7 +91,7 @@ public class SmartpayNotificationServiceTest {
         final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_AUTHORISATION,
                 randomId(), originalReference, pspReference);
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
@@ -102,7 +102,7 @@ public class SmartpayNotificationServiceTest {
         final String payload = sampleSmartpayNotification(SMARTPAY_MULTIPLE_NOTIFICATIONS_DIFFERENT_DATES,
                 randomId(), originalReference, pspReference);
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockChargeNotificationProcessor, times(1)).invoke(any(), any(), any(), any());
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
@@ -113,7 +113,7 @@ public class SmartpayNotificationServiceTest {
         final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_CAPTURE_WITH_UNKNOWN_STATUS,
                 randomId(), originalReference, pspReference);
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
@@ -124,7 +124,7 @@ public class SmartpayNotificationServiceTest {
         final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_REFUND,
                 randomId(), originalReference, StringUtils.EMPTY);
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
@@ -135,7 +135,7 @@ public class SmartpayNotificationServiceTest {
         final String payload = sampleSmartpayNotification(SMARTPAY_NOTIFICATION_REFUND,
                 randomId(), "unknown-transaction-id", pspReference);
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());
@@ -145,7 +145,7 @@ public class SmartpayNotificationServiceTest {
     public void shouldNotUpdateChargeOrRefund_WhenPayloadIsInvalid() {
         final String payload = "invalid-payload";
 
-        notificationService.handleNotificationFor(payload);
+        notificationService.handleNotificationFor(payload, null);
 
         verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
         verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any());


### PR DESCRIPTION
We are seeing quite a lot of smartpay notifications for which there is no
charge entity. After some investigation, we can confidently rule out that we're
not storing the smartpay pspReference from the authorisation response. A theory
could be services using their Smartpay account for payments outside of Pay so
we get notifications about payments we don’t know about. It'd be interesting to
see if this is the case so log the username for their gateway account.
