### PR TITLE
PP-5779 (PATCH) Backfill force emit live and card brand label

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
@@ -100,6 +100,13 @@ public class HistoricalEventEmitter {
         processPaymentDetailEnteredEvent(chargeEventEntities);
     }
 
+    public void processPatchPaymentCreatedAndPaymentDetailsEnteredEvents(ChargeEntity charge) { 
+        List<ChargeEventEntity> chargeEventEntities = getSortedChargeEvents(charge);
+
+        processSingleChargeStateTransitionEvent(charge.getId(), ChargeStatus.UNDEFINED, chargeEventEntities.get(0));
+        processPaymentDetailEnteredEvent(chargeEventEntities);
+    }
+
     @Transactional
     public void processRefundEvents(ChargeEntity charge) {
         List<RefundHistory> refundHistories = refundDao.searchAllHistoryByChargeId(charge.getId());

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterTask.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.queue.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 
 import java.io.PrintWriter;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
@@ -55,16 +56,15 @@ public class HistoricalEventEmitterTask extends Task {
 
     @Override
     public void execute(ImmutableMultimap<String, String> parameters, PrintWriter output) throws Exception {
-        Long startId = getParam(parameters, "start_id").orElse(0);
-        final OptionalLong maybeMaxId = getParam(parameters, "max_id");
-        Long patchBackfillParam = getParam(parameters, "force_patch").orElse(0);
-        boolean forcePatchBackfill = patchBackfillParam != 0;
+        Long startId = getLongParam(parameters, "start_id").orElse(0);
+        final OptionalLong maybeMaxId = getLongParam(parameters, "max_id");
+        Boolean patchBackfill = getBoolParam(parameters, "force_patch").orElse(false);
 
         logger.info("Execute called start_id={} max_id={} - processing", startId, maybeMaxId);
         
         try {
             logger.info("Request accepted");
-            if (forcePatchBackfill) {
+            if (patchBackfill) {
                 executor.execute(() -> worker.executePatchCreatedAndDetailsEntered(startId, maybeMaxId));
             } else {
                 executor.execute(() -> worker.execute(startId, maybeMaxId));
@@ -77,13 +77,23 @@ public class HistoricalEventEmitterTask extends Task {
         }
     }
 
-    private OptionalLong getParam(ImmutableMultimap<String, String> parameters, String paramName) {
+    private OptionalLong getLongParam(ImmutableMultimap<String, String> parameters, String paramName) {
         final ImmutableCollection<String> strings = parameters.get(paramName);
         
         if (strings.isEmpty()) {
             return OptionalLong.empty();
         } else {
             return OptionalLong.of(Long.valueOf(strings.asList().get(0)));
+        }
+    }
+
+    private Optional<Boolean> getBoolParam(ImmutableMultimap<String, String> parameters, String paramName) {
+        final ImmutableCollection<String> strings = parameters.get(paramName);
+
+        if (strings.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(strings.asList().get(0).equals("true"));
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterTask.java
@@ -38,7 +38,7 @@ public class HistoricalEventEmitterTask extends Task {
         this();
 
         HistoricalEventEmitter historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, refundDao,
-                false, eventService, stateTransitionService);
+                true, eventService, stateTransitionService);
         this.worker = new HistoricalEventEmitterWorker(chargeDao, refundDao, chargeEventDao, historicalEventEmitter);
         this.environment = environment;
 

--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -162,6 +162,55 @@ public class HistoricalEventEmitterWorkerTest {
     }
 
     @Test
+    public void executePatchCreatedAndDetailsEnteredShouldOnlyEmitPatchEvents() {
+        ChargeEventEntity firstEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now())
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.CREATED)
+                .build();
+
+        ChargeEventEntity secondEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now())
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.ENTERING_CARD_DETAILS)
+                .build();
+
+        ChargeEventEntity thirdEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now().plusMinutes(3))
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.AUTHORISATION_SUCCESS)
+                .build();
+
+        ChargeEventEntity fourthEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
+                .withTimestamp(ZonedDateTime.now().plusMinutes(3))
+                .withCharge(chargeEntity)
+                .withChargeStatus(ChargeStatus.CAPTURE_APPROVED)
+                .build();
+
+        chargeEntity.getEvents().clear();
+        chargeEntity.getEvents().add(firstEvent);
+        chargeEntity.getEvents().add(secondEvent);
+        chargeEntity.getEvents().add(thirdEvent);
+        chargeEntity.getEvents().add(fourthEvent);
+
+        when(chargeDao.findMaxId()).thenReturn(1L);
+        when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
+
+        worker.executePatchCreatedAndDetailsEntered(1L, OptionalLong.empty());
+
+        ArgumentCaptor<StateTransition> argument = ArgumentCaptor.forClass(StateTransition.class);
+
+        // no other valid state transitions are emitted
+        verify(stateTransitionService, times(1)).offerStateTransition(argument.capture(), any());
+
+        // payment created is emitted
+        assertThat(argument.getAllValues().get(0).getStateTransitionEventClass(), is(PaymentCreated.class));
+
+        // payment details entered is emitted
+        verify(eventService, times(1)).emitAndRecordEvent(any(PaymentDetailsEntered.class));
+    }
+
+    @Test
     public void executeShouldEmitManualEventsWithTerminalAuthenticationState() throws QueueException {
         ChargeEventEntity firstEvent = ChargeEventEntityFixture.aValidChargeEventEntity()
                 .withTimestamp(ZonedDateTime.now().plusMinutes(1))


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-connector/pull/1870.

Forces emission of `PaymentCreated` and `PaymentDetailsEntered` events. This will apply new schema to all Ledger events allowing transactions to be built with up to date info. 

Key changes to `HistoricalEventEmitter.java `.

Parameter for backfill task is `force_patch`, expecting `true` value with everything else defaulting to false.