### PR TITLE
PP-6072 Allow searching for gateway accounts by additional parameters

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -196,15 +196,20 @@ Content-Type: application/json
 
 Retrieves a collection of accounts, optionally filtering by the provided query parameters
 
-| Field          | Always present | Description                                                                                                                                |
-|:---------------|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------------|
-| `accountIds`   |                | The account IDs that the results should be filtered by. A comma separated list of IDs.                                                     |
-| `moto_enabled` |                | The accounts will be filtered by whether or not MOTO payment are enabled for the account if this parameter is provided. "true" or "false". |
+| Field                | Always present | Description                                                                                                                                      |
+|:---------------------|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `accountIds`         |                | The account IDs that the results should be filtered by. A comma separated list of IDs.                                                           |
+| `moto_enabled`       |                | The accounts will be filtered by whether or not MOTO payment are enabled for the account if this parameter is provided. "true" or "false".       |
+| `apple_pay_enabled`  |                | The accounts will be filtered by whether or not Apple pay is enabled for the account if this parameter is provided. "true" or "false".           |
+| `google_pay_enabled` |                | The accounts will be filtered by whether or not Google pay is enabled for the account if this parameter is provided. "true" or "false".          |
+| `requires_3ds`       |                | The accounts will be filtered by whether or not 3DS is required for the account if this parameter is provided. "true" or "false".                |
+| `type`               |                | The accounts will be filtered by type if this parameter is provided. "test" or "live".                                                           |
+| `payment_provider`   |                | The accounts will be filtered by payment provider if this parameter is provided. One of "sandbox" or "worldpay", "smartpay", "epdq" or "stripe". |
 
 ### Request example
 
 ```
-GET /v1/api/accounts?accountIds
+GET /v1/api/accounts?accountIds=1,2&payment_provider=worldpay
 ```
 
 ### Response example

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -14,6 +14,11 @@ public class GatewayAccountSearchParams {
 
     private static final String ACCOUNT_IDS_SQL_FIELD = "accountIds";
     private static final String ALLOW_MOTO_SQL_FIELD = "allowMoto";
+    private static final String ALLOW_APPLE_PAY_SQL_FIELD = "allowApplePay";
+    private static final String ALLOW_GOOGLE_PAY_SQL_FIELD = "allowGooglePay";
+    private static final String REQUIRES_3DS_SQL_FIELD = "requires3ds";
+    private static final String TYPE_SQL_FIELD = "type";
+    private static final String PAYMENT_PROVIDER_SQL_FIELD = "gatewayName";
     
     @QueryParam("accountIds")
     private CommaDelimitedSetParameter accountIds;
@@ -25,12 +30,57 @@ public class GatewayAccountSearchParams {
             message = "Parameter [moto_enabled] must be true or false")
     private String motoEnabled;
 
+    @QueryParam("apple_pay_enabled")
+    @Pattern(regexp = "true|false",
+            message = "Parameter [apple_pay_enabled] must be true or false")
+    private String applePayEnabled;
+    
+    @QueryParam("google_pay_enabled")
+    @Pattern(regexp = "true|false",
+            message = "Parameter [google_pay_enabled] must be true or false")
+    private String googlePayEnabled;
+
+    @QueryParam("requires_3ds")
+    @Pattern(regexp = "true|false",
+            message = "Parameter [requires_3ds] must be true or false")
+    private String requires3ds;
+    
+    @QueryParam("type")
+    @Pattern(regexp = "live|test",
+            message = "Parameter [type] must be 'live' or 'test'")
+    private String type;
+
+    @QueryParam("payment_provider")
+    @Pattern(regexp = "sandbox|worldpay|smartpay|epdq|stripe",
+            message = "Parameter [payment_provider] must be one of 'sandbox', 'worldpay', 'smartpay', 'epdq' or 'stripe'")
+    private String paymentProvider;
+
     public void setAccountIds(CommaDelimitedSetParameter accountIds) {
         this.accountIds = accountIds;
     }
 
     public void setMotoEnabled(String motoEnabled) {
         this.motoEnabled = motoEnabled;
+    }
+
+    public void setApplePayEnabled(String applePayEnabled) {
+        this.applePayEnabled = applePayEnabled;
+    }
+
+    public void setGooglePayEnabled(String googlePayEnabled) {
+        this.googlePayEnabled = googlePayEnabled;
+    }
+
+    public void setRequires3ds(String requires3ds) {
+        this.requires3ds = requires3ds;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public void setPaymentProvider(String paymentProvider) {
+        this.paymentProvider = paymentProvider;
     }
 
     public List<String> getFilterTemplates() {
@@ -41,6 +91,21 @@ public class GatewayAccountSearchParams {
         }
         if (StringUtils.isNotEmpty(motoEnabled)) {
             filters.add(" gae.allowMoto = :" + ALLOW_MOTO_SQL_FIELD);
+        }
+        if (StringUtils.isNotEmpty(applePayEnabled)) {
+            filters.add(" gae.allowApplePay = :" + ALLOW_APPLE_PAY_SQL_FIELD);
+        }
+        if (StringUtils.isNotEmpty(googlePayEnabled)) {
+            filters.add(" gae.allowGooglePay = :" + ALLOW_GOOGLE_PAY_SQL_FIELD);
+        }
+        if (StringUtils.isNotEmpty(requires3ds)) {
+            filters.add(" gae.requires3ds = :" + REQUIRES_3DS_SQL_FIELD);
+        }
+        if (StringUtils.isNotEmpty(type)) {
+            filters.add(" gae.type = :" + TYPE_SQL_FIELD);
+        }
+        if (StringUtils.isNotEmpty(paymentProvider)) {
+            filters.add(" gae.gatewayName = :" + PAYMENT_PROVIDER_SQL_FIELD);
         }
         
         return List.copyOf(filters);
@@ -55,13 +120,35 @@ public class GatewayAccountSearchParams {
         if (StringUtils.isNotEmpty(motoEnabled)) {
             queryMap.put(ALLOW_MOTO_SQL_FIELD, Boolean.valueOf(motoEnabled));
         }
+        if (StringUtils.isNotEmpty(applePayEnabled)) {
+            queryMap.put(ALLOW_APPLE_PAY_SQL_FIELD, Boolean.valueOf(applePayEnabled));
+        }
+        if (StringUtils.isNotEmpty(googlePayEnabled)) {
+            queryMap.put(ALLOW_GOOGLE_PAY_SQL_FIELD, Boolean.valueOf(googlePayEnabled));
+        }
+        if (StringUtils.isNotEmpty(requires3ds)) {
+            queryMap.put(REQUIRES_3DS_SQL_FIELD, Boolean.valueOf(requires3ds));
+        }
+        if (StringUtils.isNotEmpty(type)) {
+            queryMap.put(TYPE_SQL_FIELD, GatewayAccountEntity.Type.fromString(type));
+        }
+        if (StringUtils.isNotEmpty(paymentProvider)) {
+            queryMap.put(PAYMENT_PROVIDER_SQL_FIELD, paymentProvider);
+        }
         
         return queryMap;
     }
 
     @Override
     public String toString() {
-        return "accountIds=" + accountIds +
-                ", moto_enabled=" + motoEnabled;
+        return "GatewayAccountSearchParams{" +
+                "accountIds=" + accountIds +
+                ", motoEnabled='" + motoEnabled + '\'' +
+                ", applePayEnabled='" + applePayEnabled + '\'' +
+                ", googlePayEnabled='" + googlePayEnabled + '\'' +
+                ", requires3ds='" + requires3ds + '\'' +
+                ", type='" + type + '\'' +
+                ", paymentProvider='" + paymentProvider + '\'' +
+                '}';
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -10,27 +10,38 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
 
 public class GatewayAccountSearchParamsTest {
-    
+
     @Test
     public void shouldReturnFilterTemplatesWithAllParameters() {
         var params = new GatewayAccountSearchParams();
         params.setAccountIds(new CommaDelimitedSetParameter("1,2"));
         params.setMotoEnabled("false");
+        params.setApplePayEnabled("true");
+        params.setGooglePayEnabled("true");
+        params.setRequires3ds("true");
+        params.setType("live");
+        params.setPaymentProvider("stripe");
 
         List<String> filterTemplates = params.getFilterTemplates();
-        assertThat(filterTemplates, hasSize(2));
         assertThat(filterTemplates, containsInAnyOrder(
                 " gae.id IN :accountIds",
-                " gae.allowMoto = :allowMoto"));
+                " gae.allowMoto = :allowMoto",
+                " gae.allowApplePay = :allowApplePay",
+                " gae.allowGooglePay = :allowGooglePay",
+                " gae.requires3ds = :requires3ds",
+                " gae.type = :type",
+                " gae.gatewayName = :gatewayName"));
     }
 
     @Test
     public void shouldReturnEmptyFilterTemplatesForNoParamsSet() {
         var params = new GatewayAccountSearchParams();
-        
+
         List<String> filterTemplates = params.getFilterTemplates();
         assertThat(filterTemplates, hasSize(0));
     }
@@ -49,10 +60,21 @@ public class GatewayAccountSearchParamsTest {
         var params = new GatewayAccountSearchParams();
         params.setAccountIds(new CommaDelimitedSetParameter("1,2"));
         params.setMotoEnabled("false");
+        params.setApplePayEnabled("true");
+        params.setGooglePayEnabled("true");
+        params.setRequires3ds("true");
+        params.setType("live");
+        params.setPaymentProvider("stripe");
 
         Map<String, Object> queryMap = params.getQueryMap();
+        assertThat(queryMap, aMapWithSize(7));
         assertThat(queryMap, hasEntry("accountIds", List.of("1", "2")));
         assertThat(queryMap, hasEntry("allowMoto", false));
+        assertThat(queryMap, hasEntry("allowApplePay", true));
+        assertThat(queryMap, hasEntry("allowGooglePay", true));
+        assertThat(queryMap, hasEntry("requires3ds", true));
+        assertThat(queryMap, hasEntry("type", LIVE));
+        assertThat(queryMap, hasEntry("gatewayName", "stripe"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -461,7 +461,7 @@ public class DatabaseFixtures {
                     .withPaymentGateway(paymentProvider)
                     .withCredentials(credentials)
                     .withServiceName(serviceName)
-                    .withProviderUrlType(type)
+                    .withType(type)
                     .withDescription(description)
                     .withAnalyticsId(analyticsId)
                     .withEmailCollectionMode(emailCollectionMode)

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -12,12 +12,10 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
@@ -34,6 +32,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 
@@ -373,6 +372,111 @@ public class GatewayAccountDaoIT extends DaoITestBase {
 
         var params = new GatewayAccountSearchParams();
         params.setMotoEnabled("true");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+    }
+
+    @Test
+    public void shouldSearchForAccountsByApplePayEnabled() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withAllowApplePay(false)
+                .build());
+        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_2))
+                .withAllowApplePay(true)
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setApplePayEnabled("true");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+    }
+
+    @Test
+    public void shouldSearchForAccountsByGooglePayEnabled() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withAllowGooglePay(false)
+                .build());
+        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_2))
+                .withAllowGooglePay(true)
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setGooglePayEnabled("true");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+    }
+
+    @Test
+    public void shouldSearchForAccountsByRequires3ds() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withRequires3ds(false)
+                .build());
+        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_2))
+                .withRequires3ds(true)
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setRequires3ds("true");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+    }
+
+    @Test
+    public void shouldSearchForAccountsByType() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withType(TEST)
+                .build());
+        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_2))
+                .withType(LIVE)
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setType("live");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_2));
+    }
+
+    @Test
+    public void shouldSearchForAccountsByPaymentProvider() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withPaymentGateway("sandbox")
+                .build());
+        long gatewayAccountId_2 = gatewayAccountId_1 + 1;
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_2))
+                .withPaymentGateway("stripe")
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setPaymentProvider("stripe");
 
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
         assertThat(gatewayAccounts, hasSize(1));

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -510,10 +510,6 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
         return format("{\"card_types\": [%s]}", join(",", cardTypeIds));
     }
 
