### PR TITLE
PP-6089 Historical events emitter - emit refund only events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
@@ -45,7 +45,7 @@ public class EmittedEventsBackfillService {
         this.chargeService = chargeService;
         this.refundDao = refundDao;
         this.sweepConfig = configuration.getEmittedEventSweepConfig();
-        this.historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, refundDao, chargeDao, shouldForceEmission,
+        this.historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, refundDao, chargeService, shouldForceEmission,
                 eventService, stateTransitionService);
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -122,4 +122,13 @@ public class RefundDao extends JpaDao<RefundEntity> {
                 .setParameter("chargeExternalId", chargeExternalId)
                 .getResultList();
     }
+
+    public Long findMaxId() {
+        String query = "SELECT r.id FROM RefundEntity r ORDER BY r.id DESC";
+
+        return entityManager.get()
+                .createQuery(query, Long.class)
+                .setMaxResults(1)
+                .getSingleResult();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
@@ -77,7 +77,7 @@ public class ParityCheckWorker {
     }
 
     private void initializeHistoricalEventEmitter(Long doNotRetryEmitUntilDuration) {
-        this.historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, refundDao, chargeDao, shouldForceEmission,
+        this.historicalEventEmitter = new HistoricalEventEmitter(emittedEventDao, refundDao, chargeService, shouldForceEmission,
                 eventService, stateTransitionService, doNotRetryEmitUntilDuration);
     }
 
@@ -137,6 +137,6 @@ public class ParityCheckWorker {
 
     private void emitHistoricalEvents(ChargeEntity charge) {
         historicalEventEmitter.processPaymentEvents(charge, true);
-        historicalEventEmitter.processRefundEvents(charge);
+        historicalEventEmitter.processRefundEvents(charge.getExternalId());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/RecordType.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/RecordType.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.tasks;
+
+import org.apache.commons.lang3.StringUtils;
+
+public enum RecordType {
+    
+    CHARGE("charge"),
+    REFUND("refund");
+    
+    String value;
+
+    RecordType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String toString() {
+        return this.getValue();
+    }
+
+    public static RecordType fromString(String status) {
+        for (RecordType type : values()) {
+            if (StringUtils.equals(type.getValue(), status)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("charge status not recognized: " + status);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -137,7 +138,7 @@ public class EmittedEventsBackfillServiceTest {
         when(refundDao.searchAllHistoryByChargeExternalId(chargeEntity.getExternalId())).thenReturn(List.of(refundHistory));
         when(chargeService.findChargeByExternalId(chargeEntity.getExternalId())).thenReturn(chargeEntity);
         when(refundEntity.getChargeExternalId()).thenReturn(chargeEntity.getExternalId());
-        when(chargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        when(chargeService.findCharge(chargeEntity.getExternalId())).thenReturn(Optional.of(Charge.from(chargeEntity)));
         chargeEntity.getEvents().clear();
         emittedEventsBackfillService.backfillNotEmittedEvents();
 
@@ -164,7 +165,7 @@ public class EmittedEventsBackfillServiceTest {
         when(chargeService.findChargeByExternalId(chargeEntity.getExternalId())).thenReturn(chargeEntity);
         when(refundDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(refundEntity));
         when(refundDao.searchAllHistoryByChargeExternalId(chargeEntity.getExternalId())).thenReturn(List.of(refundHistory));
-        when(chargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
+        when(chargeService.findCharge(chargeEntity.getExternalId())).thenReturn(Optional.of(Charge.from(chargeEntity)));
 
         emittedEventsBackfillService.backfillNotEmittedEvents();
 

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -1,8 +1,5 @@
 package uk.gov.pay.connector.model.domain;
 
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
@@ -10,7 +7,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
-import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 
 public class RefundEntityFixture {
 
@@ -82,6 +78,11 @@ public class RefundEntityFixture {
     
     public RefundEntityFixture withChargeTransactionId(String transactionId) {
         this.transactionId = transactionId;
+        return this;
+    }
+
+    public RefundEntityFixture withId(Long id) {
+        this.id = id;
         return this;
     }
 }


### PR DESCRIPTION
## WHAT YOU DID

- Updated `HistoricalEventEmitterTask` to take in record_type query parameter to emit refund only events without relying on chargeEntity/charge IDs.
- Updated relevant tests
