### PR TITLE
PP-5812 Add payment provider to StateTransitionService log line

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
@@ -17,6 +17,8 @@ import javax.inject.Inject;
 import java.time.ZoneId;
 
 import static java.time.ZonedDateTime.now;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.logging.LoggingKeys.PROVIDER;
 
 public class StateTransitionService {
 
@@ -51,7 +53,11 @@ public class StateTransitionService {
                 .ifPresent(eventClass -> {
                     PaymentStateTransition transition = new PaymentStateTransition(chargeEventEntity.getId(), eventClass);
                     stateTransitionQueue.offer(transition);
-                    logger.info("Offered payment state transition to emitter queue [from={}] [to={}] [chargeEventId={}] [chargeId={}]", fromChargeState, targetChargeState, chargeEventEntity.getId(), externalId);
+                    logger.info(String.format("Offered payment state transition to emitter queue [from=%s] [to=%s] [chargeEventId=%s] [chargeId=%s]",
+                            fromChargeState, targetChargeState, chargeEventEntity.getId(), externalId),
+                            kv(PROVIDER, chargeEventEntity.getChargeEntity().getPaymentGatewayName().getName()),
+                            kv("from_state", fromChargeState),
+                            kv("to_state", targetChargeState));
 
                     eventService.recordOfferedEvent(ResourceType.PAYMENT,
                             externalId,

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -17,7 +17,6 @@ import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
 
-import static java.time.ZonedDateTime.now;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -25,12 +24,12 @@ import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.events.model.ResourceType.PAYMENT;
 import static uk.gov.pay.connector.events.model.ResourceType.REFUND;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
+import static uk.gov.pay.connector.pact.ChargeEventEntityFixture.aValidChargeEventEntity;
 import static uk.gov.pay.connector.pact.RefundHistoryEntityFixture.aValidRefundHistoryEntity;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
 
@@ -51,9 +50,9 @@ public class StateTransitionServiceTest {
 
     @Test
     public void shouldOfferPaymentStateTransitionMessageForAValidStateTransitionIntoNonLockingState() {
-        ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
-        when(chargeEvent.getId()).thenReturn(100L);
-        when(chargeEvent.getUpdated()).thenReturn(now());
+        ChargeEventEntity chargeEvent = aValidChargeEventEntity()
+                .withId(100L)
+                .build();
 
         stateTransitionService.offerPaymentStateTransition("external-id", ChargeStatus.CREATED, ENTERING_CARD_DETAILS, chargeEvent);
         ArgumentCaptor<PaymentStateTransition> paymentStateTransitionArgumentCaptor = ArgumentCaptor.forClass(PaymentStateTransition.class);


### PR DESCRIPTION
To enable our payment journey SLI we need to know the payment
provider when emitting events so that we can exclude `sandbox`. This is
being added as a structured argument.

Also take the opportunity to add the `to_state` and `from_state` as
structured arguments to the logger to make the implementation of the sli
query in Splunk simpler.
