### PR TITLE
PP-5409 Authorisation Ready Cancellable

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ExpirableChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ExpirableChargeStatus.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 public enum ExpirableChargeStatus {
     CREATED(ChargeStatus.CREATED, AuthorisationStage.PRE_AUTHORISATION, ExpiryThresholdType.REGULAR),
     ENTERING_CARD_DETAILS(ChargeStatus.ENTERING_CARD_DETAILS, AuthorisationStage.PRE_AUTHORISATION, ExpiryThresholdType.REGULAR),
+    AUTHORISATION_READY(ChargeStatus.AUTHORISATION_READY, AuthorisationStage.PRE_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_3DS_REQUIRED(ChargeStatus.AUTHORISATION_3DS_REQUIRED, AuthorisationStage.DURING_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_3DS_READY(ChargeStatus.AUTHORISATION_3DS_READY, AuthorisationStage.DURING_AUTHORISATION, ExpiryThresholdType.REGULAR),
     AUTHORISATION_SUCCESS(ChargeStatus.AUTHORISATION_SUCCESS, AuthorisationStage.POST_AUTHORISATION, ExpiryThresholdType.REGULAR),

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -120,6 +120,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_3DS_REQUIRED, ModelledEvent.of(GatewayRequires3dsAuthorisation.class));
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_CANCELLED, ModelledEvent.of(AuthorisationCancelled.class));
         graph.putEdgeValue(AUTHORISATION_READY, AUTHORISATION_SUBMITTED, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
+        graph.putEdgeValue(AUTHORISATION_READY, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
         graph.putEdgeValue(AUTHORISATION_SUBMITTED, AUTHORISATION_SUCCESS, ModelledEvent.of(AuthorisationSucceeded.class));
         graph.putEdgeValue(AUTHORISATION_SUBMITTED, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
         graph.putEdgeValue(AUTHORISATION_SUBMITTED, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -87,7 +87,8 @@ public class ChargeCancelServiceTest {
     @Test
     @Parameters({
             "AUTHORISATION 3DS REQUIRED",
-            "AUTHORISATION 3DS READY"
+            "AUTHORISATION 3DS READY",
+            "AUTHORISATION READY"
     })
     public void doSystemCancel_chargeStatusDuringAuthorisation_DoesNotNeedCancellationWithProvider(String chargeStatus) throws Exception {
         var status = ChargeStatus.fromString(chargeStatus);
@@ -197,7 +198,8 @@ public class ChargeCancelServiceTest {
     @Test
     @Parameters({
             "AUTHORISATION 3DS REQUIRED",
-            "AUTHORISATION 3DS READY"
+            "AUTHORISATION 3DS READY",
+            "AUTHORISATION READY"
     })
     public void doUserCancel_chargeStatusDuringAuthorisation_DoesNotNeedCancellationWithProvider(String chargeStatus) throws Exception {
         var status = ChargeStatus.fromString(chargeStatus);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
@@ -95,6 +96,7 @@ public class ChargeExpiryServiceTest {
     private static final List<ChargeStatus> EXPIRABLE_REGULAR_STATUSES = ImmutableList.of(
             CREATED,
             ENTERING_CARD_DETAILS,
+            AUTHORISATION_READY,
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_3DS_READY,
             AUTHORISATION_SUCCESS
@@ -185,6 +187,7 @@ public class ChargeExpiryServiceTest {
     @Parameters({
             "CREATED",
             "ENTERING CARD DETAILS",
+            "AUTHORISATION READY",
             "AUTHORISATION 3DS REQUIRED",
             "AUTHORISATION 3DS READY"
     })


### PR DESCRIPTION
Description:
- Makes AUTHORISATION_READY cancellable but it doesn't check with gateway as the payment may/may not have been made. Since the funds will be released shortly (~ 1 week) we decided to cancel it on our end
- See this [PR](https://github.com/alphagov/pay-connector/pull/1901) for context

