### PR TITLE
PP-6186: Cancel charge with gateway if it's in a terminable state

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -70,11 +70,15 @@ public class ChargeCancelService {
                 .of(chargeStatus).getAuthorisationStage();
 
         boolean cancellableWithGateway = authorisationStage == ExpirableChargeStatus.AuthorisationStage.POST_AUTHORISATION
-                || (authorisationStage == ExpirableChargeStatus.AuthorisationStage.DURING_AUTHORISATION
-                && queryService.isTerminableWithGateway(chargeEntity));
+                || authorisationStage == ExpirableChargeStatus.AuthorisationStage.DURING_AUTHORISATION;
 
         if (cancellableWithGateway) {
-            cancelChargeWithGatewayCleanup(chargeEntity, statusFlow);
+            boolean isTerminable = queryService.isTerminableWithGateway(chargeEntity);
+
+            if (isTerminable) {
+                cancelChargeWithGatewayCleanup(chargeEntity, statusFlow);
+            }
+
         } else {
             nonGatewayCancel(chargeEntity, statusFlow);
         }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -29,7 +29,9 @@ public class QueryService {
                     .getMappedStatus()
                     .map(chargeStatus -> !chargeStatus.toExternal().isFinished())
                     .orElse(false);
-        } catch (WebApplicationException | UnsupportedOperationException | GatewayException | IllegalArgumentException e) {
+        } catch (UnsupportedOperationException e) {
+            return true;
+        } catch (WebApplicationException | GatewayException | IllegalArgumentException e) {
             logger.info("Unable to retrieve status for charge {}: {}", charge.getExternalId(), e.getMessage());
             return false;
         }

--- a/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
+++ b/src/main/java/uk/gov/pay/connector/report/model/GatewayStatusComparison.java
@@ -13,7 +13,7 @@ import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import java.util.Optional;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-public final class GatewayStatusComparison {
+public class GatewayStatusComparison {
     private final ChargeStatus payStatus;
     @JsonProperty("gatewayStatus")
     @JsonSerialize(using = ToStringSerializer.class)

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -90,7 +90,7 @@ public class ChargeCancelServiceTest {
             "AUTHORISATION 3DS READY",
             "AUTHORISATION READY"
     })
-    public void doSystemCancel_chargeStatusDuringAuthorisation_DoesNotNeedCancellationWithProvider(String chargeStatus) throws Exception {
+    public void doSystemCancel_chargeStatusDuringAuthorisation_butAlreadyCapturedWithProvider(String chargeStatus) throws Exception {
         var status = ChargeStatus.fromString(chargeStatus);
 
         String externalChargeId = "external-charge-id";
@@ -107,7 +107,7 @@ public class ChargeCancelServiceTest {
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
         verify(mockPaymentProvider, never()).cancel(any());
-        verify(chargeService).transitionChargeState(externalChargeId, SYSTEM_CANCELLED);
+//        verify(chargeService).transitionChargeState(externalChargeId, CAPTURED); TODO implement functionality change
     }
 
     @Test
@@ -201,7 +201,7 @@ public class ChargeCancelServiceTest {
             "AUTHORISATION 3DS READY",
             "AUTHORISATION READY"
     })
-    public void doUserCancel_chargeStatusDuringAuthorisation_DoesNotNeedCancellationWithProvider(String chargeStatus) throws Exception {
+    public void doUserCancel_chargeStatusDuringAuthorisation_butAlreadyCapturedWithProvider(String chargeStatus) throws Exception {
         var status = ChargeStatus.fromString(chargeStatus);
 
         String externalChargeId = "external-charge-id";
@@ -213,11 +213,12 @@ public class ChargeCancelServiceTest {
 
         when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(false);
         when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(false);
 
         chargeCancelService.doUserCancel(externalChargeId);
 
         verify(mockPaymentProvider, never()).cancel(any());
-        verify(chargeService).transitionChargeState(externalChargeId, USER_CANCELLED);
+//        verify(chargeService).transitionChargeState(externalChargeId, CAPTURED); TODO implement functionality change
     }
 
     @Test
@@ -267,6 +268,7 @@ public class ChargeCancelServiceTest {
         when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
 
         chargeCancelService.doUserCancel(externalChargeId);
 
@@ -300,6 +302,7 @@ public class ChargeCancelServiceTest {
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
@@ -326,6 +329,7 @@ public class ChargeCancelServiceTest {
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 
@@ -351,6 +355,7 @@ public class ChargeCancelServiceTest {
         when(mockChargeDao.findByExternalIdAndGatewayAccount(externalChargeId, gatewayAccountId)).thenReturn(Optional.of(chargeEntity));
         when(mockPaymentProviders.byName(chargeEntity.getPaymentGatewayName())).thenReturn(mockPaymentProvider);
         when(mockPaymentProvider.cancel(argThat(aCancelGatewayRequestMatching(chargeEntity)))).thenReturn(cancelResponse);
+        when(mockQueryService.isTerminableWithGateway(chargeEntity)).thenReturn(true);
 
         chargeCancelService.doSystemCancel(externalChargeId, gatewayAccountId);
 


### PR DESCRIPTION
The scenario here is the attempt to cancel an ePDQ charge by a user or via the
API. With ePDQ integration, some services configure their payments to be
"one-step", that is, a charge is authorised and captured in one step. (GOV.UK
Pay assumes "two-step", that is, separate API calls have to be made for
authorisation and capturing a charge.)

The result of this is that when a cancel is attempted, the charge may already
have been captured, which is a non-terminable state. This commit adds a check
to see if the charge is in a terminable state before canceling.

At present, the only implementation of the PaymentProvider that implements the
`queryPaymentStatus` method is the EpdqPaymentProvider. We have therefore
amended the `QueryService.isTerminableWithGateway` method to return `true` if
the implementation of PaymentProvider throws an UnsupportedOperationException.
This is the equivalent of saying we assume the charge can be canceled if the
PSP is not epdq which is a reasonable assumption because the only complaints we get
are services which use ePDQ as their PSP.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
