### PR TITLE
PP-5842: database migration

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1324,4 +1324,11 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="add send_payer_ip_address_to_gateway column to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="send_payer_ip_address_to_gateway" type="boolean" defaultValue="false">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
In order to make configuration for including shopperIPAddress
for Worldpay order gateway account specific we need to add new db column
(by default false) to gateway_accounts table.