### PR TITLE
PP-6098 Parity checker: match settlement summary and refundability

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -213,7 +213,14 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
     }
 
     public void expungeCharge(Long id) {
-        ChargeEntity chargeEntity = entityManager.get().find(ChargeEntity.class, id);
-        entityManager.get().remove(chargeEntity);
+        entityManager.get()
+                .createNativeQuery("delete from charge_events where charge_id = ?1")
+                .setParameter(1, id)
+                .executeUpdate();
+
+        entityManager.get()
+                .createNativeQuery("delete from charges where id = ?1")
+                .setParameter(1, id)
+                .executeUpdate();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -3,10 +3,8 @@ package uk.gov.pay.connector.expunge.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import uk.gov.pay.connector.charge.model.ChargeResponse;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
-import uk.gov.pay.connector.it.util.ChargeUtils;
-import uk.gov.pay.connector.model.domain.LedgerTransactionFixture;
-import uk.gov.pay.connector.paritycheck.LedgerTransaction;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +31,7 @@ public class LedgerStub {
         ledgerTransactionFields.put("description", "This is a mismatch");
         stubResponse(externalId, ledgerTransactionFields);
     }
-    
+
     private void stubResponse(String externalId, Map<String, Object> ledgerTransactionFields) throws JsonProcessingException {
         ResponseDefinitionBuilder responseDefBuilder = aResponse()
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -47,8 +45,8 @@ public class LedgerStub {
                         )
         );
     }
-    
-    private static Map<String, Object> testChargeToLedgerTransactionJson(DatabaseFixtures.TestCharge testCharge)  {
+
+    private static Map<String, Object> testChargeToLedgerTransactionJson(DatabaseFixtures.TestCharge testCharge) {
         var map = new HashMap<String, Object>();
         Optional.ofNullable(testCharge.getExternalChargeId()).ifPresent(value -> map.put("id", value));
         Optional.of(testCharge.getAmount()).ifPresent(value -> map.put("amount", String.valueOf(value)));
@@ -79,6 +77,12 @@ public class LedgerStub {
                 account));
         Optional.ofNullable(testCharge.getTestAccount().getPaymentProvider()).ifPresent(account -> map.put("payment_provider",
                 account));
+
+        ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
+        refundSummary.setStatus("available");
+        Optional.ofNullable(testCharge.getTestAccount().getPaymentProvider()).ifPresent(account -> map.put("refund_summary",
+                refundSummary));
+
         map.put("live", false);
         return map;
     }

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -108,7 +108,7 @@ public class ParityCheckWorkerTest {
     public void executeRecordsParityStatusForChargesExistingInLedger() {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity, null).build()));
 
         worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
@@ -125,7 +125,7 @@ public class ParityCheckWorkerTest {
         when(chargeDao.findMaxId()).thenReturn(1L);
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
         when(refundDao.findRefundsByChargeExternalId(chargeEntity.getExternalId())).thenReturn(List.of(refundEntity));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity, null).build()));
         when(ledgerService.getTransaction(refundEntity.getExternalId()))
                 .thenReturn(Optional.of(aValidLedgerTransaction().withStatus("submitted").build()));
 
@@ -134,7 +134,7 @@ public class ParityCheckWorkerTest {
         verify(chargeService, times(1)).updateChargeParityStatus(chargeEntity.getExternalId(), ParityCheckStatus.EXISTS_IN_LEDGER);
         verify(ledgerService, times(2)).getTransaction(any());
         verify(ledgerService, times(1)).getTransaction(chargeEntity.getExternalId());
-        verify(refundDao, times(1)).findRefundsByChargeExternalId(chargeEntity.getExternalId());
+        verify(refundDao, times(2)).findRefundsByChargeExternalId(chargeEntity.getExternalId());
         verify(stateTransitionService, never()).offerStateTransition(any(), any(), any());
         verify(emittedEventDao, never()).recordEmission(any(), any());
         verify(chargeDao, never()).findById(2L);
@@ -161,7 +161,7 @@ public class ParityCheckWorkerTest {
                 .thenReturn(List.of(aValidRefundEntity().build(), aValidRefundEntity().build()));
         when(chargeDao.findById(1L)).thenReturn(Optional.of(chargeEntity));
         when(ledgerService.getTransaction(any())).thenReturn(Optional.empty());
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity, null).build()));
 
         worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 
@@ -179,7 +179,7 @@ public class ParityCheckWorkerTest {
         when(ledgerService.getTransaction(any())).thenReturn(Optional.empty());
         when(ledgerService.getTransaction(any())).thenReturn(Optional.of(
                 aValidLedgerTransaction().withStatus("success").build()));
-        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity).build()));
+        when(ledgerService.getTransaction(chargeEntity.getExternalId())).thenReturn(Optional.of(from(chargeEntity, null).build()));
 
         worker.execute(1L, Optional.empty(), doNotReprocessValidRecords, emptyParityCheckStatus, 1L);
 


### PR DESCRIPTION
## WHAT 
- Updated ParityChecker to match settlement, refund status fields
- `createdDate` is taken from CREATED event which is what used for PaymentCreated event
- `Expunge charge` : Updated dao method to also remove charge_events. More to be deleted in PP-6130
- Updated relevant tests
- Fixed integration test for changes - for refund_summary.status used hard coded value for
  now but this can be extended if we want to try tests with different refund-ability status
