### PR TITLE
PP-5424 Remove parallel execution of tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <forkCount>2</forkCount>
+                    <forkCount>1</forkCount>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## WHAT 

- We currently run integration threads parallely (2 separate JVM processes). Most of the tests truncate database tables during tearDown().
  This is causing deadlock due to `AccessExclusiveLock` on relations and transactions are being dependent on one another. 

- _Database exception for deadlock _
  ```
   org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException: org.postgresql.util.PSQLException: ERROR: deadlock detected
   Detail: Process 82 waits for AccessExclusiveLock on relation 16515 of database 12407; blocked by process 81.
   Process 81 waits for RowShareLock on relation 16494 of database 12407; blocked by process 82.
  ```

- We may not need to truncate tables at all for all tests, but this can only be acheived by further refactoring as most of the tests uses same identifiers. This causes unique key constraint if the data has not been truncated before running the test. Parallel executing of threads can be reinstated once refactoring to use unique identifiers (gateway_account_id, charge_id and so on..) in each test is done.
