### PR TITLE
PP-5788: Log Stripe account updated events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAccountUpdatedHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAccountUpdatedHandler.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
+
+import javax.inject.Inject;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+
+public class StripeAccountUpdatedHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StripeAccountUpdatedHandler.class);
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public StripeAccountUpdatedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void process(StripeNotification notification) {
+        try {
+            var dataObject = objectMapper.readValue(notification.getObject(), DataObject.class);
+            LOGGER.info(String.format("Received an account.updated event for stripe account %s", dataObject.getId()),
+                    kv("stripe_account_id", dataObject.getId()),
+                    kv("payouts_enabled", dataObject.isPayoutsEnabled()),
+                    kv("requirements", dataObject.getRequirements()));
+        } catch (Exception e) {
+            LOGGER.error("{} notification parsing for source object failed: {}", STRIPE.getName(), e);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class DataObject {
+
+        @JsonProperty("id")
+        private String id;
+
+        @JsonProperty("payouts_enabled")
+        private boolean payoutsEnabled;
+
+        @JsonProperty("requirements")
+        private JsonNode requirements;
+
+        private String getId() {
+            return id;
+        }
+
+        private boolean isPayoutsEnabled() {
+            return payoutsEnabled;
+        }
+
+        private String getRequirements() {
+            return requirements.toString();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.net.Webhook;
@@ -26,6 +25,7 @@ import java.util.Optional;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.ACCOUNT_UPDATED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.PAYMENT_INTENT_PAYMENT_FAILED;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.SOURCE_CANCELED;
@@ -36,22 +36,24 @@ public class StripeNotificationService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final List<StripeNotificationType> sourceTypes = ImmutableList.of(
+    private final List<StripeNotificationType> sourceTypes = List.of(
             SOURCE_CANCELED,
             SOURCE_CHARGEABLE,
             SOURCE_FAILED
     );
     
-    private final List<StripeNotificationType> paymentIntentTypes = ImmutableList.of(
+    private final List<StripeNotificationType> paymentIntentTypes = List.of(
             PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED, 
             PAYMENT_INTENT_PAYMENT_FAILED
     );
-    private final List<ChargeStatus> threeDSAuthorisableStates = ImmutableList.of(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_3DS_READY);
+    
+    private final List<ChargeStatus> threeDSAuthorisableStates = List.of(AUTHORISATION_3DS_REQUIRED, AUTHORISATION_3DS_READY);
 
     private final ChargeService chargeService;
     private final Card3dsResponseAuthService card3dsResponseAuthService;
     private final ObjectMapper objectMapper;
     private final StripeGatewayConfig stripeGatewayConfig;
+    private final StripeAccountUpdatedHandler stripeAccountUpdatedHandler;
 
     private static final String PAYMENT_GATEWAY_NAME = PaymentGatewayName.STRIPE.getName();
     private static final long DEFAULT_TOLERANCE = 300L;
@@ -59,9 +61,11 @@ public class StripeNotificationService {
     @Inject
     public StripeNotificationService(Card3dsResponseAuthService card3dsResponseAuthService,
                                      ChargeService chargeService,
-                                     StripeGatewayConfig stripeGatewayConfig) {
+                                     StripeGatewayConfig stripeGatewayConfig, 
+                                     StripeAccountUpdatedHandler stripeAccountUpdatedHandler) {
         this.card3dsResponseAuthService = card3dsResponseAuthService;
         this.chargeService = chargeService;
+        this.stripeAccountUpdatedHandler = stripeAccountUpdatedHandler;
         objectMapper = new ObjectMapper();
         this.stripeGatewayConfig = stripeGatewayConfig;
     }
@@ -86,7 +90,13 @@ public class StripeNotificationService {
             processSourceNotification(notification);
         } else if (isAPaymentIntentNotification(notification)) {
             processPaymentIntentNotification(notification);
+        } else if (isAnAccountUpdatedNotification(notification)) {
+            stripeAccountUpdatedHandler.process(notification);
         }
+    }
+
+    private boolean isAnAccountUpdatedNotification(StripeNotification notification) {
+        return StripeNotificationType.byType(notification.getType()) == ACCOUNT_UPDATED;
     }
 
     private void processPaymentIntentNotification(StripeNotification notification) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 public enum StripeNotificationType {
 
+    ACCOUNT_UPDATED("account.updated"),
     SOURCE_CANCELED("source.canceled"),
     SOURCE_CHARGEABLE("source.chargeable"),
     SOURCE_FAILED("source.failed"),

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -128,8 +128,6 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_AUTHORISATION_FAILED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/authorisation_failed_response.json";
     public static final String STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_token_response.json";
     public static final String STRIPE_CREATE_SOURCES_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_response.json";
-    public static final String STRIPE_CREATE_SOURCES_3DS_REQUIRED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_sources_3ds_required_response.json";
-    public static final String STRIPE_CREATE_3DS_SOURCES_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_3ds_sources_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_capture_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response.json";
@@ -138,16 +136,12 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_method_success_response.json";
     public static final String STRIPE_CAPTURE_SUCCESS_RESPONSE_DESTINATION_CHARGE = TEMPLATE_BASE_NAME + "/stripe/capture_success_response_destination_charge.json";
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
-    public static final String STRIPE_ERROR_RESPONSE_GENERAL = TEMPLATE_BASE_NAME + "/stripe/error_response_general.json";
-    public static final String STRIPE_CANCEL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/cancel_charge_response.json";
     public static final String STRIPE_REFUND_FULL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_charge.json";
-    public static final String STRIPE_REFUND_FULL_DESTINATION_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_destination_charge.json";
-    public static final String STRIPE_REFUND_ERROR_GREATER_AMOUNT_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_error_greater_amount.json";
-    public static final String STRIPE_REFUND_ERROR_ALREADY_REFUNDED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_error_charge_already_refunded.json";
     public static final String STRIPE_TRANSFER_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/transfer_success_response.json";
 
     public static final String STRIPE_NOTIFICATION_3DS_SOURCE = TEMPLATE_BASE_NAME + "/stripe/notification_3ds_source.json";
     public static final String STRIPE_NOTIFICATION_PAYMENT_INTENT = TEMPLATE_BASE_NAME + "/stripe/notification_payment_intent.json";
+    public static final String STRIPE_NOTIFICATION_ACCOUNT_UPDATED = TEMPLATE_BASE_NAME + "/stripe/account_updated.json";
 
     public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.xml";
     public static final String SQS_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/error-response.xml";

--- a/src/test/resources/templates/stripe/account_updated.json
+++ b/src/test/resources/templates/stripe/account_updated.json
@@ -1,0 +1,143 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "account.updated",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2019-05-16",
+  "data": {
+    "object": {
+      "id": "acct_00000000000000",
+      "object": "account",
+      "business_profile": {
+        "mcc": "5734",
+        "name": "Cabinet Office",
+        "product_description": "We collect payments for broad variety of services in the public sector in the UK",
+        "support_address": null,
+        "support_email": null,
+        "support_phone": "+442072761234",
+        "support_url": null,
+        "url": "http://www.gov.uk"
+      },
+      "business_type": "company",
+      "capabilities": {
+        "card_payments": "active",
+        "transfers": "active"
+      },
+      "charges_enabled": true,
+      "company": {
+        "address": {
+          "city": "London",
+          "country": "GB",
+          "line1": "31A Chatham Place",
+          "line2": null,
+          "postal_code": "E96FJ",
+          "state": null
+        },
+        "directors_provided": false,
+        "name": "Cabinet Office",
+        "owners_provided": true,
+        "tax_id_provided": false,
+        "verification": {
+          "document": {
+            "back": null,
+            "details": null,
+            "details_code": null,
+            "front": null
+          }
+        }
+      },
+      "country": "GB",
+      "created": 1544617488,
+      "default_currency": "gbp",
+      "details_submitted": true,
+      "email": "test@stripe.com",
+      "external_accounts": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ba_00000000000000",
+            "object": "bank_account",
+            "account": "acct_00000000000000",
+            "account_holder_name": null,
+            "account_holder_type": null,
+            "bank_name": "NAT WEST BANK PLC",
+            "country": "GB",
+            "currency": "gbp",
+            "default_for_currency": true,
+            "fingerprint": "7fAtx7OwlUupiNO8",
+            "last4": "0160",
+            "metadata": {
+            },
+            "routing_number": "60-70-80",
+            "status": "new"
+          }
+        ],
+        "has_more": false,
+        "url": "/v1/accounts/acct_1DgWlgDv3CZEaFO2/external_accounts"
+      },
+      "metadata": {
+      },
+      "payouts_enabled": false,
+      "requirements": {
+        "current_deadline": null,
+        "currently_due": [
+        ],
+        "disabled_reason": "listed",
+        "eventually_due": [
+        ],
+        "past_due": [
+        ],
+        "pending_verification": [
+        ]
+      },
+      "settings": {
+        "branding": {
+          "icon": null,
+          "logo": null,
+          "primary_color": null
+        },
+        "card_payments": {
+          "decline_on": {
+            "avs_failure": true,
+            "cvc_failure": true
+          },
+          "statement_descriptor_prefix": null
+        },
+        "dashboard": {
+          "display_name": "GOV.UK Pay Production",
+          "timezone": "Europe/London"
+        },
+        "payments": {
+          "statement_descriptor": "GOV.UK PAY",
+          "statement_descriptor_kana": null,
+          "statement_descriptor_kanji": null
+        },
+        "payouts": {
+          "debit_negative_balances": false,
+          "schedule": {
+            "delay_days": 2,
+            "interval": "daily"
+          },
+          "statement_descriptor": null
+        }
+      },
+      "tos_acceptance": {
+        "date": 1545343670,
+        "ip": "81.156.62.52",
+        "user_agent": null
+      },
+      "type": "standard",
+      "statement_descriptor": "TEST"
+    },
+    "previous_attributes": {
+      "verification": {
+        "fields_needed": [
+        ],
+        "due_by": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
At the moment we're only concerned with `requirements` and `payouts_enabled`
information.

The idea is that a Splunk alert will be set up to look for a `Received an account.updated event for stripe account` string and create a ticket in Zendesk 