### PR TITLE
PP-5793 Reduce capture process maximum retries

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -110,7 +110,7 @@ captureProcessConfig:
   # values such that we will continue retrying for at least two nights after
   # the initial attempt. See PP-2627 or commit
   # e931b4dab25284acedeb6d59d4bfd3d29e454b82 for more details.
-  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-96}
+  maximumRetries: ${CAPTURE_PROCESS_MAXIMUM_RETRIES:-48}
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
 
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}


### PR DESCRIPTION
Reduce the maximum capture retries to 48. The SQS capture queue is configured to retain messages for 3 days only, and with a maximum of 96 retries, charges were being deleted from the queue before the maximum retries was reached, meaning charges got stuck in "CAPTURE APPROVED RETRY" state rather than being moved to "CAPTURE ERROR".

We had previously increased this to 96 as before we had implemented the SQS queue, multiple connector nodes could attempt to retry the same capture in an hour, meaning that 48 capture retries didn't necessarily mean we would attempt to capture for 48 hours. The SQS queue, however,
is accurately able to retry once per hour.

We need to attempt to capture for 48 hours, as it can take up to 48 hours to receive a notification from ePDQ about the capture of a payment.