### PR TITLE
PP-5761 Add refund_external_id and secure_token to MDC logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <eclipselink.version>2.7.5</eclipselink.version>
         <guice.version>4.2.2</guice.version>
         <jackson.version>2.10.1</jackson.version>
-        <pay-java-commons.version>1.0.20191127102929</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20191127134754</pay-java-commons.version>
         <surefire.version>3.0.0-M3</surefire.version>
         <javax.persistence.version>2.2.1</javax.persistence.version>
         <jooq.version>3.12.3</jooq.version>

--- a/src/main/java/uk/gov/pay/connector/filters/LoggingMDCResponseFilter.java
+++ b/src/main/java/uk/gov/pay/connector/filters/LoggingMDCResponseFilter.java
@@ -12,6 +12,8 @@ import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_TYPE;
 import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 import static uk.gov.pay.logging.LoggingKeys.PROVIDER;
+import static uk.gov.pay.logging.LoggingKeys.REFUND_EXTERNAL_ID;
+import static uk.gov.pay.logging.LoggingKeys.SECURE_TOKEN;
 
 @Provider
 public class LoggingMDCResponseFilter implements ContainerResponseFilter {
@@ -21,5 +23,7 @@ public class LoggingMDCResponseFilter implements ContainerResponseFilter {
         MDC.remove(GATEWAY_ACCOUNT_ID);
         MDC.remove(PROVIDER);
         MDC.remove(GATEWAY_ACCOUNT_TYPE);
+        MDC.remove(REFUND_EXTERNAL_ID);
+        MDC.remove(SECURE_TOKEN);
     }
 }


### PR DESCRIPTION
Add `refund_external_id` and `secure_token` keys to MDC when they exist
as parameters in the path.

## How to test
We should see the new keys in CI output.