### PR TITLE
PP-6095 Remove RefundEntity mapping from ChargeEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -22,7 +22,6 @@ import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.UnspecifiedEvent;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
 
@@ -112,10 +111,6 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     @OneToOne(mappedBy = "chargeEntity", fetch = FetchType.EAGER)
     private FeeEntity fee;
-
-    @OneToMany(mappedBy = "chargeEntity", fetch = FetchType.EAGER)
-    @OrderBy("createdDate")
-    private List<RefundEntity> refunds = new ArrayList<>();
 
     @OneToMany(mappedBy = "chargeEntity")
     @OrderBy("updated DESC")
@@ -245,10 +240,6 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     public ZonedDateTime getCreatedDate() {
         return createdDate;
-    }
-
-    public List<RefundEntity> getRefunds() {
-        return refunds;
     }
 
     public List<ChargeEventEntity> getEvents() {

--- a/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
@@ -4,6 +4,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
+import java.util.List;
+
 /**
  * Holder for utility methods used to calculate refund amounts
  */
@@ -13,12 +15,12 @@ public class RefundCalculator {
         // prevent Java for adding a public constructor
     }
 
-    public static long getTotalAmountAvailableToBeRefunded(ChargeEntity chargeEntity) {
-        return CorporateCardSurchargeCalculator.getTotalAmountFor(chargeEntity) - getRefundedAmount(chargeEntity);
+    public static long getTotalAmountAvailableToBeRefunded(ChargeEntity chargeEntity, List<RefundEntity> refundEntities) {
+        return CorporateCardSurchargeCalculator.getTotalAmountFor(chargeEntity) - getRefundedAmount(refundEntities);
     }
 
-    public static long getRefundedAmount(ChargeEntity chargeEntity) {
-        return chargeEntity.getRefunds().stream()
+    public static long getRefundedAmount(List<RefundEntity> refundEntities) {
+        return refundEntities.stream()
                 .filter(p -> p.hasStatus(RefundStatus.CREATED, RefundStatus.REFUND_SUBMITTED, RefundStatus.REFUNDED))
                 .mapToLong(RefundEntity::getAmount)
                 .sum();

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
@@ -4,6 +4,9 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.util.List;
 
 public class RefundAvailabilityUpdatedEventDetails extends EventDetails {
     private Long amountAvailable;
@@ -17,10 +20,10 @@ public class RefundAvailabilityUpdatedEventDetails extends EventDetails {
     }
     
 
-    public static RefundAvailabilityUpdatedEventDetails from(ChargeEntity charge, ExternalChargeRefundAvailability availability) {
+    public static RefundAvailabilityUpdatedEventDetails from(ChargeEntity charge, List<RefundEntity> refundEntityList, ExternalChargeRefundAvailability availability) {
         return new RefundAvailabilityUpdatedEventDetails(
-                RefundCalculator.getTotalAmountAvailableToBeRefunded(charge),
-                RefundCalculator.getRefundedAmount(charge),
+                RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntityList),
+                RefundCalculator.getRefundedAmount(refundEntityList),
                 availability.getStatus()
         );
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -12,8 +12,10 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PaymentProvider {
@@ -36,5 +38,5 @@ public interface PaymentProvider {
 
     GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayException;
 
-    ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity);
+    ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList);
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -27,12 +27,14 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -215,8 +217,8 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
     }
 
     /**

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -22,8 +22,10 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxWalletAuthorisationHandler;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.UUID.randomUUID;
@@ -91,8 +93,8 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
     }
 
     private GatewayResponse<BaseCancelResponse> createGatewayBaseCancelResponse() {

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -29,10 +29,12 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -146,8 +148,8 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
     }
 
     private GatewayOrder buildAuthoriseOrderFor(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -35,11 +35,13 @@ import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeAuthoriseRequest;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.List;
 import java.util.Optional;
 
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
@@ -180,7 +182,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 
@@ -45,16 +46,17 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
     private static final List<ChargeStatus> STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL = ImmutableList.of(CAPTURED);
 
     @Override
-    public ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity) {
-        return calculate(chargeEntity, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL);
+    public ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
+        return calculate(chargeEntity, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
     }
 
     protected ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<ChargeStatus> statusesThatMapToExternalPending,
-                                                         List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull) {
+                                                         List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull,
+                                                         List<RefundEntity> refundEntityList) {
         if (chargeIsPending(chargeEntity, statusesThatMapToExternalPending)) {
             return EXTERNAL_PENDING;
         } else if (chargeIsAvailableOrFull(chargeEntity, statusesThatMapToExternalAvailableOrExternalFull)) {
-            if (RefundCalculator.getTotalAmountAvailableToBeRefunded(chargeEntity) > 0) {
+            if (RefundCalculator.getTotalAmountAvailableToBeRefunded(chargeEntity, refundEntityList) > 0) {
                 return EXTERNAL_AVAILABLE;
             } else {
                 return EXTERNAL_FULL;

--- a/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 
@@ -40,8 +41,8 @@ public class EpdqExternalRefundAvailabilityCalculator extends DefaultExternalRef
             CAPTURED);
 
     @Override
-    public ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity) {
-        return calculate(chargeEntity, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL);
+    public ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
+        return calculate(chargeEntity, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
@@ -2,9 +2,12 @@ package uk.gov.pay.connector.gateway.util;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.util.List;
 
 public interface ExternalRefundAvailabilityCalculator {
 
-    ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity);
+    ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList);
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalcul
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.applepay.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
@@ -185,8 +186,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
     }
 
     private GatewayOrder buildAuthoriseOrder(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -118,7 +118,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
 
     public List<RefundEntity> findRefundsByChargeExternalId(String chargeExternalId) {
         String query = "SELECT refund FROM RefundEntity refund " +
-                "WHERE refund.chargeExternalId = :chargeExternalId";
+                "WHERE refund.chargeExternalId = :chargeExternalId ORDER BY refund.createdDate ASC";
 
         return entityManager.get()
                 .createQuery(query, RefundEntity.class)

--- a/src/main/java/uk/gov/pay/connector/refund/model/RefundsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/RefundsResponse.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.refund.model;
 import black.door.hate.HalRepresentation;
 import black.door.hate.HalResource;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
@@ -15,7 +16,7 @@ public class RefundsResponse extends HalResourceResponse {
         super(refundHalRepresentation, location);
     }
 
-    public static RefundsResponse valueOf(ChargeEntity chargeEntity, UriInfo uriInfo) {
+    public static RefundsResponse valueOf(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList, UriInfo uriInfo) {
 
         String accountId = chargeEntity.getGatewayAccount().getId().toString();
         String externalChargeId = chargeEntity.getExternalId();
@@ -28,7 +29,7 @@ public class RefundsResponse extends HalResourceResponse {
                 .path("/v1/api/accounts/{accountId}/charges/{chargeId}")
                 .build(accountId, externalChargeId);
 
-        List<HalResource> refunds = chargeEntity.getRefunds().stream()
+        List<HalResource> refunds = refundEntityList.stream()
                 .map(refundEntity -> RefundResponse.valueOf(refundEntity, uriInfo))
                 .collect(Collectors.toList());
 

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import javax.inject.Inject;
+import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.fromString;
@@ -73,7 +74,8 @@ public class ChargeRefundService {
         GatewayAccountEntity gatewayAccountEntity = gatewayAccountDao.findById(accountId).orElseThrow(
                 () -> new GatewayAccountNotFoundException(accountId));
         return chargeDao.findByExternalIdAndGatewayAccount(chargeExternalId, accountId).map(chargeEntity -> {
-            long availableAmount = validateRefundAndGetAvailableAmount(chargeEntity, gatewayAccountEntity, refundRequest);
+            List<RefundEntity> refundEntityList = refundDao.findRefundsByChargeExternalId(chargeEntity.getExternalId());
+            long availableAmount = validateRefundAndGetAvailableAmount(chargeEntity, gatewayAccountEntity, refundRequest, refundEntityList);
             RefundEntity refundEntity = createRefundEntity(refundRequest, chargeEntity);
 
             logger.info("Card refund request sent - charge_external_id={}, status={}, amount={}, transaction_id={}, account_id={}, operation_type=Refund, amount_available_refund={}, amount_requested_refund={}, provider={}, provider_type={}, user_external_id={}",
@@ -162,7 +164,6 @@ public class ChargeRefundService {
         RefundEntity refundEntity = new RefundEntity(charge, refundRequest.getAmount(),
                 refundRequest.getUserExternalId(), refundRequest.getUserEmail());
         transitionRefundState(refundEntity, RefundStatus.CREATED);
-        charge.getRefunds().add(refundEntity);
         refundDao.persist(refundEntity);
 
         return refundEntity;
@@ -233,13 +234,15 @@ public class ChargeRefundService {
 
     private long validateRefundAndGetAvailableAmount(ChargeEntity chargeEntity, 
                                                      GatewayAccountEntity gatewayAccountEntity,
-                                                     RefundRequest refundRequest) {
+                                                     RefundRequest refundRequest,
+                                                     List<RefundEntity> refundEntityList) {
         ExternalChargeRefundAvailability refundAvailability = providers
                 .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
-                .getExternalChargeRefundAvailability(chargeEntity);
+                .getExternalChargeRefundAvailability(chargeEntity, refundEntityList);
         checkIfChargeIsRefundableOrTerminate(chargeEntity, refundAvailability, gatewayAccountEntity);
+        List<RefundEntity> refundEntities = refundDao.findRefundsByChargeExternalId(chargeEntity.getExternalId());
 
-        long availableToBeRefunded = RefundCalculator.getTotalAmountAvailableToBeRefunded(chargeEntity);
+        long availableToBeRefunded = RefundCalculator.getTotalAmountAvailableToBeRefunded(chargeEntity, refundEntities);
         checkIfRefundRequestIsInConflictOrTerminate(refundRequest, chargeEntity, availableToBeRefunded);
 
         checkIfRefundAmountWithinLimitOrTerminate(refundRequest, chargeEntity, refundAvailability, 

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
@@ -139,7 +139,7 @@ public class ParityCheckWorker {
     private ParityCheckStatus getChargeAndRefundsParityCheckStatus(ChargeEntity charge) {
         var parityCheckStatus = getChargeParityCheckStatus(charge);
         if (parityCheckStatus.equals(ParityCheckStatus.EXISTS_IN_LEDGER)) {
-            return getRefundsParityCheckStatus(charge.getRefunds());
+            return getRefundsParityCheckStatus(refundDao.findRefundsByChargeExternalId(charge.getExternalId()));
         }
 
         return parityCheckStatus;

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -38,7 +38,6 @@ public class ChargeEntityFixture {
     private String transactionId;
     private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
     private List<ChargeEventEntity> events = new ArrayList<>();
-    private List<RefundEntity> refunds = new ArrayList<>();
     private Auth3dsDetailsEntity auth3dsDetailsEntity;
     private String providerSessionId;
     private SupportedLanguage language = SupportedLanguage.ENGLISH;
@@ -81,7 +80,6 @@ public class ChargeEntityFixture {
         chargeEntity.setExternalId(externalId);
         chargeEntity.setCorporateSurcharge(corporateSurcharge);
         chargeEntity.getEvents().addAll(events);
-        chargeEntity.getRefunds().addAll(refunds);
         chargeEntity.setProviderSessionId(providerSessionId);
         chargeEntity.set3dsDetails(auth3dsDetailsEntity);
         chargeEntity.setSource(source);
@@ -151,11 +149,6 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withEvents(List<ChargeEventEntity> events) {
         this.events = events;
-        return this;
-    }
-
-    public ChargeEntityFixture withRefunds(List<RefundEntity> refunds) {
-        this.refunds = refunds;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -55,6 +55,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.queue.StateTransitionService;
+import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 import uk.gov.pay.connector.wallets.WalletType;
@@ -162,6 +163,9 @@ public class ChargeServiceTest {
     
     @Mock
     private StateTransitionService mockStateTransitionService;
+
+    @Mock
+    private RefundDao mockRefundDao;
     
     @Captor
     private ArgumentCaptor<ChargeEntity> chargeEntityArgumentCaptor;
@@ -261,12 +265,12 @@ public class ChargeServiceTest {
                 .getBaseUriBuilder();
 
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
-        when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
+        when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class), any(List.class))).thenReturn(EXTERNAL_AVAILABLE);
         when(mockedConfig.getEmitPaymentStateTransitionEvents()).thenReturn(true);
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
-                mockStateTransitionService, mockEventService);
+                mockStateTransitionService, mockEventService, mockRefundDao);
     }
 
     @After

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdated
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,7 +25,7 @@ public class RefundAvailabilityUpdatedTest {
         
         String event = new RefundAvailabilityUpdated(
                 charge.getExternalId(),
-                RefundAvailabilityUpdatedEventDetails.from(charge, ExternalChargeRefundAvailability.EXTERNAL_FULL),
+                RefundAvailabilityUpdatedEventDetails.from(charge, List.of(), ExternalChargeRefundAvailability.EXTERNAL_FULL),
                 ZonedDateTime.now()
         ).toJsonString();
         

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -419,15 +419,6 @@ public class ChargeDaoIT extends DaoITestBase {
         assertThat(charge.getReturnUrl(), is(defaultTestCharge.getReturnUrl()));
         assertThat(charge.getCreatedDate(), is(defaultTestCharge.getCreatedDate()));
         assertThat(charge.getCardDetails().getCardBrand(), is(defaultTestCardDetails.getCardBrand()));
-
-        assertThat(charge.getRefunds().size(), is(1));
-        RefundEntity refund = charge.getRefunds().get(0);
-        assertThat(refund.getId(), is(defaultTestRefund.getId()));
-        assertThat(refund.getAmount(), is(defaultTestRefund.getAmount()));
-        assertThat(refund.getStatus(), is(defaultTestRefund.getStatus()));
-        assertThat(refund.getCreatedDate(), is(defaultTestRefund.getCreatedDate()));
-        assertThat(refund.getChargeEntity().getId(), is(defaultTestCharge.getChargeId()));
-        assertNotNull(refund.getVersion());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/RefundResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/RefundResponseTest.java
@@ -16,6 +16,8 @@ import uk.gov.pay.connector.refund.model.RefundsResponse;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import java.util.List;
+
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -61,8 +63,7 @@ public class RefundResponseTest {
         RefundEntity refund1 = RefundEntityFixture.aValidRefundEntity().withAmount(10L).withStatus(RefundStatus.REFUNDED).build();
         RefundEntity refund2 = RefundEntityFixture.aValidRefundEntity().withAmount(20L).withStatus(RefundStatus.CREATED).build();
 
-        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withRefunds(newArrayList(refund1, refund2)).build();
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
 
         String chargeId = chargeEntity.getExternalId();
         String refundIdRefund1 = refund1.getExternalId();
@@ -75,7 +76,7 @@ public class RefundResponseTest {
                 UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"), UriBuilder.fromUri("http://app.com"));
 
         // when
-        String serializedResponse = RefundsResponse.valueOf(chargeEntity, mockUriInfo).serialize();
+        String serializedResponse = RefundsResponse.valueOf(chargeEntity, List.of(refund1, refund2), mockUriInfo).serialize();
 
         // then
         JsonAssert.with(serializedResponse)

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -67,7 +67,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, mockStateTransitionService, mockEventService);
+                null, mockConfiguration, null, mockStateTransitionService, mockEventService, mockedRefundDao);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -115,7 +115,8 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, stateTransitionService, mockEventService);
+                null, null, mockConfiguration, null,
+                stateTransitionService, mockEventService, mockedRefundDao);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -38,6 +38,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 import uk.gov.pay.connector.queue.CaptureQueue;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.StateTransitionService;
+import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import javax.persistence.OptimisticLockException;
@@ -105,6 +106,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private StateTransitionService mockStateTransitionService;
     @Mock
     private EventService mockEventService;
+    @Mock
+    private RefundDao mockRefundDao;
 
     @Before
     public void beforeTest() {
@@ -113,7 +116,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, mockStateTransitionService, mockEventService);
+                null, null, mockConfiguration, null,
+                mockStateTransitionService, mockEventService, mockRefundDao);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.refund.dao.RefundDao;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -31,6 +32,7 @@ public abstract class CardServiceTest {
     protected ChargeService chargeService;
     protected ChargeEventDao mockedChargeEventDao = mock(ChargeEventDao.class);
     protected CardTypeDao mockedCardTypeDao = mock(CardTypeDao.class);
+    protected RefundDao mockedRefundDao = mock(RefundDao.class);
 
     protected ChargeEntity createNewChargeWith(Long chargeId, ChargeStatus status) {
         ChargeEntity entity = ChargeEntityFixture

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.refund.service.ChargeRefundResponse;
 import uk.gov.pay.connector.refund.service.ChargeRefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -91,7 +92,7 @@ public class ChargeRefundServiceTest {
     public void setUp() {
         refundId = ThreadLocalRandom.current().nextLong();
         when(mockProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockProvider);
-        when(mockProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class))).thenReturn(EXTERNAL_AVAILABLE);
+        when(mockProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class), any(List.class))).thenReturn(EXTERNAL_AVAILABLE);
         chargeRefundService = new ChargeRefundService(
                 mockChargeDao, mockRefundDao, mockGatewayAccountDao, mockProviders, mockUserNotificationService, mockStateTransitionService
         );
@@ -144,7 +145,7 @@ public class ChargeRefundServiceTest {
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_SUBMITTED);
         verify(spiedRefundEntity).setReference(refundEntity.getExternalId());
 
-        verifyNoMoreInteractions(mockChargeDao, mockRefundDao);
+        verifyNoMoreInteractions(mockChargeDao);
     }
 
     @Test
@@ -225,7 +226,7 @@ public class ChargeRefundServiceTest {
         verify(spiedRefundEntity, never()).setStatus(RefundStatus.REFUNDED);
         verify(spiedRefundEntity).setReference(reference);
 
-        verifyNoMoreInteractions(mockChargeDao, mockRefundDao);
+        verifyNoMoreInteractions(mockChargeDao);
     }
 
     @Test
@@ -401,7 +402,7 @@ public class ChargeRefundServiceTest {
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_SUBMITTED);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUNDED);
 
-        verifyNoMoreInteractions(mockChargeDao, mockRefundDao);
+        verifyNoMoreInteractions(mockChargeDao);
     }
 
     @Test
@@ -561,7 +562,7 @@ public class ChargeRefundServiceTest {
         verify(mockRefundDao, times(1)).findById(refundId);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_ERROR);
 
-        verifyNoMoreInteractions(mockChargeDao, mockRefundDao);
+        verifyNoMoreInteractions(mockChargeDao);
     }
     @Test
     public void shouldOfferRefundStateTransition() {

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -51,33 +51,33 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
 
     @Test
     public void testGetChargeRefundAvailabilityReturnsPending() {
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CREATED)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(ENTERING_CARD_DETAILS)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_READY)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_REQUIRED)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_READY)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUBMITTED)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUCCESS)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_READY)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED_RETRY)), is(EXTERNAL_PENDING));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED)), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CREATED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(ENTERING_CARD_DETAILS), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_READY), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_REQUIRED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_READY), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUBMITTED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUCCESS), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_READY), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED_RETRY), List.of()), is(EXTERNAL_PENDING));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED), List.of()), is(EXTERNAL_PENDING));
     }
 
     @Test
     public void testGetChargeRefundAvailabilityReturnsUnavailable() {
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_REJECTED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_ERROR)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_ERROR)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_READY)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_FAILED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_READY)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_ERROR)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCELLED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_READY)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCELLED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_ERROR)), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_REJECTED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_READY), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_FAILED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_READY), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCELLED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_READY), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCELLED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
     }
 
     @Test
@@ -89,12 +89,12 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(199L).build()
         );
 
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L, refunds)), is(EXTERNAL_AVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L), refunds), is(EXTERNAL_AVAILABLE));
     }
 
     @Test
     public void shouldGetChargeRefundAvailabilityAsUnavailable_whenChargeStatusIsInANonRefundableState() {
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED, 500L)), is(EXTERNAL_UNAVAILABLE));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED, 500L), List.of()), is(EXTERNAL_UNAVAILABLE));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(200L).build()
         );
 
-        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L, refunds)), is(EXTERNAL_FULL));
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L), refunds), is(EXTERNAL_FULL));
 
     }
 
@@ -118,10 +118,4 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
         return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build();
     }
-
-    private static ChargeEntity chargeEntity(ChargeStatus status, long amount, List<RefundEntity> refunds) {
-        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).withRefunds(refunds).build();
-    }
-
 }

--- a/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
@@ -52,32 +52,32 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
     
     @Test
     public void testGetChargeRefundAvailabilityReturnsPending() {
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CREATED)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(ENTERING_CARD_DETAILS)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_READY)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_REQUIRED)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_READY)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUBMITTED)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUCCESS)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_READY)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED)), is(EXTERNAL_PENDING));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED_RETRY)), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CREATED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(ENTERING_CARD_DETAILS), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_READY), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_REQUIRED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_3DS_READY), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUBMITTED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_SUCCESS), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_READY), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED), List.of()), is(EXTERNAL_PENDING));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_APPROVED_RETRY), List.of()), is(EXTERNAL_PENDING));
     }
 
     @Test
     public void testGetChargeRefundAvailabilityReturnsUnavailable() {
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_REJECTED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_ERROR)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_ERROR)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_READY)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_FAILED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_READY)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_ERROR)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCELLED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_READY)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCELLED)), is(EXTERNAL_UNAVAILABLE));
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_ERROR)), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_REJECTED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(AUTHORISATION_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_READY), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRE_CANCEL_FAILED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_READY), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCEL_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(SYSTEM_CANCELLED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_READY), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCELLED), List.of()), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(USER_CANCEL_ERROR), List.of()), is(EXTERNAL_UNAVAILABLE));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(199L).build()
         );
 
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L, refunds)), is(EXTERNAL_AVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L), refunds), is(EXTERNAL_AVAILABLE));
     }
 
     @Test
@@ -101,12 +101,12 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(199L).build()
         );
 
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L, refunds)), is(EXTERNAL_AVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L), refunds), is(EXTERNAL_AVAILABLE));
     }
 
     @Test
     public void shouldGetChargeRefundAvailabilityAsUnavailable_whenChargeStatusIsInANonRefundableState() {
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED, 500L)), is(EXTERNAL_UNAVAILABLE));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(EXPIRED, 500L), List.of()), is(EXTERNAL_UNAVAILABLE));
     }
 
     @Test
@@ -117,7 +117,7 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(200L).build()
         );
 
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L, refunds)), is(EXTERNAL_FULL));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L), refunds), is(EXTERNAL_FULL));
     }
 
     @Test
@@ -128,7 +128,7 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(200L).build()
         );
 
-        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L, refunds)), is(EXTERNAL_FULL));
+        assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L), refunds), is(EXTERNAL_FULL));
     }
 
     private static ChargeEntity chargeEntity(ChargeStatus status) {
@@ -140,10 +140,4 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
         return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build();
     }
-
-    private static ChargeEntity chargeEntity(ChargeStatus status, long amount, List<RefundEntity> refunds) {
-        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).withRefunds(refunds).build();
-    }
-
 }

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -134,7 +134,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
-                null, null, mockConfiguration, null, mockStateTransitionService, mockEventService));
+                null, null, mockConfiguration, null, mockStateTransitionService,
+                mockEventService, mockedRefundDao));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
## WHAT YOU DID
- remove mapping of RefundEntitys from ChargeEntity
- update/refactor everything that uses getRefunds()
- update/refactor tests
