### PR TITLE
PP-5409 - Minor Test Refactoring to test remaining expirable charge statuses

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
@@ -14,8 +14,10 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
@@ -26,11 +28,14 @@ import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AWAITING_CAPTURE_REQUEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_FAILED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRE_CANCEL_READY;
@@ -79,12 +84,17 @@ public class ChargeExpiryResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void shouldExpireChargesOnlyAfterTheExpiryWindow() {
-        String shouldExpireCreatedChargeId = addCharge(CREATED, "ref1", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
-        String shouldntExpireCreatedChargeId = addCharge(CREATED, "ref1", ZonedDateTime.now().minusMinutes(89), RandomIdGenerator.newId());
-
-        String shouldExpireAuthReadyChargeId = addCharge(AUTHORISATION_READY, "ref2", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
-        String shouldntExpireAuthReadyChargeId = addCharge(AUTHORISATION_READY, "ref2", ZonedDateTime.now().minusMinutes(89), RandomIdGenerator.newId());
+    public void shouldExpireCharges() {
+        
+        ChargeStatus[] expirableChargeStatuses = {CREATED, ENTERING_CARD_DETAILS, AUTHORISATION_READY, AUTHORISATION_3DS_READY, AUTHORISATION_3DS_REQUIRED};
+        String[] shouldExpireChargeId = new String[5];
+        String[] shouldntExpireChargeId = new String[5];
+        Set<List<String>> events = new HashSet<>();
+        
+        for(int i = 0; i < shouldExpireChargeId.length; i++) {
+            shouldExpireChargeId[i] = addCharge(expirableChargeStatuses[i], String.valueOf(i), ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+            shouldntExpireChargeId[i] = addCharge(expirableChargeStatuses[i], String.valueOf(i), ZonedDateTime.now().minusMinutes(89), RandomIdGenerator.newId());
+        }
         
         worldpayMockClient.mockCancelSuccess();
 
@@ -92,29 +102,65 @@ public class ChargeExpiryResourceIT extends ChargingITestBase {
                 .postChargeExpiryTask()
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
-                .body("expiry-success", is(2))
+                .body("expiry-success", is(5))
                 .body("expiry-failed", is(0));
         
-        List.of(shouldExpireAuthReadyChargeId, shouldExpireCreatedChargeId).forEach(s -> {
+        for(String chargeId : shouldExpireChargeId) {
             connectorRestApiClient
                     .withAccountId(accountId)
-                    .withChargeId(s)
+                    .withChargeId(chargeId)
                     .getCharge()
                     .statusCode(OK.getStatusCode())
                     .contentType(JSON)
-                    .body(JSON_CHARGE_KEY, is(s))
+                    .body(JSON_CHARGE_KEY, is(chargeId))
                     .body(JSON_STATE_KEY, is(EXPIRED.toExternal().getStatus()));
-        });
+        }
         
+        for(int i = 0; i < shouldExpireChargeId.length; i++) {
+            events.add(databaseTestHelper.getInternalEvents(shouldExpireChargeId[i]));
+            events.add(databaseTestHelper.getInternalEvents(shouldntExpireChargeId[i]));
+        }
+        
+        assertThat(events.contains(asList(CREATED.getValue(), EXPIRED.getValue())), is(true));
+        assertThat(events.contains(Collections.singletonList(CREATED.getValue())), is(true));
+        assertThat(events.contains(asList(ENTERING_CARD_DETAILS.getValue(), EXPIRED.getValue())), is(true));
+        assertThat(events.contains(Collections.singletonList(ENTERING_CARD_DETAILS.getValue())), is(true));
+        assertThat(events.contains(asList(AUTHORISATION_READY.getValue(), EXPIRED.getValue())), is(true));
+        assertThat(events.contains(Collections.singletonList(AUTHORISATION_READY.getValue())), is(true));
+        assertThat(events.contains(asList(AUTHORISATION_3DS_READY.getValue(), EXPIRED.getValue())), is(true));
+        assertThat(events.contains(Collections.singletonList(AUTHORISATION_3DS_READY.getValue())), is(true));
+        assertThat(events.contains(asList(AUTHORISATION_3DS_REQUIRED.getValue(), EXPIRED.getValue())), is(true));
+        assertThat(events.contains(Collections.singletonList(AUTHORISATION_3DS_REQUIRED.getValue())), is(true));
+    }
+
+    @Test
+    public void shouldExpireChargesOnlyAfterTheExpiryWindow() {
+        String shouldExpireCreatedChargeId = addCharge(CREATED, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+        String shouldntExpireCreatedChargeId = addCharge(CREATED, "ref", ZonedDateTime.now().minusMinutes(89), RandomIdGenerator.newId());
+        
+        worldpayMockClient.mockCancelSuccess();
+
+        connectorRestApiClient
+                .postChargeExpiryTask()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)  §
+                .body("expiry-success", is(1))
+                .body("expiry-failed", is(0));
+        
+        connectorRestApiClient
+                .withAccountId(accountId)
+                .withChargeId(shouldExpireCreatedChargeId)
+                .getCharge()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body(JSON_CHARGE_KEY, is(shouldExpireCreatedChargeId))
+                .body(JSON_STATE_KEY, is(EXPIRED.toExternal().getStatus()));
+
         List<String> events1 = databaseTestHelper.getInternalEvents(shouldExpireCreatedChargeId);
         List<String> events2 = databaseTestHelper.getInternalEvents(shouldntExpireCreatedChargeId);
-        List<String> events3 = databaseTestHelper.getInternalEvents(shouldExpireAuthReadyChargeId);
-        List<String> events4 = databaseTestHelper.getInternalEvents(shouldntExpireAuthReadyChargeId);
 
         assertThat(asList(CREATED.getValue(), EXPIRED.getValue()), is(events1));
-        assertThat(asList(AUTHORISATION_READY.getValue(), EXPIRED.getValue()), is(events3));
         assertThat(Collections.singletonList(CREATED.getValue()), is(events2));
-        assertThat(Collections.singletonList(AUTHORISATION_READY.getValue()), is(events4));
     }
 
     @Test
@@ -297,7 +343,7 @@ public class ChargeExpiryResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldExpireWithGatewayIfExistsInCancellableStateWithGatewayEvenIfChargeIsPreAuthorisation() {
-        String chargeId = addCharge(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+        String chargeId = addCharge(AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
 
         WireMock.reset();
         worldpayMockClient.mockCancelSuccess();


### PR DESCRIPTION
Description:
- A case can arise where a charge is added to ExpirableChargeStatus but the relevant state transition is not recorded so the error will not be caught. By testing the remaining ExpirableChargeStatuses here we can prevent this.
