### PR TITLE
PP-5779 Emit only if charge events exists

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
@@ -103,8 +103,10 @@ public class HistoricalEventEmitter {
     public void processPatchPaymentCreatedAndPaymentDetailsEnteredEvents(ChargeEntity charge) { 
         List<ChargeEventEntity> chargeEventEntities = getSortedChargeEvents(charge);
 
-        processSingleChargeStateTransitionEvent(charge.getId(), ChargeStatus.UNDEFINED, chargeEventEntities.get(0));
-        processPaymentDetailEnteredEvent(chargeEventEntities);
+        if(!chargeEventEntities.isEmpty()) {
+            processSingleChargeStateTransitionEvent(charge.getId(), ChargeStatus.UNDEFINED, chargeEventEntities.get(0));
+            processPaymentDetailEnteredEvent(chargeEventEntities);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## WHAT

- For some charges, events don't exist (initial stages of developing telephone payments). Don't emit events if no charge events are found.