### PR TITLE
PP-5778 Temporarily log PaRes received during 3DS authorsation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -52,6 +53,16 @@ public class Card3dsResponseAuthService {
         Gateway3DSAuthorisationResponse gateway3DSAuthorisationResponse = providers
                 .byName(charge.getPaymentGatewayName())
                 .authorise3dsResponse(Auth3dsResponseGatewayRequest.valueOf(charge, auth3DsDetails));
+
+        if (auth3DsDetails != null && StringUtils.isNotBlank(auth3DsDetails.getPaResponse())) {
+            if (auth3DsDetails.getPaResponse().length() <= 50) {
+                LOGGER.info("3DS authorisation - PaRes '{}'", auth3DsDetails.getPaResponse());
+            } else {
+                LOGGER.info("3DS authorisation - PaRes starts with '{}' and ending '{}'",
+                        auth3DsDetails.getPaResponse().substring(0, 50),
+                        auth3DsDetails.getPaResponse().substring(auth3DsDetails.getPaResponse().length() - 50));
+            }
+        }
 
         processGateway3DSecureResponse(
                 charge.getExternalId(),


### PR DESCRIPTION
## WHAT
- We have few 3DS payments (1-2 payments/day) failing with error response (`error code: 1, error: Internal error`) from Worldpay.
  Although the exact reason is not known, Worldpay has indicated we didn't send full paRes in payload for one of the payments.
  Log paRes to rule out/to find if it cause of failure.
- Only logs part of paRes (so we can match the same with frontend logs) as size could be larger than 2kb which docker allows.