### PR TITLE
PP-6021 Specify source for external telephone payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -182,7 +182,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                         ExternalMetadata externalMetadata,
                         GatewayAccountEntity gatewayAccount,
                         String gatewayTransactionId,
-                        SupportedLanguage language) {
+                        SupportedLanguage language,
+                        Source source) {
         this.amount = amount;
         this.reference = reference;
         this.description = description;
@@ -195,6 +196,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         this.externalId = RandomIdGenerator.newId();
         this.gatewayTransactionId = gatewayTransactionId;
         this.language = language;
+        this.source = source;
     }
 
     // Only the ChargeEntityFixture should directly call this constructor

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -77,6 +77,7 @@ import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
@@ -165,7 +166,8 @@ public class ChargeService {
                     storeExtraFieldsInMetaData(telephoneChargeRequest),
                     gatewayAccount,
                     telephoneChargeRequest.getProviderId(),
-                    SupportedLanguage.ENGLISH
+                    SupportedLanguage.ENGLISH,
+                    CARD_EXTERNAL_TELEPHONE
             );
             
             chargeDao.persist(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -91,6 +91,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.commons.model.Source.CARD_API;
+import static uk.gov.pay.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.ChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
@@ -215,7 +216,8 @@ public class ChargeServiceTest {
                 externalMetadata,
                 gatewayAccount,
                 "1PROV",
-                SupportedLanguage.ENGLISH
+                SupportedLanguage.ENGLISH,
+                CARD_API
         );
 
         when(mockedChargeDao.findByGatewayTransactionId("1PROV")).thenReturn(Optional.of(returnedChargeEntity));
@@ -776,7 +778,22 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
     }
-    
+
+    @Test
+    public void shouldCreateAnExternalTelephoneChargeWithSource() {
+        PaymentOutcome paymentOutcome = new PaymentOutcome("success");
+        TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
+                .withPaymentOutcome(paymentOutcome)
+                .build();
+
+        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+
+        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+
+        assertThat(chargeEntityArgumentCaptor.getValue().getSource(), equalTo(CARD_EXTERNAL_TELEPHONE));
+    }
+
     @Test
     public void shouldNotFindCharge() {
         PaymentOutcome paymentOutcome = new PaymentOutcome("success");

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiTelephonePaymentResourceIT.java
@@ -19,6 +19,7 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static uk.gov.pay.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.PAYMENT_NOTIFICATION_CREATED;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
@@ -295,6 +296,22 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
                 .body("state.finished", is(true))
                 .body("state.message", is("Payment was cancelled by the user"));
         
+    }
+
+    @Test
+    public void createTelephoneChargeWithSource() {
+        postBody.replace("payment_outcome", Map.of("status", "success"));
+        postBody.replace("processor_id", stringOf51Characters);
+
+        connectorRestApiClient
+                .postCreateTelephoneCharge(toJson(postBody))
+                .statusCode(201)
+                .contentType(JSON);
+
+        DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
+        Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId);
+
+        assertThat(chargeDetails.get("source"), is(CARD_EXTERNAL_TELEPHONE.toString()));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- Sets the `source` field to `CARD_EXTERNAL_TELEPHONE` for payments reported via endpoint v1/api/accounts/{accountId}/telephone-charges
- Added relevant tests
