### PR TITLE
PP-6075 Remove migration to backfill moto column

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1409,10 +1409,4 @@
         <addDefaultValue tableName="charges" columnName="moto" defaultValue="false"/>
     </changeSet>
 
-    <changeSet id="update moto with default value" author="">
-        <update tableName="charges">
-            <column name="moto" value="false"/>
-        </update>
-    </changeSet>
-
 </databaseChangeLog>


### PR DESCRIPTION
This migration was very long-running and caused the connector database
to become overloaded due to the large transaction size, severely
affecting latency of calls to connector. It was therefore aborted.

Remove the migration so it will not be re-run if we attempt to migrate
the database again. A few different solutions are being explored to set
the default value including upgrading to Postgres 11 which will set
default values the next time the column is read, or running the update
query in batches.