### PR TITLE
PP-5855 EmittedEventSweeper - Ignore events being processed

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -51,7 +51,6 @@ public class ConnectorModule extends AbstractModule {
         bind(HashUtil.class);
         bind(RequestValidator.class);
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
-        bind(StateTransitionQueue.class).in(Singleton.class);
 
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(GatewayAccountServicesFactory.class));
@@ -133,6 +132,16 @@ public class ConnectorModule extends AbstractModule {
         return new NotifyClientFactory(connectorConfiguration);
     }
 
+    @Provides
+    @Singleton
+    public StateTransitionQueue stateTransitionQueue() {
+        return getStateTransitionQueue();
+    }
+
+    protected StateTransitionQueue getStateTransitionQueue() {
+        return new StateTransitionQueue();
+    }
+    
     @Provides
     public AmazonSQS sqsClient(ConnectorConfiguration connectorConfiguration) {
 

--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
@@ -21,6 +21,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.now;
 
 public class EmittedEventsBackfillService {
@@ -49,12 +50,13 @@ public class EmittedEventsBackfillService {
     public void backfillNotEmittedEvents() {
         Long lastProcessedId = 0L;
         ZonedDateTime cutoffDate = getCutoffDateForProcessingNotEmittedEvents();
-        Optional<Long> maxId = emittedEventDao.findNotEmittedEventMaxIdOlderThan(cutoffDate);
+        ZonedDateTime now = now(UTC);
+        Optional<Long> maxId = emittedEventDao.findNotEmittedEventMaxIdOlderThan(cutoffDate, now);
 
         while (maxId.isPresent()) {
             List<EmittedEventEntity> notEmittedEventsToProcess =
                     emittedEventDao.findNotEmittedEventsOlderThan(cutoffDate,
-                            PAGE_SIZE, lastProcessedId, maxId.get());
+                            PAGE_SIZE, lastProcessedId, maxId.get(), now);
 
             if (!notEmittedEventsToProcess.isEmpty()) {
                 String oldestEventDate = notEmittedEventsToProcess.stream()

--- a/src/main/java/uk/gov/pay/connector/events/EventService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventService.java
@@ -27,7 +27,7 @@ public class EventService {
             eventQueue.emitEvent(event);
             emittedEventDao.recordEmission(event);
         } catch (QueueException e) {
-            emittedEventDao.recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp());
+            emittedEventDao.recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp(), null);
             logger.error("Failed to emit event {} due to {} [externalId={}]", event.getEventType(), e.getMessage(), event.getResourceExternalId());
         }
     }
@@ -38,6 +38,6 @@ public class EventService {
     }
 
     public void recordOfferedEvent(ResourceType resourceType, String externalId, String eventType, ZonedDateTime eventDate) {
-        emittedEventDao.recordEmission(resourceType, externalId, eventType, eventDate);
+        emittedEventDao.recordEmission(resourceType, externalId, eventType, eventDate, null);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionQueue.java
@@ -22,8 +22,12 @@ public class StateTransitionQueue {
     public int size() {
         return queue.size();
     }
-    
+
     public boolean isEmpty() {
         return queue.isEmpty();
+    }
+
+    public void clear() {
+        queue.clear();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
@@ -89,16 +89,16 @@ public class EmittedEventsBackfillServiceTest {
         chargeEntity.getEvents().add(chargeEventEntity);
         refundEntity = mock(RefundEntity.class);
         when(refundEntity.getChargeEntity()).thenReturn(chargeEntity);
-        when(emittedEventDao.findNotEmittedEventMaxIdOlderThan(any(ZonedDateTime.class))).thenReturn(Optional.of(maxId));
+        when(emittedEventDao.findNotEmittedEventMaxIdOlderThan(any(ZonedDateTime.class), any())).thenReturn(Optional.of(maxId));
     }
     
     @Test
     public void logsMessageWhenNoEmittedEventsSatisfyingCriteria() {
-        when(emittedEventDao.findNotEmittedEventMaxIdOlderThan(any(ZonedDateTime.class))).thenReturn(Optional.empty());
+        when(emittedEventDao.findNotEmittedEventMaxIdOlderThan(any(ZonedDateTime.class), any())).thenReturn(Optional.empty());
         
         emittedEventsBackfillService.backfillNotEmittedEvents();
         
-        verify(emittedEventDao, never()).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), anyLong(), eq(maxId));
+        verify(emittedEventDao, never()).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), anyLong(), eq(maxId), any());
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(loggingEvents.get(0).getFormattedMessage(), is("Finished processing not emitted events [lastProcessedId=0, maxId=none]"));
@@ -107,12 +107,12 @@ public class EmittedEventsBackfillServiceTest {
     @Test
     public void backfillsEventsWhenEmittedPaymentEventSatisfyingCriteria() {
         var emittedEvent = anEmittedEventEntity().withResourceExternalId(chargeEntity.getExternalId()).build();
-        when(emittedEventDao.findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId))).thenReturn(List.of(emittedEvent));
+        when(emittedEventDao.findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any())).thenReturn(List.of(emittedEvent));
         when(chargeService.findChargeById(chargeEntity.getExternalId())).thenReturn(chargeEntity);
 
         emittedEventsBackfillService.backfillNotEmittedEvents();
 
-        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId));
+        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any());
         verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
