### PR TITLE
PP-5409 Refactor ChargeExpiryService Method to Query Service

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -1,14 +1,18 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 
 public class QueryService {
     private final PaymentProviders providers;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject
     public QueryService(PaymentProviders providers) {
@@ -17,5 +21,17 @@ public class QueryService {
     
     public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) throws GatewayException {
         return providers.byName(charge.getPaymentGatewayName()).queryPaymentStatus(charge);
+    }
+
+    public boolean isTerminableWithGateway(ChargeEntity charge) {
+        try {
+            return getChargeGatewayStatus(charge)
+                    .getMappedStatus()
+                    .map(chargeStatus -> !chargeStatus.toExternal().isFinished())
+                    .orElse(false);
+        } catch (WebApplicationException | UnsupportedOperationException | GatewayException | IllegalArgumentException e) {
+            logger.info("Unable to retrieve status for charge {}: {}", charge.getExternalId(), e.getMessage());
+            return false;
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -264,7 +264,7 @@ public class ChargeExpiryServiceTest {
 
         when(mockChargeDao.findByExternalId(preAuthorisationCharge.getExternalId())).thenReturn(Optional.of(preAuthorisationCharge));
 
-        when(mockQueryService.getChargeGatewayStatus(preAuthorisationCharge)).thenReturn(new ChargeQueryResponse(AUTHORISATION_SUCCESS, "Raw response"));
+        when(mockQueryService.isTerminableWithGateway(preAuthorisationCharge)).thenReturn(true);
         when(mockWorldpayCancelResponse.cancelStatus()).thenReturn(CancelStatus.CANCELLED);
 
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
+import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueryServiceTest {
+    
+    @Mock
+    private PaymentProvider paymentProvider;
+
+    @Mock
+    private PaymentProviders paymentProviders;
+
+    @InjectMocks
+    private QueryService queryService;
+
+    @Before
+    public void setUp() {
+        when(paymentProviders.byName(any())).thenReturn(paymentProvider);
+    }
+
+    @Test
+    public void isTerminableWithGateway_returnsTrueForNotFinishedExternalStatus() throws Exception {
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+
+        ChargeQueryResponse response = new ChargeQueryResponse(AUTHORISATION_3DS_REQUIRED, "a-response");
+        when(paymentProvider.queryPaymentStatus(chargeEntity)).thenReturn(response);
+
+        assertThat(queryService.isTerminableWithGateway(chargeEntity), is(true));
+    }
+
+    @Test
+    public void isTerminableWithGateway_returnsFalseForFinishedExternalStatus() throws Exception {
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+
+        ChargeQueryResponse response = new ChargeQueryResponse(CAPTURED, "a-response");
+        when(paymentProvider.queryPaymentStatus(chargeEntity)).thenReturn(response);
+
+        assertThat(queryService.isTerminableWithGateway(chargeEntity), is(false));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID

Description:
- This commit renames and moves isExpirableWithGateWay to isTerminableWithGateway into the QueryService class
- This is so we can reuse the code in the ChargeCancelService
- This adds 2 tests in QueryServiceTest to check that the isTerminableGateWay() returns true/false for a chargeEntity sent to a gateway
- A mock is refactored to use isTerminableGateway() in shouldCancelChargeWithGatewayWhenChargeInPreAuthorisedStateAndExistsWithGateway()
