### PR TITLE
PP-6098 Add ParityCheckService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 public enum ParityCheckStatus {
+    MATCHES_WITH_LEDGER,
     EXISTS_IN_LEDGER,
     MISSING_IN_LEDGER,
     DATA_MISMATCH

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorker.java
@@ -97,7 +97,7 @@ public class HistoricalEventEmitterWorker {
             if (maybeCharge.isPresent()) {
                 final ChargeEntity charge = maybeCharge.get();
 
-                historicalEventEmitter.processPaymentEvents(charge);
+                historicalEventEmitter.processPaymentEvents(charge, false);
                 historicalEventEmitter.processRefundEvents(charge);
             } else {
                 logger.info("[{}/{}] - not found", currentId, maxId);

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckService.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckService.java
@@ -1,0 +1,98 @@
+package uk.gov.pay.connector.tasks;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.paritycheck.LedgerService;
+import uk.gov.pay.connector.paritycheck.LedgerTransaction;
+import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.EXISTS_IN_LEDGER;
+
+public class ParityCheckService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ParityCheckService.class);
+
+    private LedgerService ledgerService;
+    private ChargeService chargeService;
+    private RefundDao refundDao;
+    private HistoricalEventEmitter historicalEventEmitter;
+
+    @Inject
+    public ParityCheckService(LedgerService ledgerService, ChargeService chargeService,
+                              RefundDao refundDao,
+                              HistoricalEventEmitter historicalEventEmitter) {
+        this.ledgerService = ledgerService;
+        this.chargeService = chargeService;
+        this.refundDao = refundDao;
+        this.historicalEventEmitter = historicalEventEmitter;
+    }
+
+    public ParityCheckStatus getChargeParityCheckStatus(ChargeEntity charge) {
+        Optional<LedgerTransaction> transaction = ledgerService.getTransaction(charge.getExternalId());
+        var externalChargeState = ChargeStatus.fromString(charge.getStatus()).toExternal().getStatusV2();
+
+        return getParityCheckStatus(transaction, externalChargeState);
+    }
+
+    public ParityCheckStatus getChargeAndRefundsParityCheckStatus(ChargeEntity charge) {
+        var parityCheckStatus = getChargeParityCheckStatus(charge);
+        if (parityCheckStatus.equals(EXISTS_IN_LEDGER)) {
+            return getRefundsParityCheckStatus(refundDao.findRefundsByChargeExternalId(charge.getExternalId()));
+        }
+
+        return parityCheckStatus;
+    }
+
+    public ParityCheckStatus getParityCheckStatus(Optional<LedgerTransaction> transaction, String externalChargeState) {
+        if (transaction.isEmpty()) {
+            return ParityCheckStatus.MISSING_IN_LEDGER;
+        }
+
+        if (externalChargeState.equalsIgnoreCase(transaction.get().getState().getStatus())) {
+            return EXISTS_IN_LEDGER;
+        }
+
+        return ParityCheckStatus.DATA_MISMATCH;
+    }
+
+
+    public ParityCheckStatus getRefundsParityCheckStatus(List<RefundEntity> refunds) {
+        for (var refund : refunds) {
+            var transaction = ledgerService.getTransaction(refund.getExternalId());
+            ParityCheckStatus parityCheckStatus = getParityCheckStatus(transaction, refund.getStatus().toExternal().getStatus());
+            if (!parityCheckStatus.equals(EXISTS_IN_LEDGER)) {
+                logger.info("refund transaction does not exist in ledger or is in a different state [externalId={},status={}] -",
+                        refund.getExternalId(), parityCheckStatus);
+                return parityCheckStatus;
+            }
+        }
+
+        return EXISTS_IN_LEDGER;
+    }
+
+    @Transactional
+    public boolean parityCheckChargeForExpunger(ChargeEntity chargeEntity) {
+        ParityCheckStatus parityCheckStatus = getChargeParityCheckStatus(chargeEntity);
+
+        //TODO (kbottla) to be replaced by `MATCHES_WITH_LEDGER`          
+        if (EXISTS_IN_LEDGER.equals(parityCheckStatus)) {
+            return true;
+        }
+
+        // force emit and update charge status
+        historicalEventEmitter.processPaymentEvents(chargeEntity, true);
+        chargeService.updateChargeParityStatus(chargeEntity.getExternalId(), parityCheckStatus);
+
+        return false;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
@@ -7,16 +7,13 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.paritycheck.LedgerService;
-import uk.gov.pay.connector.paritycheck.LedgerTransaction;
 import uk.gov.pay.connector.queue.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -30,24 +27,26 @@ public class ParityCheckWorker {
     private static final boolean shouldForceEmission = true;
     private final ChargeDao chargeDao;
     private ChargeService chargeService;
-    private LedgerService ledgerService;
+
     private EmittedEventDao emittedEventDao;
     private StateTransitionService stateTransitionService;
     private EventService eventService;
     private RefundDao refundDao;
+    private ParityCheckService parityCheckService;
     private HistoricalEventEmitter historicalEventEmitter;
     private long maxId;
 
     @Inject
     public ParityCheckWorker(ChargeDao chargeDao, ChargeService chargeService, LedgerService ledgerService, EmittedEventDao emittedEventDao,
-                             StateTransitionService stateTransitionService, EventService eventService, RefundDao refundDao) {
+                             StateTransitionService stateTransitionService, EventService eventService, RefundDao refundDao,
+                             ParityCheckService parityCheckService) {
         this.chargeDao = chargeDao;
         this.chargeService = chargeService;
-        this.ledgerService = ledgerService;
         this.emittedEventDao = emittedEventDao;
         this.stateTransitionService = stateTransitionService;
         this.eventService = eventService;
         this.refundDao = refundDao;
+        this.parityCheckService = parityCheckService;
     }
 
     public void execute(Long startId, Optional<Long> maybeMaxId, boolean doNotReprocessValidRecords,
@@ -124,7 +123,7 @@ public class ParityCheckWorker {
                 return;
             }
 
-            ParityCheckStatus parityCheckStatus = getChargeAndRefundsParityCheckStatus(charge);
+            ParityCheckStatus parityCheckStatus = parityCheckService.getChargeAndRefundsParityCheckStatus(charge);
             chargeService.updateChargeParityStatus(charge.getExternalId(), parityCheckStatus);
             logger.info("transaction parity check finished [id={},status={}]", charge.getId(), parityCheckStatus);
 
@@ -136,50 +135,8 @@ public class ParityCheckWorker {
         }
     }
 
-    private ParityCheckStatus getChargeAndRefundsParityCheckStatus(ChargeEntity charge) {
-        var parityCheckStatus = getChargeParityCheckStatus(charge);
-        if (parityCheckStatus.equals(ParityCheckStatus.EXISTS_IN_LEDGER)) {
-            return getRefundsParityCheckStatus(refundDao.findRefundsByChargeExternalId(charge.getExternalId()));
-        }
-
-        return parityCheckStatus;
-    }
-
-    private ParityCheckStatus getChargeParityCheckStatus(ChargeEntity charge) {
-        var transaction = ledgerService.getTransaction(charge.getExternalId());
-        var externalChargeState = ChargeStatus.fromString(charge.getStatus()).toExternal().getStatusV2();
-
-        return getParityCheckStatus(transaction, externalChargeState);
-    }
-
-    private ParityCheckStatus getParityCheckStatus(Optional<LedgerTransaction> transaction, String externalChargeState) {
-        if (transaction.isEmpty()) {
-            return ParityCheckStatus.MISSING_IN_LEDGER;
-        }
-
-        if (externalChargeState.equalsIgnoreCase(transaction.get().getState().getStatus())) {
-            return ParityCheckStatus.EXISTS_IN_LEDGER;
-        }
-
-        return ParityCheckStatus.DATA_MISMATCH;
-    }
-
-    private ParityCheckStatus getRefundsParityCheckStatus(List<RefundEntity> refunds) {
-        for (var refund : refunds) {
-            var transaction = ledgerService.getTransaction(refund.getExternalId());
-            ParityCheckStatus parityCheckStatus = getParityCheckStatus(transaction, refund.getStatus().toExternal().getStatus());
-            if (!parityCheckStatus.equals(ParityCheckStatus.EXISTS_IN_LEDGER)) {
-                logger.info("refund transaction does not exist in ledger or is in a different state [externalId={},status={}] -",
-                        refund.getExternalId(), parityCheckStatus);
-                return parityCheckStatus;
-            }
-        }
-
-        return ParityCheckStatus.EXISTS_IN_LEDGER;
-    }
-
     private void emitHistoricalEvents(ChargeEntity charge) {
-        historicalEventEmitter.processPaymentEvents(charge);
+        historicalEventEmitter.processPaymentEvents(charge, true);
         historicalEventEmitter.processRefundEvents(charge);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
@@ -1,0 +1,69 @@
+package uk.gov.pay.connector.tasks;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.paritycheck.LedgerService;
+import uk.gov.pay.connector.paritycheck.LedgerTransaction;
+import uk.gov.pay.connector.refund.dao.RefundDao;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.DATA_MISMATCH;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ParityCheckServiceTest {
+
+    ParityCheckService parityCheckService;
+    @Mock
+    private LedgerService mockLedgerService;
+    @Mock
+    private ChargeService mockChargeService;
+    @Mock
+    private RefundDao mockRefundDao;
+    @Mock
+    private HistoricalEventEmitter mockHistoricalEventEmitter;
+    private ChargeEntity chargeEntity;
+
+    @Before
+    public void setUp() {
+        parityCheckService = new ParityCheckService(mockLedgerService, mockChargeService, mockRefundDao,
+                mockHistoricalEventEmitter);
+
+        chargeEntity = aValidChargeEntity()
+                .withStatus(CAPTURED)
+                .build();
+    }
+
+    @Test
+    public void parityCheckChargeForExpunger_shouldReturnTrueIfChargeMatchesWithLedger() {
+        LedgerTransaction transaction = aValidLedgerTransaction().withStatus("success").build();
+        when(mockLedgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(transaction));
+
+        boolean matchesWithLedger = parityCheckService.parityCheckChargeForExpunger(chargeEntity);
+
+        assertThat(matchesWithLedger, is(true));
+    }
+
+    @Test
+    public void parityCheckChargeForExpunger_shouldReturnFalseIfChargeDoesNotMatchWithLedger() {
+        LedgerTransaction transaction = aValidLedgerTransaction().withStatus("pending").build();
+        when(mockLedgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(transaction));
+        boolean matchesWithLedger = parityCheckService.parityCheckChargeForExpunger(chargeEntity);
+
+        assertThat(matchesWithLedger, is(false));
+        verify(mockHistoricalEventEmitter).processPaymentEvents(chargeEntity, true);
+        verify(mockChargeService).updateChargeParityStatus(chargeEntity.getExternalId(), DATA_MISMATCH);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.tasks;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
@@ -46,6 +47,8 @@ public class ParityCheckWorkerTest {
     private EmittedEventDao emittedEventDao;
     @Mock
     private StateTransitionService stateTransitionService;
+    @InjectMocks
+    private ParityCheckService parityCheckService;
     @Mock
     private EventService eventService;
     @Mock
@@ -61,7 +64,7 @@ public class ParityCheckWorkerTest {
     @Before
     public void setUp() {
         worker = new ParityCheckWorker(chargeDao, chargeService, ledgerService, emittedEventDao,
-                stateTransitionService, eventService, refundDao);
+                stateTransitionService, eventService, refundDao, parityCheckService);
         CardDetailsEntity cardDetails = mock(CardDetailsEntity.class);
         chargeEntity = ChargeEntityFixture
                 .aValidChargeEntity()


### PR DESCRIPTION
## WHAT 
- Added ParityCheckService to be used solely for parity checking with ledger
- Refactored ParityCheckWorker to use new service
- Relevant tests
- `parityCheckChargeForExpunger` also backfills and updates charge. To factor out to ChargeExpungeService if needed
