### PR TITLE
PP-5855 HistoricalEventEmitter - mark events as being processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 | `STRIPE_TRANSACTION_FEE_PERCENTAGE` | - | percentage of total charge amount to recover GOV.UK Pay platform costs. |
 | `STRIPE_PLATFORM_ACCOUNT_ID` | - | the account ID for the Stripe Connect GOV.UK Pay platform. |
 | `DISABLE_INTERNAL_HTTPS` | false | disable secure connection for calls to internal APIs |
-| `DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS` | 7200 | Sets the default duration in seconds for events (emitted by parity checker worker) until which the emitted events sweeper ignores to re-emit. Value can be overridden by passing `do_not_retry_emit_until` query parameter to parity checker worker task |
+| `DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS` | 7200 | Sets the default duration in seconds for events (emitted by parity checker worker) until which the emitted events sweeper ignores to re-emit. Value can be overridden by passing `do_not_retry_emit_until` query parameter to parity checker worker or historical event emitter tasks |
 
 
 ### Queues

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -5,7 +5,7 @@ import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
-import uk.gov.pay.connector.app.config.ParityCheckerConfig;
+import uk.gov.pay.connector.app.config.EventEmitterConfig;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
@@ -79,7 +79,7 @@ public class ConnectorConfiguration extends Configuration {
     private EmittedEventSweepConfig emittedEventSweepConfig;
 
     @NotNull
-    private ParityCheckerConfig parityCheckerConfig;
+    private EventEmitterConfig eventEmitterConfig;
 
     @NotNull
     private String graphiteHost;
@@ -222,7 +222,7 @@ public class ConnectorConfiguration extends Configuration {
         return emittedEventSweepConfig;
     }
 
-    public ParityCheckerConfig getParityCheckerConfig() {
-        return parityCheckerConfig;
+    public EventEmitterConfig getEventEmitterConfig() {
+        return eventEmitterConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/EventEmitterConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/EventEmitterConfig.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.app.config;
 
 import io.dropwizard.Configuration;
 
-public class ParityCheckerConfig extends Configuration {
+public class EventEmitterConfig extends Configuration {
     
     private long defaultDoNotRetryEmittingEventUntilDurationInSeconds;
 

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckTask.java
@@ -8,7 +8,7 @@ import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.config.ParityCheckerConfig;
+import uk.gov.pay.connector.app.config.EventEmitterConfig;
 
 import java.io.PrintWriter;
 import java.util.Optional;
@@ -21,7 +21,7 @@ public class ParityCheckTask extends Task {
 
     private static final String TASK_NAME = "parity-checker";
     private static final String EXECUTOR_NAME_FORMAT = "ParityCheckWorker-%d";
-    private ParityCheckerConfig parityCheckerConfig;
+    private EventEmitterConfig eventEmitterConfig;
     private ParityCheckWorker worker;
     private ExecutorService executor;
 
@@ -44,7 +44,7 @@ public class ParityCheckTask extends Task {
                 .maxThreads(1)
                 .workQueue(new SynchronousQueue<>())
                 .build();
-        this.parityCheckerConfig = configuration.getParityCheckerConfig();
+        this.eventEmitterConfig = configuration.getEventEmitterConfig();
     }
 
     @Override
@@ -95,6 +95,6 @@ public class ParityCheckTask extends Task {
         Optional<Long> doNotRetryEmitUntil = getLongParam(parameters,
                 "do_not_retry_emit_until");
         return doNotRetryEmitUntil.orElse(
-                parityCheckerConfig.getDefaultDoNotRetryEmittingEventUntilDurationInSeconds());
+                eventEmitterConfig.getDefaultDoNotRetryEmittingEventUntilDurationInSeconds());
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -227,7 +227,7 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
-parityCheckerConfig:
+eventEmitterConfig:
   defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
 
 restClientConfig:

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -172,7 +172,7 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
-parityCheckerConfig:
+eventEmitterConfig:
   defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
 
 restClientConfig:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -171,7 +171,7 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
-parityCheckerConfig:
+eventEmitterConfig:
   defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
 
 restClientConfig:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -161,7 +161,7 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
-parityCheckerConfig:
+eventEmitterConfig:
   defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
 
 restClientConfig:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -167,7 +167,7 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
-parityCheckerConfig:
+eventEmitterConfig:
   defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
 
 restClientConfig:

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -171,7 +171,7 @@ chargesSweepConfig:
 emittedEventSweepConfig:
   notEmittedEventMaxAgeInSeconds: ${NOT_EMITTED_EVENT_MAX_AGE_IN_SECONDS:-1800}
 
-parityCheckerConfig:
+eventEmitterConfig:
   defaultDoNotRetryEmittingEventUntilDurationInSeconds: ${DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS:-7200}
 
 restClientConfig:


### PR DESCRIPTION
## WHAT
- Sets `do_not_retry_emit_until` date for events being processed by historical event emitter worker so EmittedEventsSweeper donot process the same