### PR TITLE
PP-6095 add findRefundsRefundsByChargeExternalId to RefundDao

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -115,4 +115,14 @@ public class RefundDao extends JpaDao<RefundEntity> {
                 .setParameter(4, offset)
                 .getResultList();
     }
+
+    public List<RefundEntity> findRefundsByChargeExternalId(String chargeExternalId) {
+        String query = "SELECT refund FROM RefundEntity refund " +
+                "WHERE refund.chargeExternalId = :chargeExternalId";
+
+        return entityManager.get()
+                .createQuery(query, RefundEntity.class)
+                .setParameter("chargeExternalId", chargeExternalId)
+                .getResultList();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.ConnectorModule;
+import uk.gov.pay.connector.it.util.ChargeUtils;
 import uk.gov.pay.connector.junit.ConfigOverride;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
@@ -82,8 +83,10 @@ public class SendRefundEmailIT {
         String payIdSub = "2";
         String refundExternalId = "999999";
 
-        long chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper).chargeId;
-        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 100,  REFUND_SUBMITTED, chargeId, randomAlphanumeric(10), ZonedDateTime.now());
+        ChargeUtils.ExternalChargeId chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
+        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub,
+                100,  REFUND_SUBMITTED, chargeId.chargeId, randomAlphanumeric(10),
+                ZonedDateTime.now(), chargeId.toString());
 
         given().port(testContext.getPort())
                 .body(epdqNotificationPayload(transactionId, payIdSub, "8", credentials.get(CREDENTIALS_SHA_OUT_PASSPHRASE)))

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -757,7 +757,7 @@ public class DatabaseFixtures {
             if (testCharge == null)
                 throw new IllegalStateException("Test charge must be provided.");
             id = databaseTestHelper.addRefund(externalRefundId, reference, amount, status, testCharge.getChargeId(),
-                    gatewayTransactionId, createdDate, submittedByUserExternalId, userEmail);
+                    gatewayTransactionId, createdDate, submittedByUserExternalId, userEmail, testCharge.externalChargeId);
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
@@ -310,4 +310,19 @@ public class RefundDaoJpaIT extends DaoITestBase {
         assertThat(refundHistory.getId(), is(testRefund.getId()));
         assertThat(refundHistory.getUserEmail(), is(testRefund.getUserEmail()));
     }
+
+    @Test
+    public void findByChargeExternalIdShouldReturnAListOfRefunds() {
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestRefund()
+                .withReference(randomAlphanumeric(10))
+                .withGatewayTransactionId(randomAlphanumeric(10))
+                .withTestCharge(chargeTestRecord).insert();
+
+        List<RefundEntity> refundEntityList = refundDao.findRefundsByChargeExternalId(chargeTestRecord.externalChargeId);
+        assertThat(refundEntityList.size(), is(2));
+        assertThat(refundEntityList.get(0).getChargeExternalId(), is(chargeTestRecord.externalChargeId));
+        assertThat(refundEntityList.get(1).getChargeExternalId(), is(chargeTestRecord.externalChargeId));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
@@ -108,7 +108,9 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         int refundAmount = 1000;
 
         ChargeUtils.ExternalChargeId externalChargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
-        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 1000,  REFUND_SUBMITTED, externalChargeId.chargeId, randomAlphanumeric(10), ZonedDateTime.now());
+        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 1000,
+                REFUND_SUBMITTED, externalChargeId.chargeId, randomAlphanumeric(10), ZonedDateTime.now(),
+                externalChargeId.toString());
         
         String response = notifyConnector(transactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
                 .statusCode(200)

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthIT.java
@@ -134,7 +134,9 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthIT extends Charg
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         Long chargeId = Long.parseLong(StringUtils.removeStart(externalChargeId, "charge-"));
         String externalRefundId = "refund-" + RandomUtils.nextInt();
-        int refundId = databaseTestHelper.addRefund(externalRefundId, reference, 10L, REFUND_SUBMITTED, chargeId, randomAlphanumeric(10), ZonedDateTime.now());
+        int refundId = databaseTestHelper.addRefund(externalRefundId, reference, 10L,
+                REFUND_SUBMITTED, chargeId, randomAlphanumeric(10), ZonedDateTime.now(),
+                externalChargeId);
 
         String response = notifyConnector(notificationPayloadForTransaction(externalRefundId, transactionId, reference, "notification-refund"))
                 .then()

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -187,7 +187,9 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
     private String createNewChargeWithRefund(String transactionId, String refundExternalId, long refundAmount) {
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         String chargeId = externalChargeId.substring(externalChargeId.indexOf("-") + 1);
-        databaseTestHelper.addRefund(refundExternalId, refundExternalId, refundAmount, REFUND_SUBMITTED, Long.valueOf(chargeId), randomAlphanumeric(10), ZonedDateTime.now());
+        databaseTestHelper.addRefund(refundExternalId, refundExternalId, refundAmount, REFUND_SUBMITTED,
+                Long.valueOf(chargeId), randomAlphanumeric(10), ZonedDateTime.now(),
+                externalChargeId);
         return externalChargeId;
     }
 

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -144,10 +144,10 @@ public class ContractTest {
     }
 
     private void setUpRefunds(int numberOfRefunds, Long chargeId,
-                              ZonedDateTime createdDate, RefundStatus refundStatus) {
+                              ZonedDateTime createdDate, RefundStatus refundStatus, String chargeExternalId) {
         for (int i = 0; i < numberOfRefunds; i++) {
             dbHelper.addRefund("external" + RandomUtils.nextInt(), "reference", 1L, refundStatus,
-                    chargeId, randomAlphanumeric(10), createdDate, "user_external_id1234", null);
+                    chargeId, randomAlphanumeric(10), createdDate, "user_external_id1234", null, chargeExternalId);
         }
     }
 
