### PR TITLE
PP-6065 remove foreign key constrain on charge_id on refunds table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1430,4 +1430,36 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="drop foreign key constraint on charge_id on refunds table" author="">
+        <dropForeignKeyConstraint
+                baseTableName="refunds"
+                constraintName="fk__refunds_charges"/>
+    </changeSet>
+
+    <changeSet author="" id="drop not null constraint on charge_id on refunds table">
+        <dropNotNullConstraint columnDataType="bigserial"
+                               columnName="charge_id"
+                               tableName="refunds"/>
+    </changeSet>
+
+    <changeSet author="" id="drop not null constraint on charge_id refunds_history table">
+        <dropNotNullConstraint columnDataType="bigserial"
+                               columnName="charge_id"
+                               tableName="refunds_history"/>
+    </changeSet>
+    
+    <changeSet id="drop index on charge_id on refunds table" author="">
+        <dropIndex tableName="refunds" indexName="idx_refunds_charge_id"/>
+    </changeSet>
+
+    <changeSet id="drop index on charge_id on refunds_history table" author="">
+        <dropIndex tableName="refunds_history" indexName="idx_refunds_history_charge_id"/>
+    </changeSet>
+
+    <changeSet id="create charge_external_id index on refunds_history table" runInTransaction="false" author="">
+        <sql>
+            CREATE INDEX CONCURRENTLY idx_refunds_history_charge_external_id ON refunds_history (charge_external_id);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -706,6 +706,8 @@ public class DatabaseTestHelper {
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE gateway_accounts CASCADE").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events CASCADE").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE tokens").execute());
+        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds").execute());
+        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds_history").execute());
     }
 
     public Long getChargeIdByExternalId(String externalChargeId) {


### PR DESCRIPTION
## WHAT YOU DID
This is the second part of the bigger story of de-coupling RefundsEntity from ChargeEntity.

- drop foreign key constraint
- drop not null constraints for charge_id
- drop indexes for charge_id
- add index for charge_external_id on refunds_history

