### PR TITLE
PP-6097 Add ExpungeResource

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
 import uk.gov.pay.connector.common.exception.UnsupportedOperationExceptionMapper;
 import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
 import uk.gov.pay.connector.events.resource.EmittedEventResource;
+import uk.gov.pay.connector.expunge.resource.ExpungeResource;
 import uk.gov.pay.connector.filters.LoggingMDCRequestFilter;
 import uk.gov.pay.connector.filters.LoggingMDCResponseFilter;
 import uk.gov.pay.connector.filters.SchemeRewriteFilter;
@@ -127,6 +128,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(ChargeEventsResource.class));
         environment.jersey().register(injector.getInstance(SecurityTokensResource.class));
         environment.jersey().register(injector.getInstance(ChargesApiResource.class));
+        environment.jersey().register(injector.getInstance(ExpungeResource.class));
         environment.jersey().register(injector.getInstance(ChargesFrontendResource.class));
         environment.jersey().register(injector.getInstance(ChargeRefundsResource.class));
         environment.jersey().register(injector.getInstance(NotificationResource.class));

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -6,6 +6,7 @@ import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
 import uk.gov.pay.connector.app.config.EventEmitterConfig;
+import uk.gov.pay.connector.app.config.ExpungeConfig;
 import uk.gov.pay.connector.app.config.RestClientConfig;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 
