### PR TITLE
PP-5986 Poll for charge status before proceeding with Stripe 3DS confirmation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.app;
 import io.dropwizard.Configuration;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,11 @@ public class StripeGatewayConfig extends Configuration {
     @NotNull
     private Boolean collectFee;
 
+    @Valid
+    @NotNull
+    @Min(1)
+    private int notification3dsWaitDelay;
+
     public String getUrl() {
         return url;
     }
@@ -54,5 +60,9 @@ public class StripeGatewayConfig extends Configuration {
 
     public String getPlatformAccountId() {
         return platformAccountId;
+    }
+
+    public int getNotification3dsWaitDelay() {
+        return notification3dsWaitDelay;
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -100,7 +100,7 @@ stripe:
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-false}
-  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-1000}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -100,6 +100,7 @@ stripe:
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-false}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -69,6 +69,7 @@ stripe:
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -68,6 +68,7 @@ stripe:
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -58,6 +58,7 @@ stripe:
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -64,6 +64,7 @@ stripe:
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -68,7 +68,7 @@ stripe:
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID:-stripe_platform_account_id}
-  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-1000}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -68,6 +68,7 @@ stripe:
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID:-stripe_platform_account_id}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}


### PR DESCRIPTION
## WHAT

Introduces following changes to avoid `OptimisticLockException` due to Frontend (which tries to update charge to AUTHORISATION_3DS_READY) and Stripe notification (which updates charge to AUTHORASATION_SUCCESS/REJECTED) trying to update charge at the same time

- Wait on frontend locking state (`AUTHORISATION_3DS_READY`) to proceed with Stripe 3DS confirmation
- Retry every 200 milliseconds and until specified delay (as per config variable `NOTIFICATION_3DS_WAIT_DELAY`) for charge to be in AUTHORISATION_3DS_READY state before processing 3DS authorisation
- Relevant unit tests