### PR TITLE
PP-5757 Allow transition from CREATED to USER CANCELLED

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -106,6 +106,7 @@ public class PaymentGatewayStateTransitions {
 
         graph.putEdgeValue(CREATED, ENTERING_CARD_DETAILS, ModelledEvent.of(PaymentStarted.class));
         graph.putEdgeValue(CREATED, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
+        graph.putEdgeValue(CREATED, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_READY, ModelledEvent.none());
         graph.putEdgeValue(ENTERING_CARD_DETAILS, AUTHORISATION_ABORTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));


### PR DESCRIPTION
There is an edge case where a secure token can be used but the page is reloaded before the redirect to the enter card details page. This means that the token has been used but the payment hasn't been transitioned to ENTERING CARD DETAILS.

In this case, if the user re-visits the secure page and doesn't have the session key in their cookie an error page will be shown, which will attempt to cancel the payment when a link is clicked to return to the service.

Allow this state transition.