### PR TITLE
PP-5409 Makes Cancellation of charges consistent with expiry logic

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.charge.service;
 
-import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.model.domain.ExpirableChargeStatus;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.gateway.GatewayException;
@@ -14,37 +14,34 @@ import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
+import uk.gov.pay.connector.paymentprocessor.service.QueryService;
 
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.service.StatusFlow.SYSTEM_CANCELLATION_FLOW;
 import static uk.gov.pay.connector.charge.service.StatusFlow.USER_CANCELLATION_FLOW;
 
 public class ChargeCancelService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-
-    private static List<ChargeStatus> nonGatewayStatuses = ImmutableList.of(
-            CREATED, ENTERING_CARD_DETAILS, AUTHORISATION_3DS_REQUIRED
-    );
-
+    
     private final ChargeDao chargeDao;
     private final PaymentProviders providers;
     private final ChargeService chargeService;
+    private final QueryService queryService;
 
     @Inject
     public ChargeCancelService(ChargeDao chargeDao,
                                PaymentProviders providers,
-                               ChargeService chargeService) {
+                               ChargeService chargeService,
+                               QueryService queryService) {
         this.chargeDao = chargeDao;
         this.providers = providers;
         this.chargeService = chargeService;
+        this.queryService = queryService;
     }
 
     public Optional<ChargeEntity> doSystemCancel(String chargeId, Long accountId) {
@@ -64,12 +61,22 @@ public class ChargeCancelService {
     }
 
     private void doCancel(ChargeEntity chargeEntity, StatusFlow statusFlow) {
+        
         validateChargeStatus(statusFlow, chargeEntity);
         
-        if (gatewayIsNotAwareOfCharge(chargeEntity)) {
-            nonGatewayCancel(chargeEntity, statusFlow);
-        } else {
+        ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+
+        ExpirableChargeStatus.AuthorisationStage authorisationStage = ExpirableChargeStatus
+                .of(chargeStatus).getAuthorisationStage();
+
+        boolean cancellableWithGateway = authorisationStage == ExpirableChargeStatus.AuthorisationStage.POST_AUTHORISATION
+                || (authorisationStage == ExpirableChargeStatus.AuthorisationStage.DURING_AUTHORISATION
+                && queryService.isTerminableWithGateway(chargeEntity));
+
+        if (cancellableWithGateway) {
             cancelChargeWithGatewayCleanup(chargeEntity, statusFlow);
+        } else {
+            nonGatewayCancel(chargeEntity, statusFlow);
         }
     }
 
@@ -125,11 +132,7 @@ public class ChargeCancelService {
 
         chargeService.transitionChargeState(chargeEntity.getExternalId(), completeStatus);
     }
-
-    private boolean gatewayIsNotAwareOfCharge(ChargeEntity chargeEntity) {
-        return nonGatewayStatuses.contains(ChargeStatus.fromString(chargeEntity.getStatus()));
-    }
-
+    
     private void prepareForTerminate(ChargeEntity chargeEntity, StatusFlow statusFlow) {
         ChargeStatus lockState = statusFlow.getLockState();
         ChargeStatus currentStatus = ChargeStatus.fromString(chargeEntity.getStatus());

--- a/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/StatusFlow.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.charge.service;
 
-import com.google.common.collect.ImmutableList;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ExpirableChargeStatus;
 
@@ -8,11 +7,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_FAILED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
@@ -28,13 +22,12 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCEL_
 
 public class StatusFlow {
 
+    private static final List<ChargeStatus> TERMINABLE_STATUSES = ExpirableChargeStatus.getValuesAsStream()
+            .map(ExpirableChargeStatus::getChargeStatus)
+            .collect(Collectors.toList());
+
     public static final StatusFlow USER_CANCELLATION_FLOW = new StatusFlow("User Cancellation",
-            ImmutableList.of(
-                    CREATED,
-                    ENTERING_CARD_DETAILS,
-                    AUTHORISATION_SUCCESS,
-                    AUTHORISATION_3DS_REQUIRED
-            ),
+            TERMINABLE_STATUSES,
             USER_CANCEL_READY,
             USER_CANCELLED,
             USER_CANCEL_SUBMITTED,
@@ -42,23 +35,15 @@ public class StatusFlow {
     );
 
     public static final StatusFlow SYSTEM_CANCELLATION_FLOW = new StatusFlow("System Cancellation",
-            ImmutableList.of(
-                    CREATED,
-                    ENTERING_CARD_DETAILS,
-                    AUTHORISATION_SUCCESS,
-                    AWAITING_CAPTURE_REQUEST,
-                    AUTHORISATION_3DS_REQUIRED
-            ),
+            TERMINABLE_STATUSES,
             SYSTEM_CANCEL_READY,
             SYSTEM_CANCELLED,
             SYSTEM_CANCEL_SUBMITTED,
             SYSTEM_CANCEL_ERROR
     );
-
+    
     public static final StatusFlow EXPIRE_FLOW = new StatusFlow("Expiration",
-            ExpirableChargeStatus.getValuesAsStream()
-                    .map(ExpirableChargeStatus::getChargeStatus)
-                    .collect(Collectors.toList()), 
+            TERMINABLE_STATUSES, 
             EXPIRE_CANCEL_READY,
             EXPIRED,
             EXPIRE_CANCEL_SUBMITTED,

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelFrontendResourceIT.java
@@ -129,23 +129,7 @@ public class ChargeCancelFrontendResourceIT extends ChargingITestBase {
         assertThat(events.size(), is(2));
         assertThat(events, hasItems(AUTHORISATION_3DS_REQUIRED.getValue(), USER_CANCELLED.getValue()));
     }
-
-    @Test
-    public void respondWith400_whenCancellationDuringAuth3DSReady() {
-        String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", ZonedDateTime.now().minusHours(1), "transaction-id");
-        worldpayMockClient.mockCancelSuccess();
-
-        connectorRestApiClient
-                .withChargeId(chargeId)
-                .postFrontendChargeCancellation()
-                .statusCode(400);
-
-        connectorRestApiClient
-                .withChargeId(chargeId)
-                .getCharge()
-                .body("state.status", is("started"));
-    }
-
+    
     private String userCancelChargeAndCheckApiStatus(String chargeId, ChargeStatus targetState, int httpStatusCode) {
         connectorRestApiClient
                 .withChargeId(chargeId)


### PR DESCRIPTION
## WHAT YOU DID
This PR modifies the doCancel method in ChargeCancelService to make it consistent with the logic used with expiring charges in ChargeExpiryService.

It does this by:
- Making the same set of states cancellable as those which are expirable using ExpirableChargeStatus
- Charges with an authorisation stage of DURING_AUTHORISATION are checked with the gateway whether they are cancellable

## How to test

See the new tests in ChargeCancelServiceTest