### PR TITLE
PP-6092 Refund process uses simple Charge POJO

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -1,5 +1,9 @@
 package uk.gov.pay.connector.charge.model.domain;
 
+import uk.gov.pay.connector.common.model.api.ExternalChargeState;
+
+import java.util.Optional;
+
 public class Charge {
 
     private String externalId;
@@ -7,13 +11,28 @@ public class Charge {
     private String status;
     private String gatewayTransactionId;
     private Long corporateSurcharge;
+    private String externalRefundState;
+    private boolean inFlight;
 
-    public Charge(String externalId, Long amount, String status, String gatewayTransactionId, Long corporateSurcharge) {
+    public Charge(String externalId, Long amount, String status, String gatewayTransactionId, Long corporateSurcharge, String externalRefundState, boolean inFlight) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
         this.gatewayTransactionId = gatewayTransactionId;
         this.corporateSurcharge = corporateSurcharge;
+        this.externalRefundState = externalRefundState;
+        this.inFlight = inFlight;
+    }
+    
+    public static Charge from(ChargeEntity chargeEntity) {
+        return new Charge(
+                chargeEntity.getExternalId(),
+                chargeEntity.getAmount(),
+                chargeEntity.getStatus(),
+                chargeEntity.getGatewayTransactionId(),
+                chargeEntity.getCorporateSurcharge().orElse(null),
+                null, 
+                true);
     }
 
     public String getExternalId() {
@@ -32,7 +51,15 @@ public class Charge {
         return gatewayTransactionId;
     }
 
-    public Long getCorporateSurcharge() {
-        return corporateSurcharge;
+    public Optional<Long> getCorporateSurcharge() {
+        return Optional.ofNullable(corporateSurcharge);
+    }
+
+    public boolean isInFlight() {
+        return inFlight;
+    }
+
+    public String getExternalRefundState() {
+        return externalRefundState;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.charge.model.domain;
+
+public class Charge {
+
+    private String externalId;
+    private Long amount;
+    private String status;
+    private String gatewayTransactionId;
+    private Long corporateSurcharge;
+
+    public Charge(String externalId, Long amount, String status, String gatewayTransactionId, Long corporateSurcharge) {
+        this.externalId = externalId;
+        this.amount = amount;
+        this.status = status;
+        this.gatewayTransactionId = gatewayTransactionId;
+        this.corporateSurcharge = corporateSurcharge;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public Long getCorporateSurcharge() {
+        return corporateSurcharge;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.telephone.PaymentOutcome;
 import uk.gov.pay.connector.charge.model.telephone.Supplemental;
 import uk.gov.pay.connector.charge.model.telephone.TelephoneChargeCreateRequest;
@@ -267,6 +268,11 @@ public class ChargeService {
                     return Optional.of(chargeEntity);
                 })
                 .orElseGet(Optional::empty);
+    }
+
+    public Optional<Charge> findCharge(String chargeExternalId, Long gatewayAccountId) {
+        return chargeDao.findByExternalIdAndGatewayAccount(chargeExternalId, gatewayAccountId)
+                .map(Charge::from);
     }
 
     @Transactional
@@ -711,9 +717,9 @@ public class ChargeService {
     private ChargeResponse.RefundSummary buildRefundSummary(ChargeEntity charge) {
         ChargeResponse.RefundSummary refund = new ChargeResponse.RefundSummary();
         List<RefundEntity> refundEntityList = refundDao.findRefundsByChargeExternalId(charge.getExternalId());
-        refund.setStatus(providers.byName(charge.getPaymentGatewayName()).getExternalChargeRefundAvailability(charge, refundEntityList).getStatus());
+        refund.setStatus(providers.byName(charge.getPaymentGatewayName()).getExternalChargeRefundAvailability(Charge.from(charge), refundEntityList).getStatus());
         refund.setAmountSubmitted(RefundCalculator.getRefundedAmount(refundEntityList));
-        refund.setAmountAvailable(RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntityList));
+        refund.setAmountAvailable(RefundCalculator.getTotalAmountAvailableToBeRefunded(Charge.from(charge), refundEntityList));
         return refund;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/CorporateCardSurchargeCalculator.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.util;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 
@@ -13,10 +14,16 @@ public class CorporateCardSurchargeCalculator {
         // prevent Java for adding a public constructor
     }
 
-    public static Long getTotalAmountFor(ChargeEntity charge) {
+    public static Long getTotalAmountFor(Charge charge) {
         return charge.getCorporateSurcharge()
                 .map(surcharge -> surcharge + charge.getAmount())
                 .orElseGet(charge::getAmount);
+    }
+
+    public static Long getTotalAmountFor(ChargeEntity chargeEntity) {
+        return chargeEntity.getCorporateSurcharge()
+                .map(surcharge -> surcharge + chargeEntity.getAmount())
+                .orElseGet(chargeEntity::getAmount);
     }
 
     public static Optional<Long> getCorporateCardSurchargeFor(AuthCardDetails authCardDetails, ChargeEntity chargeEntity) {

--- a/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.charge.util;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
@@ -13,6 +14,10 @@ public class RefundCalculator {
 
     private RefundCalculator() {
         // prevent Java for adding a public constructor
+    }
+
+    public static long getTotalAmountAvailableToBeRefunded(Charge charge, List<RefundEntity> refundEntities) {
+        return CorporateCardSurchargeCalculator.getTotalAmountFor(charge) - getRefundedAmount(refundEntities);
     }
 
     public static long getTotalAmountAvailableToBeRefunded(ChargeEntity chargeEntity, List<RefundEntity> refundEntities) {

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.model;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
@@ -161,7 +162,7 @@ public class EventFactory {
                                                 refundEntityList,
                                                 paymentProviders
                                                         .byName(charge.getPaymentGatewayName())
-                                                        .getExternalChargeRefundAvailability(charge, refundEntityList)
+                                                        .getExternalChargeRefundAvailability(Charge.from(charge), refundEntityList)
                                         ),
                                         eventTimestamp
                                 );

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -38,5 +39,5 @@ public interface PaymentProvider {
 
     GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayException;
 
-    ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList);
+    ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList);
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -5,6 +5,7 @@ import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.*;
@@ -217,8 +218,8 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
     }
 
     /**

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
@@ -93,8 +94,8 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
     }
 
     private GatewayResponse<BaseCancelResponse> createGatewayBaseCancelResponse() {

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.smartpay;
 
 import io.dropwizard.setup.Environment;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
@@ -148,8 +149,8 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
     }
 
     private GatewayOrder buildAuthoriseOrderFor(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
@@ -182,7 +183,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.util;
 
 import com.google.common.collect.ImmutableList;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
@@ -46,17 +47,17 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
     private static final List<ChargeStatus> STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL = ImmutableList.of(CAPTURED);
 
     @Override
-    public ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
-        return calculate(chargeEntity, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+    public ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList) {
+        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
     }
 
-    protected ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<ChargeStatus> statusesThatMapToExternalPending,
+    protected ExternalChargeRefundAvailability calculate(Charge charge, List<ChargeStatus> statusesThatMapToExternalPending,
                                                          List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull,
                                                          List<RefundEntity> refundEntityList) {
-        if (chargeIsPending(chargeEntity, statusesThatMapToExternalPending)) {
+        if (chargeIsPending(charge, statusesThatMapToExternalPending)) {
             return EXTERNAL_PENDING;
-        } else if (chargeIsAvailableOrFull(chargeEntity, statusesThatMapToExternalAvailableOrExternalFull)) {
-            if (RefundCalculator.getTotalAmountAvailableToBeRefunded(chargeEntity, refundEntityList) > 0) {
+        } else if (chargeIsAvailableOrFull(charge, statusesThatMapToExternalAvailableOrExternalFull)) {
+            if (RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntityList) > 0) {
                 return EXTERNAL_AVAILABLE;
             } else {
                 return EXTERNAL_FULL;
@@ -65,11 +66,11 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
         return EXTERNAL_UNAVAILABLE;
     }
 
-    private boolean chargeIsAvailableOrFull(ChargeEntity chargeEntity, List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull) {
-        return statusesThatMapToExternalAvailableOrExternalFull.contains(ChargeStatus.fromString(chargeEntity.getStatus()));
+    private boolean chargeIsAvailableOrFull(Charge charge, List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull) {
+        return statusesThatMapToExternalAvailableOrExternalFull.contains(ChargeStatus.fromString(charge.getStatus()));
     }
 
-    private boolean chargeIsPending(ChargeEntity chargeEntity, List<ChargeStatus> statusesThatMapToExternalPending) {
-        return statusesThatMapToExternalPending.contains(ChargeStatus.fromString(chargeEntity.getStatus()));
+    private boolean chargeIsPending(Charge charge, List<ChargeStatus> statusesThatMapToExternalPending) {
+        return statusesThatMapToExternalPending.contains(ChargeStatus.fromString(charge.getStatus()));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.util;
 
 import com.google.common.collect.ImmutableList;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
@@ -41,8 +42,8 @@ public class EpdqExternalRefundAvailabilityCalculator extends DefaultExternalRef
             CAPTURED);
 
     @Override
-    public ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
-        return calculate(chargeEntity, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+    public ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList) {
+        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.util;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
@@ -8,6 +9,6 @@ import java.util.List;
 
 public interface ExternalRefundAvailabilityCalculator {
 
-    ExternalChargeRefundAvailability calculate(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList);
+    ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList);
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -6,6 +6,7 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
@@ -186,8 +187,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(ChargeEntity chargeEntity, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(chargeEntity, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
     }
 
     private GatewayOrder buildAuthoriseOrder(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -5,9 +5,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
@@ -38,7 +41,7 @@ public class ChargeRefundService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final ChargeDao chargeDao;
+    private final ChargeService chargeService;
     private final RefundDao refundDao;
     private final GatewayAccountDao gatewayAccountDao;
     private final PaymentProviders providers;
@@ -46,10 +49,10 @@ public class ChargeRefundService {
     private StateTransitionService stateTransitionService;
 
     @Inject
-    public ChargeRefundService(ChargeDao chargeDao, RefundDao refundDao, GatewayAccountDao gatewayAccountDao, PaymentProviders providers,
+    public ChargeRefundService(ChargeService chargeService, RefundDao refundDao, GatewayAccountDao gatewayAccountDao, PaymentProviders providers,
                                UserNotificationService userNotificationService, StateTransitionService stateTransitionService
     ) {
-        this.chargeDao = chargeDao;
+        this.chargeService = chargeService;
         this.refundDao = refundDao;
         this.gatewayAccountDao = gatewayAccountDao;
         this.providers = providers;
@@ -73,16 +76,16 @@ public class ChargeRefundService {
     public RefundEntity createRefund(Long accountId, String chargeExternalId, RefundRequest refundRequest) {
         GatewayAccountEntity gatewayAccountEntity = gatewayAccountDao.findById(accountId).orElseThrow(
                 () -> new GatewayAccountNotFoundException(accountId));
-        return chargeDao.findByExternalIdAndGatewayAccount(chargeExternalId, accountId).map(chargeEntity -> {
-            List<RefundEntity> refundEntityList = refundDao.findRefundsByChargeExternalId(chargeEntity.getExternalId());
-            long availableAmount = validateRefundAndGetAvailableAmount(chargeEntity, gatewayAccountEntity, refundRequest, refundEntityList);
-            RefundEntity refundEntity = createRefundEntity(refundRequest, chargeEntity);
+        return chargeService.findCharge(chargeExternalId, gatewayAccountEntity.getId()).map(charge -> {
+            List<RefundEntity> refundEntityList = refundDao.findRefundsByChargeExternalId(charge.getExternalId());
+            long availableAmount = validateRefundAndGetAvailableAmount(charge, gatewayAccountEntity, refundRequest, refundEntityList);
+            RefundEntity refundEntity = createRefundEntity(refundRequest, charge);
 
             logger.info("Card refund request sent - charge_external_id={}, status={}, amount={}, transaction_id={}, account_id={}, operation_type=Refund, amount_available_refund={}, amount_requested_refund={}, provider={}, provider_type={}, user_external_id={}",
-                    chargeEntity.getExternalId(),
-                    fromString(chargeEntity.getStatus()),
-                    chargeEntity.getAmount(),
-                    chargeEntity.getGatewayTransactionId(),
+                    charge.getExternalId(),
+                    fromString(charge.getStatus()),
+                    charge.getAmount(),
+                    charge.getGatewayTransactionId(),
                     gatewayAccountEntity.getId(),
                     availableAmount,
                     refundRequest.getAmount(),
@@ -160,8 +163,10 @@ public class ChargeRefundService {
 
     @Transactional
     @SuppressWarnings("WeakerAccess")
-    public RefundEntity createRefundEntity(RefundRequest refundRequest, ChargeEntity charge) {
-        RefundEntity refundEntity = new RefundEntity(charge, refundRequest.getAmount(),
+    public RefundEntity createRefundEntity(RefundRequest refundRequest, Charge charge) {
+        // @TODO(sfount) PP-6095 remove charge entity from refund entity - we can then rely solely on the Charge POJO
+        ChargeEntity chargeEntity = chargeService.findChargeById(charge.getExternalId());
+        RefundEntity refundEntity = new RefundEntity(chargeEntity, refundRequest.getAmount(),
                 refundRequest.getUserExternalId(), refundRequest.getUserEmail());
         transitionRefundState(refundEntity, RefundStatus.CREATED);
         refundDao.persist(refundEntity);
@@ -174,7 +179,7 @@ public class ChargeRefundService {
         stateTransitionService.offerRefundStateTransition(refundEntity, refundStatus);
     }
 
-    private void checkIfRefundRequestIsInConflictOrTerminate(RefundRequest refundRequest, ChargeEntity reloadedCharge, long totalAmountToBeRefunded) {
+    private void checkIfRefundRequestIsInConflictOrTerminate(RefundRequest refundRequest, Charge reloadedCharge, long totalAmountToBeRefunded) {
         if (totalAmountToBeRefunded != refundRequest.getAmountAvailableForRefund()) {
             logger.info("Refund request has a mismatch on amount available for refund - charge_external_id={}, amount_actually_available_for_refund={}, refund_amount_available_in_request={}",
                     reloadedCharge.getExternalId(), totalAmountToBeRefunded, refundRequest.getAmountAvailableForRefund());
@@ -182,7 +187,7 @@ public class ChargeRefundService {
         }
     }
 
-    private void checkIfRefundAmountWithinLimitOrTerminate(RefundRequest refundRequest, ChargeEntity reloadedCharge, ExternalChargeRefundAvailability refundAvailability, GatewayAccountEntity gatewayAccount, long totalAmountToBeRefunded) {
+    private void checkIfRefundAmountWithinLimitOrTerminate(RefundRequest refundRequest, Charge reloadedCharge, ExternalChargeRefundAvailability refundAvailability, GatewayAccountEntity gatewayAccount, long totalAmountToBeRefunded) {
         if (totalAmountToBeRefunded - refundRequest.getAmount() < 0) {
 
             logger.info("Charge doesn't have sufficient amount for refund - charge_external_id={}, status={}, refund_status={}, account_id={}, operation_type=Refund, provider={}, provider_type={}, amount_available_refund={}, amount_requested_refund={}",
@@ -199,11 +204,11 @@ public class ChargeRefundService {
         }
     }
 
-    private void checkIfChargeIsRefundableOrTerminate(ChargeEntity reloadedCharge, ExternalChargeRefundAvailability refundAvailability, GatewayAccountEntity gatewayAccount) {
+    private void checkIfChargeIsRefundableOrTerminate(Charge reloadedCharge, ExternalChargeRefundAvailability refundAvailability, GatewayAccountEntity gatewayAccount) {
         if (EXTERNAL_AVAILABLE != refundAvailability) {
 
             logger.warn("Charge not available for refund - charge_external_id={}, status={}, refund_status={}, account_id={}, operation_type=Refund, provider={}, provider_type={}",
-                    reloadedCharge.getId(),
+                    reloadedCharge.getExternalId(),
                     fromString(reloadedCharge.getStatus()),
                     refundAvailability,
                     gatewayAccount.getId(),
@@ -232,20 +237,28 @@ public class ChargeRefundService {
         } else return Optional.empty();
     }
 
-    private long validateRefundAndGetAvailableAmount(ChargeEntity chargeEntity, 
+    private long validateRefundAndGetAvailableAmount(Charge charge,
                                                      GatewayAccountEntity gatewayAccountEntity,
                                                      RefundRequest refundRequest,
                                                      List<RefundEntity> refundEntityList) {
-        ExternalChargeRefundAvailability refundAvailability = providers
-                .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
-                .getExternalChargeRefundAvailability(chargeEntity, refundEntityList);
-        checkIfChargeIsRefundableOrTerminate(chargeEntity, refundAvailability, gatewayAccountEntity);
-        List<RefundEntity> refundEntities = refundDao.findRefundsByChargeExternalId(chargeEntity.getExternalId());
+        ExternalChargeRefundAvailability refundAvailability;
+        
+        if(charge.isInFlight()) {
+            refundAvailability = providers
+                    .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
+                    .getExternalChargeRefundAvailability(charge, refundEntityList);
+            checkIfChargeIsRefundableOrTerminate(charge, refundAvailability, gatewayAccountEntity);
+        } else {
+            refundAvailability = ExternalChargeRefundAvailability.valueOf(charge.getExternalRefundState());
+            checkIfChargeIsRefundableOrTerminate(charge, refundAvailability, gatewayAccountEntity);
+        }
+        
+        List<RefundEntity> refundEntities = refundDao.findRefundsByChargeExternalId(charge.getExternalId());
 
-        long availableToBeRefunded = RefundCalculator.getTotalAmountAvailableToBeRefunded(chargeEntity, refundEntities);
-        checkIfRefundRequestIsInConflictOrTerminate(refundRequest, chargeEntity, availableToBeRefunded);
+        long availableToBeRefunded = RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntities);
+        checkIfRefundRequestIsInConflictOrTerminate(refundRequest, charge, availableToBeRefunded);
 
-        checkIfRefundAmountWithinLimitOrTerminate(refundRequest, chargeEntity, refundAvailability, 
+        checkIfRefundAmountWithinLimitOrTerminate(refundRequest, charge, refundAvailability, 
                 gatewayAccountEntity, availableToBeRefunded);
 
         return availableToBeRefunded;

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.PrefilledCardHolderDetails;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -265,7 +266,7 @@ public class ChargeServiceTest {
                 .getBaseUriBuilder();
 
         when(mockedProviders.byName(any(PaymentGatewayName.class))).thenReturn(mockedPaymentProvider);
-        when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(ChargeEntity.class), any(List.class))).thenReturn(EXTERNAL_AVAILABLE);
+        when(mockedPaymentProvider.getExternalChargeRefundAvailability(any(Charge.class), any(List.class))).thenReturn(EXTERNAL_AVAILABLE);
         when(mockedConfig.getEmitPaymentStateTransitionEvents()).thenReturn(true);
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.service;
 
 import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
@@ -109,13 +110,17 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
 
     }
 
-    private static ChargeEntity chargeEntity(ChargeStatus status) {
+    private static Charge chargeEntity(ChargeStatus status) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build();
+        return Charge.from(
+                aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build()
+        );
     }
 
-    private static ChargeEntity chargeEntity(ChargeStatus status, long amount) {
+    private static Charge chargeEntity(ChargeStatus status, long amount) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build();
+        return Charge.from(
+                aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build()
+        );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.service;
 
 import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
@@ -131,13 +132,17 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
         assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L), refunds), is(EXTERNAL_FULL));
     }
 
-    private static ChargeEntity chargeEntity(ChargeStatus status) {
+    private static Charge chargeEntity(ChargeStatus status) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build();
+        return Charge.from(
+                aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build()
+        );
     }
 
-    private static ChargeEntity chargeEntity(ChargeStatus status, long amount) {
+    private static Charge chargeEntity(ChargeStatus status, long amount) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
-        return aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build();
+        return Charge.from(
+                aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build()
+        );
     }
 }


### PR DESCRIPTION
Same philosophy behind the `GatewayAccount` model, a POJO to
separate flat Charge values from the JPA `Entity`, this will avoid
confusion in usage when consumers won't be relying on database access.

This will allow us to populate this from either the database (JPA) or
other sources.