### PR TITLE
PP-6067 Remove Chained JPA Calls From doRefund

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+
+public class GatewayAccountNotFoundException extends WebApplicationException {
+    public GatewayAccountNotFoundException(Long accountId) {
+        super(notFoundResponse(format("Gateway Account with id [%s] not found.", accountId)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.refund.exception.RefundException;
 import uk.gov.pay.connector.refund.model.RefundRequest;
 import uk.gov.pay.connector.refund.model.RefundResponse;
 import uk.gov.pay.connector.refund.model.RefundsResponse;
+import uk.gov.pay.connector.refund.service.ChargeRefundResponse;
 import uk.gov.pay.connector.refund.service.ChargeRefundService;
 
 import javax.inject.Inject;
@@ -47,7 +48,7 @@ public class ChargeRefundsResource {
     @Produces(APPLICATION_JSON)
     public Response submitRefund(@PathParam("accountId") Long accountId, @PathParam("chargeId") String chargeId, RefundRequest refundRequest, @Context UriInfo uriInfo) {
         validateRefundRequest(refundRequest.getAmount());
-        final ChargeRefundService.Response refundServiceResponse = refundService.doRefund(accountId, chargeId, refundRequest);
+        final ChargeRefundResponse refundServiceResponse = refundService.doRefund(accountId, chargeId, refundRequest);
         GatewayRefundResponse refundResponse = refundServiceResponse.getGatewayRefundResponse();
         if (refundResponse.isSuccessful()) {
             return Response.accepted(RefundResponse.valueOf(refundServiceResponse.getRefundEntity(), uriInfo).serialize()).build();

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundResponse.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundResponse.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.refund.service;
+
+import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+public class ChargeRefundResponse {
+
+    private GatewayRefundResponse gatewayRefundResponse;
+    private RefundEntity refundEntity;
+
+    public ChargeRefundResponse(GatewayRefundResponse gatewayRefundResponse, RefundEntity refundEntity) {
+        this.gatewayRefundResponse = gatewayRefundResponse;
+        this.refundEntity = refundEntity;
+    }
+
+    public GatewayRefundResponse getGatewayRefundResponse() {
+        return gatewayRefundResponse;
+    }
+
+    public RefundEntity getRefundEntity() {
+        return refundEntity;
+    }
+}


### PR DESCRIPTION
- Removes chained JPA calls from doRefund() in favour of direct access
via the relevant DAO classes.

- Updates tests with new mocks to validate this behaviour.
