### PR TITLE
PP-6085: Use env-map buildpack to set env vars

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,8 +1,4 @@
 memory: 500M
-db_password: mysecretpassword
-db_user: connector
-db_name: connector
-db_ssl_option: ssl=none
 disk_quota: 500M
 disable_internal_https: 'true'
 run_migration: 'true'

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
   - name: card-connector
     buildpacks:
+      - https://github.com/alphagov/env-map-buildpack.git#v2
       - java_buildpack
     path: target/pay-connector-0.1-SNAPSHOT-allinone.jar
     health-check-type: http
@@ -9,7 +10,36 @@ applications:
     health-check-invocation-timeout: 5
     memory: ((memory))
     disk_quota: ((disk_quota))
+    services:
+      - app-catalog
+      - sqs
+      - card-connector-db
     env:
+      ENV_MAP_BP_USE_APP_PROFILE_DIR: true
+
+      # Provided by the app-catalog service - see src/main/resources/env-map.yml
+      FRONTEND_URL: ""
+
+      # Provided by the sqs service - see src/main/resources/env-map.yml
+      AWS_SQS_CAPTURE_QUEUE_URL: ""
+      AWS_SQS_ENDPOINT: ""
+      AWS_SQS_PAYMENT_EVENT_QUEUE_URL: ""
+
+      # Other sqs settings
+      AWS_ACCESS_KEY: ((aws_access_key))
+      AWS_SECRET_KEY: ((aws_secret_key))
+      AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS: '20'
+      AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT: 'true'
+      AWS_SQS_REGION: region-1
+
+      # Provided by the card-connector-db service - see src/main/resources/env-map.yml
+      DB_HOST: ""
+      DB_NAME:  ""
+      DB_PASSWORD: ""
+      DB_USER: ""
+      DB_SSL_OPTION: ""
+
+
       ADMIN_PORT: '9301'
       CAPTURE_PROCESS_SCHEDULER_INITIAL_DELAY_SECONDS: '0'
       CAPTURE_PROCESS_SCHEDULER_RANDOM_INTERVAL_MAXIMUM_SECONDS: '1'
@@ -18,29 +48,11 @@ applications:
       DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
       ENVIRONMENT: ((space))
       EVENT_QUEUE_ENABLED: ((sqs_enabled))
-      FRONTEND_URL: ((card_frontend_url))
 
       # Provided via apple-pay service
       APPLE_PAY_PAYMENT_PROCESSING_CERTIFICATE: ((apple_pay_certificate))
       APPLE_PAY_PAYMENT_PROCESSING_PRIVATE_KEY: ((apple_pay_key))
       AUTH_READ_TIMEOUT_SECONDS: '1'
-
-      # Provide via aws-sqs service
-      AWS_ACCESS_KEY: ((aws_access_key))
-      AWS_SECRET_KEY: ((aws_secret_key))
-      AWS_SQS_CAPTURE_QUEUE_URL: http://sqs-((space)).apps.internal:9324/queue/pay_capture_queue
-      AWS_SQS_ENDPOINT: http://sqs-((space)).apps.internal:9324
-      AWS_SQS_MESSAGE_MAXIMUM_WAIT_TIME_IN_SECONDS: '20'
-      AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT: 'true'
-      AWS_SQS_PAYMENT_EVENT_QUEUE_URL: http://sqs-((space)).apps.internal:9324/queue/pay_event_queue
-      AWS_SQS_REGION: region-1
-
-      # Provide via connector-db service
-      DB_HOST: postgres-((space)).apps.internal
-      DB_NAME: ((db_name))
-      DB_PASSWORD: ((db_password))
-      DB_USER: ((db_user))
-      DB_SSL_OPTION: ((db_ssl_option))
 
       # Provide via epdq service
       GDS_CONNECTOR_EPDQ_LIVE_URL: ((epdq_live_url))
@@ -74,5 +86,4 @@ applications:
       RUN_APP: 'true'
       RUN_MIGRATION: ((run_migration))
       STRIPE_TRANSACTION_FEE_PERCENTAGE: ((stripe_transaction_fee_percentage))
-    routes:
-      - route: ((card_connector_route))
+

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -1,0 +1,11 @@
+env_vars:
+  DB_HOST:                         '.[][] | select(.name == "card-connector-db") | .credentials.host                           '
+  DB_NAME:                         '.[][] | select(.name == "card-connector-db") | .credentials.name                           '
+  DB_PASSWORD:                     '.[][] | select(.name == "card-connector-db") | .credentials.password                       '
+  DB_USER:                         '.[][] | select(.name == "card-connector-db") | .credentials.username                       '
+  DB_SSL_OPTION:                   '.[][] | select(.name == "card-connector-db") | .credentials.ssl_option        // "ssl=true"'
+  FRONTEND_URL:                    '.[][] | select(.name == "app-catalog")       | .credentials.card_frontend_url              '
+  AWS_SQS_CAPTURE_QUEUE_URL:       '.[][] | select(.name == "sqs")               | .credentials.capture_queue_url              '
+  AWS_SQS_ENDPOINT:                '.[][] | select(.name == "sqs")               | .credentials.endpoint                       '
+  AWS_SQS_PAYMENT_EVENT_QUEUE_URL: '.[][] | select(.name == "sqs")               | .credentials.event_queue_url                '
+


### PR DESCRIPTION
WHAT YOU DID
------------

Should mostly be similar to the other applications we've been doing. A
few things to note:

* because this is a java app, env-map.yml needs to live in src/main/resources so it gets built and deployed with the jar file
* the jq is quite complicated because:
  * there's more than one user-provided service, so we need to disambiguate by name, not index
  * card-connector-db might be "postgres" (staging) or "user-provided" (dev)
  * ssl_option is only set in the user-provided service, and it needs a default

How to test
-----------

`cf push --vars-file staging.yml --var space=staging`

Code review checklist
---------------------

- Logging
  - [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.
- Documentation
  - [x] Updated README.md for any of the following ?
    - Introduced any new environment variables / removed existing environment variable
    - Added new API / updated existing API definition