### PR TITLE
PP-5858 Correct structured args

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/StateTransitionService.java
@@ -61,7 +61,8 @@ public class StateTransitionService {
                             fromChargeState, targetChargeState, chargeEventEntity.getId(), externalId);
                     var structuredArgs = Stream.concat(
                             chargeEventEntity.getChargeEntity().getStructuredLoggingArgs().stream(),
-                            List.of(kv("from_state", fromChargeState), kv("to_state", targetChargeState)).stream());
+                            List.of(kv("from_state", fromChargeState), kv("to_state", targetChargeState)).stream())
+                            .toArray();
 
                     logger.info(logMessage, structuredArgs);
 


### PR DESCRIPTION
The stream must be collected into an array before passing to the logger.

From the CI logs
```{"@timestamp":"2019-12-03T13:17:51.281Z","@version":"1","message":"Offered payment state transition to emitter queue [from=PAYMENT NOTIFICATION CREATED] [to=AUTHORISATION REJECTED] [chargeEventId=24] [chargeId=ql63512nho57rd9eesf1huoslg]","logger_name":"uk.gov.pay.connector.queue.StateTransitionService$$EnhancerByGuice$$d1949a65","thread_name":"dw-297 - POST /v1/api/accounts/123456/telephone-charges","level":"INFO","level_value":20000,"gateway_account_id":"123456","provider":"sandbox","gateway_account_type":"test","payment_external_id":"ql63512nho57rd9eesf1huoslg","gateway_account_id":123456,"provider":"sandbox","gateway_account_type":"test","from_state":"PAYMENT_NOTIFICATION_CREATED","to_state":"AUTHORISATION_REJECTED","container":"connector"}```