### PR TITLE
PP-5409 - Adds transitions for cancellable charge statuses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -130,11 +130,17 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_CANCELLED, ModelledEvent.of(AuthorisationCancelled.class));
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, EXPIRE_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+        graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, USER_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
+        graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, SYSTEM_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_SUCCESS, ModelledEvent.of(AuthorisationSucceeded.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRE_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, SYSTEM_CANCEL_READY, ModelledEvent.none());
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, USER_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, CAPTURE_SUBMITTED, ModelledEvent.of(CaptureSubmitted.class));
         graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(PAYMENT_NOTIFICATION_CREATED, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));


### PR DESCRIPTION
## WHAT YOU DID
- This adds transitions from AUTHORISATION_3DS_READY to USER_CANCEL_READY and SYSTEM_CANCEL_READY
- This adds transitions from AUTHORISATION_3DS_REQUIRED to USER_CANCEL_READY, USER_CANCELLED, SYSTEM_CANCEL_READY and SYSTEM_CANCELLED

This PR adds transitions from AUTHORISATION_3DS_READY and AUTHORISATION_3DS_REQUIRED as these can be cancelled. So the transitions have been added to the graph to prepare for them to be made 'cancellable.'

