### PR TITLE
PP-6130 Expunger Expunges Further Dependent Tables

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -212,9 +212,25 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .getResultList().stream().findFirst();
     }
 
-    public void expungeCharge(Long id) {
+    public void expungeCharge(Long id, String externalId) {
+
         entityManager.get()
                 .createNativeQuery("delete from charge_events where charge_id = ?1")
+                .setParameter(1, id)
+                .executeUpdate();
+
+        entityManager.get()
+                .createNativeQuery("delete from tokens where charge_id = ?1")
+                .setParameter(1, id)
+                .executeUpdate();
+
+        entityManager.get()
+                .createNativeQuery("delete from emitted_events where resource_external_id = ?1")
+                .setParameter(1, externalId)
+                .executeUpdate();
+
+        entityManager.get()
+                .createNativeQuery("delete from fees where charge_id = ?1")
                 .setParameter(1, id)
                 .executeUpdate();
 

--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -80,7 +80,7 @@ public class ChargeExpungeService {
 
     @Transactional
     public void expungeCharge(ChargeEntity chargeEntity) {
-        chargeDao.expungeCharge(chargeEntity.getId());
+        chargeDao.expungeCharge(chargeEntity.getId(), chargeEntity.getExternalId());
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
@@ -79,6 +79,6 @@ public class ChargeExpungeServiceTest {
         when(parityCheckService.parityCheckChargeForExpunger(chargeEntity)).thenReturn(true);
 
         chargeExpungeService.expunge(2);
-        verify(mockChargeDao).expungeCharge(chargeEntity.getId());
+        verify(mockChargeDao).expungeCharge(chargeEntity.getId(), chargeEntity.getExternalId());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -21,13 +21,13 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 public class LedgerStub {
 
-    public void returnLedgerTransaction(String externalId, DatabaseFixtures.TestCharge testCharge) throws JsonProcessingException {
-        Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge);
+    public void returnLedgerTransaction(String externalId, DatabaseFixtures.TestCharge testCharge, DatabaseFixtures.TestFee testFee) throws JsonProcessingException {
+        Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge, testFee);
         stubResponse(externalId, ledgerTransactionFields);
     }
 
-    public void returnLedgerTransactionWithMismatch(String externalId, DatabaseFixtures.TestCharge testCharge) throws JsonProcessingException {
-        Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge);
+    public void returnLedgerTransactionWithMismatch(String externalId, DatabaseFixtures.TestCharge testCharge, DatabaseFixtures.TestFee testFee) throws JsonProcessingException {
+        Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge, testFee);
         ledgerTransactionFields.put("description", "This is a mismatch");
         stubResponse(externalId, ledgerTransactionFields);
     }
@@ -46,7 +46,7 @@ public class LedgerStub {
         );
     }
 
-    private static Map<String, Object> testChargeToLedgerTransactionJson(DatabaseFixtures.TestCharge testCharge) {
+    private static Map<String, Object> testChargeToLedgerTransactionJson(DatabaseFixtures.TestCharge testCharge, DatabaseFixtures.TestFee fee) {
         var map = new HashMap<String, Object>();
         Optional.ofNullable(testCharge.getExternalChargeId()).ifPresent(value -> map.put("id", value));
         Optional.of(testCharge.getAmount()).ifPresent(value -> map.put("amount", String.valueOf(value)));
@@ -77,6 +77,11 @@ public class LedgerStub {
                 account));
         Optional.ofNullable(testCharge.getTestAccount().getPaymentProvider()).ifPresent(account -> map.put("payment_provider",
                 account));
+        if(fee != null) {
+            map.put("fee", 0);
+            Optional.of(testCharge.getAmount()).ifPresent(amount -> map.put("net_amount", amount));
+            Optional.of(testCharge.getAmount()).ifPresent(amount -> map.put("total_amount", amount));
+        }
 
         ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
         refundSummary.setStatus("available");

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -361,6 +361,32 @@ public class DatabaseTestHelper {
         return result > 0;
     }
 
+    public boolean containsTokenWithChargeId(Long chargeId) {
+        var result = jdbi.withHandle(h ->
+                h.createQuery("SELECT count(*) FROM tokens WHERE charge_id = :charge_id")
+                        .bind("charge_id", chargeId)
+                        .mapTo(Integer.class)
+                        .first());
+        return result > 0;
+    }
+
+    public boolean containsFeeWithChargeId(Long chargeId) {
+        var result = jdbi.withHandle(h ->
+                h.createQuery("SELECT count(*) FROM fees WHERE charge_id = :charge_id")
+                        .bind("charge_id", chargeId)
+                        .mapTo(Integer.class)
+                        .first());
+        return result > 0;
+    }
+
+    public boolean containsEmittedEventWithExternalId(String externalId) {
+        var result = jdbi.withHandle(h ->
+                h.createQuery("SELECT count(*) FROM emitted_events WHERE resource_external_id = :external_id")
+                        .bind("external_id", externalId)
+                        .mapTo(Integer.class)
+                        .first());
+        return result > 0;
+    }
 
     public Map<String, Object> getChargeByGatewayTransactionId(String gatewayTransactionId) {
         return jdbi.withHandle(h ->


### PR DESCRIPTION
- The expunging job, when run, will now delete auxiliary information
from tables that are not charges but contain fields which reference it,
either implicitly through FK relationships or tenuously.

- A test has been written to ensure this functionality works as we
expect it to.
