### PR TITLE
PP-6073 Return allow_moto field in gateway account response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -97,6 +97,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Column(name = "block_prepaid_cards")
     private boolean blockPrepaidCards;
 
+    @Column(name = "allow_moto")
+    private boolean allowMoto;
+
     @Column(name = "integration_version_3ds")
     private int integrationVersion3ds;
 
@@ -237,11 +240,17 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public boolean isAllowZeroAmount() {
         return allowZeroAmount;
     }
-    
+
     @JsonProperty("block_prepaid_cards")
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public boolean isBlockPrepaidCards() {
         return blockPrepaidCards;
+    }
+
+    @JsonProperty("allow_moto")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isAllowMoto() {
+        return allowMoto;
     }
 
     @JsonProperty("corporate_credit_card_surcharge_amount")
@@ -373,6 +382,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setBlockPrepaidCards(boolean blockPrepaidCards) {
         this.blockPrepaidCards = blockPrepaidCards;
+    }
+
+    public void setAllowMoto(boolean allowMoto) {
+        this.allowMoto = allowMoto;
     }
 
     public void setIntegrationVersion3ds(int integrationVersion3ds) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -70,6 +70,9 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("integration_version_3ds")
     private int integrationVersion3ds;
     
+    @JsonProperty("allow_moto")
+    private boolean allowMoto;
+    
     public GatewayAccountResourceDTO() {
     }
 
@@ -83,13 +86,15 @@ public class GatewayAccountResourceDTO {
                                      long corporateDebitCardSurchargeAmount,
                                      boolean allowApplePay,
                                      boolean allowGooglePay,
-                                     boolean blockPrepaidCards, long corporatePrepaidCreditCardSurchargeAmount,
+                                     boolean blockPrepaidCards,
+                                     long corporatePrepaidCreditCardSurchargeAmount,
                                      long corporatePrepaidDebitCardSurchargeAmount,
                                      Map<EmailNotificationType, EmailNotificationEntity> emailNotifications,
                                      EmailCollectionMode emailCollectionMode,
                                      boolean requires3ds,
                                      boolean allowZeroAmount,
-                                     int integrationVersion3ds) {
+                                     int integrationVersion3ds,
+                                     boolean allowMoto) {
         this.accountId = accountId;
         this.paymentProvider = paymentProvider;
         this.type = type;
@@ -108,6 +113,7 @@ public class GatewayAccountResourceDTO {
         this.requires3ds = requires3ds;
         this.allowZeroAmount = allowZeroAmount;
         this.integrationVersion3ds = integrationVersion3ds;
+        this.allowMoto = allowMoto;
     }
 
     public static GatewayAccountResourceDTO fromEntity(GatewayAccountEntity gatewayAccountEntity) {
@@ -129,7 +135,8 @@ public class GatewayAccountResourceDTO {
                 gatewayAccountEntity.getEmailCollectionMode(),
                 gatewayAccountEntity.isRequires3ds(),
                 gatewayAccountEntity.isAllowZeroAmount(),
-                gatewayAccountEntity.getIntegrationVersion3ds()
+                gatewayAccountEntity.getIntegrationVersion3ds(),
+                gatewayAccountEntity.isAllowMoto()
         );
     }
 
@@ -211,5 +218,9 @@ public class GatewayAccountResourceDTO {
 
     public int getIntegrationVersion3ds() {
         return integrationVersion3ds;
+    }
+
+    public boolean isAllowMoto() {
+        return allowMoto;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -35,6 +35,7 @@ public class GatewayAccountResourceDTOTest {
         entity.setAllowZeroAmount(true);
         entity.setIntegrationVersion3ds(2);
         entity.setBlockPrepaidCards(true);
+        entity.setAllowMoto(true);
 
         Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
@@ -60,5 +61,6 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.getEmailNotifications().get(EmailNotificationType.PAYMENT_CONFIRMED).getTemplateBody(), is("testTemplate"));
         assertThat(dto.getIntegrationVersion3ds(), is(entity.getIntegrationVersion3ds()));
         assertThat(dto.isBlockPrepaidCards(), is(entity.isBlockPrepaidCards()));
+        assertThat(dto.isAllowMoto(), is(entity.isAllowMoto()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -55,6 +55,7 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
         databaseTestHelper.allowApplePay(Long.valueOf(accountId));
         databaseTestHelper.allowZeroAmount(Long.valueOf(accountId));
         databaseTestHelper.blockPrepaidCards(Long.valueOf(accountId));
+        databaseTestHelper.allowMoto(Long.valueOf(accountId));
 
         givenSetup().accept(JSON)
                 .get(ACCOUNTS_FRONTEND_URL + accountId)
@@ -79,7 +80,8 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
                 .body("allow_google_pay", is(false))
                 .body("allow_zero_amount", is(true))
                 .body("integration_version_3ds", is(1))
-                .body("block_prepaid_cards", is(true));
+                .body("block_prepaid_cards", is(true))
+                .body("allow_moto", is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -557,6 +557,14 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
+    public void allowMoto(long accountId) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("UPDATE gateway_accounts set allow_moto=true WHERE id=:gatewayAccountId")
+                        .bind("gatewayAccountId", accountId)
+                        .execute()
+        );
+    }
+    
 
     public void addWalletType(long chargeId, WalletType walletType) {
         jdbi.withHandle(handle ->


### PR DESCRIPTION
Retrieve the value of the allow_moto column on the gateway_accounts
table from the database and return it in API responses that return a
gateway account.