### PR TITLE
PP-6092 Assert resource level external id propagation

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundIT.java
@@ -94,6 +94,7 @@ public class EpdqRefundIT extends ChargingITestBase {
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));
         assertThat(refundsFoundByChargeId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getChargeId(), refundAmount, "REFUND SUBMITTED")));
+        assertThat(refundsFoundByChargeId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundIT.java
@@ -132,6 +132,7 @@ public class SandboxRefundIT extends ChargingITestBase {
         assertThat(refundsFoundByChargeId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getChargeId(), refundAmount, "REFUNDED")));
         assertThat(refundsFoundByChargeId.get(0), hasEntry("user_external_id", userExternalId));
         assertThat(refundsFoundByChargeId.get(0), hasEntry("user_email", userEmail));
+        assertThat(refundsFoundByChargeId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
 
         assertRefundsHistoryInOrderInDBForSuccessfulOrPartialRefund(defaultTestCharge);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundIT.java
@@ -98,6 +98,7 @@ public class SmartpayRefundIT extends ChargingITestBase {
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));
         assertThat(refundsFoundByChargeId, hasItems(aRefundMatching(refundId, is("8514774917520978"), defaultTestCharge.getChargeId(), refundAmount, "REFUND SUBMITTED")));
+        assertThat(refundsFoundByChargeId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import io.restassured.response.ValidatableResponse;
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.eclipse.jetty.http.HttpStatus.ACCEPTED_202;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
@@ -99,6 +101,7 @@ public class StripeRefundIT extends ChargingITestBase {
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(testChargeCreatedWithStripeChargeAPI.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));
         assertThat(refundsFoundByChargeId.get(0).get("status"), is("REFUNDED"));
+        MatcherAssert.assertThat(refundsFoundByChargeId.get(0), hasEntry("charge_external_id", testChargeCreatedWithStripeChargeAPI.getExternalChargeId()));
         String refundId = response.extract().path("refund_id");
         
         verify(postRequestedFor(urlEqualTo("/v1/refunds"))

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundIT.java
@@ -98,6 +98,7 @@ public class WorldpayRefundIT extends ChargingITestBase {
         List<Map<String, Object>> refundsFoundByChargeId = databaseTestHelper.getRefundsByChargeId(defaultTestCharge.getChargeId());
         assertThat(refundsFoundByChargeId.size(), is(1));
         assertThat(refundsFoundByChargeId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getChargeId(), refundAmount, "REFUND SUBMITTED")));
+        assertThat(refundsFoundByChargeId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
     }
 
     @Test


### PR DESCRIPTION
Assert charge external ID is correctly added to refund entities.