### PR TITLE
PP-6072 Allow searching for gateway account by more parameters

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -194,12 +194,17 @@ Content-Type: application/json
 ---------------------------------------------------------------------------------------------------------------
 ## GET /v1/api/accounts
 
-Retrieves a collection of all the accounts
+Retrieves a collection of accounts, optionally filtering by the provided query parameters
+
+| Field          | Always present | Description                                                                                                                                |
+|:---------------|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------------|
+| `accountIds`   |                | The account IDs that the results should be filtered by. A comma separated list of IDs.                                                     |
+| `moto_enabled` |                | The accounts will be filtered by whether or not MOTO payment are enabled for the account if this parameter is provided. "true" or "false". |
 
 ### Request example
 
 ```
-GET /v1/api/accounts
+GET /v1/api/accounts?accountIds
 ```
 
 ### Response example

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -34,19 +34,6 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
                 .getResultList().stream().findFirst();
     }
 
-    public List<GatewayAccountEntity> list(List<Long> accountIds) {
-        String query = "SELECT gae"
-                + " FROM GatewayAccountEntity gae"
-                + " WHERE gae.id IN :accountIds"
-                + " ORDER BY gae.id";
-
-        return entityManager
-                .get()
-                .createQuery(query, GatewayAccountEntity.class)
-                .setParameter("accountIds", accountIds)
-                .getResultList();
-    }
-
     public List<GatewayAccountEntity> search(GatewayAccountSearchParams params) {
         List<String> filterTemplates = params.getFilterTemplates();
         String whereClause = filterTemplates.isEmpty() ?
@@ -65,16 +52,5 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
         params.getQueryMap().forEach(query::setParameter);
         
         return query.getResultList();
-    }
-
-    public List<GatewayAccountEntity> listAll() {
-        String query = "SELECT gae " +
-                "FROM GatewayAccountEntity gae " +
-                "ORDER BY gae.id";
-
-        return entityManager
-                .get()
-                .createQuery(query, GatewayAccountEntity.class)
-                .getResultList();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.common.model.api.CommaDelimitedSetParameter;
 
-import javax.ws.rs.DefaultValue;
+import javax.validation.constraints.Pattern;
 import javax.ws.rs.QueryParam;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,17 +15,21 @@ public class GatewayAccountSearchParams {
     private static final String ACCOUNT_IDS_SQL_FIELD = "accountIds";
     private static final String ALLOW_MOTO_SQL_FIELD = "allowMoto";
     
-    @DefaultValue("")
     @QueryParam("accountIds")
     private CommaDelimitedSetParameter accountIds;
+    
+    // This is a string value rather than boolean as if the parameter isn't provided, it should not filter by
+    // moto enabled/disabled
     @QueryParam("moto_enabled")
-    private Boolean motoEnabled;
+    @Pattern(regexp = "true|false",
+            message = "Parameter [moto_enabled] must be true or false")
+    private String motoEnabled;
 
     public void setAccountIds(CommaDelimitedSetParameter accountIds) {
         this.accountIds = accountIds;
     }
 
-    public void setMotoEnabled(Boolean motoEnabled) {
+    public void setMotoEnabled(String motoEnabled) {
         this.motoEnabled = motoEnabled;
     }
 
@@ -34,7 +39,7 @@ public class GatewayAccountSearchParams {
         if (accountIds != null && accountIds.isNotEmpty()) {
             filters.add(" gae.id IN :" + ACCOUNT_IDS_SQL_FIELD);
         }
-        if (motoEnabled != null) {
+        if (StringUtils.isNotEmpty(motoEnabled)) {
             filters.add(" gae.allowMoto = :" + ALLOW_MOTO_SQL_FIELD);
         }
         
@@ -47,10 +52,16 @@ public class GatewayAccountSearchParams {
         if (accountIds != null && accountIds.isNotEmpty()) {
             queryMap.put(ACCOUNT_IDS_SQL_FIELD, accountIds.getParameters());
         }
-        if (motoEnabled != null) {
-            queryMap.put(ALLOW_MOTO_SQL_FIELD, motoEnabled);
+        if (StringUtils.isNotEmpty(motoEnabled)) {
+            queryMap.put(ALLOW_MOTO_SQL_FIELD, Boolean.valueOf(motoEnabled));
         }
         
         return queryMap;
+    }
+
+    @Override
+    public String toString() {
+        return "accountIds=" + accountIds +
+                ", moto_enabled=" + motoEnabled;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 
 import javax.inject.Inject;
 import javax.ws.rs.core.UriInfo;
@@ -55,15 +56,9 @@ public class GatewayAccountService {
     public Optional<GatewayAccountEntity> getGatewayAccount(long gatewayAccountId) {
         return gatewayAccountDao.findById(gatewayAccountId);
     }
-
-    public List<GatewayAccountResourceDTO> getAllGatewayAccounts() {
-        return gatewayAccountDao.listAll().stream()
-                .map(GatewayAccountResourceDTO::fromEntity)
-                .collect(Collectors.toList());
-    }
-
-    public List<GatewayAccountResourceDTO> getGatewayAccounts(List<Long> gatewayAccountIds) {
-        return gatewayAccountDao.list(gatewayAccountIds).stream()
+    
+    public List<GatewayAccountResourceDTO> searchGatewayAccounts(GatewayAccountSearchParams params) {
+        return gatewayAccountDao.search(params).stream()
                 .map(GatewayAccountResourceDTO::fromEntity)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
-import org.hamcrest.collection.IsMapWithSize;
 import org.junit.Test;
 import uk.gov.pay.connector.common.model.api.CommaDelimitedSetParameter;
 
@@ -19,7 +18,7 @@ public class GatewayAccountSearchParamsTest {
     public void shouldReturnFilterTemplatesWithAllParameters() {
         var params = new GatewayAccountSearchParams();
         params.setAccountIds(new CommaDelimitedSetParameter("1,2"));
-        params.setMotoEnabled(false);
+        params.setMotoEnabled("false");
 
         List<String> filterTemplates = params.getFilterTemplates();
         assertThat(filterTemplates, hasSize(2));
@@ -49,7 +48,7 @@ public class GatewayAccountSearchParamsTest {
     public void shouldReturnQueryMapWithAllParameters() {
         var params = new GatewayAccountSearchParams();
         params.setAccountIds(new CommaDelimitedSetParameter("1,2"));
-        params.setMotoEnabled(false);
+        params.setMotoEnabled("false");
 
         Map<String, Object> queryMap = params.getQueryMap();
         assertThat(queryMap, hasEntry("accountIds", List.of("1", "2")));

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -316,168 +316,24 @@ public class GatewayAccountDaoIT extends DaoITestBase {
     }
 
     @Test
-    public void shouldListAllAccounts() {
-        final long gatewayAccountId_1 = nextLong();
-        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withPaymentGateway("provider-1")
-                .withCredentials(Map.of("user", "fuser", "password", "word"))
-                .withServiceName("service-name-1")
-                .withDescription("description-1")
-                .withAnalyticsId("analytics-id-1")
-                .withCorporateCreditCardSurchargeAmount(100)
-                .withCorporateDebitCardSurchargeAmount(200)
-                .withCorporatePrepaidCreditCardSurchargeAmount(300)
-                .withCorporatePrepaidDebitCardSurchargeAmount(400)
-                .build());
-        final long gatewayAccountId_2 = nextLong();
-        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withPaymentGateway("provider-2")
-                .withServiceName("service-name-2")
-                .withDescription("description-2")
-                .withAnalyticsId("analytics-id-2")
-                .withCorporateCreditCardSurchargeAmount(250)
-                .withCorporateDebitCardSurchargeAmount(50)
-                .withCorporatePrepaidCreditCardSurchargeAmount(250)
-                .withCorporatePrepaidDebitCardSurchargeAmount(50)
-                .build());
-        final long gatewayAccountId_3 = nextLong();
-        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_3))
-                .withPaymentGateway("provider-3")
-                .withServiceName("service-name-3")
-                .withDescription("description-3")
-                .withAnalyticsId("analytics-id-3")
-                .withProviderUrlType(GatewayAccountEntity.Type.LIVE)
-                .build());
-
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.listAll();
-
-        assertEquals(3, gatewayAccounts.size());
-
-        List<GatewayAccountEntity> gatewayAccountWithId_1 = gatewayAccounts.stream().filter(ga -> ga.getId() == gatewayAccountId_1).collect(Collectors.toList());
-        assertEquals(gatewayAccountWithId_1.size(), 1);
-        GatewayAccountEntity gatewayAccountEntity = gatewayAccountWithId_1.get(0);
-        assertThat(gatewayAccountEntity.getId(), is(gatewayAccountId_1));
-        assertEquals("provider-1", gatewayAccountEntity.getGatewayName());
-        assertEquals("description-1", gatewayAccountEntity.getDescription());
-        assertEquals("service-name-1", gatewayAccountEntity.getServiceName());
-        assertEquals(TEST.toString(), gatewayAccountEntity.getType());
-        assertEquals("analytics-id-1", gatewayAccountEntity.getAnalyticsId());
-        assertEquals(100L, gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount());
-        assertEquals(200L, gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount());
-        assertEquals(300L, gatewayAccountEntity.getCorporatePrepaidCreditCardSurchargeAmount());
-        assertEquals(400L, gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount());
-
-        List<GatewayAccountEntity> gatewayAccountWithId_2 = gatewayAccounts.stream().filter(ga -> ga.getId() == gatewayAccountId_2).collect(Collectors.toList());
-        assertEquals(gatewayAccountWithId_2.size(), 1);
-        gatewayAccountEntity = gatewayAccountWithId_2.get(0);
-        assertEquals("provider-2", gatewayAccountEntity.getGatewayName());
-        assertEquals(250L, gatewayAccountEntity.getCorporateNonPrepaidCreditCardSurchargeAmount());
-        assertEquals(50L, gatewayAccountEntity.getCorporateNonPrepaidDebitCardSurchargeAmount());
-        assertThat(gatewayAccountEntity.getId(), is(gatewayAccountId_2));
-
-        List<GatewayAccountEntity> gatewayAccountWithId_3 = gatewayAccounts.stream().filter(ga -> ga.getId() == gatewayAccountId_3).collect(Collectors.toList());
-        assertEquals(gatewayAccountWithId_3.size(), 1);
-        gatewayAccountEntity = gatewayAccountWithId_3.get(0);
-        assertEquals("provider-3", gatewayAccountEntity.getGatewayName());
-        assertEquals(0L, gatewayAccountEntity.getCorporatePrepaidCreditCardSurchargeAmount());
-        assertEquals(0L, gatewayAccountEntity.getCorporatePrepaidDebitCardSurchargeAmount());
-        assertThat(gatewayAccountEntity.getId(), is(gatewayAccountId_3));
-    }
-    
-    
-    @Test
-    public void shouldListASubsetOfAccountsSingle() {
+    public void shouldReturnAllAccountsWhenNoSearchParamaters() {
         long gatewayAccountId_1 = nextLong();
-        databaseTestHelper.addGatewayAccount(
-                anAddGatewayAccountParams()
-                        .withAccountId(String.valueOf(gatewayAccountId_1))
-                        .withPaymentGateway("provider-1")
-                        .withCredentials(Map.of("user", "fuser","password", "word"))
-                        .withServiceName("service-name-1")
-                        .withDescription("description-1")
-                        .withAnalyticsId("analytics-id-1")
-                        .build());
-        long gatewayAccountId_2 = nextLong();
-        databaseTestHelper.addGatewayAccount(
-                anAddGatewayAccountParams()
-                        .withAccountId(String.valueOf(gatewayAccountId_2))
-                        .withPaymentGateway("provider-2")
-                        .withServiceName("service-name-2")
-                        .withDescription("description-2")
-                        .withAnalyticsId("analytics-id-2")
-                        .build());
-
-        List<Long> accountIds = Collections.singletonList(gatewayAccountId_2);
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.list(accountIds);
-
-        assertEquals(1, gatewayAccounts.size());
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
-        assertEquals("provider-2", gatewayAccounts.get(0).getGatewayName());
-        assertEquals("description-2", gatewayAccounts.get(0).getDescription());
-        assertEquals("service-name-2", gatewayAccounts.get(0).getServiceName());
-        assertEquals(TEST.toString(), gatewayAccounts.get(0).getType());
-        assertEquals("analytics-id-2", gatewayAccounts.get(0).getAnalyticsId());
-    }
-
-    @Test
-    public void shouldListASubsetOfAccountsMultiple() {
-        final long gatewayAccountId_1 = nextLong();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId_1))
-                .withPaymentGateway("provider-1")
-                .withCredentials(Map.of("user", "fuser","password", "word"))
-                .withServiceName("service-name-1")
-                .withDescription("description-1")
-                .withAnalyticsId("analytics-id-1")
                 .build());
-        final long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId_2))
-                .withPaymentGateway("provider-2")
-                .withServiceName("service-name-2")
-                .withDescription("description-2")
-                .withAnalyticsId("analytics-id-2")
-                .withCorporateCreditCardSurchargeAmount(100)
-                .withCorporateDebitCardSurchargeAmount(200)
-                .withCorporatePrepaidCreditCardSurchargeAmount(300)
-                .withCorporatePrepaidDebitCardSurchargeAmount(400)
-                .build());
-        final long gatewayAccountId_3 = gatewayAccountId_2 + 1;
-        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId_3))
-                .withPaymentGateway("provider-3")
-                .withServiceName("service-name-3")
-                .withDescription("description-3")
-                .withAnalyticsId("analytics-id-3")
                 .build());
 
-        List<Long> accountIds = Arrays.asList(gatewayAccountId_2, gatewayAccountId_3);
-        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.list(accountIds);
+        var params = new GatewayAccountSearchParams();
 
-        assertEquals(2, gatewayAccounts.size());
-
-        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
-        assertEquals("provider-2", gatewayAccounts.get(0).getGatewayName());
-        assertEquals("description-2", gatewayAccounts.get(0).getDescription());
-        assertEquals("service-name-2", gatewayAccounts.get(0).getServiceName());
-        assertEquals(TEST.toString(), gatewayAccounts.get(0).getType());
-        assertEquals("analytics-id-2", gatewayAccounts.get(0).getAnalyticsId());
-        assertEquals(100, gatewayAccounts.get(0).getCorporateNonPrepaidCreditCardSurchargeAmount());
-        assertEquals(200L, gatewayAccounts.get(0).getCorporateNonPrepaidDebitCardSurchargeAmount());
-        assertEquals(300L, gatewayAccounts.get(0).getCorporatePrepaidCreditCardSurchargeAmount());
-        assertEquals(400L, gatewayAccounts.get(0).getCorporatePrepaidDebitCardSurchargeAmount());
-
-        assertThat(gatewayAccounts.get(1).getId(), is(gatewayAccountId_3));
-        assertEquals("provider-3", gatewayAccounts.get(1).getGatewayName());
-        assertEquals("description-3", gatewayAccounts.get(1).getDescription());
-        assertEquals("service-name-3", gatewayAccounts.get(1).getServiceName());
-        assertEquals(TEST.toString(), gatewayAccounts.get(1).getType());
-        assertEquals("analytics-id-3", gatewayAccounts.get(1).getAnalyticsId());
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(2));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+        assertThat(gatewayAccounts.get(1).getId(), is(gatewayAccountId_2));
     }
