### PR TITLE
PP-5839 Stripe - set request_three_d_secure to any

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequest.java
@@ -7,6 +7,8 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.Map;
 
+import static java.util.Map.entry;
+
 public class StripePaymentIntentRequest extends StripeRequest {
 
     private final String amount;
@@ -61,17 +63,19 @@ public class StripePaymentIntentRequest extends StripeRequest {
 
     @Override
     protected Map<String, String> params() {
-        return Map.of(
-                "payment_method", paymentMethodId,
-                "amount", amount,
-                "confirmation_method", "automatic",
-                "capture_method", "manual",
-                "currency", "GBP",
-                "description", description,
-                "transfer_group", transferGroup,
-                "on_behalf_of", stripeConnectAccountId,
-                "confirm", "true",
-                "return_url", String.format("%s/card_details/%s/3ds_required_in", frontendUrl, chargeExternalId)
+        return Map.ofEntries(
+                entry("payment_method", paymentMethodId),
+                entry("payment_method_options[card[request_three_d_secure]]", "any"),
+                entry("amount", amount),
+                entry("confirmation_method", "automatic"),
+                entry("capture_method", "manual"),
+                entry("currency", "GBP"),
+                entry("transfer_group", transferGroup),
+                entry("description", description),
+                entry("on_behalf_of", stripeConnectAccountId),
+                entry("confirm", "true"),
+                entry("return_url", String.format("%s/card_details/%s/3ds_required_in",
+                        frontendUrl, chargeExternalId))
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.message.BasicNameValuePair;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -66,6 +66,7 @@ public class StripePaymentIntentRequestTest {
         assertThat(payload, containsString("confirmation_method=automatic"));
         assertThat(payload, containsString("capture_method=manual"));
         assertThat(payload, containsString("currency=GBP"));
+        assertThat(payload, containsString("payment_method_options%5Bcard%5Brequest_three_d_secure%5D%5D=any"));
         assertThat(payload, containsString("transfer_group=" + chargeExternalId));
         assertThat(payload, containsString("on_behalf_of=" + stripeConnectAccountId));
         assertThat(payload, containsString("confirm=true"));

--- a/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json
@@ -39,7 +39,7 @@
   "payment_method": "pm_123",
   "payment_method_options": {
     "card": {
-      "request_three_d_secure": "automatic"
+      "request_three_d_secure": "any"
     }
   },
   "payment_method_types": [

--- a/src/test/resources/templates/stripe/create_payment_intent_success_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_success_response.json
@@ -33,7 +33,7 @@
   "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
   "payment_method_options": {
     "card": {
-      "request_three_d_secure": "automatic"
+      "request_three_d_secure": "any"
     }
   },
   "payment_method_types": [

--- a/src/test/resources/templates/stripe/create_payment_intent_with_charge_response.json
+++ b/src/test/resources/templates/stripe/create_payment_intent_with_charge_response.json
@@ -48,7 +48,7 @@
   "payment_method": "pm_123",
   "payment_method_options": {
     "card": {
-      "request_three_d_secure": "automatic"
+      "request_three_d_secure": "any"
     }
   },
   "payment_method_types": [


### PR DESCRIPTION
## WHAT

- For Stripe payment intents - `request_three_d_secure` attribute is not set currently, which will default it to `automatic`. In this case, 3DS authentication is only enforced if card issuer requests it.
- With `request_three_d_secure` set to `any`, Stripe requires users to perform 3DS authentication if supported by card