### PR TITLE
PP-6097 Add DAO method `findChargeToExpunge`

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -188,4 +188,26 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setMaxResults(size)
                 .getResultList();
     }
+
+    public Optional<ChargeEntity> findChargeToExpunge(int minimumAgeOfChargeInDays) {
+        String query = "SELECT c FROM ChargeEntity c " +
+                "WHERE (c.parityCheckDate is null or c.parityCheckDate < :parityCheckedBeforeDate)" +
+                " AND c.createdDate < :createdBeforeDate " +
+                " ORDER BY c.createdDate asc";
+
+        ZonedDateTime parityCheckedBeforeDate = ZonedDateTime.now()
+                .minus(Duration.ofDays(7))
+                .withZoneSameInstant(ZoneId.of("UTC"));
+
+        ZonedDateTime createdBeforeDate = ZonedDateTime.now()
+                .minus(Duration.ofDays(minimumAgeOfChargeInDays))
+                .withZoneSameInstant(ZoneId.of("UTC"));
+
+        return entityManager.get()
+                .createQuery(query, ChargeEntity.class)
+                .setParameter("parityCheckedBeforeDate", parityCheckedBeforeDate)
+                .setParameter("createdBeforeDate", createdBeforeDate)
+                .setMaxResults(1)
+                .getResultList().stream().findFirst();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -498,6 +498,7 @@ public class DatabaseFixtures {
         WalletType walletType;
         ParityCheckStatus parityCheckStatus;
         private String description = "Test description";
+        private ZonedDateTime parityCheckDate;
 
         public TestCardDetails getCardDetails() {
             return cardDetails;
@@ -573,6 +574,11 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestCharge withParityCheckDate(ZonedDateTime parityCheckDate) {
+            this.parityCheckDate = parityCheckDate;
+            return this;
+        }
+
         public TestCharge insert() {
             if (testAccount == null)
                 throw new IllegalStateException("Test Account must be provided.");
@@ -594,6 +600,7 @@ public class DatabaseFixtures {
                     .withEmail(email)
                     .withCorporateSurcharge(corporateCardSurcharge)
                     .withParityCheckStatus(parityCheckStatus)
+                    .withParityCheckDate(parityCheckDate)
                     .build());
 
             if (cardDetails != null) {

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -34,6 +34,7 @@ public class AddChargeParams {
     private final ExternalMetadata externalMetadata;
     private final ParityCheckStatus parityCheckStatus;
     private final CardType cardType;
+    private final ZonedDateTime parityCheckDate;
 
     private AddChargeParams(AddChargeParamsBuilder builder) {
         chargeId = builder.chargeId;
@@ -54,6 +55,7 @@ public class AddChargeParams {
         corporateSurcharge = builder.corporateSurcharge;
         externalMetadata = builder.externalMetadata;
         parityCheckStatus = builder.parityCheckStatus;
+        parityCheckDate = builder.parityCheckDate;
         cardType = builder.cardType;
     }
 
@@ -128,6 +130,10 @@ public class AddChargeParams {
     public ParityCheckStatus getParityCheckStatus() {
         return parityCheckStatus;
     }
+
+    public ZonedDateTime getParityCheckDate() {
+        return parityCheckDate;
+    }
     
     public CardType getCardType() {
         return cardType;
@@ -153,6 +159,7 @@ public class AddChargeParams {
         private ExternalMetadata externalMetadata;
         private ParityCheckStatus parityCheckStatus;
         private CardType cardType;
+        private ZonedDateTime parityCheckDate;
 
         private AddChargeParamsBuilder() {
         }
@@ -249,6 +256,11 @@ public class AddChargeParams {
 
         public AddChargeParamsBuilder withParityCheckStatus(ParityCheckStatus parityCheckStatus) {
             this.parityCheckStatus = parityCheckStatus;
+            return this;
+        }
+
+        public AddChargeParamsBuilder withParityCheckDate(ZonedDateTime parityCheckDate) {
+            this.parityCheckDate = parityCheckDate;
             return this;
         }
         

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -90,12 +90,12 @@ public class DatabaseTestHelper {
                 h.createUpdate("INSERT INTO charges(id, external_id, amount, " +
                         "status, gateway_account_id, return_url, gateway_transaction_id, " +
                         "description, created_date, reference, version, email, language, " +
-                        "delayed_capture, corporate_surcharge, parity_check_status, " +
+                        "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
                         "external_metadata, card_type) " +
                         "VALUES(:id, :external_id, :amount, " +
                         ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                         ":description, :created_date, :reference, :version, :email, :language, " +
-                        ":delayed_capture, :corporate_surcharge, :parity_check_status, " +
+                        ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
                         ":external_metadata, :card_type)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
@@ -113,6 +113,7 @@ public class DatabaseTestHelper {
                         .bind("delayed_capture", addChargeParams.isDelayedCapture())
                         .bind("corporate_surcharge", addChargeParams.getCorporateSurcharge())
                         .bind("parity_check_status", addChargeParams.getParityCheckStatus())
+                        .bind("parity_check_date", addChargeParams.getParityCheckDate())
                         .bindBySqlType("external_metadata", jsonMetadata, OTHER)
                         .bind("card_type", addChargeParams.getCardType())
                         .execute());


### PR DESCRIPTION
## WHAT YOU DID
- Added new DAO method `findChargeToExpunge` to find a charge to expunge based on the 'ageOfcharge` and which has not been parity checked within last week