-
+    
     @Test
     public void shouldSearchForAccountsById() {
         long gatewayAccountId_1 = nextLong();
@@ -516,7 +372,7 @@ public class GatewayAccountDaoIT extends DaoITestBase {
                 .build());
 
         var params = new GatewayAccountSearchParams();
-        params.setMotoEnabled(true);
+        params.setMotoEnabled("true");
 
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
         assertThat(gatewayAccounts, hasSize(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -173,78 +173,63 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     }
 
     @Test
-    public void shouldReturnCollectionOfAccounts() {
-        DatabaseFixtures
-                .withDatabaseTestHelper(databaseTestHelper)
-                .aTestAccount()
-                .withAccountId(100)
-                .withPaymentProvider("sandbox")
-                .withType(TEST)
-                .insert();
-        DatabaseFixtures
-                .withDatabaseTestHelper(databaseTestHelper)
-                .aTestAccount()
-                .withAccountId(200)
-                .withPaymentProvider("sandbox")
-                .withType(LIVE)
-                .insert();
-        DatabaseFixtures
-                .withDatabaseTestHelper(databaseTestHelper)
-                .aTestAccount()
-                .withAccountId(300)
-                .withPaymentProvider("smartpay")
-                .withType(LIVE)
-                .insert();
-        DatabaseFixtures
-                .withDatabaseTestHelper(databaseTestHelper)
-                .aTestAccount()
-                .withAccountId(400)
-                .withPaymentProvider("worldpay")
-                .withType(TEST)
-                .withServiceName(null)
-                .insert();
-
-        // assert properties are there
-        givenSetup()
-                .get("/v1/api/accounts")
-                .then()
-                .statusCode(200)
-                .body("accounts", hasSize(4))
-                .body("accounts[0].gateway_account_id", is(100))
-                .body("accounts[0].payment_provider", is("sandbox"))
-                .body("accounts[0].type", is(TEST.toString()))
-                .body("accounts[0].description", is("a description"))
-                .body("accounts[0].service_name", is("service_name"))
-                .body("accounts[0].analytics_id", is("an analytics id"))
-                .body("accounts[0].corporate_credit_card_surcharge_amount", is(0))
-                .body("accounts[0].corporate_debit_card_surcharge_amount", is(0))
-                .body("accounts[0]._links.self.href", is("https://localhost:" + testContext.getPort() + ACCOUNTS_API_URL + 100))
-                // and credentials should be missing
-                .body("accounts[0].credentials", nullValue())
-
-                .body("accounts[2].gateway_account_id", is(300))
-                .body("accounts[2].payment_provider", is("smartpay"))
-                .body("accounts[2].type", is(LIVE.toString()))
-                .body("accounts[2].description", is("a description"))
-                .body("accounts[2].service_name", is("service_name"))
-                .body("accounts[2].analytics_id", is("an analytics id"))
-                .body("accounts[2].corporate_credit_card_surcharge_amount", is(0))
-                .body("accounts[2].corporate_debit_card_surcharge_amount", is(0))
-                .body("accounts[2]._links.self.href", is("https://localhost:" + testContext.getPort() + ACCOUNTS_API_URL + 300))
-                // and credentials should be missing
-                .body("accounts[2].credentials", nullValue())
-
-                // service name for the last one should be absent in response as its null
-                .body("accounts[3].service_name", nullValue());
-    }
-
-    @Test
     public void shouldReturnEmptyCollectionOfAccountsWhenNoneFound() {
         givenSetup()
                 .get("/v1/api/accounts")
                 .then()
                 .statusCode(200)
                 .body("accounts", hasSize(0));
+    }
+
+    @Test
+    public void shouldGetAllGatewayAccountsWhenSearchWithNoParams() {
+        String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
+        updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
+        createAGatewayAccountFor("sandbox");
+
+        givenSetup()
+                .get("/v1/api/accounts")
+                .then()
+                .statusCode(OK.getStatusCode())
+                .body("accounts", hasSize(2));
+    }
+
+    @Test
+    public void shouldGetGatewayAccountsByIds() {
+        String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
+        String gatewayAccountId2 = createAGatewayAccountFor("sandbox");
+        createAGatewayAccountFor("sandbox");
+
+        givenSetup()
+                .get("/v1/api/accounts?accountIds=" + gatewayAccountId1 + "," + gatewayAccountId2)
+                .then()
+                .statusCode(OK.getStatusCode())
+                .body("accounts", hasSize(2))
+                .body("accounts[0].gateway_account_id", is(Integer.valueOf(gatewayAccountId1)))
+                .body("accounts[1].gateway_account_id", is(Integer.valueOf(gatewayAccountId2)));
+    }
+
+    @Test
+    public void shouldGetGatewayAccountsByMotoEnabled() {
+        String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
+        updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
+        createAGatewayAccountFor("sandbox");
+
+        givenSetup()
+                .get("/v1/api/accounts?moto_enabled=true")
+                .then()
+                .statusCode(OK.getStatusCode())
+                .body("accounts", hasSize(1))
+                .body("accounts[0].gateway_account_id", is(Integer.valueOf(gatewayAccountId1)));
+    }
+
+    @Test
+    public void shouldReturn422ForMotoEnabledNotBooleanValue() {
+        givenSetup()
+                .get("/v1/api/accounts?moto_enabled=blah")
+                .then()
+                .statusCode(422)
+                .body("message[0]", is("Parameter [moto_enabled] must be true or false"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -224,6 +224,20 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     }
 
     @Test
+    public void shouldGetGatewayAccountsByMotoDisabled() {
+        String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
+        updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
+        String gatewayAccountId2 = createAGatewayAccountFor("sandbox");
+
+        givenSetup()
+                .get("/v1/api/accounts?moto_enabled=false")
+                .then()
+                .statusCode(OK.getStatusCode())
+                .body("accounts", hasSize(1))
+                .body("accounts[0].gateway_account_id", is(Integer.valueOf(gatewayAccountId2)));
+    }
+
+    @Test
     public void shouldReturn422ForMotoEnabledNotBooleanValue() {
         givenSetup()
                 .get("/v1/api/accounts?moto_enabled=blah")

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -86,6 +86,18 @@ public class GatewayAccountResourceTestBase {
                 .contentType(JSON);
     }
 
+    void updateGatewayAccount(String gatewayAccountId, String path, Object value) {
+        given()
+                .port(testContext.getPort())
+                .contentType(JSON)
+                .body(Map.of("path", path,
+                        "op", "replace",
+                        "value", value))
+                .patch(ACCOUNTS_API_URL + gatewayAccountId)
+                .then()
+                .statusCode(200);
+    }
+
     public static void assertGettingAccountReturnsProviderName(int port, ValidatableResponse response, String providerName, GatewayAccountEntity.Type providerUrlType) {
         given().port(port)
                 .contentType(JSON)
@@ -97,7 +109,7 @@ public class GatewayAccountResourceTestBase {
                 .body("gateway_account_id", is(notNullValue()))
                 .body("type", is(providerUrlType.toString()));
     }
-    
+
     public static void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountEntity.Type type, String description, String analyticsId, String name) {
         String accountId = response.extract().path("gateway_account_id");
         String urlSlug = "api/accounts/" + accountId;

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,6 +16,7 @@ import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 
 import java.util.Arrays;
@@ -72,21 +72,12 @@ public class GatewayAccountServiceTest {
     }
 
     @Test
-    public void shouldGetAllGatewayAccounts() {
-        when(mockGatewayAccountDao.listAll()).thenReturn(Arrays.asList(getMockGatewayAccountEntity1, getMockGatewayAccountEntity2));
-        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.getAllGatewayAccounts();
+    public void shouldSearchGatewayAccounts() {
+        GatewayAccountSearchParams gatewayAccountSearchParams = new GatewayAccountSearchParams();
+        when(mockGatewayAccountDao.search(gatewayAccountSearchParams))
+                .thenReturn(Arrays.asList(getMockGatewayAccountEntity1, getMockGatewayAccountEntity2));
 
-        assertThat(gatewayAccounts, hasSize(2));
-        assertThat(gatewayAccounts.get(0).getServiceName(), is("service one"));
-        assertThat(gatewayAccounts.get(1).getServiceName(), is("service two"));
-    }
-
-    @Test
-    public void shouldGetGatewayAccountsByIds() {
-        List<Long> accountIds = Arrays.asList(1L, 2L);
-        when(mockGatewayAccountDao.list(accountIds)).thenReturn(Arrays.asList(getMockGatewayAccountEntity1, getMockGatewayAccountEntity2));
-
-        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.getGatewayAccounts(accountIds);
+        List<GatewayAccountResourceDTO> gatewayAccounts = gatewayAccountService.searchGatewayAccounts(gatewayAccountSearchParams);
 
         assertThat(gatewayAccounts, hasSize(2));
         assertThat(gatewayAccounts.get(0).getServiceName(), is("service one"));


### PR DESCRIPTION
Previously, could just search by a list of gateway account ids. Now can provide an additional query parameter `moto_enabled` to filter gateway accounts by whether or not they allow moto payments or not.

Use a bean for the query parameters for the get gateway accounts endpoint and a new search method that was added to the DAO previously. Clean up the old methods that are no longer needed now.