### PR TITLE
BAU Parse Reason Field In Smartpay Notification

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotification.java
@@ -22,6 +22,7 @@ public class SmartpayNotification implements ChargeStatusRequest, Comparable<Sma
     private String eventCode;
     private String originalReference;
     private String pspReference;
+    private String reason;
     private String success;
 
     private Optional<ChargeStatus> chargeStatus = Optional.empty();
@@ -35,6 +36,7 @@ public class SmartpayNotification implements ChargeStatusRequest, Comparable<Sma
         this.pspReference = (String) notification.get("pspReference");
         this.success = (String) notification.get("success");
         this.eventDate = ZonedDateTime.parse((String) notification.get("eventDate"));
+        this.reason = (String) notification.getOrDefault("reason", null);
     }
 
     private void verify(Map<String, Object> notification, Set<String> mandatoryFields) {
@@ -66,6 +68,10 @@ public class SmartpayNotification implements ChargeStatusRequest, Comparable<Sma
         return "true".equals(success);
     }
 
+    public String getReason() {
+        return reason;
+    }
+
     public ZonedDateTime getEventDate() {
         return eventDate;
     }
@@ -94,6 +100,7 @@ public class SmartpayNotification implements ChargeStatusRequest, Comparable<Sma
                 ", eventCode='" + eventCode + '\'' +
                 ", originalReference='" + originalReference + '\'' +
                 ", pspReference='" + pspReference + '\'' +
+                ", reason='" + reason + '\'' +
                 ", success='" + success + '\'' +
                 ", chargeStatus=" + chargeStatus +
                 '}';

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class SmartpayNotificationTest {
@@ -32,11 +33,13 @@ public class SmartpayNotificationTest {
                 "originalReference", "originalReference",
                 "pspReference", "pspReference",
                 "eventCode", "eventCode",
+                "reason", "It failed because",
                 "success", "true",
                 "eventDate", "2015-10-08T13:48:30+02:00");
         assertThat(smartpayNotification.getTransactionId(), is("pspReference"));
         assertThat(smartpayNotification.getOriginalReference(), is("originalReference"));
         assertThat(smartpayNotification.getPspReference(), is("pspReference"));
+        assertThat(smartpayNotification.getReason(), is ("It failed because"));
         assertThat(smartpayNotification.getEventCode(), is("eventCode"));
         assertThat(smartpayNotification.isSuccessFul(), is(true));
 
@@ -67,6 +70,25 @@ public class SmartpayNotificationTest {
         assertThat(earlyNotification, is(lessThan(laterNotification)));
         assertThat(laterNotification, is(greaterThan(earlyNotification)));
     }
+
+    @Test
+    public void simpleFieldsShould_simplyMapWithNullReason() {
+        SmartpayNotification smartpayNotification = aNotificationWith(
+                "originalReference", "originalReference",
+                "pspReference", "pspReference",
+                "eventCode", "eventCode",
+                "success", "true",
+                "eventDate", "2015-10-08T13:48:30+02:00");
+        assertThat(smartpayNotification.getTransactionId(), is("pspReference"));
+        assertThat(smartpayNotification.getOriginalReference(), is("originalReference"));
+        assertThat(smartpayNotification.getPspReference(), is("pspReference"));
+        assertThat(smartpayNotification.getReason(), is(nullValue()));
+        assertThat(smartpayNotification.getEventCode(), is("eventCode"));
+        assertThat(smartpayNotification.isSuccessFul(), is(true));
+
+        assertThat(smartpayNotification.getEventDate(), is(ZonedDateTime.of(2015, 10, 8, 13, 48, 30, 0, ZoneOffset.ofHours(2))));
+    }
+
 
     private final static Map<String, Object> defaults = ImmutableMap.of(
             "pspReference", "1234-5678-9012",


### PR DESCRIPTION
- When we receive a notification from Smartpay, this somtimes has
success=false as a condition, in those circumstances we receive a reason
field we do not currently parse or log, this PR fixes that, capturing it
if it is null
