### PR TITLE
BAU Log ConstraintViolationExceptions at INFO

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/exception/ConstraintViolationExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/ConstraintViolationExceptionMapper.java
@@ -20,7 +20,7 @@ public class ConstraintViolationExceptionMapper implements ExceptionMapper<Const
 
     @Override
     public Response toResponse(ConstraintViolationException exception) {
-        LOGGER.error(exception.getMessage());
+        LOGGER.info(exception.getMessage());
         List<String> constraintViolationMessages = exception
                 .getConstraintViolations().stream()
                 .map(ConstraintViolation::getMessage)


### PR DESCRIPTION
`ConstraintViolationExceptions` are expected and handled as a result of a
client sending invalid data, we do not need to log them at `ERRROR` level.

## WHAT YOU DID
This is in response to cleaning up the following issues in Sentry
https://pay-sentry.cloudapps.digital/sentry/connector/?query=logger%3A%22uk.gov.pay.connector.common.exception.ConstraintViolationExce...%22