### PR TITLE
PP-6092 Clarify charge external ID during refund

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -80,7 +80,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .findFirst();
     }
 
-    public Optional<ChargeEntity> findByExternalIdAndGatewayAccount(String externalId, Long accountId) {
+    public Optional<ChargeEntity> findByExternalIdAndGatewayAccount(String chargeExternalId, Long accountId) {
 
         String query = "SELECT c FROM ChargeEntity c " +
                 "WHERE c.externalId = :externalId " +
@@ -88,7 +88,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)
-                .setParameter("externalId", externalId)
+                .setParameter("externalId", chargeExternalId)
                 .setParameter("accountId", accountId)
                 .getResultList().stream().findFirst();
     }

--- a/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
@@ -46,9 +46,9 @@ public class ChargeRefundsResource {
     @Path("/v1/api/accounts/{accountId}/charges/{chargeId}/refunds")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public Response submitRefund(@PathParam("accountId") Long accountId, @PathParam("chargeId") String chargeId, RefundRequest refundRequest, @Context UriInfo uriInfo) {
+    public Response submitRefund(@PathParam("accountId") Long accountId, @PathParam("chargeId") String chargeExternalId, RefundRequest refundRequest, @Context UriInfo uriInfo) {
         validateRefundRequest(refundRequest.getAmount());
-        final ChargeRefundResponse refundServiceResponse = refundService.doRefund(accountId, chargeId, refundRequest);
+        final ChargeRefundResponse refundServiceResponse = refundService.doRefund(accountId, chargeExternalId, refundRequest);
         GatewayRefundResponse refundResponse = refundServiceResponse.getGatewayRefundResponse();
         if (refundResponse.isSuccessful()) {
             return Response.accepted(RefundResponse.valueOf(refundServiceResponse.getRefundEntity(), uriInfo).serialize()).build();


### PR DESCRIPTION
`chargeId` can be conflated with the charge id column in the database,
clarify that this is the external identifier being used.