### PR TITLE
PP-6143 Update parity check status for non-expungeable charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ParityCheckStatus.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 public enum ParityCheckStatus {
+    SKIPPED,
     EXISTS_IN_LEDGER,
     MISSING_IN_LEDGER,
     DATA_MISMATCH

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -264,8 +264,8 @@ public class ChargeService {
     }
 
     @Transactional
-    public Optional<ChargeEntity> updateChargeParityStatus(String chargeId, ParityCheckStatus parityCheckStatus) {
-        return chargeDao.findByExternalId(chargeId)
+    public Optional<ChargeEntity> updateChargeParityStatus(String externalId, ParityCheckStatus parityCheckStatus) {
+        return chargeDao.findByExternalId(externalId)
                 .map(chargeEntity -> {
                     chargeEntity.updateParityCheck(parityCheckStatus);
                     return Optional.of(chargeEntity);


### PR DESCRIPTION
## WHAT 
- Added parity check status SKIPPED so that the charges can be marked as skipped,
  and to avoid these charges being picked up for duration specific as `EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS`
