### PR TITLE
PP-6075 Rename ChargesApiResource test classes

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -68,7 +68,7 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
                 @ConfigOverride(key = "captureProcessConfig.backgroundProcessingEnabled", value = "true")
         }
 )
-public class ChargesApiCreateResourceIT extends ChargingITestBase {
+public class ChargesApiResourceCreateIT extends ChargingITestBase {
 
     private static final String FRONTEND_CARD_DETAILS_URL = "/secure";
     private static final String JSON_AMOUNT_KEY = "amount";
@@ -99,7 +99,7 @@ public class ChargesApiCreateResourceIT extends ChargingITestBase {
     private static final String JSON_REFERENCE_VALUE = "Test reference";
     private static final String JSON_DESCRIPTION_VALUE = "Test description";
 
-    public ChargesApiCreateResourceIT() {
+    public ChargesApiResourceCreateIT() {
         super(PROVIDER_NAME);
     }
     

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -30,7 +30,7 @@ import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
         app = ConnectorApp.class,
         config = "config/test-it-config.yaml"
 )
-public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
+public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     private static final String PROVIDER_NAME = "sandbox";
     private static final HashMap<String, Object> postBody = new HashMap<>();
@@ -39,7 +39,7 @@ public class ChargesApiTelephonePaymentResourceIT extends ChargingITestBase {
 
     private final String providerId = "17498-8412u9-1273891239";
 
-    public ChargesApiTelephonePaymentResourceIT() {
+    public ChargesApiResourceTelephonePaymentsIT() {
         super(PROVIDER_NAME);
     }
 


### PR DESCRIPTION
The current names mean they're not easily discoverable, you would expect
the name of the resource it's testing in the class name. This means the
keyboard shortcut to jump between the class under test and the test
classes does not work.

ChargesApiCreateResourceIT -> ChargesApiResourceCreateIT
ChargesApiTelephonePaymentResourceIT -> ChargesApiResourceTelephonePaymentsIT