@@ -124,12 +124,12 @@ public class EmittedEventsBackfillServiceTest {
     public void backfillsEventsWhenEmittedRefundEventSatisfyingCriteria() {
         var emittedEvent = anEmittedEventEntity().withResourceType("refund")
                 .withResourceExternalId(chargeEntity.getExternalId()).build();
-        when(emittedEventDao.findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId))).thenReturn(List.of(emittedEvent));
+        when(emittedEventDao.findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any())).thenReturn(List.of(emittedEvent));
         when(refundDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(refundEntity));
 
         emittedEventsBackfillService.backfillNotEmittedEvents();
 
-        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId));
+        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any());
         verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
@@ -144,13 +144,13 @@ public class EmittedEventsBackfillServiceTest {
                 .withEventDate(ZonedDateTime.parse("2019-09-20T09:00Z"))
                 .withResourceExternalId(chargeEntity.getExternalId())
                 .build();
-        when(emittedEventDao.findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId))).thenReturn(List.of(emittedPaymentEvent, emittedRefundEvent));
+        when(emittedEventDao.findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any())).thenReturn(List.of(emittedPaymentEvent, emittedRefundEvent));
         when(refundDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(refundEntity));
         when(chargeService.findChargeById(chargeEntity.getExternalId())).thenReturn(chargeEntity);
 
         emittedEventsBackfillService.backfillNotEmittedEvents();
 
