### PR TITLE
PP-6091 Add external charge ID to refund tables

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1409,4 +1409,17 @@
         <addDefaultValue tableName="charges" columnName="moto" defaultValue="false"/>
     </changeSet>
 
+    <changeSet id="add charge_external_id column to refunds and refunds_history table" author="">
+        <addColumn tableName="refunds">
+            <column name="charge_external_id" type="char(26)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="refunds_history">
+            <column name="charge_external_id" type="char(26)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Connector will need to be able to process actions (refunds) on terminal charges that may or may not have been removed from its working database. In order to maintain the relationship between charges and refunds after the charge has been removed, we should also store a link the to the external charge ID (available in the Ledger database).

* `external_charge_id` column added to refund and refund history tables
* nullable columns, indexes to follow depending on how foreign keys/
unique constraints should be added