### PR TITLE
PP-6184 RefundNotificationProcessor - Log charge external ID

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -31,16 +31,16 @@ public class RefundNotificationProcessor {
     public void invoke(PaymentGatewayName gatewayName, RefundStatus newStatus, GatewayAccountEntity gatewayAccountEntity,
                        String reference, String transactionId, Charge charge) {
         if (isBlank(reference)) {
-            logger.warn("{} refund notification could not be used to update charge (missing reference)",
-                    gatewayName);
+            logger.warn("{} refund notification could not be used to update charge [{}] (missing reference)",
+                    gatewayName, charge.getExternalId());
             return;
         }
 
         Optional<RefundEntity> optionalRefundEntity 
                 = refundService.findByChargeExternalIdAndReference(charge.getExternalId(), reference);
         if (optionalRefundEntity.isEmpty()) {
-            logger.warn("{} notification '{}' could not be used to update refund (associated refund entity not found)",
-                    gatewayName, reference);
+            logger.warn("{} notification '{}' could not be used to update refund (associated refund entity not found) for charge [{}]",
+                    gatewayName, reference, charge.getExternalId());
             return;
         }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -96,7 +96,9 @@ public class RefundNotificationProcessorTest {
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        String expectedLogMessage = String.format("%s refund notification could not be used to update charge (missing reference)", paymentGatewayName);
+        String expectedLogMessage = String.format("%s refund notification could not be used to update charge [%s] (missing reference)", 
+                paymentGatewayName,
+                charge.getExternalId());
 
         assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
     }
@@ -107,9 +109,10 @@ public class RefundNotificationProcessorTest {
         verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
 
         List<LoggingEvent> logStatement = loggingEventArgumentCaptor.getAllValues();
-        String expectedLogMessage = String.format("%s notification '%s' could not be used to update refund (associated refund entity not found)",
+        String expectedLogMessage = String.format("%s notification '%s' could not be used to update refund (associated refund entity not found) for charge [%s]",
                 paymentGatewayName,
-                "unknown");
+                "unknown",
+                charge.getExternalId());
 
         assertThat(logStatement.get(0).getFormattedMessage(), is(expectedLogMessage));
     }


### PR DESCRIPTION
## WHAT YOU DID

- We now have charge object in RefundNotificationProcessor. Added charge external ID to logs to identify associated charge easily
