### PR TITLE
PP-6143 Epunger exception for legacy capture submitted charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
@@ -14,6 +14,10 @@ public class ExpungeConfig extends Configuration {
 
     @Valid
     @NotNull
+    private int minimumAgeForHistoricChargeExceptions;
+
+    @Valid
+    @NotNull
     @Min(1)
     private int numberOfChargesToExpunge;
 
@@ -38,5 +42,9 @@ public class ExpungeConfig extends Configuration {
 
     public boolean isExpungeChargesEnabled() {
         return expungeChargesEnabled;
+    }
+
+    public int getMinimumAgeForHistoricChargeExceptions() {
+        return minimumAgeForHistoricChargeExceptions;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
@@ -34,6 +34,7 @@ public class ExpungeResource {
         String correlationId = MDC.get(HEADER_REQUEST_ID) == null ? "ExpungeResource-" + UUID.randomUUID().toString() : MDC.get(HEADER_REQUEST_ID);
         MDC.put(HEADER_REQUEST_ID, correlationId);
         chargeExpungeService.expunge(noOfChargesToExpunge);
+        MDC.remove(HEADER_REQUEST_ID);
         return status(OK).build();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -238,3 +238,4 @@ expungeConfig:
   excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -183,3 +183,4 @@ expungeConfig:
   excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -182,3 +182,4 @@ expungeConfig:
   excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -172,3 +172,4 @@ expungeConfig:
   excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -178,3 +178,4 @@ expungeConfig:
   excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -177,3 +177,4 @@ expungeConfig:
   excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-10}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-true}
+  minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}


### PR DESCRIPTION
Legacy payments in Connector may be stuck in `CAPTURE_SUBMITTED`, add a
configurable value which will allow us to label these as 'legacy' so
that they can be expunged correctly.