### PR TITLE
PP-6184 Handle notifications for expunged charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -296,15 +296,13 @@ public class ChargeService {
     }
 
     public Optional<Charge> findByProviderAndTransactionIdFromDbOrLedger(String paymentGatewayName, String gatewayTransactionId) {
-        Optional<ChargeEntity> maybeChargeEntity = chargeDao.findByProviderAndTransactionId(paymentGatewayName, gatewayTransactionId);
+        return Optional.ofNullable(chargeDao.findByProviderAndTransactionId(paymentGatewayName, gatewayTransactionId)
+                .map(Charge::from)
+                .orElseGet(() -> findChargeFromLedger(paymentGatewayName, gatewayTransactionId).orElse(null)));
+    }
 
-        if(maybeChargeEntity.isPresent()) {
-            return maybeChargeEntity.map(Charge::from);
-        }
-        else{
-            return ledgerService.getTransactionForProviderAndGatewayTransactionId(paymentGatewayName,gatewayTransactionId)
-                    .map(Charge::from);
-        }
+    private Optional<Charge> findChargeFromLedger(String paymentGatewayName, String gatewayTransactionId) {
+        return ledgerService.getTransactionForProviderAndGatewayTransactionId(paymentGatewayName,gatewayTransactionId).map(Charge::from);
     }
 
     @Transactional

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -302,7 +302,7 @@ public class ChargeService {
             return maybeChargeEntity.map(Charge::from);
         }
         else{
-            return ledgerService.findByProviderAndGatewayTransactionId(paymentGatewayName,gatewayTransactionId)
+            return ledgerService.getTransactionForProviderAndGatewayTransactionId(paymentGatewayName,gatewayTransactionId)
                     .map(Charge::from);
         }
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -295,6 +295,18 @@ public class ChargeService {
         }
     }
 
