### PR TITLE
bau: Add toString method for Event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -75,4 +75,13 @@ public abstract class Event {
     public int hashCode() {
         return Objects.hash(resourceExternalId, eventDetails, timestamp);
     }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+                "resourceExternalId='" + resourceExternalId + '\'' +
+                ", eventDetails=" + eventDetails.getClass().getCanonicalName() +
+                ", timestamp=" + timestamp +
+                '}';
+    }
 }


### PR DESCRIPTION
We're logging the Event in the ChargeEntity but at the moment it's not really
useful:

```
{
   @timestamp: 2019-11-01T15:15:22.510Z
   @version: 1
   chargeId: xxx
   container: connector
   level: INFO
   level_value: 20000
   logger_name: uk.gov.pay.connector.charge.model.domain.ChargeEntity
   message: Changing charge status for externalId [xxx] [CAPTURE READY]->[CAPTURE SUBMITTED] [event=uk.gov.pay.connector.events.model.UnspecifiedEvent@d9f15d19]
   thread_name: sqs-message-chargeCaptureMessageReceiver
}
```
