### PR TITLE
PP-6098 Parity checker: various fixes

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -2,9 +2,9 @@ package uk.gov.pay.connector.charge.model;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 public enum ParityCheckStatus {
-    MATCHES_WITH_LEDGER,
     EXISTS_IN_LEDGER,
     MISSING_IN_LEDGER,
     DATA_MISMATCH

--- a/src/main/java/uk/gov/pay/connector/paritycheck/Address.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/Address.java
@@ -20,6 +20,10 @@ public class Address {
     private String county;
     private String country;
 
+    public Address() {
+
+    }
+
     public Address(String line1, String line2, String postcode,
                    String city, String county, String country) {
         this.line1 = line1;

--- a/src/main/java/uk/gov/pay/connector/paritycheck/CardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/CardDetails.java
@@ -3,15 +3,9 @@ package uk.gov.pay.connector.paritycheck;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.connector.cardtype.model.domain.CardType;
-import uk.gov.pay.connector.common.model.api.ToLowerCaseStringSerializer;
 
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -25,10 +19,14 @@ public class CardDetails {
     private String lastDigitsCardNumber;
     private String firstDigitsCardNumber;
     private String expiryDate;
-    private CardType cardType;
+    private String cardType;
+
+    public CardDetails() {
+
+    }
 
     public CardDetails(String cardholderName, Address billingAddress, String cardBrand,
-                       String lastDigitsCardNumber, String firstDigitsCardNumber, String cardExpiryDate, CardType cardType) {
+                       String lastDigitsCardNumber, String firstDigitsCardNumber, String cardExpiryDate, String cardType) {
         this.cardholderName = cardholderName;
         this.billingAddress = billingAddress;
         this.cardBrand = cardBrand;
@@ -62,10 +60,9 @@ public class CardDetails {
         return expiryDate;
     }
 
-    @Enumerated(EnumType.STRING)
-    @JsonProperty("card_type")
-    @JsonSerialize(using = ToLowerCaseStringSerializer.class)
-    public CardType getCardType() { return cardType; }
+    public String getCardType() {
+        return cardType;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerService.java
@@ -4,9 +4,9 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 
 import javax.inject.Inject;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
-
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -29,16 +29,7 @@ public class LedgerService {
                 .path(format("/v1/transaction/%s", id))
                 .queryParam("override_account_id_restriction", "true");
 
-        Response response = client
-                .target(uri)
-                .request()
-                .get();
-
-        if (response.getStatus() == SC_OK) {
-            return Optional.of(response.readEntity(LedgerTransaction.class));
-        }
-
-        return Optional.empty();
+        return getTransactionFromLedger(uri);
     }
 
     public Optional<LedgerTransaction> getTransactionForGatewayAccount(String id, Long gatewayAccountId) {
@@ -47,9 +38,14 @@ public class LedgerService {
                 .path(format("/v1/transaction/%s", id))
                 .queryParam("account_id", gatewayAccountId);
 
+        return getTransactionFromLedger(uri);
+    }
+
+    private Optional<LedgerTransaction> getTransactionFromLedger(UriBuilder uri) {
         Response response = client
                 .target(uri)
                 .request()
+                .accept(MediaType.APPLICATION_JSON)
                 .get();
 
         if (response.getStatus() == SC_OK) {
@@ -58,4 +54,5 @@ public class LedgerService {
 
         return Optional.empty();
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerTransaction.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.paritycheck;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -18,7 +19,7 @@ public class LedgerTransaction {
 
     private String transactionId;
     private Long amount;
-    private Long gatewayAccountId;
+    private String gatewayAccountId;
     private String description;
     private String reference;
     private String email;
@@ -33,7 +34,7 @@ public class LedgerTransaction {
     private String returnUrl;
     private String paymentProvider;
     private ChargeResponse.RefundSummary refundSummary;
-    private ChargeResponse.SettlementSummary settlementSummary;
+    private SettlementSummary settlementSummary;
     private CardDetails cardDetails;
     @JsonDeserialize(using = SupportedLanguageJsonDeserializer.class)
     private SupportedLanguage language;
@@ -41,7 +42,12 @@ public class LedgerTransaction {
     private Boolean live;
     private Source source;
     private String walletType;
+    @JsonProperty("metadata")
     private Map<String, Object> externalMetaData;
+
+    public LedgerTransaction() {
+
+    }
 
     public Long getAmount() {
         return amount;
@@ -135,11 +141,11 @@ public class LedgerTransaction {
         this.state = transactionState;
     }
 
-    public Long getGatewayAccountId() {
+    public String getGatewayAccountId() {
         return gatewayAccountId;
     }
 
-    public void setGatewayAccountId(Long gatewayAccountId) {
+    public void setGatewayAccountId(String gatewayAccountId) {
         this.gatewayAccountId = gatewayAccountId;
     }
 
@@ -175,11 +181,11 @@ public class LedgerTransaction {
         this.refundSummary = refundSummary;
     }
 
-    public ChargeResponse.SettlementSummary getSettlementSummary() {
+    public SettlementSummary getSettlementSummary() {
         return settlementSummary;
     }
 
-    public void setSettlementSummary(ChargeResponse.SettlementSummary settlementSummary) {
+    public void setSettlementSummary(SettlementSummary settlementSummary) {
         this.settlementSummary = settlementSummary;
     }
 

--- a/src/main/java/uk/gov/pay/connector/paritycheck/SettlementSummary.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/SettlementSummary.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.paritycheck;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.gov.pay.commons.api.json.ApiResponseDateTimeDeserializer;
+
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public class SettlementSummary {
+    @JsonDeserialize(using = ApiResponseDateTimeDeserializer.class)
+    @JsonProperty("capture_submit_time")
+    private ZonedDateTime captureSubmitTime;
+    @JsonProperty("captured_date")
+    private String capturedDate;
+
+    public String getCaptureSubmitTime() {
+        return (captureSubmitTime != null) ? ISO_INSTANT_MILLISECOND_PRECISION.format(captureSubmitTime) : null;
+    }
+
+    public void setCaptureSubmitTime(ZonedDateTime captureSubmitTime) {
+        this.captureSubmitTime = captureSubmitTime;
+    }
+
+    public String getCapturedDate() {
+        return capturedDate;
+    }
+
+    public void setCapturedDate(String capturedDate) {
+        this.capturedDate = capturedDate;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/paritycheck/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paritycheck/LedgerServiceTest.java
@@ -1,0 +1,66 @@
+package uk.gov.pay.connector.paritycheck;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import java.util.Optional;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.LEDGER_GET_TRANSACTION;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LedgerServiceTest {
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    private LedgerService ledgerService;
+
+    @Before
+    public void setUp() throws JsonProcessingException {
+        Client mockClient = mock(Client.class);
+        ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
+        WebTarget mockWebTarget = mock(WebTarget.class);
+        Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
+        Response mockResponse = mock(Response.class);
+
+        when(mockConnectorConfiguration.getLedgerBaseUrl()).thenReturn("http://ledgerUrl");
+        when(mockClient.target(any(UriBuilder.class))).thenReturn(mockWebTarget);
+        when(mockWebTarget.request()).thenReturn(mockBuilder);
+        when(mockBuilder.accept(APPLICATION_JSON)).thenReturn(mockBuilder);
+        when(mockBuilder.get()).thenReturn(mockResponse);
+
+        when(mockResponse.readEntity(LedgerTransaction.class)).thenReturn(objectMapper.readValue(load(LEDGER_GET_TRANSACTION), LedgerTransaction.class));
+        when(mockResponse.getStatus()).thenReturn(SC_OK);
+        ledgerService = new LedgerService(mockClient, mockConnectorConfiguration);
+    }
+
+    @Test
+    public void getTransaction_shouldSerialiseLedgerTransaction() {
+        String externalId = "external-id";
+        Optional<LedgerTransaction> mayBeTransaction = ledgerService.getTransaction("external-id");
+
+        assertThat(mayBeTransaction.isPresent(), is(true));
+        LedgerTransaction transaction = mayBeTransaction.get();
+        assertThat(transaction.getTransactionId(), is(externalId));
+        assertThat(transaction.getAmount(), is(12000L));
+        assertThat(transaction.getGatewayAccountId(), is("3"));
+        assertThat(transaction.getExternalMetaData(), is(notNullValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -147,6 +147,8 @@ public class TestTemplateResourceLoader {
     public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.xml";
     public static final String SQS_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/error-response.xml";
     
+    public static final String LEDGER_GET_TRANSACTION = TEMPLATE_BASE_NAME + "/ledger/transaction.json";
+
     public static String load(String location) {
         return fixture(location);
     }

--- a/src/test/resources/templates/ledger/transaction.json
+++ b/src/test/resources/templates/ledger/transaction.json
@@ -1,0 +1,53 @@
+{
+  "gateway_account_id": "3",
+  "amount": 12000,
+  "total_amount": 12000,
+  "state": {
+    "finished": true,
+    "status": "success"
+  },
+  "description": "New passport application",
+  "reference": "1_86",
+  "language": "cy",
+  "return_url": "https://service-name.gov.uk/transactions/12345",
+  "email": "Joe.Bogs@example.org",
+  "payment_provider": "sandbox",
+  "created_date": "2020-02-13T16:26:04.204Z",
+  "card_details": {
+    "cardholder_name": "J. Bogs",
+    "billing_address": {
+      "line1": "address line 1",
+      "line2": "address line 2",
+      "postcode": "E6 6BL",
+      "city": "address city",
+      "country": "GB"
+    },
+    "card_brand": "Visa",
+    "last_digits_card_number": "4242",
+    "first_digits_card_number": "424242",
+    "expiry_date": "11/21",
+    "card_type": "credit"
+  },
+  "delayed_capture": false,
+  "gateway_transaction_id": "a8d5dff4-404b-4f65-b2ea-65e4ea9daabc",
+  "refund_summary": {
+    "status": "available",
+    "user_external_id": null,
+    "amount_available": 12000,
+    "amount_submitted": 0,
+    "amount_refunded": 123
+  },
+  "settlement_summary": {
+    "capture_submit_time": "2020-02-13T16:26:30.242Z",
+    "captured_date": "2020-02-13"
+  },
+  "metadata": {
+    "cost code": "value 1"
+  },
+  "transaction_type": "PAYMENT",
+  "moto": false,
+  "live": false,
+  "source": "CARD_API",
+  "wallet": "APPLE_Pay",
+  "transaction_id": "external-id"
+}


### PR DESCRIPTION
## WHAT
- Fixed issues with serialising Ledger transaction (types, constructor on CardDetails & Address)
- Create separate `SettlementSummary` for Ledger transaction as ChargeResponse.SettlementSummary doesn't line up with annotations for deserialisation
- Test for LedgerService
- Paritycheck for metadata -> only checks for existence vs non-existence of metadata on charge and transaction