### PR TITLE
PP-6075 Allow creation of moto charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -27,6 +27,7 @@ import uk.gov.pay.commons.utils.metrics.DatabaseMetricsService;
 import uk.gov.pay.commons.utils.xray.Xray;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
+import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.resource.ChargesFrontendResource;
@@ -118,6 +119,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new JsonMappingExceptionMapper());
         environment.jersey().register(new ZeroAmountNotAllowedForGatewayAccountExceptionMapper());
         environment.jersey().register(new ConflictWebApplicationExceptionMapper());
+        environment.jersey().register(new MotoPaymentNotAllowedForGatewayAccountExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/MotoPaymentNotAllowedForGatewayAccountException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/MotoPaymentNotAllowedForGatewayAccountException.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.charge.exception;
+
+public class MotoPaymentNotAllowedForGatewayAccountException extends RuntimeException {
+    public MotoPaymentNotAllowedForGatewayAccountException(Long gatewayAccountId) {
+        super("Attempt to create a MOTO payment for gateway account " + gatewayAccountId + ", which does not have MOTO payments enabled");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/MotoPaymentNotAllowedForGatewayAccountExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/MotoPaymentNotAllowedForGatewayAccountExceptionMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class MotoPaymentNotAllowedForGatewayAccountExceptionMapper implements ExceptionMapper<MotoPaymentNotAllowedForGatewayAccountException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MotoPaymentNotAllowedForGatewayAccountExceptionMapper.class);
+
+    private static final String RESPONSE_ERROR_MESSAGE = "MOTO payments are not enabled for this gateway account";
+
+    @Override
+    public Response toResponse(MotoPaymentNotAllowedForGatewayAccountException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.MOTO_NOT_ALLOWED, List.of(RESPONSE_ERROR_MESSAGE));
+
+        return Response.status(422)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -62,6 +62,9 @@ public class ChargeCreateRequest {
     @JsonProperty("source")
     @JsonDeserialize(using = SourceDeserialiser.class)
     private Source source;
+    
+    @JsonProperty("moto")
+    private boolean moto;
 
     public ChargeCreateRequest() {
         // for Jackson
@@ -76,7 +79,8 @@ public class ChargeCreateRequest {
                         SupportedLanguage language,
                         PrefilledCardHolderDetails prefilledCardHolderDetails,
                         ExternalMetadata externalMetadata,
-                        Source source) {
+                        Source source,
+                        boolean moto) {
         this.amount = amount;
         this.description = description;
         this.reference = reference;
@@ -87,6 +91,7 @@ public class ChargeCreateRequest {
         this.prefilledCardHolderDetails = prefilledCardHolderDetails;
         this.externalMetadata = externalMetadata;
         this.source = source;
+        this.moto = moto;
     }
 
     public long getAmount() {
@@ -129,6 +134,10 @@ public class ChargeCreateRequest {
         return source;
     }
 
+    public boolean isMoto() {
+        return moto;
+    }
+
     public String toStringWithoutPersonalIdentifiableInformation() {
         return "ChargeCreateRequest{" +
                 "amount=" + amount +
@@ -136,6 +145,7 @@ public class ChargeCreateRequest {
                 ", returnUrl='" + returnUrl + '\'' +
                 ", delayed_capture=" + delayedCapture +
                 ", source=" + source +
+                ", moto=" + moto +
                 (language != null ? ", language=" + language.toString() : "") +
                 '}';
     }

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -126,6 +126,9 @@ public class ChargeResponse {
     @JsonSerialize(using = ExternalMetadataSerialiser.class)
     private ExternalMetadata externalMetadata;
 
+    @JsonProperty("moto")
+    private boolean moto;
+
     ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
         this.dataLinks = builder.getLinks();
         this.chargeId = builder.getChargeId();
@@ -157,6 +160,7 @@ public class ChargeResponse {
         this.netAmount = builder.getNetAmount();
         this.walletType = builder.getWalletType();
         this.externalMetadata = builder.getExternalMetadata();
+        this.moto = builder.isMoto();
     }
 
     public List<Map<String, Object>> getDataLinks() {
@@ -287,12 +291,17 @@ public class ChargeResponse {
                 .get();
     }
 
+    public boolean isMoto() {
+        return moto;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ChargeResponse that = (ChargeResponse) o;
         return delayedCapture == that.delayedCapture &&
+                moto == that.moto &&
                 Objects.equals(dataLinks, that.dataLinks) &&
                 Objects.equals(chargeId, that.chargeId) &&
                 Objects.equals(amount, that.amount) &&
@@ -301,25 +310,36 @@ public class ChargeResponse {
                 Objects.equals(gatewayTransactionId, that.gatewayTransactionId) &&
                 Objects.equals(returnUrl, that.returnUrl) &&
                 Objects.equals(email, that.email) &&
+                Objects.equals(telephoneNumber, that.telephoneNumber) &&
                 Objects.equals(description, that.description) &&
                 Objects.equals(reference, that.reference) &&
                 Objects.equals(providerName, that.providerName) &&
+                Objects.equals(processorId, that.processorId) &&
+                Objects.equals(providerId, that.providerId) &&
                 Objects.equals(createdDate, that.createdDate) &&
+                Objects.equals(authorisedDate, that.authorisedDate) &&
+                Objects.equals(paymentOutcome, that.paymentOutcome) &&
                 Objects.equals(refundSummary, that.refundSummary) &&
                 Objects.equals(settlementSummary, that.settlementSummary) &&
+                Objects.equals(authCode, that.authCode) &&
                 Objects.equals(auth3dsData, that.auth3dsData) &&
                 Objects.equals(cardDetails, that.cardDetails) &&
                 language == that.language &&
                 Objects.equals(corporateCardSurcharge, that.corporateCardSurcharge) &&
+                Objects.equals(fee, that.fee) &&
                 Objects.equals(totalAmount, that.totalAmount) &&
-                walletType == that.walletType;
+                Objects.equals(netAmount, that.netAmount) &&
+                walletType == that.walletType &&
+                Objects.equals(externalMetadata, that.externalMetadata);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(dataLinks, chargeId, amount, state, cardBrand, gatewayTransactionId, returnUrl, email,
-                description, reference, providerName, createdDate, refundSummary, settlementSummary, auth3dsData,
-                cardDetails, language, delayedCapture, corporateCardSurcharge, totalAmount, walletType);
+                telephoneNumber, description, reference, providerName, processorId, providerId, createdDate,
+                authorisedDate, paymentOutcome, refundSummary, settlementSummary, authCode, auth3dsData, cardDetails,
+                language, delayedCapture, corporateCardSurcharge, fee, totalAmount, netAmount, walletType,
+                externalMetadata, moto);
     }
 
     @Override
@@ -344,6 +364,7 @@ public class ChargeResponse {
                 ", corporateCardSurcharge=" + corporateCardSurcharge +
                 ", totalAmount=" + totalAmount +
                 ", walletType=" + walletType +
+                ", moto=" + moto +
                 '}';
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -47,6 +47,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected Long netAmount;
     protected WalletType walletType;
     protected ExternalMetadata externalMetadata;
+    protected boolean moto;
 
     protected abstract T thisObject();
 
@@ -210,6 +211,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         this.externalMetadata = externalMetadata;
         return thisObject();
     }
+    
+    public T withMoto(boolean moto) {
+        this.moto = moto;
+        return thisObject();
+    }
 
     public String getChargeId() {
         return chargeId;
@@ -331,5 +337,9 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public String getAuthCode() {
         return authCode;
+    }
+
+    public boolean isMoto() {
+        return moto;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -163,6 +163,9 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
     @Column(name = "source")
     @Enumerated(EnumType.STRING)
     private Source source;
+    
+    @Column(name = "moto")
+    private boolean moto;
 
     public ChargeEntity() {
         //for jpa
@@ -183,7 +186,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
             ExternalMetadata externalMetadata,
             Source source,
             String gatewayTransactionId,
-            CardDetailsEntity cardDetails
+            CardDetailsEntity cardDetails,
+            boolean moto
     ) {
         this.amount = amount;
         this.status = status.getValue();
@@ -200,6 +204,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         this.source = source;
         this.gatewayTransactionId = gatewayTransactionId;
         this.cardDetails = cardDetails;
+        this.moto = moto;
     }
 
     public Long getId() {
@@ -264,6 +269,10 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     public Optional<ExternalMetadata> getExternalMetadata() {
         return Optional.ofNullable(externalMetadata);
+    }
+
+    public boolean isMoto() {
+        return moto;
     }
 
     public void setExternalId(String externalId) {
@@ -429,6 +438,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         private boolean delayedCapture;
         private ExternalMetadata externalMetadata;
         private Source source;
+        private boolean moto;
 
         private WebChargeEntityBuilder() {
         }
@@ -486,6 +496,11 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
             this.source = source;
             return this;
         }
+        
+        public WebChargeEntityBuilder withMoto(boolean moto) {
+            this.moto = moto;
+            return this;
+        }
 
         public ChargeEntity build() {
             return new ChargeEntity(
@@ -502,7 +517,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                     externalMetadata,
                     source,
                     null,
-                    null);
+                    null,
+                    moto);
         }
     }
 
@@ -578,7 +594,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                     externalMetadata,
                     CARD_EXTERNAL_TELEPHONE,
                     gatewayTransactionId,
-                    cardDetails);
+                    cardDetails,
+                    false);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -173,7 +173,8 @@ public class ChargesFrontendResource {
                 .withLink("self", GET, locationUriFor("/v1/frontend/charges/{chargeId}", uriInfo, chargeId))
                 .withLink("cardAuth", POST, locationUriFor("/v1/frontend/charges/{chargeId}/cards", uriInfo, chargeId))
                 .withLink("cardCapture", POST, locationUriFor("/v1/frontend/charges/{chargeId}/capture", uriInfo, chargeId))
-                .withWalletType(charge.getWalletType());
+                .withWalletType(charge.getWalletType())
+                .withMoto(charge.isMoto());
 
         if (charge.getCardDetails() != null) {
             var persistedCard = charge.getCardDetails().toCard();

--- a/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
@@ -15,6 +15,7 @@ public final class ChargeCreateRequestBuilder {
     private PrefilledCardHolderDetails prefilledCardHolderDetails;
     private ExternalMetadata externalMetadata;
     private Source source;
+    private boolean moto;
 
     private ChargeCreateRequestBuilder() {
     }
@@ -72,9 +73,14 @@ public final class ChargeCreateRequestBuilder {
         this.source = source;
         return this;
     }
+    
+    public ChargeCreateRequestBuilder withMoto(boolean moto) {
+        this.moto = moto;
+        return this;   
+    }
 
     public ChargeCreateRequest build() {
         return new ChargeCreateRequest(amount, description, reference, returnUrl, email, delayedCapture, language,
-                prefilledCardHolderDetails, externalMetadata, source);
+                prefilledCardHolderDetails, externalMetadata, source, moto);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -51,6 +51,7 @@ public class ChargeEntityFixture {
     private ParityCheckStatus parityCheckStatus = null;
     private String gatewayTransactionId = null;
     private Source source = null;
+    private boolean moto;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -74,7 +75,8 @@ public class ChargeEntityFixture {
                 externalMetadata,
                 source, 
                 gatewayTransactionId, 
-                cardDetails);
+                cardDetails,
+                moto);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setCorporateSurcharge(corporateSurcharge);
@@ -236,6 +238,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withEmail(String email) {
         this.email = email;
+        return this;
+    }
+    
+    public ChargeEntityFixture withMoto(boolean moto) {
+        this.moto = moto;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -275,7 +275,7 @@ public class ChargeServiceTest {
     }
 
     @Test
-    public void shouldCreateAChargeWithDefaultLanguageAndDefaultDelayedCapture() {
+    public void shouldCreateAChargeWithDefaults() {
         service.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
         
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.commons.model.SupportedLanguage;
@@ -21,6 +22,7 @@ import uk.gov.pay.connector.app.LinksConfig;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountException;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountException;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
@@ -123,36 +125,51 @@ public class ChargeServiceTest {
 
     @Mock
     private TokenDao mockedTokenDao;
+    
     @Mock
     private ChargeDao mockedChargeDao;
+    
     @Mock
     private ChargeEventDao mockedChargeEventDao;
+    
     @Mock
     private ChargeEventEntity mockChargeEvent;
 
 
     @Mock
     private GatewayAccountDao mockedGatewayAccountDao;
+    
     @Mock
     private CardTypeDao mockedCardTypeDao;
+    
     @Mock
     private ConnectorConfiguration mockedConfig;
+    
     @Mock
     private UriInfo mockedUriInfo;
+    
     @Mock
     private LinksConfig mockedLinksConfig;
+    
     @Mock
     private PaymentProviders mockedProviders;
+    
     @Mock
     private PaymentProvider mockedPaymentProvider;
+    
     @Mock
     private EventService mockEventService;
+    
     @Mock
     private StateTransitionService mockStateTransitionService;
+    
+    @Captor
+    private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
+    
+    @Captor ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor;
 
     private ChargeService service;
     private GatewayAccountEntity gatewayAccount;
-    private ChargeEntity returnedChargeEntity;
 
     @Before
     public void setUp() {
@@ -206,7 +223,7 @@ public class ChargeServiceTest {
                 CardType.valueOf("DEBIT")
         );
 
-        returnedChargeEntity = aValidChargeEntity()
+        ChargeEntity returnedChargeEntity = aValidChargeEntity()
                 .withAmount(100L)
                 .withDescription("Some description")
                 .withReference(ServicePaymentReference.of("Some reference"))
@@ -260,8 +277,7 @@ public class ChargeServiceTest {
     @Test
     public void shouldCreateAChargeWithDefaultLanguageAndDefaultDelayedCapture() {
         service.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -280,6 +296,7 @@ public class ChargeServiceTest {
         assertThat(createdChargeEntity.isDelayedCapture(), is(false));
         assertThat(createdChargeEntity.getCorporateSurcharge().isPresent(), is(false));
         assertThat(createdChargeEntity.getWalletType(), is(nullValue()));
+        assertThat(createdChargeEntity.isMoto(), is(false));
 
         verify(mockedChargeEventDao).persistChargeEventOf(eq(createdChargeEntity), isNull());
     }
@@ -288,8 +305,7 @@ public class ChargeServiceTest {
     public void shouldCreateAChargeWithDelayedCaptureTrue() {
         final ChargeCreateRequest request = requestBuilder.withDelayedCapture(true).build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
     }
 
@@ -297,8 +313,7 @@ public class ChargeServiceTest {
     public void shouldCreateAChargeWithDelayedCaptureFalse() {
         final ChargeCreateRequest request = requestBuilder.withDelayedCapture(false).build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
     }
 
@@ -313,7 +328,6 @@ public class ChargeServiceTest {
 
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         assertThat(chargeEntityArgumentCaptor.getValue().getExternalMetadata().get().getMetadata(), equalTo(metadata));
     }
@@ -323,8 +337,7 @@ public class ChargeServiceTest {
         final ChargeCreateRequest request = requestBuilder.withLanguage(SupportedLanguage.WELSH).build();
 
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -339,7 +352,6 @@ public class ChargeServiceTest {
 
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -352,6 +364,27 @@ public class ChargeServiceTest {
 
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
+        verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
+    }
+
+    @Test
+    public void shouldCreateMotoChargeIfGatewayAccountAllowsIt() {
+        gatewayAccount.setAllowMoto(true);
+
+        ChargeCreateRequest request = requestBuilder.withMoto(true).build();
+        service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        
+        verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
+        
+        ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
+        assertThat(createdChargeEntity.isMoto(), is(true));
+    }
+
+    @Test(expected = MotoPaymentNotAllowedForGatewayAccountException.class)
+    public void shouldThrowExceptionWhenCreateMotoChargeIfGatewayAccountDoesNotAllowIt() {
+        ChargeCreateRequest request = requestBuilder.withMoto(true).build();
+        service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
+        
         verify(mockedChargeDao, never()).persist(any(ChargeEntity.class));
     }
 
@@ -384,7 +417,6 @@ public class ChargeServiceTest {
         final ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
         assertThat(createdChargeEntity.getCardDetails(), is(notNullValue()));
@@ -408,7 +440,7 @@ public class ChargeServiceTest {
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
 
@@ -433,7 +465,7 @@ public class ChargeServiceTest {
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
 
@@ -456,7 +488,7 @@ public class ChargeServiceTest {
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
 
@@ -473,7 +505,7 @@ public class ChargeServiceTest {
 
         ChargeCreateRequest request = requestBuilder.withPrefilledCardHolderDetails(cardHolderDetails).build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
 
@@ -493,7 +525,7 @@ public class ChargeServiceTest {
     public void shouldCreateAChargeWhenPrefilledCardHolderDetailsAreNotPresent() {
         ChargeCreateRequest request = requestBuilder.build();
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
         assertThat(createdChargeEntity.getCardDetails(), is(nullValue()));
@@ -505,8 +537,7 @@ public class ChargeServiceTest {
                 withSource(CARD_API).build();
 
         service.create(request, GATEWAY_ACCOUNT_ID, mockedUriInfo);
-
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
+        
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
         assertThat(chargeEntityArgumentCaptor.getValue().getSource(), equalTo(CARD_API));
     }
@@ -515,7 +546,6 @@ public class ChargeServiceTest {
     public void shouldCreateAToken() {
         service.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = forClass(TokenEntity.class);
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
 
         TokenEntity tokenEntity = tokenEntityArgumentCaptor.getValue();
@@ -542,7 +572,6 @@ public class ChargeServiceTest {
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -593,7 +622,6 @@ public class ChargeServiceTest {
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -643,7 +671,6 @@ public class ChargeServiceTest {
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -698,7 +725,6 @@ public class ChargeServiceTest {
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -752,7 +778,6 @@ public class ChargeServiceTest {
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -787,7 +812,6 @@ public class ChargeServiceTest {
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         assertThat(chargeEntityArgumentCaptor.getValue().getSource(), equalTo(CARD_EXTERNAL_TELEPHONE));
@@ -804,10 +828,10 @@ public class ChargeServiceTest {
 
         Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(telephoneChargeCreateRequest);
 
-        ArgumentCaptor<String> chargeEntityArgumentCaptor = forClass(String.class);
-        verify(mockedChargeDao).findByGatewayTransactionId(chargeEntityArgumentCaptor.capture());
+        ArgumentCaptor<String> gatewayTransactionIdArgumentCaptor = forClass(String.class);
+        verify(mockedChargeDao).findByGatewayTransactionId(gatewayTransactionIdArgumentCaptor.capture());
 
-        String providerId = chargeEntityArgumentCaptor.getValue();
+        String providerId = gatewayTransactionIdArgumentCaptor.getValue();
         assertThat(providerId, is("new"));
         assertThat(telephoneChargeResponse.isPresent(), is(false));
     }
@@ -824,10 +848,10 @@ public class ChargeServiceTest {
 
         Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(telephoneChargeCreateRequest);
 
-        ArgumentCaptor<String> chargeEntityArgumentCaptor = forClass(String.class);
-        verify(mockedChargeDao).findByGatewayTransactionId(chargeEntityArgumentCaptor.capture());
+        ArgumentCaptor<String> gatewayTransactionIdArgumentCaptor = forClass(String.class);
+        verify(mockedChargeDao).findByGatewayTransactionId(gatewayTransactionIdArgumentCaptor.capture());
 
-        String providerId = chargeEntityArgumentCaptor.getValue();
+        String providerId = gatewayTransactionIdArgumentCaptor.getValue();
         assertThat(providerId, is("1PROV"));
         assertThat(telephoneChargeResponse.isPresent(), is(true));
         assertThat(telephoneChargeResponse.get().getAmount(), is(100L));
@@ -863,7 +887,6 @@ public class ChargeServiceTest {
 
         ChargeResponse chargeResponse = service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID).get();
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         assertThat(chargeResponse.getAmount(), is(100L));
@@ -900,7 +923,6 @@ public class ChargeServiceTest {
 
         ChargeResponse chargeResponse = service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID).get();
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         assertThat(chargeResponse.getAmount(), is(100L));
@@ -933,10 +955,7 @@ public class ChargeServiceTest {
     public void shouldCreateAResponse() throws Exception {
         ChargeResponse response = service.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo).get();
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
-
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = forClass(TokenEntity.class);
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -990,7 +1009,6 @@ public class ChargeServiceTest {
 
         Optional<ChargeResponse> chargeResponseForAccount = service.findChargeForAccount(externalId, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = ArgumentCaptor.forClass(TokenEntity.class);
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
 
         assertThat(chargeResponseForAccount.isPresent(), is(true));
@@ -1021,7 +1039,6 @@ public class ChargeServiceTest {
 
         Optional<ChargeResponse> chargeResponseForAccount = service.findChargeForAccount(externalId, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = ArgumentCaptor.forClass(TokenEntity.class);
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
 
         assertThat(chargeResponseForAccount.isPresent(), is(true));
@@ -1048,7 +1065,6 @@ public class ChargeServiceTest {
 
         Optional<ChargeResponse> chargeResponseForAccount = service.findChargeForAccount(externalId, GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<TokenEntity> tokenEntityArgumentCaptor = ArgumentCaptor.forClass(TokenEntity.class);
         verify(mockedTokenDao).persist(tokenEntityArgumentCaptor.capture());
 
         TokenEntity tokenEntity = tokenEntityArgumentCaptor.getValue();
@@ -1118,7 +1134,6 @@ public class ChargeServiceTest {
     public void shouldUpdateTransactionStatus_whenUpdatingChargeStatusFromInitialStatus() {
         service.create(requestBuilder.build(), GATEWAY_ACCOUNT_ID, mockedUriInfo);
 
-        ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor = forClass(ChargeEntity.class);
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
         ChargeEntity createdChargeEntity = chargeEntityArgumentCaptor.getValue();
@@ -1184,7 +1199,8 @@ public class ChargeServiceTest {
                 .withRefunds(refunds)
                 .withSettlement(settlement)
                 .withReturnUrl(chargeEntity.getReturnUrl())
-                .withLanguage(chargeEntity.getLanguage());
+                .withLanguage(chargeEntity.getLanguage())
+                .withMoto(chargeEntity.isMoto());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -363,8 +363,4 @@ public class ChargingITestBase {
 
         return externalChargeId;
     }
-
-    protected void allowZeroAmountForGatewayAccount() {
-        databaseTestHelper.updateGatewayAccountAllowZeroAmount(Long.valueOf(accountId), true);
-    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -147,6 +147,7 @@ public class ChargesFrontendResourceIT {
                 .body("delayed_capture", is(true))
                 .body("corporate_card_surcharge", is(213))
                 .body("total_amount", is(6447))
+                .body("moto", is(false))
                 .body("links", hasSize(3))
                 .body("links", containsLink("self", GET, expectedLocation))
                 .body("links", containsLink("cardAuth", POST, expectedLocation + "/cards"))

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -21,7 +21,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -76,16 +75,6 @@ public class DatabaseTestHelper {
         }
     }
 
-    public void updateGatewayAccountAllowZeroAmount(long gatewayAccountId, boolean allowZeroAmount) {
-        jdbi.withHandle(handle ->
-                handle
-                        .createUpdate("UPDATE gateway_accounts SET allow_zero_amount=:allow_zero_amount WHERE id=:gateway_account_id")
-                        .bind("gateway_account_id", gatewayAccountId)
-                        .bind("allow_zero_amount", allowZeroAmount)
-                        .execute()
-        );
-    }
-
     public void addCharge(AddChargeParams addChargeParams) {
         PGobject jsonMetadata = new PGobject();
         jsonMetadata.setType("json");
@@ -108,25 +97,25 @@ public class DatabaseTestHelper {
                         ":description, :created_date, :reference, :version, :email, :language, " +
                         ":delayed_capture, :corporate_surcharge, :parity_check_status, " +
                         ":external_metadata, :card_type)")
-                    .bind("id", addChargeParams.getChargeId())
-                    .bind("external_id", addChargeParams.getExternalChargeId())
-                    .bind("amount", addChargeParams.getAmount())
-                    .bind("status", addChargeParams.getStatus().getValue())
-                    .bind("gateway_account_id", Long.valueOf(addChargeParams.getGatewayAccountId()))
-                    .bind("return_url", addChargeParams.getReturnUrl())
-                    .bind("gateway_transaction_id", addChargeParams.getTransactionId())
-                    .bind("description", addChargeParams.getDescription())
-                    .bind("created_date", Timestamp.from(addChargeParams.getCreatedDate().toInstant()))
-                    .bind("reference", addChargeParams.getReference().toString())
-                    .bind("version", addChargeParams.getVersion())
-                    .bind("email", addChargeParams.getEmail())
-                    .bind("language", addChargeParams.getLanguage().toString())
-                    .bind("delayed_capture", addChargeParams.isDelayedCapture())
-                    .bind("corporate_surcharge", addChargeParams.getCorporateSurcharge())
-                    .bind("parity_check_status", addChargeParams.getParityCheckStatus())
-                    .bindBySqlType("external_metadata", jsonMetadata, OTHER)
-                    .bind("card_type", addChargeParams.getCardType())
-                    .execute());
+                        .bind("id", addChargeParams.getChargeId())
+                        .bind("external_id", addChargeParams.getExternalChargeId())
+                        .bind("amount", addChargeParams.getAmount())
+                        .bind("status", addChargeParams.getStatus().getValue())
+                        .bind("gateway_account_id", Long.valueOf(addChargeParams.getGatewayAccountId()))
+                        .bind("return_url", addChargeParams.getReturnUrl())
+                        .bind("gateway_transaction_id", addChargeParams.getTransactionId())
+                        .bind("description", addChargeParams.getDescription())
+                        .bind("created_date", Timestamp.from(addChargeParams.getCreatedDate().toInstant()))
+                        .bind("reference", addChargeParams.getReference().toString())
+                        .bind("version", addChargeParams.getVersion())
+                        .bind("email", addChargeParams.getEmail())
+                        .bind("language", addChargeParams.getLanguage().toString())
+                        .bind("delayed_capture", addChargeParams.isDelayedCapture())
+                        .bind("corporate_surcharge", addChargeParams.getCorporateSurcharge())
+                        .bind("parity_check_status", addChargeParams.getParityCheckStatus())
+                        .bindBySqlType("external_metadata", jsonMetadata, OTHER)
+                        .bind("card_type", addChargeParams.getCardType())
+                        .execute());
     }
 
     public void deleteAllChargesOnAccount(long accountId) {
@@ -140,7 +129,7 @@ public class DatabaseTestHelper {
         return addRefund(externalId, reference, amount, status, chargeId, gatewayTransactionId, createdDate, null, null);
     }
 
-    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, 
+    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId,
                          String gatewayTransactionId, ZonedDateTime createdDate, String submittedByUserExternalId,
                          String userEmail) {
         int refundId = RandomUtils.nextInt();
@@ -549,7 +538,7 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
-    
+
     public void blockPrepaidCards(Long accountId) {
         jdbi.withHandle(handle ->
                 handle.createUpdate("UPDATE gateway_accounts set block_prepaid_cards=true WHERE id=:gatewayAccountId")
@@ -557,6 +546,7 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
+
     public void allowMoto(long accountId) {
         jdbi.withHandle(handle ->
                 handle.createUpdate("UPDATE gateway_accounts set allow_moto=true WHERE id=:gatewayAccountId")
@@ -564,7 +554,7 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
-    
+
 
     public void addWalletType(long chargeId, WalletType walletType) {
         jdbi.withHandle(handle ->
@@ -706,7 +696,7 @@ public class DatabaseTestHelper {
     public void truncateEmittedEvents() {
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events").execute());
     }
-    
+
     public void truncateAllData() {
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE gateway_accounts CASCADE").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events CASCADE").execute());
@@ -750,7 +740,7 @@ public class DatabaseTestHelper {
     }
 
     public void addEmittedEvent(String resourceType, String externalId, Instant eventDate, String eventType,
-                                Instant emittedDate , Instant doNotRetryEmitUntil) {
+                                Instant emittedDate, Instant doNotRetryEmitUntil) {
         jdbi.withHandle(handle ->
                 handle
                         .createUpdate("INSERT INTO emitted_events(resource_type, resource_external_id, event_date, " +
@@ -765,7 +755,7 @@ public class DatabaseTestHelper {
                         .execute()
         );
     }
-    
+
     public Map<String, Object> readEmittedEvent(Long id) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * from emitted_events WHERE id = :id")
@@ -791,23 +781,24 @@ public class DatabaseTestHelper {
                         .bind("jwtMacKey", jwtMacKey)
                         .bind("issuer", issuer)
                         .bind("organisationalUnitId", organisationalUnitId)
-                        .bind("version", version) 
+                        .bind("version", version)
                         .execute()
         );
     }
+
     public Map<String, Object> getWorldpay3dsFlexCredentials(Long accountId) {
-        return jdbi.withHandle(handle -> 
+        return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM worldpay_3ds_flex_credentials WHERE gateway_account_id = :accountId")
-                .bind("accountId", accountId)
-                .mapToMap()
-                .first());
+                        .bind("accountId", accountId)
+                        .mapToMap()
+                        .first());
     }
 
     public Map<String, Object> getGatewayAccount(Long accountId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM gateway_accounts WHERE id = :accountId")
-                .bind("accountId", accountId)
-                .mapToMap()
-                .first());
+                        .bind("accountId", accountId)
+                        .mapToMap()
+                        .first());
     }
 }


### PR DESCRIPTION
Accept a `moto` boolean field in a create charge request. If moto payments are enabled for the gateway account, create a charge and persist it with the moto flag set to true.

If moto payments are not enabled for the gateway account, return a 422 response with the `MOTO_NOT_ALLOWED` error_identifier.

Return the `moto` field in charge API responses.