### PR TITLE
PP-5964 userEmail for Refunds resource

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/RefundRequest.java
@@ -13,6 +13,9 @@ public class RefundRequest {
     @JsonProperty("user_external_id")
     private String userExternalId;
 
+    @JsonProperty("user_email")
+    private String userEmail;
+
     public RefundRequest() {}
 
     public RefundRequest(long amount, long amountAvailableForRefund, String userExternalId) {
@@ -30,4 +33,6 @@ public class RefundRequest {
     }
 
     public String getUserExternalId() { return userExternalId; }
+
+    public String getUserEmail() { return userEmail; }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -94,12 +94,13 @@ public class RefundEntity extends AbstractVersionedEntity {
         //for jpa
     }
 
-    public RefundEntity(ChargeEntity chargeEntity, Long amount, String userExternalId) {
+    public RefundEntity(ChargeEntity chargeEntity, Long amount, String userExternalId, String userEmail) {
         this.externalId = RandomIdGenerator.newId();
         this.chargeEntity = chargeEntity;
         this.amount = amount;
         this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
         this.userExternalId = userExternalId;
+        this.userEmail = userEmail;
     }
 
     public String getExternalId() {

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -169,7 +169,8 @@ public class ChargeRefundService {
     @Transactional
     @SuppressWarnings("WeakerAccess")
     public RefundEntity createRefundEntity(RefundRequest refundRequest, ChargeEntity charge) {
-        RefundEntity refundEntity = new RefundEntity(charge, refundRequest.getAmount(), refundRequest.getUserExternalId());
+        RefundEntity refundEntity = new RefundEntity(charge, refundRequest.getAmount(), 
+                refundRequest.getUserExternalId(), refundRequest.getUserEmail());
         transitionRefundState(refundEntity, RefundStatus.CREATED);
         charge.getRefunds().add(refundEntity);
         refundDao.persist(refundEntity);

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -52,6 +52,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_STATUS_DECLINED_RESPONSE;
@@ -188,7 +189,7 @@ public abstract class BaseEpdqPaymentProviderTest {
     }
 
     private RefundGatewayRequest buildTestRefundRequest(ChargeEntity chargeEntity) {
-        return RefundGatewayRequest.valueOf(new RefundEntity(chargeEntity, chargeEntity.getAmount() - 100, userExternalId));
+        return RefundGatewayRequest.valueOf(new RefundEntity(chargeEntity, chargeEntity.getAmount() - 100, userExternalId, userEmail));
     }
 
     private GatewayAccountEntity buildTestGatewayAccountEntity() {

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -57,6 +57,7 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.util.SystemUtils.envOrThrow;
 
@@ -283,7 +284,7 @@ public class EpdqPaymentProviderTest {
     }
 
     private static RefundGatewayRequest buildRefundRequest(ChargeEntity chargeEntity, Long refundAmount) {
-        return RefundGatewayRequest.valueOf(new RefundEntity(chargeEntity, refundAmount, userExternalId));
+        return RefundGatewayRequest.valueOf(new RefundEntity(chargeEntity, refundAmount, userExternalId, userEmail));
     }
 
     private CancelGatewayRequest buildCancelRequest(ChargeEntity chargeEntity, String transactionId) {

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.util.SystemUtils.envOrThrow;
 
@@ -230,7 +231,7 @@ public class SmartpayPaymentProviderTest {
         CaptureResponse captureGatewayResponse = smartpay.capture(CaptureGatewayRequest.valueOf(chargeEntity));
         assertTrue(captureGatewayResponse.isSuccessful());
 
-        RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId);
+        RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId, userEmail);
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
         GatewayRefundResponse refundResponse = smartpay.refund(refundRequest);
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -39,6 +39,7 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 
 /**
  * This is an integration test with Stripe that should be run manually. In order to make it work you need to set
@@ -110,7 +111,7 @@ public class StripePaymentProviderTest {
         CaptureGatewayRequest request = CaptureGatewayRequest.valueOf(chargeEntity);
 
         stripePaymentProvider.capture(request);
-        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount, "some-user-external-id");
+        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount, "some-user-external-id", userEmail);
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
@@ -126,7 +127,7 @@ public class StripePaymentProviderTest {
         CaptureGatewayRequest request = CaptureGatewayRequest.valueOf(chargeEntity);
 
         stripePaymentProvider.capture(request);
-        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount / 2, "some-user-external-id");
+        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount / 2, "some-user-external-id", userEmail);
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
@@ -142,7 +143,7 @@ public class StripePaymentProviderTest {
         CaptureGatewayRequest request = CaptureGatewayRequest.valueOf(chargeEntity);
 
         stripePaymentProvider.capture(request);
-        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount + 1L, "some-user-external-id");
+        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount + 1L, "some-user-external-id", userEmail);
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
@@ -160,14 +161,14 @@ public class StripePaymentProviderTest {
         CaptureGatewayRequest request = CaptureGatewayRequest.valueOf(chargeEntity);
 
         stripePaymentProvider.capture(request);
-        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount, "some-user-external-id");
+        final RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeAmount, "some-user-external-id", userEmail);
 
         RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.isSuccessful());
 
-        RefundEntity secondRefundEntity = new RefundEntity(chargeEntity, 1L, "some-user-external-id");
+        RefundEntity secondRefundEntity = new RefundEntity(chargeEntity, 1L, "some-user-external-id", userEmail);
 
         refundRequest = RefundGatewayRequest.valueOf(secondRefundEntity);
         refundResponse = stripePaymentProvider.refund(refundRequest);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.util.SystemUtils.envOrThrow;
 
@@ -228,7 +229,7 @@ public class WorldpayPaymentProviderTest {
 
         assertThat(captureResponse.isSuccessful(), is(true));
 
-        RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId);
+        RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId, userEmail);
 
         GatewayRefundResponse refundResponse = paymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity));
 

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -20,7 +20,7 @@ public class RefundEntityFixture {
     private ChargeEntity charge;
     private String reference = "reference";
     public static String userExternalId = "AA213FD51B3801043FBC";
-    public static String userEmail = "test@test.com";
+    public static String userEmail = "test@example.com";
     private String externalId = "someExternalId";
     private String transactionId = "123456";
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
@@ -31,7 +31,7 @@ public class RefundEntityFixture {
 
     public RefundEntity build() {
         ChargeEntity chargeEntity = charge == null ? buildChargeEntity() : charge;
-        RefundEntity refundEntity = new RefundEntity(chargeEntity, amount, userExternalId);
+        RefundEntity refundEntity = new RefundEntity(chargeEntity, amount, userExternalId, userEmail);
         refundEntity.setId(id);
         refundEntity.setStatus(status);
         refundEntity.setReference(reference);

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.model.domain;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -13,6 +12,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.connector.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
+import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
@@ -25,7 +25,7 @@ public class RefundEntityTest {
         ChargeEntity chargeEntity = aValidChargeEntity().build();
         Long amount = 100L;
 
-        RefundEntity refundEntity = new RefundEntity(chargeEntity, amount, userExternalId);
+        RefundEntity refundEntity = new RefundEntity(chargeEntity, amount, userExternalId, userEmail);
 
         assertNotNull(refundEntity.getExternalId());
         assertThat(refundEntity.getChargeEntity(), is(chargeEntity));

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -303,7 +303,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefund(long refundId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id " +
+                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id, user_email " +
                         "FROM refunds " +
                         "WHERE id = :refund_id")
                         .bind("refund_id", refundId)
@@ -313,7 +313,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefundsByChargeId(long chargeId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id " +
+                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id, user_email " +
                         "FROM refunds r " +
                         "WHERE charge_id = :charge_id")
                         .bind("charge_id", chargeId)


### PR DESCRIPTION
## WHAT YOU DID
- Allows `user_email` to be passed to resource endpoint `/v1/api/accounts/{accountId}/charges/{chargeId}/refunds` (POST)
- Updated relevant tests
- Replaced `test@test.com` (as this is valid domain) references with `test@example.com`