### PR TITLE
PP-5709: update order template to include ip address only for 3ds payments

### DIFF
--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -31,10 +31,12 @@
                     </cardAddress>
                     </#if>
                 </VISA-SSL>
+                <#if requires3ds>
                 <#if authCardDetails.ipAddress.isPresent()>
                 <session id="${sessionId?xml}" shopperIPAddress="${authCardDetails.ipAddress.get()}"/>
-                <#elseif requires3ds>
+                <#else>
                 <session id="${sessionId?xml}"/>
+                </#if>
                 </#if>
             </paymentDetails>
             <#if requires3ds>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -93,7 +93,6 @@ public class WorldpayOrderRequestBuilderTest {
         Address fullAddress = new Address("123 My Street", "This road", "SW8URR", "London", "London county", "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(fullAddress);
-        authCardDetails.setIpAddress("127.0.0.1");
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
                 .withSessionId("uniqueSessionId")

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -141,7 +141,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
                 .thenReturn(gatewayResponse);
 
         var worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
-        worldpayPaymentProvider.authorise(getCardAuthorisationRequest(chargeEntity, "127.0.0.1"));
+        worldpayPaymentProvider.authorise(getCardAuthorisationRequest(chargeEntity));
 
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
         verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), anyMap());

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds.xml
@@ -25,7 +25,6 @@
                         </address>
                     </cardAddress>
                 </VISA-SSL>
-                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
             </paymentDetails>
         </order>
     </submit>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-full-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-full-address.xml
@@ -25,7 +25,6 @@
                         </address>
                     </cardAddress>
                 </VISA-SSL>
-                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
             </paymentDetails>
         </order>
     </submit>


### PR DESCRIPTION
Continuation of https://github.com/alphagov/pay-connector/pull/1887
One of the smoke tests has shown that when the session element is included
in the authorisation order, Worldpay test account throws an error
```error code: 7, error: Invalid payment details : missing info for 3D-secure transaction: acceptHeader```.
For the time-being we're going to include shopperIPAddress only for 3ds transactions (and discuss what
to do with non-3ds payments).

Changes:
* update template to include `shopperIPAddress` only for 3ds payments
* update tests