### PR TITLE
PP-5409 AUTHORISATION_READY to EXPIRED

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -101,6 +101,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(UNDEFINED, PAYMENT_NOTIFICATION_CREATED, ModelledEvent.of(PaymentNotificationCreated.class));
         graph.putEdgeValue(CREATED, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(ENTERING_CARD_DETAILS, EXPIRED, ModelledEvent.of(PaymentExpired.class));
+        graph.putEdgeValue(AUTHORISATION_READY, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, EXPIRED, ModelledEvent.of(PaymentExpired.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRED, ModelledEvent.of(PaymentExpired.class));
 


### PR DESCRIPTION
## WHAT YOU DID
Fixes an error with the previous PR as AUTHORISATION_READY to EXPIRED wasn't added to payment gateway transitions which caused an error in the ChargeExpiryService. This change now ensures that AUTHORISATION_READY is now a cancellable state.
