### PR TITLE
PP-6098 Parity checker: match common fields

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
@@ -45,16 +45,32 @@ public class LedgerTransaction {
         return amount;
     }
 
+    public void setAmount(Long amount) {
+        this.amount = amount;
+    }
+
     public String getDescription() {
         return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String getReference() {
         return reference;
     }
 
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
     public String getEmail() {
         return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 
     public boolean getDelayedCapture() {
@@ -65,24 +81,48 @@ public class LedgerTransaction {
         return corporateCardSurcharge;
     }
 
+    public void setCorporateCardSurcharge(Long corporateCardSurcharge) {
+        this.corporateCardSurcharge = corporateCardSurcharge;
+    }
+
     public Long getTotalAmount() {
         return totalAmount;
+    }
+
+    public void setTotalAmount(Long totalAmount) {
+        this.totalAmount = totalAmount;
     }
 
     public Long getFee() {
         return fee;
     }
 
+    public void setFee(Long fee) {
+        this.fee = fee;
+    }
+
     public Long getNetAmount() {
         return netAmount;
+    }
+
+    public void setNetAmount(Long netAmount) {
+        this.netAmount = netAmount;
     }
 
     public String getCreatedDate() {
         return createdDate;
     }
 
+    public void setCreatedDate(String createdDate) {
+        this.createdDate = createdDate;
+    }
+
     public String getTransactionId() {
         return transactionId;
+    }
+
+    public void setTransactionId(String transactionId) {
+        this.transactionId = transactionId;
     }
 
     public TransactionState getState() {
@@ -97,55 +137,111 @@ public class LedgerTransaction {
         return gatewayAccountId;
     }
 
+    public void setGatewayAccountId(Long gatewayAccountId) {
+        this.gatewayAccountId = gatewayAccountId;
+    }
+
     public boolean isDelayedCapture() {
         return delayedCapture;
+    }
+
+    public void setDelayedCapture(boolean delayedCapture) {
+        this.delayedCapture = delayedCapture;
     }
 
     public String getReturnUrl() {
         return returnUrl;
     }
 
+    public void setReturnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
+    }
+
     public String getPaymentProvider() {
         return paymentProvider;
+    }
+
+    public void setPaymentProvider(String paymentProvider) {
+        this.paymentProvider = paymentProvider;
     }
 
     public ChargeResponse.RefundSummary getRefundSummary() {
         return refundSummary;
     }
 
+    public void setRefundSummary(ChargeResponse.RefundSummary refundSummary) {
+        this.refundSummary = refundSummary;
+    }
+
     public ChargeResponse.SettlementSummary getSettlementSummary() {
         return settlementSummary;
+    }
+
+    public void setSettlementSummary(ChargeResponse.SettlementSummary settlementSummary) {
+        this.settlementSummary = settlementSummary;
     }
 
     public CardDetails getCardDetails() {
         return cardDetails;
     }
 
+    public void setCardDetails(CardDetails cardDetails) {
+        this.cardDetails = cardDetails;
+    }
+
     public SupportedLanguage getLanguage() {
         return language;
+    }
+
+    public void setLanguage(SupportedLanguage language) {
+        this.language = language;
     }
 
     public boolean isMoto() {
         return moto;
     }
 
+    public void setMoto(boolean moto) {
+        this.moto = moto;
+    }
+
     public Boolean getLive() {
         return live;
+    }
+
+    public void setLive(Boolean live) {
+        this.live = live;
     }
 
     public Source getSource() {
         return source;
     }
 
+    public void setSource(Source source) {
+        this.source = source;
+    }
+
     public String getGatewayTransactionId() {
         return gatewayTransactionId;
+    }
+
+    public void setGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
     }
 
     public String getWalletType() {
         return walletType;
     }
 
+    public void setWalletType(String walletType) {
+        this.walletType = walletType;
+    }
+
     public Map<String, Object> getExternalMetaData() {
         return externalMetaData;
+    }
+
+    public void setExternalMetaData(Map<String, Object> externalMetaData) {
+        this.externalMetaData = externalMetaData;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckService.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckService.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.persist.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
@@ -14,14 +15,19 @@ import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.DATA_MISMATCH;
 import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.EXISTS_IN_LEDGER;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.MISSING_IN_LEDGER;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
 public class ParityCheckService {
 
+    public static final String FIELD_NAME = "field_name";
     private static final Logger logger = LoggerFactory.getLogger(ParityCheckService.class);
-
     private LedgerService ledgerService;
     private ChargeService chargeService;
     private RefundDao refundDao;
@@ -37,15 +43,14 @@ public class ParityCheckService {
         this.historicalEventEmitter = historicalEventEmitter;
     }
 
-    public ParityCheckStatus getChargeParityCheckStatus(ChargeEntity charge) {
-        Optional<LedgerTransaction> transaction = ledgerService.getTransaction(charge.getExternalId());
-        var externalChargeState = ChargeStatus.fromString(charge.getStatus()).toExternal().getStatusV2();
+    public ParityCheckStatus getChargeParityCheckStatus(ChargeEntity chargeEntity) {
+        Optional<LedgerTransaction> transaction = ledgerService.getTransaction(chargeEntity.getExternalId());
 
-        return getParityCheckStatus(transaction, externalChargeState);
+        return checkParity(chargeEntity, transaction.orElse(null));
     }
 
     public ParityCheckStatus getChargeAndRefundsParityCheckStatus(ChargeEntity charge) {
-        var parityCheckStatus = getChargeParityCheckStatus(charge);
+        ParityCheckStatus parityCheckStatus = getChargeParityCheckStatus(charge);
         if (parityCheckStatus.equals(EXISTS_IN_LEDGER)) {
             return getRefundsParityCheckStatus(refundDao.findRefundsByChargeExternalId(charge.getExternalId()));
         }
@@ -55,14 +60,14 @@ public class ParityCheckService {
 
     public ParityCheckStatus getParityCheckStatus(Optional<LedgerTransaction> transaction, String externalChargeState) {
         if (transaction.isEmpty()) {
-            return ParityCheckStatus.MISSING_IN_LEDGER;
+            return MISSING_IN_LEDGER;
         }
 
         if (externalChargeState.equalsIgnoreCase(transaction.get().getState().getStatus())) {
             return EXISTS_IN_LEDGER;
         }
 
-        return ParityCheckStatus.DATA_MISMATCH;
+        return DATA_MISMATCH;
     }
 
 
@@ -84,7 +89,7 @@ public class ParityCheckService {
     public boolean parityCheckChargeForExpunger(ChargeEntity chargeEntity) {
         ParityCheckStatus parityCheckStatus = getChargeParityCheckStatus(chargeEntity);
 
-        //TODO (kbottla) to be replaced by `MATCHES_WITH_LEDGER`          
+        //TODO (kbottla) PP-6098: to be replaced by `MATCHES_WITH_LEDGER`
         if (EXISTS_IN_LEDGER.equals(parityCheckStatus)) {
             return true;
         }
@@ -94,5 +99,55 @@ public class ParityCheckService {
         chargeService.updateChargeParityStatus(chargeEntity.getExternalId(), parityCheckStatus);
 
         return false;
+    }
+
+    private ParityCheckStatus checkParity(ChargeEntity chargeEntity, LedgerTransaction transaction) {
+        String externalId = chargeEntity.getExternalId();
+        ParityCheckStatus parityCheckStatus;
+
+        MDC.put(PAYMENT_EXTERNAL_ID, externalId);
+
+        if (transaction == null) {
+            logger.info("Transaction missing in Ledger for Charge");
+            parityCheckStatus = MISSING_IN_LEDGER;
+        } else {
+            boolean fieldsMatch;
+
+            fieldsMatch = matchCommonFields(chargeEntity, transaction);
+
+            if (fieldsMatch) {
+                parityCheckStatus = EXISTS_IN_LEDGER;
+            } else {
+                parityCheckStatus = DATA_MISMATCH;
+            }
+        }
+        MDC.remove(PAYMENT_EXTERNAL_ID);
+        return parityCheckStatus;
+    }
+
+    private boolean matchCommonFields(ChargeEntity chargeEntity, LedgerTransaction transaction) {
+        boolean fieldsMatch = isEquals(chargeEntity.getExternalId(), transaction.getTransactionId(), "external_id");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getAmount(), transaction.getAmount(), "amount");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getDescription(), transaction.getDescription(), "description");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getReference().toString(), transaction.getReference(), "reference");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getLanguage(), transaction.getLanguage(), "language");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getEmail(), transaction.getEmail(), "email");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getReturnUrl(), transaction.getReturnUrl(), "return_url");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getGatewayTransactionId(), transaction.getGatewayTransactionId(), "gateway_transaction_id");
+
+        String chargeExternalStatus = ChargeStatus.fromString(chargeEntity.getStatus()).toExternal().getStatusV2();
+        fieldsMatch = fieldsMatch && isEquals(chargeExternalStatus, transaction.getState().getStatus(), "status");
+
+        return fieldsMatch;
+    }
+
+    private boolean isEquals(Object value1, Object value2, String fieldName) {
+        if (Objects.equals(value1, value2)) {
+            return true;
+        } else {
+            logger.info("Field value does not match between ledger and connector",
+                    kv(FIELD_NAME, fieldName));
+            return false;
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -1,23 +1,97 @@
 package uk.gov.pay.connector.model.domain;
 
+import uk.gov.pay.commons.model.SupportedLanguage;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.paritycheck.LedgerTransaction;
 import uk.gov.pay.connector.paritycheck.TransactionState;
 
 public class LedgerTransactionFixture {
     private String status = "created";
+    private String externalId;
+    private Long amount;
+    private String description;
+    private String reference;
+    private String email;
+    private String gatewayTransactionId;
+    private String returnUrl;
+    private SupportedLanguage language;
 
     public static LedgerTransactionFixture aValidLedgerTransaction() {
         return new LedgerTransactionFixture();
     }
 
+    public static LedgerTransactionFixture from(ChargeEntity chargeEntity) {
+        LedgerTransactionFixture ledgerTransactionFixture = aValidLedgerTransaction()
+                .withStatus(ChargeStatus.fromString(chargeEntity.getStatus()).toExternal().getStatusV2())
+                .withExternalId(chargeEntity.getExternalId())
+                .withAmount(chargeEntity.getAmount())
+                .withDescription(chargeEntity.getDescription())
+                .withReference(chargeEntity.getReference().toString())
+                .withLanguage(chargeEntity.getLanguage())
+                .withEmail(chargeEntity.getEmail())
+                .withReturnUrl(chargeEntity.getReturnUrl())
+                .withGatewayTransactionId(chargeEntity.getGatewayTransactionId());
+
+        return ledgerTransactionFixture;
+    }
+
     public LedgerTransaction build() {
         var ledgerTransaction = new LedgerTransaction();
         ledgerTransaction.setState(new TransactionState(status));
+        ledgerTransaction.setTransactionId(externalId);
+        ledgerTransaction.setAmount(amount);
+        ledgerTransaction.setDescription(description);
+        ledgerTransaction.setReference(reference);
+        ledgerTransaction.setEmail(email);
+        ledgerTransaction.setGatewayTransactionId(gatewayTransactionId);
+        ledgerTransaction.setReturnUrl(returnUrl);
+        ledgerTransaction.setLanguage(language);
         return ledgerTransaction;
     }
 
     public LedgerTransactionFixture withStatus(String status) {
         this.status = status;
+        return this;
+    }
+
+    public LedgerTransactionFixture withExternalId(String externalId) {
+        this.externalId = externalId;
+        return this;
+    }
+
+    public LedgerTransactionFixture withAmount(Long amount) {
+        this.amount = amount;
+        return this;
+    }
+
+    public LedgerTransactionFixture withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public LedgerTransactionFixture withReference(String reference) {
+        this.reference = reference;
+        return this;
+    }
+
+    public LedgerTransactionFixture withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public LedgerTransactionFixture withReturnUrl(String returnUrl) {
+        this.returnUrl = returnUrl;
+        return this;
+    }
+
+    public LedgerTransactionFixture withGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+        return this;
+    }
+
+    public LedgerTransactionFixture withLanguage(SupportedLanguage language) {
+        this.language = language;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
@@ -21,11 +21,12 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aVali
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.DATA_MISMATCH;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.from;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParityCheckServiceTest {
 
-    ParityCheckService parityCheckService;
+    private ParityCheckService parityCheckService;
     @Mock
     private LedgerService mockLedgerService;
     @Mock
@@ -47,8 +48,8 @@ public class ParityCheckServiceTest {
     }
 
     @Test
-    public void parityCheckChargeForExpunger_shouldReturnTrueIfChargeMatchesWithLedger() {
-        LedgerTransaction transaction = aValidLedgerTransaction().withStatus("success").build();
+    public void parityCheckChargeForExpunger_shouldReturnTrueIfChargeMatchesCommonFieldsWithLedger() {
+        LedgerTransaction transaction = from(chargeEntity).build();
         when(mockLedgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(transaction));
 
         boolean matchesWithLedger = parityCheckService.parityCheckChargeForExpunger(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.from;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ParityCheckWorkerTest {
@@ -97,7 +98,7 @@ public class ParityCheckWorkerTest {
     public void executeRecordsParityStatusForChargesExistingInLedger() {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
 
         worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
@@ -114,7 +115,7 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
         when(refundDao.findRefundsByChargeExternalId(chargeEntity.getExternalId())).thenReturn(List.of(refundEntity));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().withStatus("timedout").build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
         when(ledgerService.getTransaction(refundEntity.getExternalId()))
                 .thenReturn(Optional.of(aValidLedgerTransaction().withStatus("submitted").build()));
 
@@ -150,7 +151,7 @@ public class ParityCheckWorkerTest {
                 .thenReturn(List.of(aValidRefundEntity().build(), aValidRefundEntity().build()));
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
         when(ledgerService.getTransaction(any())).thenReturn(Optional.empty());
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
 
         worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
@@ -168,7 +169,7 @@ public class ParityCheckWorkerTest {
         when(ledgerService.getTransaction(any())).thenReturn(Optional.empty());
         when(ledgerService.getTransaction(any())).thenReturn(Optional.of(
                 aValidLedgerTransaction().withStatus("success").build()));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(aValidLedgerTransaction().build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
 
         worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 


### PR DESCRIPTION
## WHAT 
- Updated ParityCheckerService to match common fields for payments. More matching to come in next set of PRs
- Transaction & charge matcher matches all fields and logs (mismatches) before returning true/false.
- Updated POJO/Fixtures for common fields accessors/mutators
- Updated relevant tests
