### PR TITLE
PP-5409 Improve charge cancellation check

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
@@ -5,8 +5,10 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ExpirableChargeStatus;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -28,8 +30,10 @@ public class StatusFlow {
 
     public static final StatusFlow USER_CANCELLATION_FLOW = new StatusFlow("User Cancellation",
             ImmutableList.of(
+                    CREATED,
                     ENTERING_CARD_DETAILS,
-                    AUTHORISATION_SUCCESS
+                    AUTHORISATION_SUCCESS,
+                    AUTHORISATION_3DS_REQUIRED
             ),
             USER_CANCEL_READY,
             USER_CANCELLED,
@@ -42,7 +46,8 @@ public class StatusFlow {
                     CREATED,
                     ENTERING_CARD_DETAILS,
                     AUTHORISATION_SUCCESS,
-                    AWAITING_CAPTURE_REQUEST
+                    AWAITING_CAPTURE_REQUEST,
+                    AUTHORISATION_3DS_REQUIRED
             ),
             SYSTEM_CANCEL_READY,
             SYSTEM_CANCELLED,
@@ -98,5 +103,9 @@ public class StatusFlow {
 
     public ChargeStatus getFailureTerminalState() {
         return failureTerminalState;
+    }
+    
+    public boolean isInProgress(ChargeStatus chargeStatus) {
+        return Set.of(lockState, submittedState).contains(chargeStatus);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
@@ -121,7 +121,7 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void respondWith204With3DSRequeirdState_whenCancellationBeforeAuth() {
+    public void respondWith204With3DSRequiredState_whenCancellationBeforeAuth() {
 
         String chargeId = addCharge(AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelvant");
         userCancelChargeAndCheckApiStatus(chargeId, USER_CANCELLED, 204);
@@ -131,14 +131,14 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void respondWith409_whenCancellationDuringAuth3DSReady() {
+    public void respondWith400_whenCancellationDuringAuth3DSReady() {
         String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", ZonedDateTime.now().minusHours(1), "transaction-id");
         worldpayMockClient.mockCancelSuccess();
 
         connectorRestApiClient
                 .withChargeId(chargeId)
                 .postFrontendChargeCancellation()
-                .statusCode(409);
+                .statusCode(400);
 
         connectorRestApiClient
                 .withChargeId(chargeId)
@@ -180,14 +180,14 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void respondWith409_whenCancellationDuringAuthReady() {
+    public void respondWith400_whenCancellationDuringAuthReady() {
         String chargeId = addCharge(AUTHORISATION_READY, "ref", ZonedDateTime.now().minusHours(1), "transaction-id");
         worldpayMockClient.mockCancelSuccess();
 
         connectorRestApiClient
                 .withChargeId(chargeId)
                 .postFrontendChargeCancellation()
-                .statusCode(409);
+                .statusCode(400);
 
         connectorRestApiClient
                 .withChargeId(chargeId)


### PR DESCRIPTION
## WHAT YOU DID

- Adds an isCancelOrExpiryInProgress() method to StatusFlow to indicate whether a cancel or expiry is in progress
- Modifies validateChargeStatus so that it checks whether a cancel or expiry is in progress (i.e. statusFlow.isStarted) and also checks whether the charge is in a terminable state. In both cases if the condition fails an exception is thrown
- Modifies validateChargeStatus method signature as 2 parameters are unused and moves method call into doCancel()