-    private String createAGatewayAccountFor(String provider, String desc, String id) {
-        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, desc, id));
-    }
-
     private DatabaseFixtures.TestAccount createAccountRecordWithCards(CardTypeEntity... cardTypes) {
         return databaseFixtures
                 .aTestAccount()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -53,6 +53,14 @@ public class GatewayAccountResourceTestBase {
         return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider));
     }
 
+    protected String createAGatewayAccountFor(String provider, String desc, String analyticsId) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, desc, analyticsId));
+    }
+    
+    protected String createAGatewayAccountFor(String provider, String description, String analyticsId, String requires3ds, String type) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, description, analyticsId, requires3ds, type));
+    }
+
     public static String extractGatewayAccountId(ValidatableResponse validatableResponse) {
         return validatableResponse.extract().path("gateway_account_id");
     }
@@ -62,10 +70,10 @@ public class GatewayAccountResourceTestBase {
     }
 
     public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId) {
-        return createAGatewayAccountFor(port, testProvider, description, analyticsId, null);
+        return createAGatewayAccountFor(port, testProvider, description, analyticsId, null, "test");
     }
 
-    public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId, String requires_3ds) {
+    public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId, String requires3ds, String type) {
         Map<String, String> payload = Maps.newHashMap();
         payload.put("payment_provider", testProvider);
         if (description != null) {
@@ -74,8 +82,11 @@ public class GatewayAccountResourceTestBase {
         if (analyticsId != null) {
             payload.put("analytics_id", analyticsId);
         }
-        if (requires_3ds != null) {
-            payload.put("requires_3ds", requires_3ds);
+        if (requires3ds != null) {
+            payload.put("requires_3ds", requires3ds);
+        }
+        if (type != null) {
+            payload.put("type", type);
         }
         return given().port(port)
                 .contentType(JSON)

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -13,7 +13,7 @@ public class AddGatewayAccountParams {
     private String paymentGateway;
     private Map<String, String> credentials;
     private String serviceName;
-    private GatewayAccountEntity.Type providerUrlType;
+    private GatewayAccountEntity.Type type;
     private String description;
     private String analyticsId;
     private EmailCollectionMode emailCollectionMode;
@@ -23,6 +23,9 @@ public class AddGatewayAccountParams {
     private long corporatePrepaidDebitCardSurchargeAmount;
     private int integrationVersion3ds;
     private boolean allowMoto;
+    private boolean allowApplePay;
+    private boolean allowGooglePay;
+    private boolean requires3ds;
 
     public int getIntegrationVersion3ds() {
         return integrationVersion3ds;
@@ -44,8 +47,8 @@ public class AddGatewayAccountParams {
         return serviceName;
     }
 
-    public GatewayAccountEntity.Type getProviderUrlType() {
-        return providerUrlType;
+    public GatewayAccountEntity.Type getType() {
+        return type;
     }
 
     public String getDescription() {
@@ -80,12 +83,24 @@ public class AddGatewayAccountParams {
         return allowMoto;
     }
 
+    public boolean isAllowApplePay() {
+        return allowApplePay;
+    }
+
+    public boolean isAllowGooglePay() {
+        return allowGooglePay;
+    }
+
+    public boolean isRequires3ds() {
+        return requires3ds;
+    }
+
     public static final class AddGatewayAccountParamsBuilder {
         private String accountId;
         private String paymentGateway = "provider";
         private Map<String, String> credentials;
         private String serviceName = "service name";
-        private GatewayAccountEntity.Type providerUrlType = TEST;
+        private GatewayAccountEntity.Type type = TEST;
         private String description = "description";
         private String analyticsId;
         private EmailCollectionMode emailCollectionMode = MANDATORY;
@@ -95,6 +110,9 @@ public class AddGatewayAccountParams {
         private long corporatePrepaidDebitCardSurchargeAmount;
         private int integrationVersion3ds = 2;
         private boolean allowMoto;
+        private boolean allowApplePay;
+        private boolean allowGooglePay;
+        private boolean requires3ds;
 
         private AddGatewayAccountParamsBuilder() {
         }
@@ -123,8 +141,8 @@ public class AddGatewayAccountParams {
             return this;
         }
 
-        public AddGatewayAccountParamsBuilder withProviderUrlType(GatewayAccountEntity.Type providerUrlType) {
-            this.providerUrlType = providerUrlType;
+        public AddGatewayAccountParamsBuilder withType(GatewayAccountEntity.Type type) {
+            this.type = type;
             return this;
         }
 
@@ -167,6 +185,21 @@ public class AddGatewayAccountParams {
             this.allowMoto = allowMoto;
             return this;
         }
+        
+        public AddGatewayAccountParamsBuilder withAllowApplePay(boolean allowApplePay) {
+            this.allowApplePay = allowApplePay;
+            return this;
+        }
+        
+        public AddGatewayAccountParamsBuilder withAllowGooglePay(boolean allowGooglePay) {
+            this.allowGooglePay = allowGooglePay;
+            return this;
+        }
+        
+        public AddGatewayAccountParamsBuilder withRequires3ds(boolean requires3ds) {
+            this.requires3ds = requires3ds;
+            return this;
+        }
 
         public AddGatewayAccountParams build() {
             AddGatewayAccountParams addGatewayAccountParams = new AddGatewayAccountParams();
@@ -175,7 +208,7 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.corporatePrepaidDebitCardSurchargeAmount = this.corporatePrepaidDebitCardSurchargeAmount;
             addGatewayAccountParams.analyticsId = this.analyticsId;
             addGatewayAccountParams.corporatePrepaidCreditCardSurchargeAmount = this.corporatePrepaidCreditCardSurchargeAmount;
-            addGatewayAccountParams.providerUrlType = this.providerUrlType;
+            addGatewayAccountParams.type = this.type;
             addGatewayAccountParams.credentials = this.credentials;
             addGatewayAccountParams.description = this.description;
             addGatewayAccountParams.serviceName = this.serviceName;
@@ -184,6 +217,9 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.corporateDebitCardSurchargeAmount = this.corporateDebitCardSurchargeAmount;
             addGatewayAccountParams.integrationVersion3ds = this.integrationVersion3ds;
             addGatewayAccountParams.allowMoto = this.allowMoto;
+            addGatewayAccountParams.allowApplePay = this.allowApplePay;
+            addGatewayAccountParams.allowGooglePay = this.allowGooglePay;
+            addGatewayAccountParams.requires3ds = this.requires3ds;
             return addGatewayAccountParams;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -50,17 +50,19 @@ public class DatabaseTestHelper {
                             "service_name, type, description, analytics_id, email_collection_mode, " +
                             "integration_version_3ds, corporate_credit_card_surcharge_amount, " +
                             "corporate_debit_card_surcharge_amount, corporate_prepaid_credit_card_surcharge_amount, " +
-                            "corporate_prepaid_debit_card_surcharge_amount, allow_moto) " +
+                            "corporate_prepaid_debit_card_surcharge_amount, allow_moto, allow_apple_pay, " +
+                            "allow_google_pay, requires_3ds) " +
                             "VALUES (:id, :payment_provider, :credentials, :service_name, :type, " +
                             ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                             ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
                             ":corporate_prepaid_credit_card_surcharge_amount, " +
-                            ":corporate_prepaid_debit_card_surcharge_amount, :allow_moto)")
+                            ":corporate_prepaid_debit_card_surcharge_amount, :allow_moto, :allow_apple_pay, " +
+                            ":allow_google_pay, :requires_3ds)")
                             .bind("id", Long.valueOf(params.getAccountId()))
                             .bind("payment_provider", params.getPaymentGateway())
                             .bindBySqlType("credentials", jsonObject, OTHER)
                             .bind("service_name", params.getServiceName())
-                            .bind("type", params.getProviderUrlType())
+                            .bind("type", params.getType())
                             .bind("description", params.getDescription())
                             .bind("analytics_id", params.getAnalyticsId())
                             .bind("email_collection_mode", params.getEmailCollectionMode())
@@ -70,6 +72,9 @@ public class DatabaseTestHelper {
                             .bind("corporate_prepaid_credit_card_surcharge_amount", params.getCorporatePrepaidCreditCardSurchargeAmount())
                             .bind("corporate_prepaid_debit_card_surcharge_amount", params.getCorporatePrepaidDebitCardSurchargeAmount())
                             .bind("allow_moto", params.isAllowMoto())
+                            .bind("allow_apple_pay", params.isAllowApplePay())
+                            .bind("allow_google_pay", params.isAllowGooglePay())
+                            .bind("requires_3ds", params.isRequires3ds())
                             .execute());
         } catch (SQLException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Amend query parameters and query construction for the DAO to allow for
filtering gateway accounts by additional parameters:
`apple_pay_enabled`
`google_pay_enabled`
`requires_3ds`
`type` (test/live)
`payment_provider`

This is for use in toolbox for finding which gateway accounts have certain features enabled etc, which is implemented here https://github.com/alphagov/pay-toolbox/pull/295