-        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId));
+        verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any());
         verify(stateTransitionService, times(2)).offerStateTransition(any(), any());
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -45,7 +45,7 @@ public class EventServiceTest {
 
         verify(eventQueue).emitEvent(event);
         verify(emittedEventDao, never()).recordEmission(event);
-        verify(emittedEventDao).recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp());
+        verify(emittedEventDao).recordEmission(event.getResourceType(), event.getResourceExternalId(), event.getEventType(), event.getTimestamp(), null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
@@ -151,7 +151,7 @@ public class EmittedEventResourceIT extends ChargingITestBase {
 
     private static class ConnectorModuleWithOverrides extends ConnectorModule {
 
-        ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
+        public ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
             super(configuration, environment);
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/EmittedEventResourceIT.java
@@ -1,0 +1,163 @@
+package uk.gov.pay.connector.it.events;
+
+import io.dropwizard.setup.Environment;
+import org.apache.commons.lang.math.RandomUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.ConnectorModule;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.ConfigOverride;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.queue.StateTransitionQueue;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(
+        app = EmittedEventResourceIT.ConnectorAppWithCustomStateTransitionQueue.class,
+        config = "config/test-it-config.yaml",
+        withDockerSQS = true,
+        configOverrides = {
+                @ConfigOverride(key = "emittedEventSweepConfig.notEmittedEventMaxAgeInSeconds", value = "0")
+        }
+)
+public class EmittedEventResourceIT extends ChargingITestBase {
+
+    private static StateTransitionQueue stateTransitionQueue = new StateTransitionQueue();
+    private String externalChargeId;
+
+    public EmittedEventResourceIT() {
+        super("sandbox");
+    }
+
+    @Override
+    @Before
+    public void setUp() {
+        super.setUp();
+        databaseTestHelper.truncateEmittedEvents();
+        stateTransitionQueue.clear();
+    }
+
+    @Test
+    public void shouldSweepEmittedEventsIfDoNotRetryEmitUntilIsNull() {
+        long chargeId = addCharge();
+        databaseTestHelper.addEvent(chargeId, CREATED.toString());
+
+        databaseTestHelper.addEmittedEvent("payment", externalChargeId, Instant.now(),
+                "PAYMENT_CREATED", null, null);
+
+        connectorRestApiClient
+                .postEmittedEventsSweepTask()
+                .statusCode(OK.getStatusCode());
+
+        assertThat(stateTransitionQueue.size(), is(1));
+
+        List<Map<String, Object>> emittedEvents = databaseTestHelper.readEmittedEvents();
+
+        // emitted events sweeper adds duplicate event to table (and doesn't remove existing event)
+        assertThat(emittedEvents.size(), is(2));
+        assertEmittedEvent(emittedEvents.get(0), null);
+        assertEmittedEvent(emittedEvents.get(1), null);
+    }
+
+    @Test
+    public void shouldSweepEmittedEventsIfDoNotRetryEmitUntilValueIsInThePast() {
+        long chargeId = addCharge();
+        databaseTestHelper.addEvent(chargeId, CREATED.toString());
+
+        Instant doNotRetryEmitUntil = Instant.now().minusSeconds(60);
+        databaseTestHelper.addEmittedEvent("payment", externalChargeId, Instant.now(),
+                "PAYMENT_CREATED", null, doNotRetryEmitUntil);
+
+        connectorRestApiClient
+                .postEmittedEventsSweepTask()
+                .statusCode(OK.getStatusCode());
+
+        assertThat(stateTransitionQueue.size(), is(1));
+
+        List<Map<String, Object>> emittedEvents = databaseTestHelper.readEmittedEvents();
+
+        // emitted events sweeper adds duplicate event to table (and doesn't remove existing event)
+        assertThat(emittedEvents.size(), is(2));
+
+        assertEmittedEvent(emittedEvents.get(0), doNotRetryEmitUntil);
+        assertEmittedEvent(emittedEvents.get(1), null);
+    }
+
+    @Test
+    public void shouldNotSweepEmittedEventsIfDoNotRetryEmitUntilValueIsInTheFuture() {
+        long chargeId = addCharge();
+        databaseTestHelper.addEvent(chargeId, CREATED.toString());
+
+        Instant doNotRetryEmitUntil = Instant.now().plusSeconds(60);
+        databaseTestHelper.addEmittedEvent("payment", externalChargeId, Instant.now(),
+                "PAYMENT_CREATED", null, doNotRetryEmitUntil);
+
+        connectorRestApiClient
+                .postEmittedEventsSweepTask()
+                .statusCode(OK.getStatusCode());
+
+        assertThat(stateTransitionQueue.size(), is(0));
+
+        List<Map<String, Object>> emittedEvents = databaseTestHelper.readEmittedEvents();
+
+        assertThat(emittedEvents.size(), is(1));
+        assertEmittedEvent(emittedEvents.get(0), doNotRetryEmitUntil);
+    }
+
+    private long addCharge() {
+        long chargeId = RandomUtils.nextInt();
+        externalChargeId = "charge" + chargeId;
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withGatewayAccountId(accountId)
+                .withAmount(100)
+                .withStatus(CREATED)
+                .build());
+        return chargeId;
+    }
+
+    private void assertEmittedEvent(Map<String, Object> emittedEvent, Instant expectedDoNotRetryEmitUntil) {
+        assertThat(emittedEvent.get("event_type"), is("PAYMENT_CREATED"));
+        Optional.ofNullable(expectedDoNotRetryEmitUntil).ifPresentOrElse(
+                value -> assertThat(emittedEvent.get("do_not_retry_emit_until"), is(Timestamp.from(expectedDoNotRetryEmitUntil))),
+                () -> assertThat(emittedEvent.get("do_not_retry_emit_until"), is(nullValue()))
+        );
+    }
+
+    public static class ConnectorAppWithCustomStateTransitionQueue extends ConnectorApp {
+
+        @Override
+        protected ConnectorModule getModule(ConnectorConfiguration configuration, Environment environment) {
+            return new EmittedEventResourceIT.ConnectorModuleWithOverrides(configuration, environment);
+        }
+    }
+
+    private static class ConnectorModuleWithOverrides extends ConnectorModule {
+
+        ConnectorModuleWithOverrides(ConnectorConfiguration configuration, Environment environment) {
+            super(configuration, environment);
+        }
+
+        @Override
+        protected StateTransitionQueue getStateTransitionQueue() {
+            return stateTransitionQueue;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.util;
 import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 
+import javax.ws.rs.client.Entity;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -106,6 +107,13 @@ public class RestAssuredClient {
     public ValidatableResponse postChargeExpiryTask() {
         return given().port(port)
                 .post("/v1/tasks/expired-charges-sweep")
+                .then();
+    }
+
+    public ValidatableResponse postEmittedEventsSweepTask() {
+        return given().port(port)
+                .body(Entity.json(""))
+                .post("/v1/tasks/emitted-events-sweep")
                 .then();
     }
 


### PR DESCRIPTION
## WHAT
- Emitted event sweeper currently picks up all events from emitted events and tries to emit them even though there may be another background process (parity checker, historical events emitter) that is doing the same job.
- We want to change it so that events emitted by the parity checker are not immediately picked up by the emitted events sweeper.
  This is done by using `emitted_events -> do_not_retry_emit_until`. If field value is null or is in the past emitted events sweeper can process the events. If `do_not_retry_emit_until` value is in the future, events are ignored by sweeper


with @alexbishop1