### PR TITLE
PP-6143 Update parity checker

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
@@ -52,7 +52,7 @@ public class HistoricalEventEmitter {
     private final ChargeDao chargeDao;
     private boolean shouldForceEmission;
 
-    private final List<ChargeStatus> TERMINAL_AUTHENTICATION_STATES = List.of(
+    public static final List<ChargeStatus> TERMINAL_AUTHENTICATION_STATES = List.of(
             AUTHORISATION_3DS_REQUIRED,
             AUTHORISATION_SUBMITTED,
             AUTHORISATION_SUCCESS,


### PR DESCRIPTION
## WHAT YOU DID
- Updated parity checker for card details so details are matched only if card details are available in connector
- Match total amount only for charge gone through entering card details event