@@ -299,8 +299,8 @@ public class ContractTest {
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(accountId));
         long chargeId = 1234L;
         setUpSingleCharge(accountId, chargeId, chargeExternalId, ChargeStatus.CAPTURED, ZonedDateTime.now(), false);
-        setUpRefunds(1, chargeId, ZonedDateTime.parse("2016-01-25T13:23:55Z"), REFUNDED);
-        setUpRefunds(1, chargeId, ZonedDateTime.parse("2016-01-25T16:23:55Z"), REFUND_ERROR);
+        setUpRefunds(1, chargeId, ZonedDateTime.parse("2016-01-25T13:23:55Z"), REFUNDED, chargeExternalId);
+        setUpRefunds(1, chargeId, ZonedDateTime.parse("2016-01-25T16:23:55Z"), REFUND_ERROR, chargeExternalId);
     }
 
     @State("a payment refund exists")
@@ -326,7 +326,8 @@ public class ContractTest {
                 .withEmail("test@test.com")
                 .build());
         dbHelper.addRefund(refundId, "reference", 100L, REFUNDED,
-                paymentId, randomAlphanumeric(10), createdDate);
+                paymentId, randomAlphanumeric(10), createdDate,
+                Long.toString(paymentId));
     }
 
     @State("a charge with corporate surcharge exists")

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -125,20 +125,20 @@ public class DatabaseTestHelper {
                         .execute());
     }
 
-    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, String gatewayTransactionId, ZonedDateTime createdDate) {
-        return addRefund(externalId, reference, amount, status, chargeId, gatewayTransactionId, createdDate, null, null);
+    public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId, String gatewayTransactionId, ZonedDateTime createdDate, String chargeExternalId) {
+        return addRefund(externalId, reference, amount, status, chargeId, gatewayTransactionId, createdDate, null, null, chargeExternalId);
     }
 
     public int addRefund(String externalId, String reference, long amount, RefundStatus status, Long chargeId,
                          String gatewayTransactionId, ZonedDateTime createdDate, String submittedByUserExternalId,
-                         String userEmail) {
+                         String userEmail, String chargeExternalId) {
         int refundId = RandomUtils.nextInt();
         jdbi.withHandle(handle ->
                 handle
                         .createUpdate("INSERT INTO refunds(id, external_id, reference, amount, status, charge_id," +
-                                " gateway_transaction_id, created_date, user_external_id, user_email) " +
+                                " gateway_transaction_id, created_date, user_external_id, user_email, charge_external_id) " +
                                 "VALUES (:id, :external_id, :reference, :amount, :status, :charge_id, " +
-                                ":gateway_transaction_id, :created_date, :user_external_id, :user_email)")
+                                ":gateway_transaction_id, :created_date, :user_external_id, :user_email, :charge_external_id)")
                         .bind("id", refundId)
                         .bind("external_id", externalId)
                         .bind("reference", reference)
@@ -149,6 +149,7 @@ public class DatabaseTestHelper {
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
                         .bind("user_external_id", submittedByUserExternalId)
                         .bind("user_email", userEmail)
+                        .bind("charge_external_id", chargeExternalId)
                         .bind("version", 1)
                         .execute()
         );


### PR DESCRIPTION
## WHAT YOU DID
- add new method to RefundDao (so getRefunds() can be decoupled from ChargeEntity)
- update DatabaseFixtures accordingly
- update existing tests to use chargeExternalId
- add JPA test for RefundDao
