### PR TITLE
PP-6186 allow the status of a charge to be forcibly updated

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -288,6 +288,19 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         }
     }
 
+    /**
+     * This bypasses checks that we can move from the current charge status to the target charge status as enforced by
+     * the standard payment flow.
+     * Should be used to set the status only when correcting the charge status when the status we have conflicts with
+     * the status with the payment gateway.
+     */
+    public void setStatusIgnoringValidTransitions(ChargeStatus targetStatus) {
+        var logMessage = format("Forcibly changing charge status for externalId [%s] [%s]->[%s]",
+                this.externalId, this.status, targetStatus.getValue());
+        logger.info(logMessage, getStructuredLoggingArgs());
+        this.status = targetStatus.getValue();
+    }
+
     public List<StructuredArgument> getStructuredLoggingArgs() {
         return List.of(
                 kv(PAYMENT_EXTERNAL_ID, externalId),

--- a/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/dao/ChargeEventDao.java
@@ -22,8 +22,8 @@ public class ChargeEventDao extends JpaDao<ChargeEventEntity> {
         super(entityManager);
     }
 
-    public void persistChargeEventOf(ChargeEntity chargeEntity) {
-        this.persistChargeEventOf(chargeEntity, null);
+    public ChargeEventEntity persistChargeEventOf(ChargeEntity chargeEntity) {
+        return this.persistChargeEventOf(chargeEntity, null);
     }
 
     public ChargeEventEntity persistChargeEventOf(ChargeEntity chargeEntity, ZonedDateTime gatewayEventDate) {

--- a/src/main/java/uk/gov/pay/connector/common/exception/InvalidForceStateTransitionException.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/InvalidForceStateTransitionException.java
@@ -1,4 +1,12 @@
 package uk.gov.pay.connector.common.exception;
 
-public class InvalidForceStateTransitionException {
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+
+import static java.lang.String.format;
+
+public class InvalidForceStateTransitionException extends IllegalStateException {
+
+    public InvalidForceStateTransitionException(ChargeStatus currentState, ChargeStatus targetState) {
+        super(format("Cannot force charge state transition [%s] -> [%s].", currentState.getValue(), targetState.getValue()));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/common/exception/InvalidForceStateTransitionException.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/InvalidForceStateTransitionException.java
@@ -1,0 +1,4 @@
+package uk.gov.pay.connector.common.exception;
+
+public class InvalidForceStateTransitionException {
+}

--- a/src/main/java/uk/gov/pay/connector/common/exception/InvalidStateTransitionException.java
+++ b/src/main/java/uk/gov/pay/connector/common/exception/InvalidStateTransitionException.java
@@ -19,7 +19,7 @@ public class InvalidStateTransitionException extends IllegalStateException {
     }
 
     public InvalidStateTransitionException(String currentState, String targetState, Event event) {
-        super(format("Charge state transition [%s] -> [%s] not allowed [event={}]", currentState, targetState, event));
+        super(format("Charge state transition [%s] -> [%s] not allowed [event={%s}]", currentState, targetState, event));
         this.currentState = currentState;
         this.targetState = targetState;
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import java.time.ZonedDateTime;
+
+public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEventWithoutDetails {
+    public StatusCorrectedToCapturedToMatchGatewayStatus(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}


### PR DESCRIPTION
- Allow a charge to be forcibly transitioned from any state to certain
target states (for now just `CAPTURED`).
- This is to allow for the gateway considering the charge to be in a
different state to what we think it's in.
- This adds new events to be emitted to ledger per status to be
transitioned to. These events need to be added into the enum in the
ledger codebase to link them to the appropriate TransactionStatus.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
