### PR TITLE
PP-6092 Refund entity has charge external id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -62,7 +62,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
     public List<RefundHistory> searchHistoryByChargeId(Long chargeId) {
 
         String query = "SELECT id, external_id, amount, status, charge_id, created_date, version, reference, " +
-                "history_start_date, history_end_date, user_external_id, gateway_transaction_id, user_email " +
+                "history_start_date, history_end_date, user_external_id, gateway_transaction_id, user_email, charge_external_id " +
                 "FROM refunds_history r " +
                 "WHERE charge_id = ?1 AND status != ?2";
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -90,6 +90,9 @@ public class RefundEntity extends AbstractVersionedEntity {
     @Convert(converter = UTCDateTimeConverter.class)
     private ZonedDateTime createdDate;
 
+    @Column(name = "charge_external_id")
+    private String chargeExternalId;
+
     public RefundEntity() {
         //for jpa
     }
@@ -101,6 +104,7 @@ public class RefundEntity extends AbstractVersionedEntity {
         this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
         this.userExternalId = userExternalId;
         this.userEmail = userEmail;
+        this.chargeExternalId = chargeEntity.getExternalId();
     }
 
     public String getExternalId() {
@@ -203,5 +207,13 @@ public class RefundEntity extends AbstractVersionedEntity {
                 ", gatewayTransactionId=" + gatewayTransactionId +
                 ", createdDate=" + createdDate +
                 '}';
+    }
+
+    public String getChargeExternalId() {
+        return chargeExternalId;
+    }
+
+    public void setChargeExternalId(String chargeExternalId) {
+        this.chargeExternalId = chargeExternalId;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
@@ -143,6 +143,7 @@ public class RefundDaoJpaIT extends DaoITestBase {
         assertThat(refundByIdFound.get(0), hasEntry("created_date", java.sql.Timestamp.from(refundEntity.getCreatedDate().toInstant())));
         assertThat(refundByIdFound.get(0), hasEntry("user_external_id", userExternalId));
         assertThat(refundByIdFound.get(0), hasEntry("user_email", userEmail));
+        assertThat(refundByIdFound.get(0), hasEntry("charge_external_id", chargeEntity.getExternalId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
@@ -176,6 +176,7 @@ public class RefundDaoJpaIT extends DaoITestBase {
         assertThat(refundEntity.getUserEmail(), is(refundEntity.getUserEmail()));
         assertThat(refundHistory.getUserExternalId(), is(refundEntity.getUserExternalId()));
         assertThat(refundHistory.getGatewayTransactionId(), is(refundEntity.getGatewayTransactionId()));
+        assertThat(refundHistory.getChargeExternalId(), is(chargeEntity.getExternalId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
@@ -32,6 +32,7 @@ public class RefundEntityTest {
         assertThat(refundEntity.getReference(), is(nullValue()));
         assertThat(refundEntity.getAmount(), is(amount));
         assertThat(refundEntity.getUserExternalId(), is(userExternalId));
+        assertThat(refundEntity.getChargeExternalId(), is(chargeEntity.getExternalId()));
         assertNotNull(refundEntity.getCreatedDate());
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -171,6 +171,7 @@ public class ChargeRefundServiceTest {
 
         assertThat(refundEntity.getAmount(), is(refundAmount));
         assertThat(refundEntity.getStatus(), is(CREATED));
+        assertThat(refundEntity.getChargeExternalId(), is(externalChargeId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -275,7 +275,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefund(long refundId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id, user_email " +
+                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id, user_email, charge_external_id " +
                         "FROM refunds " +
                         "WHERE id = :refund_id")
                         .bind("refund_id", refundId)
@@ -286,7 +286,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefundsByChargeId(long chargeId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id, user_email " +
+                h.createQuery("SELECT external_id, reference, amount, status, created_date, charge_id, user_external_id, user_email, charge_external_id " +
                         "FROM refunds r " +
                         "WHERE charge_id = :charge_id")
                         .bind("charge_id", chargeId)


### PR DESCRIPTION
Following https://github.com/alphagov/pay-connector/pull/2062, add the `chargeExternalId` attribute to the `RefundEntity`. 

This will propagate through to the refund history table. 

This can then be used to get refunds for a given charge that may have been removed from Connector.