+    public Optional<Charge> findByProviderAndTransactionIdFromDbOrLedger(String paymentGatewayName, String gatewayTransactionId) {
+        Optional<ChargeEntity> maybeChargeEntity = chargeDao.findByProviderAndTransactionId(paymentGatewayName, gatewayTransactionId);
+
+        if(maybeChargeEntity.isPresent()) {
+            return maybeChargeEntity.map(Charge::from);
+        }
+        else{
+            return ledgerService.findByProviderAndGatewayTransactionId(paymentGatewayName,gatewayTransactionId)
+                    .map(Charge::from);
+        }
+    }
+
     @Transactional
     public Optional<ChargeEntity> updateCharge(String chargeId, PatchRequestBuilder.PatchRequest chargePatchRequest) {
         return chargeDao.findByExternalId(chargeId)

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.processor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
@@ -21,7 +22,8 @@ public class ChargeNotificationProcessor {
         this.chargeService = chargeService;
     }
 
-    public void invoke(String transactionId, ChargeEntity chargeEntity, ChargeStatus newStatus, ZonedDateTime gatewayEventDate) {
+    public void invoke(String transactionId, Charge charge, ChargeStatus newStatus, ZonedDateTime gatewayEventDate) {
+        ChargeEntity chargeEntity = chargeService.findChargeByExternalId(charge.getExternalId());
         GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
         String oldStatus = chargeEntity.getStatus();
 

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -4,7 +4,6 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
@@ -30,7 +29,7 @@ public class RefundNotificationProcessor {
     }
 
     public void invoke(PaymentGatewayName gatewayName, RefundStatus newStatus, GatewayAccountEntity gatewayAccountEntity,
-                       String reference, String transactionId, ChargeEntity chargeEntity) {
+                       String reference, String transactionId, Charge charge) {
         if (isBlank(reference)) {
             logger.warn("{} refund notification could not be used to update charge (missing reference)",
                     gatewayName);
@@ -50,7 +49,7 @@ public class RefundNotificationProcessor {
         refundService.transitionRefundState(refundEntity, newStatus);
 
         if (RefundStatus.REFUNDED.equals(newStatus)) {
-            userNotificationService.sendRefundIssuedEmail(refundEntity, Charge.from(chargeEntity), gatewayAccountEntity);
+            userNotificationService.sendRefundIssuedEmail(refundEntity, charge, gatewayAccountEntity);
         }
 
         logger.info("Notification received for refund. Updating refund - charge_external_id={}, refund_reference={}, transaction_id={}, status={}, "

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -120,14 +120,12 @@ public class StripeNotificationService {
 
             ChargeEntity charge = maybeCharge.get();
 
-
             if (PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED.getType().equals(notification.getType()) &&
                     !paymentIntent.getAmountCapturable().equals(charge.getAmount())) {
                 logger.error("{} notification for payment intent [{}] does not have amount capturable equal to original charge {}",
                         PAYMENT_GATEWAY_NAME, paymentIntent.getId(), charge.getExternalId());
                 return;
             }
-
 
             if (isChargeIn3DSRequiredOrReadyState(ChargeStatus.fromString(charge.getStatus()))) {
                 executePost3DSAuthorisation(charge, notification.getType());

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerService.java
@@ -32,6 +32,16 @@ public class LedgerService {
         return getTransactionFromLedger(uri);
     }
 
+    public Optional<LedgerTransaction> findByProviderAndGatewayTransactionId(String paymentGatewayName,
+                                                                             String gatewayTransactionId) {
+        var uri = UriBuilder
+                .fromPath(ledgerUrl)
+                .path(format("/v1/transaction/gateway-transaction/%s", gatewayTransactionId))
+                .queryParam("payment_provider", paymentGatewayName);
+
+        return getTransactionFromLedger(uri);
+    }
+
     public Optional<LedgerTransaction> getTransactionForGatewayAccount(String id, Long gatewayAccountId) {
         var uri = UriBuilder
                 .fromPath(ledgerUrl)

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerService.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerService.java
@@ -32,8 +32,8 @@ public class LedgerService {
         return getTransactionFromLedger(uri);
     }
 
-    public Optional<LedgerTransaction> findByProviderAndGatewayTransactionId(String paymentGatewayName,
-                                                                             String gatewayTransactionId) {
+    public Optional<LedgerTransaction> getTransactionForProviderAndGatewayTransactionId(String paymentGatewayName,
+                                                                                        String gatewayTransactionId) {
         var uri = UriBuilder
                 .fromPath(ledgerUrl)
                 .path(format("/v1/transaction/gateway-transaction/%s", gatewayTransactionId))

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -1375,4 +1375,21 @@ public class ChargeServiceTest {
         assertThat(result.getAmount(), is(chargeEntity.getAmount()));
         assertThat(result.getExternalId(), is(chargeEntity.getExternalId()));
     }
+
+    @Test
+    public void findByProviderAndTransactionIdFromDbOrLedger_shouldReturnEmptyOptionalIfChargeIsNotInDbOrLedger() {
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+
+        when(mockedChargeDao.findByProviderAndTransactionId(
+                "sandbox", chargeEntity.getExternalId()
+        )).thenReturn(Optional.empty());
+
+        when(ledgerService.getTransactionForProviderAndGatewayTransactionId("sandbox",
+                chargeEntity.getExternalId())).thenReturn(Optional.empty());
+
+        Optional<Charge> charge = service.findByProviderAndTransactionIdFromDbOrLedger("sandbox",
+                chargeEntity.getExternalId());
+
+        assertThat(charge.isPresent(), is(false));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -1364,7 +1364,7 @@ public class ChargeServiceTest {
                 chargeEntity.getExternalId()
         )).thenReturn(Optional.empty());
 
-        when(ledgerService.findByProviderAndGatewayTransactionId("sandbox",
+        when(ledgerService.getTransactionForProviderAndGatewayTransactionId("sandbox",
                 chargeEntity.getExternalId())).thenReturn(Optional.of(transaction));
 
         Optional<Charge> charge = service.findByProviderAndTransactionIdFromDbOrLedger("sandbox",

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -81,10 +81,10 @@ import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.UriBuilder.fromUri;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -1328,5 +1328,51 @@ public class ChargeServiceTest {
         final Charge result = charge.get();
         assertThat(result.getExternalId(), is(chargeEntity.getExternalId()));
         assertThat(result.getAmount(), is(chargeEntity.getAmount()));
+    }
+
+    @Test
+    public void findByProviderAndTransactionIdFromDbOrLedger_fromDbIfExists() {
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+
+        when(mockedChargeDao.findByProviderAndTransactionId(
+                "sandbox",
+                chargeEntity.getExternalId()
+        )).thenReturn(Optional.of(chargeEntity));
+
+        Optional<Charge> charge = service.findByProviderAndTransactionIdFromDbOrLedger("sandbox",
+                chargeEntity.getExternalId());
+
+        verifyNoInteractions(ledgerService);
+
+        assertThat(charge.isPresent(), is(true));
+        final Charge result = charge.get();
+        assertThat(result.getAmount(), is(chargeEntity.getAmount()));
+        assertThat(result.getExternalId(), is(chargeEntity.getExternalId()));
+    }
+
+    @Test
+    public void findByProviderAndTransactionIdFromDbOrLedger_fromLedgerIfNotExists() {
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+
+        LedgerTransaction transaction = new LedgerTransaction();
+        transaction.setTransactionId(chargeEntity.getExternalId());
+        transaction.setAmount(chargeEntity.getAmount());
+        transaction.setCreatedDate(ZonedDateTime.now(ZoneId.of("UTC")).toString());
+        transaction.setGatewayAccountId(String.valueOf(GATEWAY_ACCOUNT_ID));
+        when(mockedChargeDao.findByProviderAndTransactionId(
+                "sandbox",
+                chargeEntity.getExternalId()
+        )).thenReturn(Optional.empty());
+
+        when(ledgerService.findByProviderAndGatewayTransactionId("sandbox",
+                chargeEntity.getExternalId())).thenReturn(Optional.of(transaction));
+
+        Optional<Charge> charge = service.findByProviderAndTransactionIdFromDbOrLedger("sandbox",
+                chargeEntity.getExternalId());
+
+        assertThat(charge.isPresent(), is(true));
+        final Charge result = charge.get();
+        assertThat(result.getAmount(), is(chargeEntity.getAmount()));
+        assertThat(result.getExternalId(), is(chargeEntity.getExternalId()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -32,6 +32,19 @@ public class LedgerStub {
         stubResponse(externalId, ledgerTransactionFields);
     }
 
+    public void returnNotFoundForFindByProviderAndGatewayTransactionId(String paymentProvider, String gatewayTransactionId) throws JsonProcessingException {
+        ResponseDefinitionBuilder responseDefBuilder = aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                .withStatus(404);
+        stubFor(
+                get(urlPathEqualTo(format("/v1/transaction/gateway-transaction/%s", gatewayTransactionId)))
+                        .withQueryParam("payment_provider", equalTo(paymentProvider))
+                        .willReturn(
+                                responseDefBuilder
+                        )
+        );
+    }
+
     private void stubResponse(String externalId, Map<String, Object> ledgerTransactionFields) throws JsonProcessingException {
         ResponseDefinitionBuilder responseDefBuilder = aResponse()
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -15,6 +15,7 @@ import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.expunge.service.LedgerStub;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -67,6 +68,7 @@ public class ChargingITestBase {
     protected static final WorldpayMockClient worldpayMockClient = new WorldpayMockClient();
     protected static final SmartpayMockClient smartpayMockClient = new SmartpayMockClient();
     protected static final EpdqMockClient epdqMockClient = new EpdqMockClient();
+    protected static final LedgerStub ledgerStub = new LedgerStub();
 
     private final String paymentProvider;
     protected RestAssuredClient connectorRestApiClient;

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -479,8 +479,6 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
         givenSetup()
                 .get("/v1/frontend/accounts/" + gatewayAccountId)
                 .then()
-                .log()
-                .all()
                 .statusCode(200)
                 .body("$", not(hasKey("worldpay_3ds_flex")));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.it.resources.epdq;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.restassured.response.ValidatableResponse;
 import junitparams.Parameters;
 import org.junit.Test;
@@ -139,8 +140,9 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void shouldNotUpdateStatusToDatabaseIfGatewayAccountIsNotFound() {
+    public void shouldNotUpdateStatusToDatabaseIfGatewayAccountIsNotFound() throws JsonProcessingException {
         String chargeId = createNewCharge(AUTHORISATION_SUCCESS);
+        ledgerStub.returnNotFoundForFindByProviderAndGatewayTransactionId( "epdq", "unknown-transation-id");
 
         notifyConnector("unknown-transation-id", "GARBAGE", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
                 .statusCode(200)

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -103,7 +103,9 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReturnNon2xxStatusIfChargeIsNotFoundForTransaction() throws Exception {
-        notifyConnector("unknown-transation-id", "GARBAGE")
+        ledgerStub.returnNotFoundForFindByProviderAndGatewayTransactionId("worldpay", 
+                "unknown-transaction-id");
+        notifyConnector("unknown-transaction-id", "GARBAGE")
                 .statusCode(403)
                 .extract().body()
                 .asString();


### PR DESCRIPTION
## WHAT 
- Refunds are allowed for charges expunged from connector and so  we should be able to process relevant refunds notifications for expunge charges. Refund notifications for all payment providers need to get charge and also gateway account information to be able to verify notification signature, send refund emails to users.

- Added a new ChargeService method `findByProviderAndTransactionIdFromDbOrLedger` which looks  up Ledger if charge has been expunged
- Updated notifications to use new ChargeService method
- Epdq notifications still need connector internal charge status, to map target status but
  only for inflight payments. So it should be safe to continue using it
  https://github.com/alphagov/pay-connector/blob/5ac4d251a1b7009cfc4f90260565951e8e4556f3/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java#L145

More to come ...
- To remove reliance on internal `ChargeStatus` for all SmartPay notifications
