### PR TITLE
PP-6143 Resource identifier for expunging job

### DIFF
--- a/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.expunge.resource;
 
+import org.slf4j.MDC;
 import uk.gov.pay.connector.expunge.service.ChargeExpungeService;
 
 import javax.inject.Inject;
@@ -9,9 +10,12 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
+import java.util.UUID;
+
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.status;
+import static uk.gov.pay.connector.filters.RestClientLoggingFilter.HEADER_REQUEST_ID;
 
 @Path("/")
 public class ExpungeResource {
@@ -27,6 +31,8 @@ public class ExpungeResource {
     @Path("/v1/tasks/expunge")
     @Produces(APPLICATION_JSON)
     public Response expungeCharges(@QueryParam("number_of_charges_to_expunge") Integer noOfChargesToExpunge) {
+        String correlationId = MDC.get(HEADER_REQUEST_ID) == null ? "ExpungeResource-" + UUID.randomUUID().toString() : MDC.get(HEADER_REQUEST_ID);
+        MDC.put(HEADER_REQUEST_ID, correlationId);
         chargeExpungeService.expunge(noOfChargesToExpunge);
         return status(OK).build();
     }


### PR DESCRIPTION
* use existing correlation id if it exists, if not generate one for the
running expunger job
* include payment external id uniformly across logging contexts