### PR TITLE
PP-5855 ParityChecker - mark events as being processed

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -5,6 +5,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
+import uk.gov.pay.connector.app.config.ParityCheckerConfig;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
@@ -76,6 +77,9 @@ public class ConnectorConfiguration extends Configuration {
 
     @NotNull
     private EmittedEventSweepConfig emittedEventSweepConfig;
+
+    @NotNull
+    private ParityCheckerConfig parityCheckerConfig;
 
     @NotNull
     private String graphiteHost;
@@ -216,5 +220,9 @@ public class ConnectorConfiguration extends Configuration {
 
     public EmittedEventSweepConfig getEmittedEventSweepConfig() {
         return emittedEventSweepConfig;
+    }
+
+    public ParityCheckerConfig getParityCheckerConfig() {
+        return parityCheckerConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/ParityCheckerConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/ParityCheckerConfig.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.app.config;
+
+import io.dropwizard.Configuration;
+
+public class ParityCheckerConfig extends Configuration {
+    
+    private long defaultDoNotRetryEmittingEventUntilDurationInSeconds;
+
+    public long getDefaultDoNotRetryEmittingEventUntilDurationInSeconds() {
+        return defaultDoNotRetryEmittingEventUntilDurationInSeconds;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/events/dao/EmittedEventDao.java
@@ -41,13 +41,13 @@ public class EmittedEventDao extends JpaDao<EmittedEventEntity> {
         return !singleResult.isEmpty();
     }
 
-    public void recordEmission(Event event) {
+    public void recordEmission(Event event, ZonedDateTime doNotRetryEmitUntilDate) {
         final EmittedEventEntity emittedEvent = new EmittedEventEntity(event.getResourceType().getLowercase(),
                 event.getResourceExternalId(),
                 event.getEventType(),
                 event.getTimestamp(),
                 now(),
-                null
+                doNotRetryEmitUntilDate
         );
 
         persist(emittedEvent);

--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.refund.service.RefundStateEventMap;
 
 import javax.inject.Inject;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 import static java.time.ZonedDateTime.now;
 import static net.logstash.logback.argument.StructuredArguments.kv;
@@ -68,9 +69,10 @@ public class StateTransitionService {
     }
 
     @Transactional
-    public void offerStateTransition(StateTransition stateTransition, Event event) {
+    public void offerStateTransition(StateTransition stateTransition, Event event,
+                                     ZonedDateTime doNotRetryEmitUntilDate) {
         stateTransitionQueue.offer(stateTransition);
         eventService.recordOfferedEvent(event.getResourceType(), event.getResourceExternalId(),
-                event.getEventType(), event.getTimestamp());
+                event.getEventType(), event.getTimestamp(), doNotRetryEmitUntilDate);
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -227,6 +227,9 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
+parityCheckerConfig:
+  defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
+
 restClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 

--- a/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
@@ -36,6 +36,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -113,7 +114,7 @@ public class EmittedEventsBackfillServiceTest {
         emittedEventsBackfillService.backfillNotEmittedEvents();
 
         verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), isNull());
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(loggingEvents.get(0).getFormattedMessage(), is("Processing not emitted events [lastProcessedId=0, no.of.events=1, oldestDate=2019-09-20T10:00Z]"));
@@ -130,7 +131,7 @@ public class EmittedEventsBackfillServiceTest {
         emittedEventsBackfillService.backfillNotEmittedEvents();
 
         verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), isNull());
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(loggingEvents.get(0).getFormattedMessage(), is("Processing not emitted events [lastProcessedId=0, no.of.events=1, oldestDate=2019-09-20T10:00Z]"));
@@ -151,7 +152,7 @@ public class EmittedEventsBackfillServiceTest {
         emittedEventsBackfillService.backfillNotEmittedEvents();
 
         verify(emittedEventDao, times(1)).findNotEmittedEventsOlderThan(any(ZonedDateTime.class), anyInt(), eq(0L), eq(maxId), any());
-        verify(stateTransitionService, times(2)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(2)).offerStateTransition(any(), any(), isNull());
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> loggingEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(loggingEvents.get(0).getFormattedMessage(), is("Processing not emitted events [lastProcessedId=0, no.of.events=2, oldestDate=2019-09-20T09:00Z]"));

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -17,6 +17,8 @@ import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
 
+import static java.time.ZoneOffset.UTC;
+import static java.time.ZonedDateTime.now;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -109,8 +111,9 @@ public class StateTransitionServiceTest {
                 .withExternalId("external-id")
                 .build();
         RefundCreatedByUser refundCreatedByUser = RefundCreatedByUser.from(refundHistory);
+        ZonedDateTime doNotEmitRetryUntil = now(UTC);
 
-        stateTransitionService.offerStateTransition(refundStateTransition, refundCreatedByUser);
+        stateTransitionService.offerStateTransition(refundStateTransition, refundCreatedByUser, doNotEmitRetryUntil);
 
         ArgumentCaptor<RefundStateTransition> refundStateTransitionArgumentCaptor = ArgumentCaptor.forClass(RefundStateTransition.class);
         verify(mockStateTransitionQueue).offer(refundStateTransitionArgumentCaptor.capture());
@@ -119,6 +122,6 @@ public class StateTransitionServiceTest {
         assertThat(refundStateTransitionArgumentCaptor.getValue().getStateTransitionEventClass(), is(RefundCreatedByUser.class));
 
         verify(mockEventService).recordOfferedEvent(REFUND, refundHistory.getExternalId(),
-                "REFUND_CREATED_BY_USER", refundHistory.getHistoryStartDate());
+                "REFUND_CREATED_BY_USER", refundHistory.getHistoryStartDate(), doNotEmitRetryUntil);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -79,11 +80,12 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
 
-        worker.execute(1L, Optional.empty(), true, emptyParityCheckStatus);
+        worker.execute(1L, Optional.empty(), true, 
+                emptyParityCheckStatus, null);
 
         verify(chargeService, never()).updateChargeParityStatus(any(), any());
-        verify(stateTransitionService, never()).offerStateTransition(any(), any());
-        verify(emittedEventDao, never()).recordEmission(any());
+        verify(stateTransitionService, never()).offerStateTransition(any(), any(), any());
+        verify(emittedEventDao, never()).recordEmission(any(), any());
         verify(chargeDao, never()).findById(2L);
     }
 
@@ -93,11 +95,11 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
 
-        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus);
+        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.EXISTS_IN_LEDGER);
-        verify(stateTransitionService, never()).offerStateTransition(any(), any());
-        verify(emittedEventDao, never()).recordEmission(any());
+        verify(stateTransitionService, never()).offerStateTransition(any(), any(), any());
+        verify(emittedEventDao, never()).recordEmission(any(), any());
         verify(chargeDao, never()).findById(2L);
     }
 
@@ -111,14 +113,14 @@ public class ParityCheckWorkerTest {
         when(ledgerService.getTransaction(chargeEntity.getRefunds().get(0).getExternalId()))
                 .thenReturn(Optional.of(aValidLedgerTransaction().withStatus("submitted").build()));
 
-        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus);
+        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.EXISTS_IN_LEDGER);
         verify(ledgerService, times(2)).getTransaction(any());
         verify(ledgerService, times(1)).getTransaction(chargeEntity.getExternalId());
         verify(ledgerService, times(1)).getTransaction(chargeEntity.getRefunds().get(0).getExternalId());
-        verify(stateTransitionService, never()).offerStateTransition(any(), any());
-        verify(emittedEventDao, never()).recordEmission(any());
+        verify(stateTransitionService, never()).offerStateTransition(any(), any(), any());
+        verify(emittedEventDao, never()).recordEmission(any(), any());
         verify(chargeDao, never()).findById(2L);
     }
 
@@ -129,13 +131,13 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().withStatus("started").build()));
 
