### PR TITLE
PP-5709: add shopperIPAddress to authorisation request (Worldpay)

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -24,6 +24,7 @@ public class AuthCardDetails implements AuthorisationDetails {
     private PayersCardPrepaidStatus payersCardPrepaidStatus;
     private Boolean corporateCard;
     private String worldpay3dsFlexDdcResult;
+    private String ipAddress;
 
     public static AuthCardDetails anAuthCardDetails() {
         return new AuthCardDetails();
@@ -89,6 +90,11 @@ public class AuthCardDetails implements AuthorisationDetails {
         this.worldpay3dsFlexDdcResult = worldpay3dsFlexDdcResult;
     }
 
+    @JsonProperty("ip_address")
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
     public String getCardNo() {
         return cardNo;
     }
@@ -145,5 +151,9 @@ public class AuthCardDetails implements AuthorisationDetails {
 
     public Optional<String> getWorldpay3dsFlexDdcResult() {
         return Optional.ofNullable(worldpay3dsFlexDdcResult);
+    }
+
+    public Optional<String> getIpAddress() {
+        return Optional.ofNullable(ipAddress);
     }
 }

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -31,7 +31,9 @@
                     </cardAddress>
                     </#if>
                 </VISA-SSL>
-                <#if requires3ds>
+                <#if authCardDetails.ipAddress.isPresent()>
+                <session id="${sessionId?xml}" shopperIPAddress="${authCardDetails.ipAddress.get()}"/>
+                <#elseif requires3ds>
                 <session id="${sessionId?xml}"/>
                 </#if>
             </paymentDetails>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -93,6 +93,7 @@ public class WorldpayOrderRequestBuilderTest {
         Address fullAddress = new Address("123 My Street", "This road", "SW8URR", "London", "London county", "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(fullAddress);
+        authCardDetails.setIpAddress("127.0.0.1");
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
                 .withSessionId("uniqueSessionId")

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -24,6 +24,7 @@ public final class AuthCardDetailsFixture {
     private PayersCardPrepaidStatus payersCardPrepaidStatus = PayersCardPrepaidStatus.UNKNOWN;
     private Boolean corporateCard = Boolean.FALSE;
     private String worldpay3dsFlexDdcResult;
+    private String ipAddress;
 
     private AuthCardDetailsFixture() {
     }
@@ -131,6 +132,12 @@ public final class AuthCardDetailsFixture {
         authCardDetails.setPayersCardPrepaidStatus(payersCardPrepaidStatus);
         authCardDetails.setCorporateCard(corporateCard);
         authCardDetails.setWorldpay3dsFlexDdcResult(worldpay3dsFlexDdcResult);
+        authCardDetails.setIpAddress(ipAddress);
         return authCardDetails;
+    }
+
+    public AuthCardDetailsFixture withIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+        return this;
     }
 }

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds.xml
@@ -25,6 +25,7 @@
                         </address>
                     </cardAddress>
                 </VISA-SSL>
+                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
             </paymentDetails>
         </order>
     </submit>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-full-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-full-address.xml
@@ -25,6 +25,7 @@
                         </address>
                     </cardAddress>
                 </VISA-SSL>
+                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
             </paymentDetails>
         </order>
     </submit>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds.xml
@@ -25,7 +25,7 @@
                         </address>
                     </cardAddress>
                 </VISA-SSL>
-                <session id="uniqueSessionId"/>
+                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
             </paymentDetails>
             <shopper>
                 <browser>


### PR DESCRIPTION
Adding shopperIPAddress attribute to authorisation request can be
used by Worldpay for fraud checks.
It's an IP address which has been used by payer.
We want to add it in all cases (not only for 3ds payments).

Changes:
* update to AuthCardDetails to include ip address
* update to WorldpayAuthoriseOrderTemplate.xml to include additional
attribute and change to the condition for displaying session element
when it's 3ds payment or we have information about IP address
* update to logic in WorldpayPaymentProvider to include property determining
when session element should be added to the request
* update to tests