### PR TITLE
PP-5795 Add Get 3ds Flex Credentials Endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -34,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -111,6 +113,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @OneToOne(mappedBy = "accountEntity", cascade = CascadeType.PERSIST)
     private NotificationCredentials notificationCredentials;
+
+    @OneToOne(mappedBy = "gatewayAccountEntity", cascade = CascadeType.PERSIST)
+    private Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity;
 
     @ManyToMany
     @JoinTable(
@@ -194,6 +199,15 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @JsonView(Views.ApiView.class)
     public NotificationCredentials getNotificationCredentials() {
         return notificationCredentials;
+    }
+
+    @JsonInclude(NON_NULL)
+    @JsonProperty("worldpay_3ds_flex")
+    public Worldpay3dsFlexCredentials getWorldpay3dsFlexCredentialsEntity() {
+        if(worldpay3dsFlexCredentialsEntity != null) {
+            return Worldpay3dsFlexCredentials.fromEntity(worldpay3dsFlexCredentialsEntity);
+        }
+        return null;
     }
 
     public boolean isRequires3ds() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Worldpay3dsFlexCredentials {
+
+    private String issuer;
+    private String organisationalUnitId;
+
+    public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId) {
+        this.issuer = issuer;
+        this.organisationalUnitId = organisationalUnitId;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public String getOrganisationalUnitId() {
+        return organisationalUnitId;
+    }
+
+    public static Worldpay3dsFlexCredentials fromEntity(Worldpay3dsFlexCredentialsEntity entity) {
+        return new Worldpay3dsFlexCredentials(entity.getIssuer(), entity.getOrganisationalUnitId());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
@@ -7,6 +7,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
@@ -20,6 +21,9 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
     @GeneratedValue(generator = "worldpay_3ds_flex_credentials_id_seq", strategy = GenerationType.SEQUENCE)
     @Column(name = "id")
     private Long id;
+
+    @JoinColumn(name = "gateway_account_id", updatable = false, insertable = false)
+    private GatewayAccountEntity gatewayAccountEntity;
 
     @Column(name = "gateway_account_id")
     private Long gatewayAccountId;
@@ -77,6 +81,10 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
 
     public void setJwtMacKey(String jwtMacKey) {
         this.jwtMacKey = jwtMacKey;
+    }
+
+    public GatewayAccountEntity getGatewayAccountEntity() {
+        return gatewayAccountEntity;
     }
 
     public static final class Worldpay3dsFlexCredentialsEntityBuilder {

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -758,6 +758,18 @@ public class DatabaseTestHelper {
         );
     }
 
+    public void insertWorldpay3dsFlexCredential(Long gatewayAccountId, String jwtMacKey, String issuer, String organisationalUnitId, Long version) {
+        jdbi.withHandle(handle ->
+                handle
+                        .createStatement("INSERT INTO worldpay_3ds_flex_credentials(gateway_account_id, jwt_mac_key, issuer, organisational_unit_id, version) VALUES (:gatewayAccountId, :jwtMacKey, :issuer, :organisationalUnitId, :version)")
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .bind("jwtMacKey", jwtMacKey)
+                        .bind("issuer", issuer)
+                        .bind("organisationalUnitId", organisationalUnitId)
+                        .bind("version", version) 
+                        .execute()
+        );
+    }
     public Map<String, Object> getWorldpay3dsFlexCredentials(Long accountId) {
         return jdbi.withHandle(handle -> 
                 handle.createQuery("SELECT * FROM worldpay_3ds_flex_credentials WHERE gateway_account_id = :accountId")


### PR DESCRIPTION
- Adds a `worldpay_3ds_flex` object to the standard
`frontend/accounts/{accountId}` endpoint that is included if credentials
exist for a gateway account.

- Adds tests to verify the behaviour outlined in the ticket.