### PR TITLE
PP-6072 Add DAO method to search for gateway accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/CommaDelimitedSetParameter.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/CommaDelimitedSetParameter.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.common.model.api;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+public class CommaDelimitedSetParameter {
+    private List<String> elements;
+    private String queryString;
+
+    public CommaDelimitedSetParameter(String queryString) {
+        this.queryString = queryString;
+        elements = isBlank(queryString)
+                ? new ArrayList<>()
+                : List.of(queryString.split(","));
+    }
+
+    public boolean isNotEmpty() {
+        return !elements.isEmpty();
+    }
+
+    public String getRawString() {
+        return queryString;
+    }
+
+    public List<String> getParameters() {
+        return elements;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import uk.gov.pay.connector.common.model.api.CommaDelimitedSetParameter;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.QueryParam;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GatewayAccountSearchParams {
+
+    private static final String ACCOUNT_IDS_SQL_FIELD = "accountIds";
+    private static final String ALLOW_MOTO_SQL_FIELD = "allowMoto";
+    
+    @DefaultValue("")
+    @QueryParam("accountIds")
+    private CommaDelimitedSetParameter accountIds;
+    @QueryParam("moto_enabled")
+    private Boolean motoEnabled;
+
+    public void setAccountIds(CommaDelimitedSetParameter accountIds) {
+        this.accountIds = accountIds;
+    }
+
+    public void setMotoEnabled(Boolean motoEnabled) {
+        this.motoEnabled = motoEnabled;
+    }
+
+    public List<String> getFilterTemplates() {
+        List<String> filters = new ArrayList<>();
+
+        if (accountIds != null && accountIds.isNotEmpty()) {
+            filters.add(" gae.id IN :" + ACCOUNT_IDS_SQL_FIELD);
+        }
+        if (motoEnabled != null) {
+            filters.add(" gae.allowMoto = :" + ALLOW_MOTO_SQL_FIELD);
+        }
+        
+        return List.copyOf(filters);
+    }
+    
+    public Map<String, Object> getQueryMap() {
+        HashMap<String, Object> queryMap = new HashMap<>();
+        
+        if (accountIds != null && accountIds.isNotEmpty()) {
+            queryMap.put(ACCOUNT_IDS_SQL_FIELD, accountIds.getParameters());
+        }
+        if (motoEnabled != null) {
+            queryMap.put(ALLOW_MOTO_SQL_FIELD, motoEnabled);
+        }
+        
+        return queryMap;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
 
 public class GatewayAccountSearchParamsTest {
     
@@ -60,7 +61,7 @@ public class GatewayAccountSearchParamsTest {
         var params = new GatewayAccountSearchParams();
 
         Map<String, Object> queryMap = params.getQueryMap();
-        assertThat(queryMap, IsMapWithSize.anEmptyMap());
+        assertThat(queryMap, anEmptyMap());
     }
 
     @Test
@@ -69,6 +70,6 @@ public class GatewayAccountSearchParamsTest {
         params.setAccountIds(new CommaDelimitedSetParameter(""));
 
         Map<String, Object> queryMap = params.getQueryMap();
-        assertThat(queryMap, IsMapWithSize.anEmptyMap());
+        assertThat(queryMap, anEmptyMap());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import org.hamcrest.collection.IsMapWithSize;
+import org.junit.Test;
+import uk.gov.pay.connector.common.model.api.CommaDelimitedSetParameter;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+
+public class GatewayAccountSearchParamsTest {
+    
+    @Test
+    public void shouldReturnFilterTemplatesWithAllParameters() {
+        var params = new GatewayAccountSearchParams();
+        params.setAccountIds(new CommaDelimitedSetParameter("1,2"));
+        params.setMotoEnabled(false);
+
+        List<String> filterTemplates = params.getFilterTemplates();
+        assertThat(filterTemplates, hasSize(2));
+        assertThat(filterTemplates, containsInAnyOrder(
+                " gae.id IN :accountIds",
+                " gae.allowMoto = :allowMoto"));
+    }
+
+    @Test
+    public void shouldReturnEmptyFilterTemplatesForNoParamsSet() {
+        var params = new GatewayAccountSearchParams();
+        
+        List<String> filterTemplates = params.getFilterTemplates();
+        assertThat(filterTemplates, hasSize(0));
+    }
+
+    @Test
+    public void shouldNotIncludeAccountIdsInFilterTemplatesForEmptyString() {
+        var params = new GatewayAccountSearchParams();
+        params.setAccountIds(new CommaDelimitedSetParameter(""));
+
+        List<String> filterTemplates = params.getFilterTemplates();
+        assertThat(filterTemplates, hasSize(0));
+    }
+
+    @Test
+    public void shouldReturnQueryMapWithAllParameters() {
+        var params = new GatewayAccountSearchParams();
+        params.setAccountIds(new CommaDelimitedSetParameter("1,2"));
+        params.setMotoEnabled(false);
+
+        Map<String, Object> queryMap = params.getQueryMap();
+        assertThat(queryMap, hasEntry("accountIds", List.of("1", "2")));
+        assertThat(queryMap, hasEntry("allowMoto", false));
+    }
+
+    @Test
+    public void shouldReturnEmptyQueryMapForNoParamsSet() {
+        var params = new GatewayAccountSearchParams();
+
+        Map<String, Object> queryMap = params.getQueryMap();
+        assertThat(queryMap, IsMapWithSize.anEmptyMap());
+    }
+
+    @Test
+    public void shouldNotIncludeAccountIdsInQueryMapForEmptyString() {
+        var params = new GatewayAccountSearchParams();
+        params.setAccountIds(new CommaDelimitedSetParameter(""));
+
+        Map<String, Object> queryMap = params.getQueryMap();
+        assertThat(queryMap, IsMapWithSize.anEmptyMap());
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -22,6 +22,7 @@ public class AddGatewayAccountParams {
     private long corporatePrepaidCreditCardSurchargeAmount;
     private long corporatePrepaidDebitCardSurchargeAmount;
     private int integrationVersion3ds;
+    private boolean allowMoto;
 
     public int getIntegrationVersion3ds() {
         return integrationVersion3ds;
@@ -75,13 +76,17 @@ public class AddGatewayAccountParams {
         return corporatePrepaidDebitCardSurchargeAmount;
     }
 
+    public boolean isAllowMoto() {
+        return allowMoto;
+    }
+
     public static final class AddGatewayAccountParamsBuilder {
         private String accountId;
-        private String paymentGateway;
+        private String paymentGateway = "provider";
         private Map<String, String> credentials;
-        private String serviceName;
+        private String serviceName = "service name";
         private GatewayAccountEntity.Type providerUrlType = TEST;
-        private String description;
+        private String description = "description";
         private String analyticsId;
         private EmailCollectionMode emailCollectionMode = MANDATORY;
         private long corporateCreditCardSurchargeAmount;
@@ -89,6 +94,7 @@ public class AddGatewayAccountParams {
         private long corporatePrepaidCreditCardSurchargeAmount;
         private long corporatePrepaidDebitCardSurchargeAmount;
         private int integrationVersion3ds = 2;
+        private boolean allowMoto;
 
         private AddGatewayAccountParamsBuilder() {
         }
@@ -156,6 +162,11 @@ public class AddGatewayAccountParams {
             this.corporatePrepaidDebitCardSurchargeAmount = corporatePrepaidDebitCardSurchargeAmount;
             return this;
         }
+        
+        public AddGatewayAccountParamsBuilder withAllowMoto(boolean allowMoto) {
+            this.allowMoto = allowMoto;
+            return this;
+        }
 
         public AddGatewayAccountParams build() {
             AddGatewayAccountParams addGatewayAccountParams = new AddGatewayAccountParams();
@@ -172,6 +183,7 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.emailCollectionMode = this.emailCollectionMode;
             addGatewayAccountParams.corporateDebitCardSurchargeAmount = this.corporateDebitCardSurchargeAmount;
             addGatewayAccountParams.integrationVersion3ds = this.integrationVersion3ds;
+            addGatewayAccountParams.allowMoto = this.allowMoto;
             return addGatewayAccountParams;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -50,12 +50,12 @@ public class DatabaseTestHelper {
                             "service_name, type, description, analytics_id, email_collection_mode, " +
                             "integration_version_3ds, corporate_credit_card_surcharge_amount, " +
                             "corporate_debit_card_surcharge_amount, corporate_prepaid_credit_card_surcharge_amount, " +
-                            "corporate_prepaid_debit_card_surcharge_amount) " +
+                            "corporate_prepaid_debit_card_surcharge_amount, allow_moto) " +
                             "VALUES (:id, :payment_provider, :credentials, :service_name, :type, " +
                             ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                             ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
                             ":corporate_prepaid_credit_card_surcharge_amount, " +
-                            ":corporate_prepaid_debit_card_surcharge_amount)")
+                            ":corporate_prepaid_debit_card_surcharge_amount, :allow_moto)")
                             .bind("id", Long.valueOf(params.getAccountId()))
                             .bind("payment_provider", params.getPaymentGateway())
                             .bindBySqlType("credentials", jsonObject, OTHER)
@@ -69,6 +69,7 @@ public class DatabaseTestHelper {
                             .bind("corporate_debit_card_surcharge_amount", params.getCorporateDebitCardSurchargeAmount())
                             .bind("corporate_prepaid_credit_card_surcharge_amount", params.getCorporatePrepaidCreditCardSurchargeAmount())
                             .bind("corporate_prepaid_debit_card_surcharge_amount", params.getCorporatePrepaidDebitCardSurchargeAmount())
+                            .bind("allow_moto", params.isAllowMoto())
                             .execute());
         } catch (SQLException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Add method to search gateway accounts by multiple parameters. Currently this is just by gateway account ids and whether MOTO is enabled or not. The is being added so we can filter gateway accounts in toolbox, and is intended to be extended in future with additional search parameters.

Add GatewayAccountSearchParams which is the query parameters bean which will be populated by the resource. This follows the pattern used for searching in ledger.

This new DAO method will be used by the GET `/v1/api/accounts` search resource, and will replace the existing `list` method in the DAO that takes a list of gateway account ids as a parameter.