### PR TITLE
PP-5939 set integration version 3ds during credential update

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayUpdate3dsFlexCredentialsRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayUpdate3dsFlexCredentialsRequest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
 
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
+
 public class WorldpayUpdate3dsFlexCredentialsRequest {
 
     @JsonProperty("issuer")
@@ -38,6 +40,10 @@ public class WorldpayUpdate3dsFlexCredentialsRequest {
 
     public String getJwtMacKey() {
         return jwtMacKey;
+    }
+
+    public boolean hasAllCredentials() {
+        return isNoneBlank(issuer, organisationalUnitId, jwtMacKey);
     }
 
     public static final class WorldpayUpdate3dsFlexCredentialsRequestBuilder {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/IntegrationVersion3DS.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/IntegrationVersion3DS.java
@@ -1,0 +1,16 @@
+package uk.gov.pay.connector.gatewayaccount.service;
+
+public enum IntegrationVersion3DS {
+    ONE(1),
+    TWO(2);
+
+    private final int value;
+
+    IntegrationVersion3DS(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResourceIT.java
@@ -70,6 +70,9 @@ public class GatewayAccount3dsFlexCredentialsResourceIT {
         assertThat(result.get("issuer"), is("testissuer"));
         assertThat(result.get("organisational_unit_id"), is("hihihi"));
         assertThat(result.get("jwt_mac_key"), is("hihihihihi"));
+
+        result = databaseTestHelper.getGatewayAccount(accountId);
+        assertThat(result.get("integration_version_3ds"), is(2));
     }
 
     @Test
@@ -98,6 +101,9 @@ public class GatewayAccount3dsFlexCredentialsResourceIT {
         assertThat(result.get("issuer"), is("updated_issuer"));
         assertThat(result.get("organisational_unit_id"), is("updated_organisational_unit_id"));
         assertThat(result.get("jwt_mac_key"), is("updated_jwt_mac_key"));
+
+        result = databaseTestHelper.getGatewayAccount(accountId);
+        assertThat(result.get("integration_version_3ds"), is(2));
     }
 
     @Test
@@ -192,5 +198,26 @@ public class GatewayAccount3dsFlexCredentialsResourceIT {
                 .then()
                 .statusCode(404)
                 .body("message[0]", is("Not a Worldpay gateway account"));
+    }
+
+    @Test
+    public void setIntegrationVersion3DSTo1WhenCredentialsAreBlank() throws JsonProcessingException {
+        String payload = new ObjectMapper().writeValueAsString(Map.of(
+                "issuer", "",
+                "organisational_unit_id", "hihihi",
+                "jwt_mac_key", "hihihihihi"
+        ));
+        givenSetup()
+                .body(payload)
+                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
+                .then()
+                .statusCode(200);
+        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId);
+        assertThat(result.get("issuer"), is(""));
+        assertThat(result.get("organisational_unit_id"), is("hihihi"));
+        assertThat(result.get("jwt_mac_key"), is("hihihihihi"));
+
+        result = databaseTestHelper.getGatewayAccount(accountId);
+        assertThat(result.get("integration_version_3ds"), is(1));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -786,4 +786,11 @@ public class DatabaseTestHelper {
                 .bind("accountId", accountId)
                 .first());
     }
+
+    public Map<String, Object> getGatewayAccount(Long accountId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * FROM gateway_accounts WHERE id = :accountId")
+                .bind("accountId", accountId)
+                .first());
+    }
 }


### PR DESCRIPTION
Setting worldpay credentials in self service doesn’t actually set the account configuration to use 3DS flex – this means flex will never be used.

## WHAT YOU DID
- when a request for WorldpayUpdate3dsFlexCredentialsRequest is being processed, update integration_version_3ds on the matching gateway account
- use the new enums when updating

with @kbottla
