### PR TITLE
PP-5791 Update Worldpay 3DS Flex Creds Endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -40,6 +40,7 @@ import uk.gov.pay.connector.events.resource.EmittedEventResource;
 import uk.gov.pay.connector.filters.SchemeRewriteFilter;
 import uk.gov.pay.connector.gateway.smartpay.auth.BasicAuthUser;
 import uk.gov.pay.connector.gateway.smartpay.auth.SmartpayAccountSpecificAuthenticator;
+import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccount3dsFlexCredentialsResource;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountResource;
 import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountResource;
 import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountSetupResource;
@@ -137,7 +138,8 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(SearchRefundsResource.class));
         environment.jersey().register(injector.getInstance(DiscrepancyResource.class));
         environment.jersey().register(injector.getInstance(EmittedEventResource.class));
-
+        environment.jersey().register(injector.getInstance(GatewayAccount3dsFlexCredentialsResource.class));
+        
         environment.jersey().register(ChargeIdMDCLoggingFeature.class);
         
         if(configuration.getCaptureProcessConfig().getBackgroundProcessingEnabled()) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/Worldpay3dsFlexCredentialsDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/Worldpay3dsFlexCredentialsDao.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.gatewayaccount.dao;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import uk.gov.pay.connector.common.dao.JpaDao;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
