### PR TITLE
PP-6066 Refund process can map from Transaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
@@ -386,6 +387,7 @@ public class ChargeResponse {
 
 
     @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class RefundSummary {
 
         @JsonProperty("status")

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.charge.model.domain;
 
+import uk.gov.pay.connector.paritycheck.LedgerTransaction;
+
 import java.util.Optional;
 
 public class Charge {
@@ -21,7 +23,7 @@ public class Charge {
         this.refundAvailabilityStatus = refundAvailabilityStatus;
         this.historic = historic;
     }
-    
+
     public static Charge from(ChargeEntity chargeEntity) {
         return new Charge(
                 chargeEntity.getExternalId(),
@@ -31,6 +33,24 @@ public class Charge {
                 chargeEntity.getCorporateSurcharge().orElse(null),
                 null, 
                 false);
+    }
+
+    public static Charge from(LedgerTransaction transaction) {
+        String externalRefundState = null;
+
+        if (transaction.getRefundSummary() != null ) {
+            externalRefundState = transaction.getRefundSummary().getStatus();
+        }
+
+        return new Charge(
+                transaction.getTransactionId(),
+                transaction.getAmount(),
+                null,
+                transaction.getGatewayTransactionId(),
+                transaction.getCorporateCardSurcharge(),
+                externalRefundState,
+                false
+        );
     }
 
     public String getExternalId() {

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -53,6 +53,8 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paritycheck.LedgerService;
+import uk.gov.pay.connector.paritycheck.LedgerTransaction;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 import uk.gov.pay.connector.queue.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
@@ -111,6 +113,7 @@ public class ChargeService {
     private final PaymentProviders providers;
 
     private final StateTransitionService stateTransitionService;
+    private final LedgerService ledgerService;
     private final Boolean shouldEmitPaymentStateTransitionEvents;
     private final RefundDao refundDao;
     private EventService eventService;
@@ -119,7 +122,7 @@ public class ChargeService {
     public ChargeService(TokenDao tokenDao, ChargeDao chargeDao, ChargeEventDao chargeEventDao,
                          CardTypeDao cardTypeDao, GatewayAccountDao gatewayAccountDao,
                          ConnectorConfiguration config, PaymentProviders providers,
-                         StateTransitionService stateTransitionService, EventService eventService,
+                         StateTransitionService stateTransitionService, LedgerService ledgerService, EventService eventService,
                          RefundDao refundDao) {
         this.tokenDao = tokenDao;
         this.chargeDao = chargeDao;
@@ -131,6 +134,7 @@ public class ChargeService {
         this.captureProcessConfig = config.getCaptureProcessConfig();
         this.stateTransitionService = stateTransitionService;
         this.shouldEmitPaymentStateTransitionEvents = config.getEmitPaymentStateTransitionEvents();
+        this.ledgerService = ledgerService;
         this.eventService = eventService;
         this.refundDao = refundDao;
     }
@@ -213,7 +217,7 @@ public class ChargeService {
             SupportedLanguage language = chargeRequest.getLanguage() != null
                     ? chargeRequest.getLanguage()
                     : SupportedLanguage.ENGLISH;
-            
+
             ChargeEntity chargeEntity = aWebChargeEntity()
                     .withAmount(chargeRequest.getAmount())
                     .withReturnUrl(chargeRequest.getReturnUrl())
@@ -271,8 +275,14 @@ public class ChargeService {
     }
 
     public Optional<Charge> findCharge(String chargeExternalId, Long gatewayAccountId) {
-        return chargeDao.findByExternalIdAndGatewayAccount(chargeExternalId, gatewayAccountId)
-                .map(Charge::from);
+        Optional<ChargeEntity> maybeChargeEntity = chargeDao.findByExternalIdAndGatewayAccount(chargeExternalId, gatewayAccountId);
+
+        if(maybeChargeEntity.isPresent()) {
+            return maybeChargeEntity.map(Charge::from);
+        }
+        else{
+            return ledgerService.getTransaction(chargeExternalId).map(Charge::from);
+        }
     }
 
     @Transactional
@@ -801,7 +811,7 @@ public class ChargeService {
             throw new ZeroAmountNotAllowedForGatewayAccountException(gatewayAccount.getId());
         }
     }
-    
+
     private void checkIfMotoPaymentsAllowed(boolean moto, GatewayAccountEntity gatewayAccount) {
         if (moto && !gatewayAccount.isAllowMoto()) {
             throw new MotoPaymentNotAllowedForGatewayAccountException(gatewayAccount.getId());

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -54,7 +54,6 @@ import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paritycheck.LedgerService;
-import uk.gov.pay.connector.paritycheck.LedgerTransaction;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
 import uk.gov.pay.connector.queue.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ExternalChargeRefundAvailability.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ExternalChargeRefundAvailability.java
@@ -26,4 +26,13 @@ public enum ExternalChargeRefundAvailability {
         return this.value;
     }
 
+    public static ExternalChargeRefundAvailability from(String value) {
+        for (ExternalChargeRefundAvailability status : values()) {
+            if (status.value.equalsIgnoreCase(value)) {
+                return status;
+            }
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
@@ -155,4 +155,8 @@ public class LedgerTransaction {
     public void setAmount(Long amount) {
         this.amount = amount;
     }
+
+    public void setRefundSummary(ChargeResponse.RefundSummary refundSummary) {
+        this.refundSummary = refundSummary;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
-
 import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -27,6 +26,7 @@ public class LedgerTransaction {
     private Long fee;
     private Long netAmount;
     private String createdDate;
+    private String gatewayTransactionId;
     private TransactionState state;
     private String returnUrl;
     private String paymentProvider;
@@ -37,7 +37,6 @@ public class LedgerTransaction {
     private boolean moto;
     private Boolean live;
     private Source source;
-    private String gatewayTransactionId;
     private String walletType;
     private Map<String, Object> externalMetaData;
 
@@ -109,6 +108,10 @@ public class LedgerTransaction {
         return paymentProvider;
     }
 
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
     public ChargeResponse.RefundSummary getRefundSummary() {
         return refundSummary;
     }
@@ -137,15 +140,19 @@ public class LedgerTransaction {
         return source;
     }
 
-    public String getGatewayTransactionId() {
-        return gatewayTransactionId;
-    }
-
     public String getWalletType() {
         return walletType;
     }
 
     public Map<String, Object> getExternalMetaData() {
         return externalMetaData;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    public void setAmount(Long amount) {
+        this.amount = amount;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -81,7 +81,7 @@ public class ChargeRefundService {
 
             logger.info("Card refund request sent - charge_external_id={}, status={}, amount={}, transaction_id={}, account_id={}, operation_type=Refund, amount_available_refund={}, amount_requested_refund={}, provider={}, provider_type={}, user_external_id={}",
                     charge.getExternalId(),
-                    fromString(charge.getStatus()),
+                    charge.getStatus(),
                     charge.getAmount(),
                     charge.getGatewayTransactionId(),
                     gatewayAccountEntity.getId(),

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -84,7 +84,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
@@ -21,6 +22,7 @@ import uk.gov.pay.connector.gateway.model.Auth3dsDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
+import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.queue.StateTransitionService;
 import uk.gov.pay.connector.util.AuthUtils;
 
@@ -49,6 +51,9 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 @RunWith(MockitoJUnitRunner.class)
 public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
+    @Mock
+    private LedgerService ledgerService;
+
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
     private ChargeEntity charge = createNewChargeWith("worldpay", 1L, AUTHORISATION_3DS_REQUIRED, GENERATED_TRANSACTION_ID);
@@ -67,7 +72,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, mockStateTransitionService, mockEventService, mockedRefundDao);
+                null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockEventService, mockedRefundDao);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -40,6 +40,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.queue.StateTransitionService;
 
@@ -102,6 +103,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     private StateTransitionService stateTransitionService;
 
     @Mock
+    private LedgerService ledgerService;
+
+    @Mock
     private EventQueue eventQueue;
     @Mock
     private EventService mockEventService;
@@ -116,7 +120,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                stateTransitionService, mockEventService, mockedRefundDao);
+                stateTransitionService, ledgerService, mockEventService, mockedRefundDao);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -35,6 +35,7 @@ import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
+import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.queue.CaptureQueue;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.StateTransitionService;
@@ -105,6 +106,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     @Mock
     private StateTransitionService mockStateTransitionService;
     @Mock
+    private LedgerService ledgerService;
+    @Mock
     private EventService mockEventService;
     @Mock
     private RefundDao mockRefundDao;
@@ -117,7 +120,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                mockStateTransitionService, mockEventService, mockRefundDao);
+                mockStateTransitionService, ledgerService, mockEventService, mockRefundDao);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -163,6 +163,8 @@ public class ChargeRefundServiceTest {
 
         GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
+
+        // @TODO(sfount) Requires PP-6066 to remove the requirements on the charge entity
         ChargeEntity charge = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transaction-id")

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
@@ -103,6 +104,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     private StateTransitionService mockStateTransitionService;
 
     @Mock
+    private LedgerService ledgerService;
+
+    @Mock
     private EventQueue eventQueue;
     @Mock
     private EmittedEventDao emittedEventDao;
@@ -135,7 +139,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null, mockStateTransitionService,
-                mockEventService, mockedRefundDao));
+                ledgerService, mockEventService, mockedRefundDao));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-connector/pull/2082

Uses Ledger API for historic payments that are no longer available to the in-flight Connector database.

Refund process becomes fully independant from database records, relies on PP-6095 to remove the requirement to reference a charge entity when creating a refund entity https://github.com/alphagov/pay-connector/blob/master/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java#L164