### PR TITLE
PP-6016 add `source` to payment events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -34,6 +35,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
     private final String addressCity;
     private final String addressCounty;
     private final String addressCountry;
+    private final Source source;
 
     public PaymentCreatedEventDetails(Builder builder) {
         this.amount = builder.amount;
@@ -54,6 +56,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
         this.addressCity = builder.addressCity;
         this.addressCounty = builder.addressCounty;
         this.addressCountry = builder.addressCountry;
+        this.source = builder.source;
     }
 
     public static PaymentCreatedEventDetails from(ChargeEntity charge) {
@@ -68,7 +71,8 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 .withDelayedCapture(charge.isDelayedCapture())
                 .withLive(charge.getGatewayAccount().isLive())
                 .withExternalMetadata(charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null))
-                .withEmail(charge.getEmail());
+                .withEmail(charge.getEmail())
+                .withSource(charge.getSource());
 
         if (isInCreatedState(charge) || hasNotGoneThroughAuthorisation(charge)) {
             addCardDetailsIfExist(charge, builder);
@@ -176,6 +180,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
         return addressCountry;
     }
 
+    public Source getSource() {
+        return source;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -198,13 +206,14 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 Objects.equals(addressPostcode, that.addressPostcode) &&
                 Objects.equals(addressCity, that.addressCity) &&
                 Objects.equals(addressCounty, that.addressCounty) &&
-                Objects.equals(addressCountry, that.addressCountry);
+                Objects.equals(addressCountry, that.addressCountry) &&
+                Objects.equals(source, that.source);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(amount, description, reference, returnUrl, gatewayAccountId, paymentProvider, language,
-                delayedCapture, live, externalMetadata);
+                delayedCapture, live, externalMetadata, source);
     }
 
     public static class Builder {
@@ -226,6 +235,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
         private String addressCity;
         private String addressCounty;
         private String addressCountry;
+        private Source source;
 
         public PaymentCreatedEventDetails build() {
             return new PaymentCreatedEventDetails(this);
@@ -318,6 +328,11 @@ public class PaymentCreatedEventDetails extends EventDetails {
 
         public Builder withAddressCountry(String addressCountry) {
             this.addressCountry = addressCountry;
+            return this;
+        }
+
+        public Builder withSource(Source source) {
+            this.source = source;
             return this;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
@@ -24,14 +25,15 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     private final boolean live;
     private final String paymentProvider;
     private final Map<String, Object> externalMetadata;
-
+    private Source source;
 
     private PaymentNotificationCreatedEventDetails(Long gatewayAccountId, Long amount, String reference,
                                                    String description, String gatewayTransactionId,
                                                    String firstDigitsCardNumber, String lastDigitsCardNumber,
                                                    String cardholderName, String email, String expiryDate,
                                                    String cardBrand, String cardBrandLabel, boolean live,
-                                                   String paymentProvider, Map<String, Object> externalMetadata) {
+                                                   String paymentProvider, Map<String, Object> externalMetadata,
+                                                   Source source) {
         this.gatewayAccountId = gatewayAccountId;
         this.amount = amount;
         this.reference = reference;
@@ -47,6 +49,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
         this.live = live;
         this.externalMetadata = externalMetadata;
         this.paymentProvider = paymentProvider;
+        this.source = source;
     }
 
     public static PaymentNotificationCreatedEventDetails from(ChargeEntity charge) {
@@ -85,7 +88,8 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                     cardBrandLabel,
                     charge.getGatewayAccount().isLive(),
                     charge.getGatewayAccount().getGatewayName(),
-                    charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null));
+                    charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null),
+                    charge.getSource());
     }
 
     @Override
@@ -106,14 +110,15 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                 Objects.equals(cardBrand, that.cardBrand) &&
                 Objects.equals(cardBrandLabel, that.cardBrandLabel) &&
                 Objects.equals(live, that.live) &&