@@ -75,6 +76,11 @@ public class ConnectorConfiguration extends Configuration {
 
     @NotNull
     private EventEmitterConfig eventEmitterConfig;
+
+    @Valid
+    @NotNull
+    @JsonProperty("expungeConfig")
+    private ExpungeConfig expungeConfig;
 
     @NotNull
     private String graphiteHost;
@@ -215,5 +221,9 @@ public class ConnectorConfiguration extends Configuration {
 
     public EventEmitterConfig getEventEmitterConfig() {
         return eventEmitterConfig;
+    }
+
+    public ExpungeConfig getExpungeConfig() {
+        return expungeConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.app.config;
+
+import io.dropwizard.Configuration;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+public class ExpungeConfig extends Configuration {
+
+    @Valid
+    @NotNull
+    private int minimumAgeOfChargeInDays;
+    
+    @Valid
+    @NotNull
+    @Min(1)
+    private int numberOfChargesToExpunge;
+
+    public int getMinimumAgeOfChargeInDays() {
+        return minimumAgeOfChargeInDays;
+    }
+
+    public int getNumberOfChargesToExpunge() {
+        return numberOfChargesToExpunge;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.expunge.resource;
+
+import uk.gov.pay.connector.expunge.service.ChargeExpungeService;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.status;
+
+@Path("/")
+public class ExpungeResource {
+
+    private ChargeExpungeService chargeExpungeService;
+
+    @Inject
+    public ExpungeResource(ChargeExpungeService chargeExpungeService) {
+        this.chargeExpungeService = chargeExpungeService;
+    }
+
+    @POST
+    @Path("/v1/tasks/expunge")
+    @Produces(APPLICATION_JSON)
+    public Response expungeCharges(@QueryParam("number_of_charges_to_expire") Integer noOfChargesToExpunge) {
+        chargeExpungeService.expunge(noOfChargesToExpunge);
+        return status(OK).build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.expunge.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.ExpungeConfig;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+
+public class ChargeExpungeService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final ChargeDao chargeDao;
+    private final ExpungeConfig expungeConfig;
+
+    @Inject
+    public ChargeExpungeService(ChargeDao chargeDao, ConnectorConfiguration connectorConfiguration) {
+        this.chargeDao = chargeDao;
+        expungeConfig = connectorConfiguration.getExpungeConfig();
+    }
+
+    public void expunge(Integer noOfChargesToExpungeQueryParam) {
+        int noOfChargesToExpunge = getNumberOfChargesToExpunge(noOfChargesToExpungeQueryParam);
+
+        int noOfChargesProcessed = 0;
+
+        while (noOfChargesProcessed < noOfChargesToExpunge) {
+            Optional<ChargeEntity> mayBeChargeEntity = chargeDao.findChargeToExpunge(expungeConfig.getMinimumAgeOfChargeInDays());
+
+            mayBeChargeEntity.ifPresent(chargeEntity -> {
+                // TODO: in PP-6098 
+                // Parity check charges with Ledger and 1. delete charge if matches or 2. update charge with parity_check_date
+
+                logger.info("Charge expunged from connector", kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()));
+            });
+
+            if (mayBeChargeEntity.isEmpty())
+                break;
+            noOfChargesProcessed++;
+        }
+    }
+
+    private int getNumberOfChargesToExpunge(Integer noOfChargesToExpungeQueryParam) {
+        if (noOfChargesToExpungeQueryParam != null && noOfChargesToExpungeQueryParam > 0) {
+            return noOfChargesToExpungeQueryParam;
+        }
+        return expungeConfig.getNumberOfChargesToExpunge();
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -232,3 +232,7 @@ restClientConfig:
   disabledSecureConnection: ${DISABLE_INTERNAL_HTTPS:-false}
 
 ledgerBaseURL: ${LEDGER_URL}
+
+expungeConfig:
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.expunge.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.app.config.ExpungeConfig;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ChargeExpungeServiceTest {
+
+    private ChargeEntity chargeEntity = new ChargeEntity();
+    private ChargeExpungeService chargeExpungeService;
+    private int minimumAgeOfChargeInDays = 3;
+    private int defaultNumberOfChargesToExpunge = 10;
+
+    @Mock
+    private ExpungeConfig mockExpungeConfig;
+    @Mock
+    private ChargeDao mockChargeDao;
+    @Mock
+    private ConnectorConfiguration mockConnectorConfiguration;
+
+    @Before
+    public void setUp() {
+        when(mockConnectorConfiguration.getExpungeConfig()).thenReturn(mockExpungeConfig);
+        when(mockExpungeConfig.getNumberOfChargesToExpunge()).thenReturn(defaultNumberOfChargesToExpunge);
+        when(mockExpungeConfig.getMinimumAgeOfChargeInDays()).thenReturn(minimumAgeOfChargeInDays);
+
+        when(mockChargeDao.findChargeToExpunge(minimumAgeOfChargeInDays)).thenReturn(Optional.of(chargeEntity));
+        chargeExpungeService = new ChargeExpungeService(mockChargeDao, mockConnectorConfiguration);
+    }
+
+    @Test
+    public void expunge_shouldExpungeCharges() {
+        chargeExpungeService.expunge(2);
+        verify(mockChargeDao, times(2)).findChargeToExpunge(minimumAgeOfChargeInDays);
+    }
+
+    @Test
+    public void expunge_shouldExpungeNoOfChargesAsPerConfiguration() {
+        chargeExpungeService.expunge(null);
+        verify(mockChargeDao, times(defaultNumberOfChargesToExpunge)).findChargeToExpunge(minimumAgeOfChargeInDays);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.it.resources;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class ExpungeResourceIT {
+
+    @DropwizardTestContext
+    protected TestContext testContext;
+
+    public ExpungeResourceIT() {
+    }
+
+    @Test
+    public void shouldExpireChargesBeforeAndAfterAuthorisationAndShouldHaveTheRightEvents() {
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .post("/v1/tasks/expunge")
+                .then()
+                .statusCode(200);
+
+        // TODO: in PP-6098 
+        // insert charges and assert that the charge has been expunged or marked as parity checked
+    }
+
+}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -177,3 +177,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+
+expungeConfig:
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -176,3 +176,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+
+expungeConfig:
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -166,3 +166,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+
+expungeConfig:
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -172,3 +172,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+
+expungeConfig:
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -171,3 +171,7 @@ restClientConfig:
   disabledSecureConnection: true
 
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
+
+expungeConfig:
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}


### PR DESCRIPTION
## WHAT YOU DID
- Added new resource ExpungeResource (`POST /v1/tasks/expunge`) which can be invoked by scheduler or manually to expunge charges of given batch size
- `ChargeExpungeService` skeleton, which gets a charge to expunge and does nothing. Parity checking and expunging charge to be covered in PP-6098
- Relevant tests
