### PR TITLE
PP-6067 Pass GatewayAccountEntity to RefundGatewayRequest.value()

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -64,10 +64,10 @@ public class RefundGatewayRequest implements GatewayRequest {
      *          - Their reference to the Refund in smartpay will be returned as `pspReference`.
      * </p>
      */
-    public static RefundGatewayRequest valueOf(RefundEntity refundEntity) {
+    public static RefundGatewayRequest valueOf(RefundEntity refundEntity, GatewayAccountEntity gatewayAccountEntity) {
         return new RefundGatewayRequest(
                 refundEntity.getChargeEntity().getGatewayTransactionId(),
-                refundEntity.getChargeEntity().getGatewayAccount(),
+                gatewayAccountEntity,
                 String.valueOf(refundEntity.getAmount()),
                 refundEntity.getExternalId(),
                 refundEntity.getChargeEntity().getExternalId()

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -62,7 +62,7 @@ public class ChargeRefundService {
         RefundEntity refundEntity = createRefund(accountId, chargeId, refundRequest);
         GatewayRefundResponse gatewayRefundResponse = providers
                 .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
-                .refund(RefundGatewayRequest.valueOf(refundEntity));
+                .refund(RefundGatewayRequest.valueOf(refundEntity, gatewayAccountEntity));
         RefundEntity refund = processRefund(gatewayRefundResponse, refundEntity.getId(), gatewayAccountEntity);
         return new ChargeRefundResponse(gatewayRefundResponse, refund);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -189,7 +189,8 @@ public abstract class BaseEpdqPaymentProviderTest {
     }
 
     private RefundGatewayRequest buildTestRefundRequest(ChargeEntity chargeEntity) {
-        return RefundGatewayRequest.valueOf(new RefundEntity(chargeEntity, chargeEntity.getAmount() - 100, userExternalId, userEmail));
+        RefundEntity refundEntity = new RefundEntity(chargeEntity, chargeEntity.getAmount() - 100, userExternalId, userEmail);
+        return RefundGatewayRequest.valueOf(refundEntity, buildTestGatewayAccountEntity());
     }
 
     private GatewayAccountEntity buildTestGatewayAccountEntity() {

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -30,6 +31,7 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 public class SandboxPaymentProviderTest {
 
     private SandboxPaymentProvider provider;
+    private GatewayAccountEntity gatewayAccountEntity;
 
     private static final String AUTH_SUCCESS_CARD_NUMBER = "4242424242424242";
     private static final String AUTH_REJECTED_CARD_NUMBER = "4000000000000069";
@@ -41,6 +43,7 @@ public class SandboxPaymentProviderTest {
     @Before
     public void setup() {
         provider = new SandboxPaymentProvider();
+        gatewayAccountEntity = new GatewayAccountEntity();
     }
 
     @Test
@@ -130,7 +133,8 @@ public class SandboxPaymentProviderTest {
     @Test
     public void refund_shouldSucceedWhenRefundingAnyCharge() {
 
-        GatewayRefundResponse refundResponse = provider.refund(RefundGatewayRequest.valueOf(RefundEntityFixture.aValidRefundEntity().build()));
+        GatewayRefundResponse refundResponse = provider.refund(RefundGatewayRequest.valueOf(RefundEntityFixture.aValidRefundEntity().build(),
+                gatewayAccountEntity));
 
         assertThat(refundResponse.isSuccessful(), is(true));
         assertThat(refundResponse.getReference().isPresent(), is(true));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -68,7 +68,7 @@ public class StripeRefundHandlerTest {
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
-        refundRequest = RefundGatewayRequest.valueOf(refundEntity);
+        refundRequest = RefundGatewayRequest.valueOf(refundEntity, gatewayAccount);
 
         GatewayClient.Response response = mock(GatewayClient.Response.class);
         when(response.getEntity()).thenReturn(load(STRIPE_PAYMENT_INTENT_WITH_CHARGE_RESPONSE));
@@ -83,7 +83,7 @@ public class StripeRefundHandlerTest {
                 .withChargeTransactionId("pi_123")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
-        refundRequest = RefundGatewayRequest.valueOf(refundEntity);
+        refundRequest = RefundGatewayRequest.valueOf(refundEntity, gatewayAccount);
         mockTransferSuccess();
         mockRefundSuccess();
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -44,8 +44,6 @@ public class StripeRefundRequestTest {
     public void setUp() {
         when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
 
-        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
-
         when(refund.getAmount()).thenReturn(refundAmount);
         when(refund.getExternalId()).thenReturn(refundExternalId);
         when(refund.getChargeEntity()).thenReturn(charge);
@@ -53,7 +51,7 @@ public class StripeRefundRequestTest {
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
 
-        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund, gatewayAccount);
 
         stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, stripeChargeId, stripeGatewayConfig);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequestTest.java
@@ -35,12 +35,11 @@ public class StripeRequestTest {
     @Before
     public void setUp() {
         when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_connect_account_id"));
-        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(refund.getChargeEntity()).thenReturn(charge);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeAuthTokens.getLive()).thenReturn("live");
         when(stripeAuthTokens.getTest()).thenReturn("test");
-        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund, gatewayAccount);
 
         stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, "charge_id", stripeGatewayConfig);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -48,7 +48,6 @@ public class StripeTransferInRequestTest {
     public void setUp() {
         when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
 
-        when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);
 
         when(refund.getAmount()).thenReturn(refundAmount);
@@ -59,7 +58,7 @@ public class StripeTransferInRequestTest {
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeGatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
 
-        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund);
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(refund, gatewayAccount);
 
         stripeTransferInRequest = StripeTransferInRequest.of(refundGatewayRequest, stripeChargeId, stripeGatewayConfig);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -107,7 +107,7 @@ public class WorldpayPaymentProviderTest extends WorldpayBasePaymentProviderTest
                 .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         var worldpayPaymentProvider = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
-        worldpayPaymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity));
+        worldpayPaymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity, gatewayAccountEntity));
 
         String expectedRefundRequest =
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -71,6 +71,7 @@ public class EpdqPaymentProviderTest {
     private String password = envOrThrow("GDS_CONNECTOR_EPDQ_PASSWORD");
     private String shaInPassphrase = envOrThrow("GDS_CONNECTOR_EPDQ_SHA_IN_PASSPHRASE");
     private ChargeEntity chargeEntity;
+    private GatewayAccountEntity gatewayAccountEntity;
     private EpdqPaymentProvider paymentProvider;
 
     @Mock
@@ -261,15 +262,14 @@ public class EpdqPaymentProviderTest {
                     "username", username,
                     "password", password,
                     "sha_in_passphrase", shaInPassphrase);
-            GatewayAccountEntity validGatewayAccount = new GatewayAccountEntity();
-            validGatewayAccount.setId(123L);
-            validGatewayAccount.setGatewayName("epdq");
-            validGatewayAccount.setCredentials(validEpdqCredentials);
-            validGatewayAccount.setType(TEST);
-            validGatewayAccount.setRequires3ds(require3ds);
+            gatewayAccountEntity.setId(123L);
+            gatewayAccountEntity.setGatewayName("epdq");
+            gatewayAccountEntity.setCredentials(validEpdqCredentials);
+            gatewayAccountEntity.setType(TEST);
+            gatewayAccountEntity.setRequires3ds(require3ds);
 
             chargeEntity = aValidChargeEntity()
-                    .withGatewayAccountEntity(validGatewayAccount)
+                    .withGatewayAccountEntity(gatewayAccountEntity)
                     .withTransactionId(randomUUID().toString())
                     .build();
 
@@ -283,8 +283,9 @@ public class EpdqPaymentProviderTest {
         return CaptureGatewayRequest.valueOf(chargeEntity);
     }
 
-    private static RefundGatewayRequest buildRefundRequest(ChargeEntity chargeEntity, Long refundAmount) {
-        return RefundGatewayRequest.valueOf(new RefundEntity(chargeEntity, refundAmount, userExternalId, userEmail));
+    private RefundGatewayRequest buildRefundRequest(ChargeEntity chargeEntity, Long refundAmount) {
+        return RefundGatewayRequest.valueOf(new RefundEntity(chargeEntity, refundAmount, userExternalId, userEmail),
+                gatewayAccountEntity);
     }
 
     private CancelGatewayRequest buildCancelRequest(ChargeEntity chargeEntity, String transactionId) {

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -232,7 +232,7 @@ public class SmartpayPaymentProviderTest {
         assertTrue(captureGatewayResponse.isSuccessful());
 
         RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId, userEmail);
-        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity);
+        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(refundEntity, gatewayAccountEntity);
         GatewayRefundResponse refundResponse = smartpay.refund(refundRequest);
 
         assertThat(refundResponse.isSuccessful(), is(true));

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -231,7 +231,7 @@ public class WorldpayPaymentProviderTest {
 
         RefundEntity refundEntity = new RefundEntity(chargeEntity, 1L, userExternalId, userEmail);
 
-        GatewayRefundResponse refundResponse = paymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity));
+        GatewayRefundResponse refundResponse = paymentProvider.refund(RefundGatewayRequest.valueOf(refundEntity, validGatewayAccount));
 
         assertTrue(refundResponse.isSuccessful());
     }


### PR DESCRIPTION
## WHAT YOU DID
- Passes GatewayAccountEntity to build refund gateway request instead of using changeEntity.getGatewayAccountEntity()
- Few other places still need JPA way as GatewayAccount can only be derived from charge entity. This can be changed once Connector starts using chargeExternalId everywhere for refunds and also uses ledger to get payment information if charge doesn't exists in connector
  https://github.com/alphagov/pay-connector/blob/d239965797d5f1966e61d3484828f53b53134844/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java#L53
https://github.com/alphagov/pay-connector/blob/3865a9a5c329a33fb2874a6e10fc15e88fdd34b2/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java#L20
