### PR TITLE
PP-6097 Add config `excludeChargesParityCheckedWithInDays`

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
@@ -11,11 +11,16 @@ public class ExpungeConfig extends Configuration {
     @Valid
     @NotNull
     private int minimumAgeOfChargeInDays;
-    
+
     @Valid
     @NotNull
     @Min(1)
     private int numberOfChargesToExpunge;
+
+    @Valid
+    @NotNull
+    @Min(0)
+    private int excludeChargesParityCheckedWithInDays;
 
     public int getMinimumAgeOfChargeInDays() {
         return minimumAgeOfChargeInDays;
@@ -23,5 +28,9 @@ public class ExpungeConfig extends Configuration {
 
     public int getNumberOfChargesToExpunge() {
         return numberOfChargesToExpunge;
+    }
+
+    public int getExcludeChargesParityCheckedWithInDays() {
+        return excludeChargesParityCheckedWithInDays;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -189,14 +189,15 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .getResultList();
     }
 
-    public Optional<ChargeEntity> findChargeToExpunge(int minimumAgeOfChargeInDays) {
+    public Optional<ChargeEntity> findChargeToExpunge(int minimumAgeOfChargeInDays,
+                                                      int excludeChargesParityCheckedWithInDays) {
         String query = "SELECT c FROM ChargeEntity c " +
                 "WHERE (c.parityCheckDate is null or c.parityCheckDate < :parityCheckedBeforeDate)" +
                 " AND c.createdDate < :createdBeforeDate " +
                 " ORDER BY c.createdDate asc";
 
         ZonedDateTime parityCheckedBeforeDate = ZonedDateTime.now()
-                .minus(Duration.ofDays(7))
+                .minus(Duration.ofDays(excludeChargesParityCheckedWithInDays))
                 .withZoneSameInstant(ZoneId.of("UTC"));
 
         ZonedDateTime createdBeforeDate = ZonedDateTime.now()

--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -31,7 +31,10 @@ public class ChargeExpungeService {
         int noOfChargesProcessed = 0;
 
         while (noOfChargesProcessed < noOfChargesToExpunge) {
-            Optional<ChargeEntity> mayBeChargeEntity = chargeDao.findChargeToExpunge(expungeConfig.getMinimumAgeOfChargeInDays());
+            Optional<ChargeEntity> mayBeChargeEntity =
+                    chargeDao.findChargeToExpunge(expungeConfig.getMinimumAgeOfChargeInDays(),
+                            expungeConfig.getExcludeChargesParityCheckedWithInDays()
+                    );
 
             mayBeChargeEntity.ifPresent(chargeEntity -> {
                 // TODO: in PP-6098 

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -235,4 +235,5 @@ ledgerBaseURL: ${LEDGER_URL}
 
 expungeConfig:
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
@@ -23,6 +23,7 @@ public class ChargeExpungeServiceTest {
     private ChargeExpungeService chargeExpungeService;
     private int minimumAgeOfChargeInDays = 3;
     private int defaultNumberOfChargesToExpunge = 10;
+    private int defaultExcludeChargesParityCheckedWithInDays = 1;
 
     @Mock
     private ExpungeConfig mockExpungeConfig;
@@ -36,20 +37,23 @@ public class ChargeExpungeServiceTest {
         when(mockConnectorConfiguration.getExpungeConfig()).thenReturn(mockExpungeConfig);
         when(mockExpungeConfig.getNumberOfChargesToExpunge()).thenReturn(defaultNumberOfChargesToExpunge);
         when(mockExpungeConfig.getMinimumAgeOfChargeInDays()).thenReturn(minimumAgeOfChargeInDays);
+        when(mockExpungeConfig.getExcludeChargesParityCheckedWithInDays()).thenReturn(defaultExcludeChargesParityCheckedWithInDays);
 
-        when(mockChargeDao.findChargeToExpunge(minimumAgeOfChargeInDays)).thenReturn(Optional.of(chargeEntity));
+        when(mockChargeDao.findChargeToExpunge(minimumAgeOfChargeInDays, defaultExcludeChargesParityCheckedWithInDays))
+                .thenReturn(Optional.of(chargeEntity));
         chargeExpungeService = new ChargeExpungeService(mockChargeDao, mockConnectorConfiguration);
     }
 
     @Test
     public void expunge_shouldExpungeCharges() {
         chargeExpungeService.expunge(2);
-        verify(mockChargeDao, times(2)).findChargeToExpunge(minimumAgeOfChargeInDays);
+        verify(mockChargeDao, times(2)).findChargeToExpunge(minimumAgeOfChargeInDays, 1);
     }
 
     @Test
     public void expunge_shouldExpungeNoOfChargesAsPerConfiguration() {
         chargeExpungeService.expunge(null);
-        verify(mockChargeDao, times(defaultNumberOfChargesToExpunge)).findChargeToExpunge(minimumAgeOfChargeInDays);
+        verify(mockChargeDao, times(defaultNumberOfChargesToExpunge)).findChargeToExpunge(minimumAgeOfChargeInDays,
+                defaultExcludeChargesParityCheckedWithInDays);
     }
 }

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -180,4 +180,5 @@ ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -179,4 +179,5 @@ ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -169,4 +169,5 @@ ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -175,4 +175,5 @@ ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -174,4 +174,5 @@ ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}


### PR DESCRIPTION
## WHAT YOU DID
- Added configurable environment variable to exclude the charges parity checked within configured number of days
- Default is 7 days, but this can reduced when we run expunger for historic data
