### PR TITLE
PP-5976 Send moto flag to Stripe

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -14,11 +14,13 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.net.URI;
+import java.net.URLEncoder;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -70,7 +72,7 @@ public class StripePaymentIntentRequestTest {
         assertThat(payload, containsString("on_behalf_of=" + stripeConnectAccountId));
         assertThat(payload, containsString("confirm=true"));
         assertThat(payload, containsString("description=" + description));
-        assertThat(payload, containsString("return_url=" + frontendUrl + "%2Fcard_details%2F" + chargeExternalId + "%2F3ds_required_in"));
+        assertThat(payload, containsString("return_url=" + URLEncoder.encode(frontendUrl + "/card_details/" + chargeExternalId + "/3ds_required_in", UTF_8)));
     }
 
     @Test
@@ -97,7 +99,7 @@ public class StripePaymentIntentRequestTest {
         StripePaymentIntentRequest stripePaymentIntentRequest = createStripePaymentIntentRequest();
 
         String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
-        assertThat(payload, containsString("payment_method_options%5Bcard%5Bmoto%5D%5D=true"));
+        assertThat(payload, containsString(URLEncoder.encode("payment_method_options[card[moto]]", UTF_8) + "=true"));
     }
     
     @Test
@@ -107,7 +109,7 @@ public class StripePaymentIntentRequestTest {
         StripePaymentIntentRequest stripePaymentIntentRequest = createStripePaymentIntentRequest();
 
         String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
-        assertThat(payload, not(containsString("payment_method_options%5Bcard%5Bmoto%5D%5D")));
+        assertThat(payload, not(containsString(URLEncoder.encode("payment_method_options[card[moto]]", UTF_8))));
     }
     
     private StripePaymentIntentRequest createStripePaymentIntentRequest() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -17,29 +17,32 @@ import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripePaymentIntentRequestTest {
+
+    @Mock
+    private ChargeEntity charge;
+
+    @Mock
+    private GatewayAccountEntity gatewayAccount;
+
+    @Mock
+    private StripeAuthTokens stripeAuthTokens;
+
+    @Mock
+    private StripeGatewayConfig stripeGatewayConfig;
+
     private final String stripeConnectAccountId = "stripeConnectAccountId";
     private final String chargeExternalId = "payChargeExternalId";
     private final String stripeBaseUrl = "stripeUrl";
-
-    private StripePaymentIntentRequest stripePaymentIntentRequest;
-
-    @Mock
-    ChargeEntity charge;
-    @Mock
-    GatewayAccountEntity gatewayAccount;
-    @Mock
-    StripeAuthTokens stripeAuthTokens;
-    @Mock
-    StripeGatewayConfig stripeGatewayConfig;
-    private String paymentMethodId = "123abc";
-    private String frontendUrl = "frontendUrl";
-    private Long amount = 100L;
-    private String description = "description";
+    private final String paymentMethodId = "123abc";
+    private final String frontendUrl = "frontendUrl";
+    private final Long amount = 100L;
+    private final String description = "description";
 
     @Before
     public void setUp() {
@@ -51,15 +54,12 @@ public class StripePaymentIntentRequestTest {
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
-
-        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
-
-        stripePaymentIntentRequest = StripePaymentIntentRequest.of(authorisationGatewayRequest, paymentMethodId, stripeGatewayConfig, frontendUrl);
     }
 
     @Test
     public void shouldHaveCorrectParametersWithAddress() {
-        
+        StripePaymentIntentRequest stripePaymentIntentRequest = createStripePaymentIntentRequest();
+
         String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
         assertThat(payload, containsString("payment_method=" + paymentMethodId));
         assertThat(payload, containsString("amount=" + amount));
@@ -75,6 +75,8 @@ public class StripePaymentIntentRequestTest {
 
     @Test
     public void createsCorrectIdempotencyKey() {
+        StripePaymentIntentRequest stripePaymentIntentRequest = createStripePaymentIntentRequest();
+
         assertThat(
                 stripePaymentIntentRequest.getHeaders().get("Idempotency-Key"),
                 is("payment_intent" + chargeExternalId));
@@ -82,6 +84,34 @@ public class StripePaymentIntentRequestTest {
 
     @Test
     public void shouldCreateCorrectUrl() {
+        StripePaymentIntentRequest stripePaymentIntentRequest = createStripePaymentIntentRequest();
+
         assertThat(stripePaymentIntentRequest.getUrl(), is(URI.create(stripeBaseUrl + "/v1/payment_intents")));
+    }
+
+
+    @Test
+    public void shouldIncludeMotoFlagWhenChargeIsMoto() {
+        when(charge.isMoto()).thenReturn(true);
+
+        StripePaymentIntentRequest stripePaymentIntentRequest = createStripePaymentIntentRequest();
+
+        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+        assertThat(payload, containsString("payment_method_options%5Bcard%5Bmoto%5D%5D=true"));
+    }
+    
+    @Test
+    public void shouldNotIncludeMotoFlagWhenChargeIsNotMoto() {
+        when(charge.isMoto()).thenReturn(false);
+
+        StripePaymentIntentRequest stripePaymentIntentRequest = createStripePaymentIntentRequest();
+
+        String payload = stripePaymentIntentRequest.getGatewayOrder().getPayload();
+        assertThat(payload, not(containsString("payment_method_options%5Bcard%5Bmoto%5D%5D")));
+    }
+    
+    private StripePaymentIntentRequest createStripePaymentIntentRequest() {
+        var authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, new AuthCardDetails());
+        return StripePaymentIntentRequest.of(authorisationGatewayRequest, paymentMethodId, stripeGatewayConfig, frontendUrl);
     }
 }


### PR DESCRIPTION
If a charge has the `moto` flag set to true, include the parameter `payment_method_options[card[moto]]` in the request payload with a value of true.

If the charge is not a moto charge, omit this parameter.

I've tested that this creates the charge successfully in Stripe testing using Pay local against the test production Stripe account. When the payment intent is created in Stripe with the moto flag, the response contains:

```
"payment_method_details": {
          "card": {
            ...
            "moto": true,
            ...
          },
          "type": "card"
        },
```