### PR TITLE
PP-5792 Worldpay 3ds flex JWT token credentials use new table

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexJwtCredentialsException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/Worldpay3dsFlexJwtCredentialsException.java
@@ -8,4 +8,8 @@ public class Worldpay3dsFlexJwtCredentialsException extends ConflictWebApplicati
         super(format("Cannot generate Worldpay 3ds Flex JWT for account %s because the following credential is unavailable: %s",
                 accountId,  missingCredential));
     }
+
+    public Worldpay3dsFlexJwtCredentialsException(Long accountId) {
+        super(format("Cannot generate Worldpay 3ds Flex JWT for account %s because credentials are unavailable", accountId));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -13,7 +13,6 @@ import uk.gov.pay.connector.charge.model.FrontendChargeResponse;
 import uk.gov.pay.connector.charge.model.NewChargeStatusRequest;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.charge.service.Worldpay3dsFlexJwtService;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
@@ -83,6 +82,7 @@ public class ChargesFrontendResource {
 
         ChargeEntity chargeEntity = chargeService.findChargeById(chargeId);
         GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
+        Worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials();
         String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, chargeEntity.getCreatedDate());
 
         return Response.ok().entity(Map.of("jwt", token)).build();

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -82,8 +83,8 @@ public class ChargesFrontendResource {
 
         ChargeEntity chargeEntity = chargeService.findChargeById(chargeId);
         GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
-        Worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials();
-        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, chargeEntity.getCreatedDate());
+        Worldpay3dsFlexCredentials worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials();
+        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, chargeEntity.getCreatedDate());
 
         return Response.ok().entity(Map.of("jwt", token)).build();
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
@@ -44,6 +44,7 @@ public class Worldpay3dsFlexJwtService {
      */
     public String generateDdcToken(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials, ZonedDateTime chargeCreatedTime) {
         validateGatewayIsWorldpay(gatewayAccount);
+        validateFlexCredentials(gatewayAccount, worldpay3dsFlexCredentials);
 
         var claims = generateDdcClaims(gatewayAccount, worldpay3dsFlexCredentials, chargeCreatedTime);
         return createJwt(gatewayAccount, worldpay3dsFlexCredentials, claims);
@@ -67,7 +68,9 @@ public class Worldpay3dsFlexJwtService {
     private String generateChallengeToken(ChargeEntity chargeEntity) {
         GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
         Worldpay3dsFlexCredentials worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials();
+
         validateGatewayIsWorldpay(gatewayAccount);
+        validateFlexCredentials(gatewayAccount, worldpay3dsFlexCredentials);
 
         var claims = generateChallengeClaims(chargeEntity, gatewayAccount, worldpay3dsFlexCredentials);
         return createJwt(gatewayAccount, worldpay3dsFlexCredentials, claims);
@@ -76,6 +79,12 @@ public class Worldpay3dsFlexJwtService {
     private void validateGatewayIsWorldpay(GatewayAccount gatewayAccount) {
         if (!gatewayAccount.getGatewayName().equals(PaymentGatewayName.WORLDPAY.getName())) {
             throw new Worldpay3dsFlexJwtPaymentProviderException(gatewayAccount.getId());
+        }
+    }
+
+    private void validateFlexCredentials(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials) { 
+        if (worldpay3dsFlexCredentials == null) {
+            throw new Worldpay3dsFlexJwtCredentialsException(gatewayAccount.getId());
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -203,7 +203,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @JsonInclude(NON_NULL)
     @JsonProperty("worldpay_3ds_flex")
-    public Worldpay3dsFlexCredentials getWorldpay3dsFlexCredentialsEntity() {
+    public Worldpay3dsFlexCredentials getWorldpay3dsFlexCredentials() {
         if(worldpay3dsFlexCredentialsEntity != null) {
             return Worldpay3dsFlexCredentials.fromEntity(worldpay3dsFlexCredentialsEntity);
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -363,6 +363,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         this.integrationVersion3ds = integrationVersion3ds;
     }
 
+    public void setWorldpay3dsFlexCredentialsEntity(Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity) {
+        this.worldpay3dsFlexCredentialsEntity = worldpay3dsFlexCredentialsEntity;
+    }
+
     public class Views {
         public class ApiView {
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -10,7 +10,7 @@ public class Worldpay3dsFlexCredentials {
     private String issuer;
     private String organisationalUnitId;
 
-    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @JsonIgnore
     private String jwtMacKey;
 
     public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
@@ -9,9 +10,13 @@ public class Worldpay3dsFlexCredentials {
     private String issuer;
     private String organisationalUnitId;
 
-    public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId) {
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String jwtMacKey;
+
+    public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey) {
         this.issuer = issuer;
         this.organisationalUnitId = organisationalUnitId;
+        this.jwtMacKey = jwtMacKey;
     }
 
     public String getIssuer() {
@@ -22,7 +27,11 @@ public class Worldpay3dsFlexCredentials {
         return organisationalUnitId;
     }
 
+    public String getJwtMacKey() {
+        return jwtMacKey;
+    }
+
     public static Worldpay3dsFlexCredentials fromEntity(Worldpay3dsFlexCredentialsEntity entity) {
-        return new Worldpay3dsFlexCredentials(entity.getIssuer(), entity.getOrganisationalUnitId());
+        return new Worldpay3dsFlexCredentials(entity.getIssuer(), entity.getOrganisationalUnitId(), entity.getJwtMacKey());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -35,6 +35,7 @@ public final class GatewayAccountEntityFixture {
     private EmailCollectionMode emailCollectionMode = EmailCollectionMode.MANDATORY;
     private NotificationCredentials notificationCredentials;
     private List<CardTypeEntity> cardTypes = newArrayList();
+    private Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity;
 
     private GatewayAccountEntityFixture() {
     }
@@ -148,6 +149,11 @@ public final class GatewayAccountEntityFixture {
         return this;
     }
 
+    public GatewayAccountEntityFixture withWorldpay3dsFlexCredentialsEntity(Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity) {
+        this.worldpay3dsFlexCredentialsEntity = worldpay3dsFlexCredentialsEntity;
+        return this;
+    }
+
     public GatewayAccountEntity build() {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity();
         gatewayAccountEntity.setId(id);
@@ -171,6 +177,7 @@ public final class GatewayAccountEntityFixture {
         gatewayAccountEntity.setEmailCollectionMode(emailCollectionMode);
         gatewayAccountEntity.setNotificationCredentials(notificationCredentials);
         gatewayAccountEntity.setCardTypes(cardTypes);
+        gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
         return gatewayAccountEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -96,14 +96,11 @@ public class FrontendContractTest {
                 .withAccountId(gatewayAccountId)
                 .withPaymentProvider("worldpay")
                 .withCardTypeEntities(Collections.singletonList(dbHelper.getVisaDebitCard()))
-                .withCredentials(Map.of(
-                        "jwt_mac_id", "1A4rIZWXzXxqH7hZQUJ5aIUlFgPJFKLfrOGKxASaaV3YWMrcS616L7H86UhnTg5u",
-                        "organisational_unit_id", "a-org-unit-id",
-                        "issuer", "an-issuer"
-                ))
                 .insert();
 
         String chargeExternalId = "testChargeId";
+
+        dbHelper.insertWorldpay3dsFlexCredential(gatewayAccountId, "1A4rIZWXzXxqH7hZQUJ5aIUlFgPJFKLfrOGKxASaaV3YWMrcS616L7H86UhnTg5u", "an-issuer", "a-org-unit-id", 2L);
 
         dbHelper.addCharge(anAddChargeParams()
                 .withExternalChargeId(chargeExternalId)
@@ -120,15 +117,12 @@ public class FrontendContractTest {
                 .withAccountId(gatewayAccountId)
                 .withPaymentProvider("worldpay")
                 .withCardTypeEntities(Collections.singletonList(dbHelper.getVisaDebitCard()))
-                .withCredentials(Map.of(
-                        "jwt_mac_id", "1A4rIZWXzXxqH7hZQUJ5aIUlFgPJFKLfrOGKxASaaV3YWMrcS616L7H86UhnTg5u",
-                        "organisational_unit_id", "a-org-unit-id",
-                        "issuer", "an-issuer"
-                ))
                 .insert();
 
         Long chargeId = nextLong();
         String chargeExternalId = "testChargeId";
+
+        dbHelper.insertWorldpay3dsFlexCredential(gatewayAccountId, "1A4rIZWXzXxqH7hZQUJ5aIUlFgPJFKLfrOGKxASaaV3YWMrcS616L7H86UhnTg5u", "an-issuer", "a-org-unit-id", 2L);
 
         dbHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)


### PR DESCRIPTION
* Add `jwtMacKey` to flex credentials object as a write only object,
this means it will only be serialised and shouldn't be deserialised

Token generation:
* use worldpay 3ds flex credentials POJO in favour of bundles gateway
account credentials column
* pass credentials to service from dependant resources
* update tests to mock 3ds flex credentials entity and database fixtures
* removed integration tests for partially complete flex credentials in
the database, this is now enforced at creation (non-null columns)

The details required by this change will block 3ds flex smoke tests until the account details are updated in each environment.