### PR TITLE
PP-5757 Increase ePDQ auth timeout

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -77,7 +77,7 @@ epdq:
   # generous timeouts for all operations.
   jerseyClientOverrides:
     auth:
-      readTimeout: 20000ms
+      readTimeout: 50000ms
     cancel:
       readTimeout: 20000ms
     refund:


### PR DESCRIPTION
Over the past 30 days, 3 payments have timed out on authorisation.

For Worldpay we have a timeout of 50s, but only 20s for ePDQ. The
reasoning we give for setting the Worldpay timeout at 50s should apply
for ePDQ too, so increase this timeout to match.

The reasoning for Worldpay was:

Auth is run in a background thread which will release the HTTP request
from frontend after 1 second supports a polling mechanism. The
background thread will wait for the auth request to complete and make
its status available to frontend. Median auth time is 1500ms. There are
occasional spikes in the auth time, up to 80 seconds. We don't want to
leave a user waiting on a spinner for that long, so we'll cut off after
50 seconds and abort the auth attempt. This threshold is chosen to be
just below the timeout of 60 seconds used by the egress proxies.
Previously we tried as low as 10 seconds and then 20 seconds but
services reported an increase in AUTHORISATION ERROR states ultimately
caused by GATEWAY_CONNECTION_TIMEOUT_ERROR so we are increasing it to
try to not get those outliers.