-                Objects.equals(externalMetadata, that.externalMetadata);
+                Objects.equals(externalMetadata, that.externalMetadata) &&
+                Objects.equals(source, that.source);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(gatewayAccountId, amount, reference, description, gatewayTransactionId,
                 firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, email, expiryDate,
-                cardBrand, cardBrandLabel, live, externalMetadata);
+                cardBrand, cardBrandLabel, live, externalMetadata, source);
     }
 
     public Long getGatewayAccountId() {
@@ -174,5 +179,9 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
 
     public Map<String, Object> getExternalMetadata() {
         return externalMetadata;
+    }
+
+    public Source getSource() {
+        return source;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -6,6 +6,7 @@ import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -39,6 +40,7 @@ public class PaymentCreatedTest {
             .withAmount(100L)
             .withCorporateSurcharge(77L)
             .withEmail(null)
+            .withSource(Source.CARD_API)
             .withExternalMetadata(new ExternalMetadata(ImmutableMap.of("key1", "value1", "key2", "value2")));
     private ChargeEntity chargeEntity;
 
@@ -152,6 +154,7 @@ public class PaymentCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.delayed_capture", equalTo(chargeEntity.isDelayedCapture())));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.key1", equalTo("value1")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.key2", equalTo("value2")));
+        assertThat(actual, hasJsonPath("$.event_details.source", equalTo("CARD_API")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 
 public class PaymentNotificationCreatedTest {
@@ -29,12 +30,13 @@ public class PaymentNotificationCreatedTest {
     private ChargeEntityFixture chargeEntityFixture;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(ZonedDateTime.parse(time))
                 .withStatus(ChargeStatus.PAYMENT_NOTIFICATION_CREATED)
                 .withExternalId(paymentId)
                 .withTransactionId(providerId)
+                .withSource(CARD_EXTERNAL_TELEPHONE)
                 .withCardDetails(anAuthCardDetails().withAddress(null).getCardDetailsEntity())
                 .withAmount(100L);
     }
@@ -71,6 +73,7 @@ public class PaymentNotificationCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.cardholder_name", equalTo("Mr Test")));
         assertThat(actual, hasJsonPath("$.event_details.expiry_date", equalTo("12/99")));
         assertThat(actual, hasJsonPath("$.event_details.payment_provider", equalTo("sandbox")));
+        assertThat(actual, hasJsonPath("$.event_details.source", equalTo("CARD_EXTERNAL_TELEPHONE")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.processor_id", equalTo("processorID")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.auth_code", equalTo("012345")));
         assertThat(actual, hasJsonPath("$.event_details.external_metadata.telephone_number", equalTo("+447700900796")));
@@ -97,6 +100,7 @@ public class PaymentNotificationCreatedTest {
         assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
         assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo(providerId)));
         assertThat(actual, hasJsonPath("$.event_details.payment_provider", equalTo("sandbox")));
+        assertThat(actual, hasJsonPath("$.event_details.source", equalTo("CARD_EXTERNAL_TELEPHONE")));
 
         assertThat(actual, hasNoJsonPath("$.event_details.card_brand"));
         assertThat(actual, hasNoJsonPath("$.event_details.first_digits_card_number"));

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -12,18 +12,18 @@ import au.com.dius.pact.provider.junit.target.TestTarget;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
-import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureSubmittedEventDetails;
+import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentDetailsEnteredEventDetails;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
-import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
+import static uk.gov.pay.commons.model.Source.CARD_API;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.pact.RefundHistoryEntityFixture.aValidRefundHistoryEntity;
 
@@ -57,6 +58,7 @@ public class QueueMessageContractTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withExternalMetadata(new ExternalMetadata(ImmutableMap.of("key", "value")))
                 .withCorporateSurcharge(55L)
+                .withSource(CARD_API)
                 .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -37,6 +37,7 @@ import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static uk.gov.pay.commons.model.Source.CARD_API;
+import static uk.gov.pay.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.pact.RefundHistoryEntityFixture.aValidRefundHistoryEntity;
 
@@ -164,6 +165,7 @@ public class QueueMessageContractTest {
                 .withStatus(ChargeStatus.PAYMENT_NOTIFICATION_CREATED)
                 .withGatewayTransactionId("providerId")
                 .withEmail("j.doe@example.org")
+                .withSource(CARD_EXTERNAL_TELEPHONE)
                 .withCardDetails(anAuthCardDetails().withAddress(null).getCardDetailsEntity())
                 .withExternalMetadata(externalMetadata)
                 .build();


### PR DESCRIPTION
## WHAT YOU DID
- Added new field `source` available in DB to `PaymentCreated` & `PaymentNotificationCreated` events
- Updated relevant tests and pact states