### PR TITLE
[PP-5823] change when email notification is sent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -80,8 +80,10 @@ public class CardCaptureService {
     public ChargeEntity markChargeAsEligibleForCapture(String externalId) {
         ChargeEntity charge = chargeService.markChargeAsEligibleForCapture(externalId);
 
-        if (!charge.isDelayedCapture())
+        if (!charge.isDelayedCapture()) {
             addChargeToCaptureQueue(charge);
+            userNotificationService.sendPaymentConfirmedEmail(charge);
+        }
 
         return charge;
     }
@@ -125,7 +127,7 @@ public class CardCaptureService {
                 charge.getGatewayAccount().getType(),
                 charge.getGatewayAccount().getId(), nextStatus.toString())).inc();
 
-        if (captureResponse.isSuccessful()) {
+        if (captureResponse.isSuccessful() && charge.isDelayedCapture()) {
             userNotificationService.sendPaymentConfirmedEmail(charge);
         }
     }


### PR DESCRIPTION
Send card payment confirmation emails when user successfully completes
the payment journey (non-delayed captures).
It used to be send after the successful gateway request to capture the payment.

Why?
See RFC-049;

tl;dr;
we frequently get timeouts from ePDQ when sending the capture request.
That causes us not to send confirmation emails to the payers.

Changing the time of sending the email will mitigate the issue.

During the kick-off we've decided that for the delayed-capture payments the
confirmation emails will be sent in the old way though.

Changes:
* update the logic for sending the confirmation email in `markChargeAsEligibleForCapture`
and `processGatewayCaptureResponse` methods
* update the tests (to verify sending email invocation)
* replace deprecated `verifyZeroInteractions` method with `verifyNoInteractions`
* remove redundant tests