-        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus);
+        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.DATA_MISMATCH);
         verify(ledgerService, times(1)).getTransaction(any());
         verify(ledgerService, times(1)).getTransaction(chargeEntity.getExternalId());
         verify(ledgerService, never()).getTransaction(chargeEntity.getRefunds().get(0).getExternalId());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), notNull());
     }
 
     @Test
@@ -147,11 +149,11 @@ public class ParityCheckWorkerTest {
         when(ledgerService.getTransaction(any())).thenReturn(Optional.empty());
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
 
-        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus);
+        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.MISSING_IN_LEDGER);
         verify(ledgerService, times(2)).getTransaction(any());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), notNull());
     }
 
     @Test
@@ -165,11 +167,11 @@ public class ParityCheckWorkerTest {
                 aValidLedgerTransaction().withStatus("success").build()));
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
 
-        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus);
+        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.DATA_MISMATCH);
         verify(ledgerService, times(2)).getTransaction(any());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), notNull());
     }
 
     @Test
@@ -178,11 +180,13 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.empty());
 
-        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus);
+        worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 
+                120L);
 
-        verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.MISSING_IN_LEDGER);
+        verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(),
+                ParityCheckStatus.MISSING_IN_LEDGER);
         verify(ledgerService, times(1)).getTransaction(any());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), notNull());
     }
 
     @Test