+
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+public class Worldpay3dsFlexCredentialsDao extends JpaDao<Worldpay3dsFlexCredentialsEntity> {
+
+    @Inject
+    public Worldpay3dsFlexCredentialsDao(Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+
+    public Optional<Worldpay3dsFlexCredentialsEntity> findById(Long accountId) {
+        return super.findById(Worldpay3dsFlexCredentialsEntity.class, accountId);
+    }
+
+    public Optional<Worldpay3dsFlexCredentialsEntity> findByGatewayAccountId(Long gatewayAccountId) {
+        return entityManager.get()
+                .createQuery("SELECT c FROM Worldpay3dsFlexCredentialsEntity c WHERE c.gatewayAccountId = :accountId", Worldpay3dsFlexCredentialsEntity.class)
+                .setParameter("accountId", gatewayAccountId)
+                .getResultStream()
+                .findFirst();
+    }
+
+    @Override
+    public void persist(Worldpay3dsFlexCredentialsEntity object) {
+        super.persist(object);
+    }
+
+    @Override
+    public Worldpay3dsFlexCredentialsEntity merge(Worldpay3dsFlexCredentialsEntity object) {
+        return super.merge(object);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
@@ -1,0 +1,124 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@SequenceGenerator(name="worldpay_3ds_flex_credentials_id_seq",
+        sequenceName = "worldpay_3ds_flex_credentials_id_seq", allocationSize = 1)
+@Table(name = "worldpay_3ds_flex_credentials")
+public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
+
+    @Id
+    @GeneratedValue(generator = "worldpay_3ds_flex_credentials_id_seq", strategy = GenerationType.SEQUENCE)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "gateway_account_id")
+    private Long gatewayAccountId;
+
+    @Column
+    private String issuer;
+
+    @Column(name = "organisational_unit_id")
+    private String organisationalUnitId;
+
+    @Column(name = "jwt_mac_key")
+    private String jwtMacKey;
+
+    public Worldpay3dsFlexCredentialsEntity() {
+        super();
+    }
+
+    public Worldpay3dsFlexCredentialsEntity(Long gatewayAccountId, String issuer, String organisationalUnitId, String jwtMacKey) {
+        super();
+        this.gatewayAccountId = gatewayAccountId;
+        this.issuer = issuer;
+        this.organisationalUnitId = organisationalUnitId;
+        this.jwtMacKey = jwtMacKey;
+    }
+
+    public Long getId() { return id; }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public String getOrganisationalUnitId() {
+        return organisationalUnitId;
+    }
+
+    public String getJwtMacKey() {
+        return jwtMacKey;
+    }
+
+    public void setGatewayAccountId(Long gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+    }
+
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    public void setOrganisationalUnitId(String organisationalUnitId) {
+        this.organisationalUnitId = organisationalUnitId;
+    }
+
+    public void setJwtMacKey(String jwtMacKey) {
+        this.jwtMacKey = jwtMacKey;
+    }
+
+    public static final class Worldpay3dsFlexCredentialsEntityBuilder {
+        private Long gatewayAccountId;
+        private String issuer;
+        private String organisationalUnitId;
+        private String jwtMacKey;
+
+        private Worldpay3dsFlexCredentialsEntityBuilder() {
+        }
+
+        public static Worldpay3dsFlexCredentialsEntityBuilder aWorldpay3dsFlexCredentialsEntity() {
+            return new Worldpay3dsFlexCredentialsEntityBuilder();
+        }
+
+        public Worldpay3dsFlexCredentialsEntityBuilder withGatewayAccountId(Long gatewayAccountId) {
+            this.gatewayAccountId = gatewayAccountId;
+            return this;
+        }
+
+        public Worldpay3dsFlexCredentialsEntityBuilder withIssuer(String issuer) {
+            this.issuer = issuer;
+            return this;
+        }
+
+        public Worldpay3dsFlexCredentialsEntityBuilder withOrganisationalUnitId(String organisationalUnitId) {
+            this.organisationalUnitId = organisationalUnitId;
+            return this;
+        }
+
+        public Worldpay3dsFlexCredentialsEntityBuilder withJwtMacKey(String jwtMacKey) {
+            this.jwtMacKey = jwtMacKey;
+            return this;
+        }
+
+        public Worldpay3dsFlexCredentialsEntity build() {
+            Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity = new Worldpay3dsFlexCredentialsEntity();
+            worldpay3dsFlexCredentialsEntity.jwtMacKey = this.jwtMacKey;
+            worldpay3dsFlexCredentialsEntity.gatewayAccountId = this.gatewayAccountId;
+            worldpay3dsFlexCredentialsEntity.organisationalUnitId = this.organisationalUnitId;
+            worldpay3dsFlexCredentialsEntity.issuer = this.issuer;
+            return worldpay3dsFlexCredentialsEntity;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayUpdate3dsFlexCredentialsRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayUpdate3dsFlexCredentialsRequest.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.NotNull;
+
+public class WorldpayUpdate3dsFlexCredentialsRequest {
+
+    @JsonProperty("issuer")
+    @NotNull(message = "Field [issuer] cannot be null")
+    private String issuer;
+
+    @JsonProperty("organisational_unit_id")
+    @NotNull(message = "Field [organisational_unit_id] cannot be null")
+    private String organisationalUnitId;
+
+    @JsonProperty("jwt_mac_key")
+    @NotNull(message = "Field [jwt_mac_key] cannot be null")
+    private String jwtMacKey;
+
+    public WorldpayUpdate3dsFlexCredentialsRequest() {
+        //Blank Constructor Needed For Instantiation
+    }
+
+    private WorldpayUpdate3dsFlexCredentialsRequest(WorldpayUpdate3dsFlexCredentialsRequestBuilder builder) {
+        this.issuer = builder.issuer;
+        this.organisationalUnitId = builder.organisationalUnitId;
+        this.jwtMacKey = builder.jwtMacKey;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public String getOrganisationalUnitId() {
+        return organisationalUnitId;
+    }
+
+    public String getJwtMacKey() {
+        return jwtMacKey;
+    }
+
+    public static final class WorldpayUpdate3dsFlexCredentialsRequestBuilder {
+        private String issuer;
+        private String organisationalUnitId;
+        private String jwtMacKey;
+
+        private WorldpayUpdate3dsFlexCredentialsRequestBuilder() {
+        }
+
+        public static WorldpayUpdate3dsFlexCredentialsRequestBuilder aWorldpayUpdate3dsFlexCredentialsRequest() {
+            return new WorldpayUpdate3dsFlexCredentialsRequestBuilder();
+        }
+
+        public WorldpayUpdate3dsFlexCredentialsRequestBuilder withIssuer(String issuer) {
+            this.issuer = issuer;
+            return this;
+        }
+
+        public WorldpayUpdate3dsFlexCredentialsRequestBuilder withOrganisationalUnitId(String organisationalUnitId) {
+            this.organisationalUnitId = organisationalUnitId;
+            return this;
+        }
+
+        public WorldpayUpdate3dsFlexCredentialsRequestBuilder withJwtMacKey(String jwtMacKey) {
+            this.jwtMacKey = jwtMacKey;
+            return this;
+        }
+
+        public WorldpayUpdate3dsFlexCredentialsRequest build() {
+            return new WorldpayUpdate3dsFlexCredentialsRequest(this);
+        }
+    }
+}
+

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResource.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.gatewayaccount.resource;
+
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayUpdate3dsFlexCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccount.service.Worldpay3dsFlexCredentialsService;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+
+@Path("/")
+public class GatewayAccount3dsFlexCredentialsResource {
+
+    private final GatewayAccountService gatewayAccountService;
+    private final Worldpay3dsFlexCredentialsService worldpay3dsFlexCredentialsService;
+
+    @Inject
+    public GatewayAccount3dsFlexCredentialsResource(GatewayAccountService gatewayAccountService,
+                                                    Worldpay3dsFlexCredentialsService worldpay3dsFlexCredentialsService) {
+        this.gatewayAccountService = gatewayAccountService;
+        this.worldpay3dsFlexCredentialsService = worldpay3dsFlexCredentialsService;
+    }
+
+    @POST
+    @Path("/v1/api/accounts/{accountId}/3ds-flex-credentials")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public Response createOrUpdateWorldpay3dsCredentials(@PathParam("accountId") Long gatewayAccountId,
+                                                         @Valid WorldpayUpdate3dsFlexCredentialsRequest worldpay3dsCredentials) {
+
+        return gatewayAccountService.getGatewayAccount(gatewayAccountId)
+                .filter(gatewayAccountEntity ->
+                        gatewayAccountEntity.getGatewayName().equals(PaymentGatewayName.WORLDPAY.getName()))
+                .map(gatewayAccountEntity -> {
+                    worldpay3dsFlexCredentialsService.setGatewayAccountWorldpay3dsFlexCredentials(worldpay3dsCredentials,
+                            gatewayAccountEntity);
+                    return Response.ok().build();
+                })
+                .orElseGet(() -> notFoundResponse("Not a Worldpay gateway account"));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.gatewayaccount.service;
+
+import uk.gov.pay.connector.gatewayaccount.dao.Worldpay3dsFlexCredentialsDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayUpdate3dsFlexCredentialsRequest;
+
+import javax.inject.Inject;
+
+import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
+
+public class Worldpay3dsFlexCredentialsService {
+
+    private Worldpay3dsFlexCredentialsDao worldpay3dsFlexCredentialsDao;
+
+    @Inject
+    public Worldpay3dsFlexCredentialsService(Worldpay3dsFlexCredentialsDao worldpay3dsFlexCredentialsDao) {
+        this.worldpay3dsFlexCredentialsDao = worldpay3dsFlexCredentialsDao;
+    }
+
+    public void setGatewayAccountWorldpay3dsFlexCredentials(WorldpayUpdate3dsFlexCredentialsRequest worldpayUpdate3dsFlexCredentialsRequest, GatewayAccountEntity gatewayAccountEntity) {
+        worldpay3dsFlexCredentialsDao.findByGatewayAccountId(gatewayAccountEntity.getId()).ifPresentOrElse(worldpay3dsFlexCredentialsEntity -> {
+            worldpay3dsFlexCredentialsEntity.setIssuer(worldpayUpdate3dsFlexCredentialsRequest.getIssuer());
+            worldpay3dsFlexCredentialsEntity.setJwtMacKey(worldpayUpdate3dsFlexCredentialsRequest.getJwtMacKey());
+            worldpay3dsFlexCredentialsEntity.setOrganisationalUnitId(worldpayUpdate3dsFlexCredentialsRequest.getOrganisationalUnitId());
+            worldpay3dsFlexCredentialsDao.merge(worldpay3dsFlexCredentialsEntity);
+        }, () -> {
+            var newWorldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity()
+                    .withGatewayAccountId(gatewayAccountEntity.getId())
+                    .withIssuer(worldpayUpdate3dsFlexCredentialsRequest.getIssuer())
+                    .withJwtMacKey(worldpayUpdate3dsFlexCredentialsRequest.getJwtMacKey())
+                    .withOrganisationalUnitId(worldpayUpdate3dsFlexCredentialsRequest.getOrganisationalUnitId())
+                    .build();
+            worldpay3dsFlexCredentialsDao.merge(newWorldpay3dsFlexCredentialsEntity);
+        });
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResourceIT.java
@@ -1,0 +1,196 @@
+package uk.gov.pay.connector.gatewayaccount.resource;
+
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.lang.math.RandomUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class GatewayAccount3dsFlexCredentialsResourceIT {
+    private DatabaseFixtures.TestAccount testAccount;
+
+    private static final String ACCOUNTS_API_URL = "/v1/api/accounts/%s/3ds-flex-credentials";
+
+    @DropwizardTestContext
+    protected TestContext testContext;
+    protected DatabaseTestHelper databaseTestHelper;
+    private DatabaseFixtures databaseFixtures;
+    private Long accountId = 1L;
+
+    @Before
+    public void setUp() {
+        accountId = RandomUtils.nextLong();
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+        databaseFixtures = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper);
+        testAccount = databaseFixtures.aTestAccount().withPaymentProvider("worldpay")
+                .withIntegrationVersion3ds(2)
+                .withAccountId(accountId)
+                .insert();
+    }
+
+    protected RequestSpecification givenSetup() {
+        return given().port(testContext.getPort())
+                .contentType(JSON);
+    }
+
+    @Test
+    public void setWorldpay3dsFlexCredentialsWhenThereAreNonExisting() throws JsonProcessingException {
+         String payload = new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "testissuer",
+                "organisational_unit_id", "hihihi",
+                "jwt_mac_key", "hihihihihi"
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId); 
+        assertThat(result.get("issuer"), is("testissuer"));
+        assertThat(result.get("organisational_unit_id"), is("hihihi"));
+        assertThat(result.get("jwt_mac_key"), is("hihihihihi"));
+    }
+
+    @Test
+    public void overrideSetWorldpay3dsCredentials() throws JsonProcessingException {
+        String payload =new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "testissuer",
+                "organisational_unit_id", "hihihi",
+                "jwt_mac_key", "hihihihihi"
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+        payload = new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "updated_issuer",
+                "organisational_unit_id", "updated_organisational_unit_id",
+                "jwt_mac_key", "updated_jwt_mac_key"
+        ));
+        givenSetup()
+                .body(payload) 
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId);
+        assertThat(result.get("issuer"), is("updated_issuer"));
+        assertThat(result.get("organisational_unit_id"), is("updated_organisational_unit_id"));
+        assertThat(result.get("jwt_mac_key"), is("updated_jwt_mac_key"));
+    }
+
+    @Test
+    public void missingFieldsReturnCorrectError() throws JsonProcessingException {
+        String payload = new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "testissuer",
+                "jwt_mac_key", "hihihihihi"
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(422)
+                .body("message[0]", is("Field [organisational_unit_id] cannot be null"));
+        payload = new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "testissuer",
+                "organisational_unit_id", "hihihi"
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(422)
+                .body("message[0]", is("Field [jwt_mac_key] cannot be null"));
+        payload = new ObjectMapper().writeValueAsString(Map.of(
+                "organisational_unit_id", "hihihi",
+                "jwt_mac_key", "hihihihihi"
+        ));        
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(422)
+                .body("message[0]", is("Field [issuer] cannot be null"));
+        payload = new ObjectMapper().writeValueAsString(Map.of(
+                "organisational_unit_id", "hihihi"
+        ));        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(422)
+                .body("message", hasItem("Field [jwt_mac_key] cannot be null"))
+                .body("message", hasItem("Field [issuer] cannot be null"));
+    }
+
+    @Test
+    public void postRequestWithNullParameter() throws JsonProcessingException {
+        HashMap<String, String> payloadMap = new HashMap<>();
+        payloadMap.put("issuer", "testissuer");
+        payloadMap.put("organisational_unit_id", null);
+        payloadMap.put("jwt_mac_key", "hihihihihi");
+        String payload = new ObjectMapper().writeValueAsString(payloadMap);
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,accountId))
+                .then()
+                .statusCode(422)
+                .body("message[0]", is("Field [organisational_unit_id] cannot be null"));
+    }
+
+    @Test
+    public void nonExistentGatewayAccountReturns404() throws JsonProcessingException {
+        Long fakeAccountId = RandomUtils.nextLong();
+        String payload = new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "testissuer",
+                "organisational_unit_id", "hihihi",
+                "jwt_mac_key", "hihihihihi"
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,fakeAccountId))
+                .then()
+                .statusCode(404)
+                .body("message[0]", is("Not a Worldpay gateway account"));
+    }
+
+    @Test
+    public void nonWorldpayGatewayAccountReturns404() throws JsonProcessingException {
+        long fakeAccountId = RandomUtils.nextLong();
+        databaseFixtures.aTestAccount().withPaymentProvider("smartpay")
+                .withIntegrationVersion3ds(2)
+                .withAccountId(fakeAccountId)
+                .insert();
+        String payload = new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "testissuer",
+                "organisational_unit_id", "hihihi",
+                "jwt_mac_key", "hihihihihi"
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,fakeAccountId))
+                .then()
+                .statusCode(404)
+                .body("message[0]", is("Not a Worldpay gateway account"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -757,4 +757,11 @@ public class DatabaseTestHelper {
                 handle.createQuery("SELECT * from emitted_events").list()
         );
     }
+
+    public Map<String, Object> getWorldpay3dsFlexCredentials(Long accountId) {
+        return jdbi.withHandle(handle -> 
+                handle.createQuery("SELECT * FROM worldpay_3ds_flex_credentials WHERE gateway_account_id = :accountId")
+                .bind("accountId", accountId)
+                .first());
+    }
 }


### PR DESCRIPTION
- When the new worldpay 3DS2 Flex credentials endpoint is posted, the
required credentials are stored in the database.

- If there is an error in the submitted json credentials, an error
matching the user's mistake is returned with the correct message and
status code

- Added tests to ensure that the functionality is correct.
