### PR TITLE
PP-6130 Modify Delete Emitted Events Query

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -225,8 +225,9 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .executeUpdate();
 
         entityManager.get()
-                .createNativeQuery("delete from emitted_events where resource_external_id = ?1")
-                .setParameter(1, externalId)
+                .createNativeQuery("delete from emitted_events where resource_type = ?1 AND resource_external_id = ?2")
+                .setParameter(1, "PAYMENT")
+                .setParameter(2, externalId)
                 .executeUpdate();
 
         entityManager.get()

--- a/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
@@ -310,6 +310,7 @@ public class ExpungeResourceIT {
         insertChargeEvent(expungeableCharge1);
         emittedEventDao.persist(anEmittedEventEntity()
                 .withResourceExternalId(expungeableCharge1.getExternalChargeId())
+                .withResourceType("PAYMENT")
                 .withId(RandomUtils.nextLong())
                 .build());
 


### PR DESCRIPTION
- Krishna rightly raised that the lack of indexed use on the
`external_id` field would make the current delete query slow, this adds
an extra discriminatory parameter to use an index and speed up query
execution.