@@ -190,11 +194,11 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findById((any()))).thenReturn(Optional.of(chargeEntity));
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.empty());
 
-        worker.execute(1L, Optional.of(1L), doNotReprocessValidRecords, emptyParityCheckStatus);
+        worker.execute(1L, Optional.of(1L), doNotReprocessValidRecords, emptyParityCheckStatus, 120L);
 
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.MISSING_IN_LEDGER);
         verify(ledgerService, times(1)).getTransaction(any());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), notNull());
     }
 
     @Test
@@ -203,11 +207,11 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findByParityCheckStatus(ParityCheckStatus.DATA_MISMATCH, 100, 0L)).thenReturn(List.of(chargeEntity));
         when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.empty());
 
-        worker.execute(0L, Optional.empty(), doNotReprocessValidRecords, Optional.of("DATA_MISMATCH"));
+        worker.execute(0L, Optional.empty(), doNotReprocessValidRecords, Optional.of("DATA_MISMATCH"), 1L);
 
         verify(chargeDao, times(2)).findByParityCheckStatus(eq(ParityCheckStatus.DATA_MISMATCH), anyInt(), any());
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.MISSING_IN_LEDGER);
         verify(ledgerService, times(1)).getTransaction(any());
-        verify(stateTransitionService, times(1)).offerStateTransition(any(), any());
+        verify(stateTransitionService, times(1)).offerStateTransition(any(), any(), notNull());
     }
 }

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -172,6 +172,9 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
+parityCheckerConfig:
+  defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
+
 restClientConfig:
   disabledSecureConnection: true
 

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -171,6 +171,9 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
+parityCheckerConfig:
+  defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
+
 restClientConfig:
   disabledSecureConnection: true
 

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -161,6 +161,9 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
+parityCheckerConfig:
+  defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
+
 restClientConfig:
   disabledSecureConnection: true
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -167,6 +167,9 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
+parityCheckerConfig:
+  defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
+
 restClientConfig:
   disabledSecureConnection: true
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -171,6 +171,9 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
+parityCheckerConfig:
+  defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
+
 restClientConfig:
   disabledSecureConnection: true
 


### PR DESCRIPTION
## WHAT

- Adds configuration (default value) & task parameter to set  `do_not_retry_emit_until` duration.
  Emitted event sweeper ignores events, if `do_not_retry_emit_until` value is in the future as per https://github.com/alphagov/pay-connector/commit/64d7e343e1a327b3aa000bff4baf2b2aba65e850
- Sets `do_not_retry_emit_until` date for events being processed by parity checker worker.
- Rest of the tasks (EmittedEventsSweeper, HistoricalEventEmitter) do not need to set `do_not_retry_emit_until`