### PR TITLE
PP-5855 Add index for emitted_events.do_not_retry_emit_until

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 | `STRIPE_TRANSACTION_FEE_PERCENTAGE` | - | percentage of total charge amount to recover GOV.UK Pay platform costs. |
 | `STRIPE_PLATFORM_ACCOUNT_ID` | - | the account ID for the Stripe Connect GOV.UK Pay platform. |
 | `DISABLE_INTERNAL_HTTPS` | false | disable secure connection for calls to internal APIs |
+| `DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS` | 7200 | Sets the default duration in seconds for events (emitted by parity checker worker) until which the emitted events sweeper ignores to re-emit. Value can be overridden by passing `do_not_retry_emit_until` query parameter to parity checker worker task |
 
 
 ### Queues

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1338,4 +1338,10 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add index to emitted_events.do_not_retry_emit_until" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_emitted_events_do_not_retry_emit_until ON emitted_events (do_not_retry_emit_until);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
- Adds index for emitted_events.do_not_retry_emit_until column
- Update README.md for environment variable `DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS`