### PR TITLE
PP-6098 Extend LedgerTransaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paritycheck/Address.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/Address.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.paritycheck;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Address {
+
+    private String line1;
+    private String line2;
+    private String postcode;
+    private String city;
+    private String county;
+    private String country;
+
+    public Address(String line1, String line2, String postcode,
+                   String city, String county, String country) {
+        this.line1 = line1;
+        this.line2 = line2;
+        this.postcode = postcode;
+        this.city = city;
+        this.county = county;
+        this.country = country;
+    }
+
+    public String getLine1() {
+        return line1;
+    }
+
+    public String getLine2() {
+        return line2;
+    }
+
+    public String getPostcode() {
+        return postcode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public String getCounty() {
+        return county;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address address = (Address) o;
+        return Objects.equals(line1, address.line1) &&
+                Objects.equals(line2, address.line2) &&
+                Objects.equals(postcode, address.postcode) &&
+                Objects.equals(city, address.city) &&
+                Objects.equals(county, address.county) &&
+                Objects.equals(country, address.country);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(line1, line2, postcode, city, county, country);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paritycheck/CardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/CardDetails.java
@@ -1,0 +1,87 @@
+package uk.gov.pay.connector.paritycheck;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.connector.cardtype.model.domain.CardType;
+import uk.gov.pay.connector.common.model.api.ToLowerCaseStringSerializer;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class CardDetails {
+
+    private String cardholderName;
+    private Address billingAddress;
+    private String cardBrand;
+    private String lastDigitsCardNumber;
+    private String firstDigitsCardNumber;
+    private String expiryDate;
+    private CardType cardType;
+
+    public CardDetails(String cardholderName, Address billingAddress, String cardBrand,
+                       String lastDigitsCardNumber, String firstDigitsCardNumber, String cardExpiryDate, CardType cardType) {
+        this.cardholderName = cardholderName;
+        this.billingAddress = billingAddress;
+        this.cardBrand = cardBrand;
+        this.lastDigitsCardNumber = lastDigitsCardNumber;
+        this.firstDigitsCardNumber = firstDigitsCardNumber;
+        this.expiryDate = cardExpiryDate;
+        this.cardType = cardType;
+    }
+
+    public String getCardholderName() {
+        return cardholderName;
+    }
+
+    public Address getBillingAddress() {
+        return billingAddress;
+    }
+
+    public String getCardBrand() {
+        return cardBrand == null ? "" : cardBrand;
+    }
+
+    public String getLastDigitsCardNumber() {
+        return lastDigitsCardNumber;
+    }
+
+    public String getFirstDigitsCardNumber() {
+        return firstDigitsCardNumber;
+    }
+
+    public String getExpiryDate() {
+        return expiryDate;
+    }
+
+    @Enumerated(EnumType.STRING)
+    @JsonProperty("card_type")
+    @JsonSerialize(using = ToLowerCaseStringSerializer.class)
+    public CardType getCardType() { return cardType; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CardDetails that = (CardDetails) o;
+        return Objects.equals(cardholderName, that.cardholderName) &&
+                Objects.equals(billingAddress, that.billingAddress) &&
+                Objects.equals(cardBrand, that.cardBrand) &&
+                Objects.equals(lastDigitsCardNumber, that.lastDigitsCardNumber) &&
+                Objects.equals(firstDigitsCardNumber, that.firstDigitsCardNumber) &&
+                Objects.equals(cardType, that.cardType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cardholderName, billingAddress, cardBrand, lastDigitsCardNumber, firstDigitsCardNumber, cardType);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import uk.gov.pay.commons.model.Source;
+import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.connector.charge.model.ChargeResponse;
+
+import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -12,6 +17,7 @@ public class LedgerTransaction {
 
     private String transactionId;
     private Long amount;
+    private Long gatewayAccountId;
     private String description;
     private String reference;
     private String email;
@@ -22,6 +28,18 @@ public class LedgerTransaction {
     private Long netAmount;
     private String createdDate;
     private TransactionState state;
+    private String returnUrl;
+    private String paymentProvider;
+    private ChargeResponse.RefundSummary refundSummary;
+    private ChargeResponse.SettlementSummary settlementSummary;
+    private CardDetails cardDetails;
+    private SupportedLanguage language;
+    private boolean moto;
+    private Boolean live;
+    private Source source;
+    private String gatewayTransactionId;
+    private String walletType;
+    private Map<String, Object> externalMetaData;
 
     public Long getAmount() {
         return amount;
@@ -73,5 +91,61 @@ public class LedgerTransaction {
 
     public void setState(TransactionState transactionState) {
         this.state = transactionState;
+    }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public boolean isDelayedCapture() {
+        return delayedCapture;
+    }
+
+    public String getReturnUrl() {
+        return returnUrl;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public ChargeResponse.RefundSummary getRefundSummary() {
+        return refundSummary;
+    }
+
+    public ChargeResponse.SettlementSummary getSettlementSummary() {
+        return settlementSummary;
+    }
+
+    public CardDetails getCardDetails() {
+        return cardDetails;
+    }
+
+    public SupportedLanguage getLanguage() {
+        return language;
+    }
+
+    public boolean isMoto() {
+        return moto;
+    }
+
+    public Boolean getLive() {
+        return live;
+    }
+
+    public Source getSource() {
+        return source;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getWalletType() {
+        return walletType;
+    }
+
+    public Map<String, Object> getExternalMetaData() {
+        return externalMetaData;
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Extended LedgerTransaction with all attributes required to deserialize ledger response during parity check
- LedgerTransaction can potentially be moved to pay-java-commons to use in ledger as well as connector to serialise/deserialise Ledger transaction

