### PR TITLE
PP-6182 Notification resource - ITests for expunged charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
@@ -93,7 +93,7 @@ public class EpdqNotificationService {
                 gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId());
 
         if (mayBeGatewayAccountEntity.isEmpty()) {
-            logger.error("{} notification {} could not be processes (associated gateway account [{}] not found for charge [{}] {}, {})",
+            logger.error("{} notification {} could not be processed (associated gateway account [{}] not found for charge [{}] {}, {})",
                     PAYMENT_GATEWAY_NAME, notification,
                     charge.getGatewayAccountId(),
                     charge.getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -36,7 +36,8 @@ public class RefundNotificationProcessor {
             return;
         }
 
-        Optional<RefundEntity> optionalRefundEntity = refundService.findByProviderAndReference(gatewayName.getName(), reference);
+        Optional<RefundEntity> optionalRefundEntity 
+                = refundService.findByChargeExternalIdAndReference(charge.getExternalId(), reference);
         if (optionalRefundEntity.isEmpty()) {
             logger.warn("{} notification '{}' could not be used to update refund (associated refund entity not found)",
                     gatewayName, reference);

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
@@ -86,7 +86,7 @@ public class SmartpayNotificationService {
                 gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId());
 
         if (mayBeGatewayAccountEntity.isEmpty()) {
-            logger.error("{} notification {} could not be processes (associated gateway account [{}] not found for charge [{}] {}, {})",
+            logger.error("{} notification {} could not be processed (associated gateway account [{}] not found for charge [{}] {}, {})",
                     PAYMENT_GATEWAY_NAME, notification,
                     charge.getGatewayAccountId(),
                     charge.getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -114,7 +114,7 @@ public class WorldpayNotificationService {
                 gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId());
 
         if (mayBeGatewayAccountEntity.isEmpty()) {
-            logger.error("{} notification {} could not be processes (associated gateway account [{}] not found for charge [{}] {}, {})",
+            logger.error("{} notification {} could not be processed (associated gateway account [{}] not found for charge [{}] {}, {})",
                     PAYMENT_GATEWAY_NAME, notification,
                     charge.getGatewayAccountId(),
                     charge.getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -28,17 +28,15 @@ public class RefundDao extends JpaDao<RefundEntity> {
         return super.findById(RefundEntity.class, refundId);
     }
 
-    public Optional<RefundEntity> findByProviderAndReference(String provider, String reference) {
+    public Optional<RefundEntity> findByChargeExternalIdAndReference(String chargeExternalId, String reference) {
 
         String query = "SELECT refund FROM RefundEntity refund " +
-                "JOIN ChargeEntity charge ON refund.chargeExternalId = charge.externalId " +
-                "JOIN GatewayAccountEntity gatewayAccount ON charge.gatewayAccount.id = gatewayAccount.id " +
-                "WHERE refund.reference = :reference AND gatewayAccount.gatewayName = :provider";
+                "WHERE refund.reference = :reference AND refund.chargeExternalId = :chargeExternalId";
 
         return entityManager.get()
                 .createQuery(query, RefundEntity.class)
                 .setParameter("reference", reference)
-                .setParameter("provider", provider)
+                .setParameter("chargeExternalId", chargeExternalId)
                 .getResultList().stream().findFirst();
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -91,8 +91,8 @@ public class ChargeRefundService {
         return refundEntity;
     }
 
-    public Optional<RefundEntity> findByProviderAndReference(String name, String reference) {
-        return refundDao.findByProviderAndReference(name, reference);
+    public Optional<RefundEntity> findByChargeExternalIdAndReference(String chargeExternalId, String reference) {
+        return refundDao.findByChargeExternalIdAndReference(chargeExternalId, reference);
     }
 
     private RefundEntity processRefund(GatewayRefundResponse gatewayRefundResponse, Long refundEntityId,

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -68,7 +68,7 @@ public class RefundNotificationProcessorTest {
         refundEntity = aValidRefundEntity().build();
         Optional<RefundEntity> optionalRefundEntity = Optional.of(refundEntity);
 
-        when(refundService.findByProviderAndReference(paymentGatewayName.getName(), reference)).thenReturn(optionalRefundEntity);
+        when(refundService.findByChargeExternalIdAndReference(charge.getExternalId(), reference)).thenReturn(optionalRefundEntity);
 
         refundNotificationProcessor = new RefundNotificationProcessor(refundService, userNotificationService);
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
@@ -88,8 +88,8 @@ public class RefundDaoJpaIT extends DaoITestBase {
     }
 
     @Test
-    public void findByProviderAndReference_shouldFindRefund() {
-        Optional<RefundEntity> refundEntityOptional = refundDao.findByProviderAndReference(sandboxAccount.getPaymentProvider(), refundTestRecord.getReference());
+    public void findByChargeExternalIdAndReference_shouldFindRefund() {
+        Optional<RefundEntity> refundEntityOptional = refundDao.findByChargeExternalIdAndReference(chargeTestRecord.getExternalChargeId(), refundTestRecord.getReference());
 
         assertThat(refundEntityOptional.isPresent(), is(true));
 
@@ -104,17 +104,17 @@ public class RefundDaoJpaIT extends DaoITestBase {
     }
 
     @Test
-    public void findByProviderAndReference_shouldNotFindRefundIfProviderDoesNotMatch() {
+    public void findByChargeExternalIdAndReference_shouldNotFindRefundIfChargeExternalIdDoesNotMatch() {
 
-        Optional<RefundEntity> refundEntityOptional = refundDao.findByProviderAndReference("worldpay", refundTestRecord.getReference());
+        Optional<RefundEntity> refundEntityOptional = refundDao.findByChargeExternalIdAndReference("charge-externalid-00", refundTestRecord.getReference());
 
         assertThat(refundEntityOptional, is(Optional.empty()));
     }
 
     @Test
-    public void findByProviderAndReference_shouldNotFindRefundIfReferenceDoesNotMatch() {
+    public void findByChargeExternalIdAndReference_shouldNotFindRefundIfReferenceDoesNotMatch() {
         String noExistingReference = "refund_0";
-        assertThat(refundDao.findByProviderAndReference(sandboxAccount.getPaymentProvider(), noExistingReference).isPresent(), is(false));
+        assertThat(refundDao.findByChargeExternalIdAndReference(chargeTestRecord.getExternalChargeId(), noExistingReference).isPresent(), is(false));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -346,7 +346,8 @@ public class DatabaseTestHelper {
                 h.createQuery("SELECT * FROM charges WHERE external_id = :external_id")
                         .bind("external_id", externalId)
                         .mapToMap()
-                        .first());
+                        .findFirst()
+                        .orElse(null));
     }
 
     public boolean containsChargeWithExternalId(String externalId) {


### PR DESCRIPTION
## WHAT YOU DID
- Added integration tests for refund notifications for expunged charges
- RefundDao - removed `findByProviderAndReference` as we can no longer use payment provider
  to find refund. Replaced the same with `findByChargeExternalIdAndReference` to use
  in notification services
