### PR TITLE
PP-6184 Handle notifications for historic charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -1,8 +1,9 @@
 package uk.gov.pay.connector.charge.model.domain;
 
+import uk.gov.pay.connector.paritycheck.LedgerTransaction;
+
 import java.time.ZonedDateTime;
 import java.util.Objects;
-import uk.gov.pay.connector.paritycheck.LedgerTransaction;
 import java.util.Optional;
 
 public class Charge {
@@ -168,5 +169,9 @@ public class Charge {
 
     public String getPaymentGatewayName() {
         return paymentGatewayName;
+    }
+
+    public void setHistoric(boolean historic) {
+        this.historic = historic;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
@@ -5,9 +5,7 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.model.status.InterpretedStatus;
 import uk.gov.pay.connector.gateway.model.status.MappedChargeStatus;
@@ -22,8 +20,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+import static uk.gov.pay.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
 public class SmartpayNotificationService {
 
@@ -81,13 +82,32 @@ public class SmartpayNotificationService {
         }
 
         Charge charge = maybeCharge.get();
-        
-        GatewayAccountEntity gatewayAccountEntity =
-                gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId()).get();
+
+        Optional<GatewayAccountEntity> mayBeGatewayAccountEntity =
+                gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId());
+
+        if (mayBeGatewayAccountEntity.isEmpty()) {
+            logger.error("{} notification {} could not be processes (associated gateway account [{}] not found for charge [{}] {}, {})",
+                    PAYMENT_GATEWAY_NAME, notification,
+                    charge.getGatewayAccountId(),
+                    charge.getExternalId(),
+                    kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
+                    kv(GATEWAY_ACCOUNT_ID, charge.getGatewayAccountId()));
+            return;
+        }
+        GatewayAccountEntity gatewayAccountEntity = mayBeGatewayAccountEntity.get();
 
         InterpretedStatus interpretedStatus = interpretStatus(notification);
 
         if (interpretedStatus instanceof MappedChargeStatus) {
+            if(charge.isHistoric()){
+                logger.error("{} notification {} could not be processed as charge [{}] has been expunged from connector {} {}",
+                        PAYMENT_GATEWAY_NAME, notification,
+                        charge.getExternalId(),
+                        kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
+                        kv(GATEWAY_ACCOUNT_ID, charge.getGatewayAccountId()));
+                return;
+            }
             chargeNotificationProcessor.invoke(
                     notification.getOriginalReference(),
                     charge,

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -17,9 +17,8 @@ import java.util.Optional;
 
 import static java.time.ZonedDateTime.now;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
@@ -89,7 +88,7 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
 
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
         notificationService.handleNotificationFor(payload);
-        verify(mockChargeNotificationProcessor, times(1)).invoke(payId, charge, SYSTEM_CANCELLATION_FLOW.getSuccessTerminalState(), null);
+        verify(mockChargeNotificationProcessor).invoke(payId, charge, SYSTEM_CANCELLATION_FLOW.getSuccessTerminalState(), null);
     }
 
     @Test
@@ -128,7 +127,7 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
 
         notificationService.handleNotificationFor(payload);
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verifyNoInteractions(mockChargeNotificationProcessor);
     }
 
     @Test
@@ -141,7 +140,7 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
 
         notificationService.handleNotificationFor(payload);
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verifyNoInteractions(mockChargeNotificationProcessor);
     }
 
     @Test
@@ -153,7 +152,7 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
 
         notificationService.handleNotificationFor(payload);
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verifyNoInteractions(mockChargeNotificationProcessor);
     }
 
     @Test
@@ -161,7 +160,7 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         final String payload = notificationPayloadForTransaction(payId, UNKNOWN);
         notificationService.handleNotificationFor(payload);
 
-        verify(mockChargeNotificationProcessor, never()).invoke(any(), any(), any(), any());
+        verifyNoInteractions(mockChargeNotificationProcessor);
     }
 
     @Test
@@ -209,7 +208,7 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         final String payload = notificationPayloadForTransaction(payId, UNKNOWN);
 
         notificationService.handleNotificationFor(payload);
-        verify(mockRefundNotificationProcessor, never()).invoke(any(), any(), any(), any(), any(), any());
+        verifyNoInteractions(mockChargeNotificationProcessor);
     }
     
     private Charge getCharge(boolean isHistoric){


### PR DESCRIPTION
## WHAT YOU DID
Followup for https://github.com/alphagov/pay-connector/pull/2129

- If for any reason we receive charge notifications for historic charges (expunged from connector), they are ignored
  and logged as error (this is required until notifications can be handled by connector for expunged charges)

- Similarly, if gateway account is not found for a charge (from Connector / Ledger),
  error is logger (as gateway account should always be there!)
   - For Worldpay notifications, follows the pattern when Charge is not found (which returns false) for Worldpay to retry notifications.

- Added new tests for above scenarios

- Cleaned up notifications tests to use `verifyNoInteractions` instead of verify(xxx, never())
- Also removed `gatewayName` from WorldpayNotificationService as linter keeps complaining about invoking conditionally during logging