### PR TITLE
PP-6073 Add ability to patch allow_moto setting

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -39,6 +39,7 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_ALLOW_ZERO_AMOUNT = "allow_zero_amount";
     public static final String FIELD_INTEGRATION_VERSION_3DS = "integration_version_3ds";
     public static final String FIELD_BLOCK_PREPAID_CARDS = "block_prepaid_cards";
+    public static final String FIELD_ALLOW_MOTO = "allow_moto";
 
     private static final List<String> VALID_PATHS = asList(
             CREDENTIALS_GATEWAY_MERCHANT_ID,
@@ -52,7 +53,8 @@ public class GatewayAccountRequestValidator {
             FIELD_CORPORATE_PREPAID_DEBIT_CARD_SURCHARGE_AMOUNT,
             FIELD_ALLOW_ZERO_AMOUNT,
             FIELD_INTEGRATION_VERSION_3DS,
-            FIELD_BLOCK_PREPAID_CARDS);
+            FIELD_BLOCK_PREPAID_CARDS,
+            FIELD_ALLOW_MOTO);
 
     private final RequestValidator requestValidator;
 
@@ -84,6 +86,7 @@ public class GatewayAccountRequestValidator {
             case FIELD_BLOCK_PREPAID_CARDS:
             case FIELD_ALLOW_ZERO_AMOUNT:
             case FIELD_ALLOW_APPLE_PAY:
+            case FIELD_ALLOW_MOTO:
                 validateReplaceBooleanValue(payload);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -28,7 +28,9 @@ import java.util.stream.Collectors;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.CREDENTIALS_GATEWAY_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_APPLE_PAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_GOOGLE_PAY;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_MOTO;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_ALLOW_ZERO_AMOUNT;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_BLOCK_PREPAID_CARDS;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_DEBIT_CARD_SURCHARGE_AMOUNT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_CORPORATE_PREPAID_CREDIT_CARD_SURCHARGE_AMOUNT;
@@ -36,7 +38,6 @@ import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequest
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_EMAIL_COLLECTION_MODE;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_INTEGRATION_VERSION_3DS;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_NOTIFY_SETTINGS;
-import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_BLOCK_PREPAID_CARDS;
 
 public class GatewayAccountService {
 
@@ -133,6 +134,8 @@ public class GatewayAccountService {
                         (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setIntegrationVersion3ds(gatewayAccountRequest.valueAsInt()));
                 put(FIELD_BLOCK_PREPAID_CARDS,
                         (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setBlockPrepaidCards(gatewayAccountRequest.valueAsBoolean()));
+                put(FIELD_ALLOW_MOTO,
+                        (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setAllowMoto(gatewayAccountRequest.valueAsBoolean()));
             }};
 
     private void throwIfNotDigitalWalletSupportedGateway(GatewayAccountEntity gatewayAccountEntity) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -63,6 +63,9 @@ public class GatewayAccountRequestValidatorTest {
             "bad, block_prepaid_cards, true, Operation [bad] is not valid for path [block_prepaid_cards]",
             "replace, block_prepaid_cards, null, Field [value] is required",
             "replace, block_prepaid_cards, unfalse, Value [unfalse] must be of type boolean for path [block_prepaid_cards]",
+            "bad, allow_moto, true, Operation [bad] is not valid for path [allow_moto]",
+            "replace, allow_moto, null, Field [value] is required",
+            "replace, allow_moto, unfalse, Value [unfalse] must be of type boolean for path [allow_moto]"
     })
     public void shouldThrowWhenRequestsAreInvalid(String op, String path, @Nullable String value, String expectedErrorMessage) {
         Map<String, String> patch = new HashMap<String, String>() {{

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -258,6 +258,33 @@ public class GatewayAccountServiceTest {
     }
 
     @Test
+    public void shouldUpdateAllowMotoTrue() {
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+                "path", "allow_moto",
+                "value", true)));
+
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setAllowMoto(true);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
+    public void shouldUpdateAllowMotoFalse() {
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+                "path", "allow_moto",
+                "value", false)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setAllowMoto(false);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+    
+    @Test
     public void shouldUpdateIntegrationVersion3ds() {
         JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
                 "op", "replace",


### PR DESCRIPTION
Add ability to update the `allow_moto` setting using a PATCH request
to `/v1/api/accounts/{accountId}` and add validation for this path.