### PR TITLE
PP-6206 set EMIT_PAYMENT_STATE_TRANSITION_EVENTS to true

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -85,4 +85,5 @@ applications:
       NOTIFY_EMAIL_ENABLED: 'true'
       RUN_APP: 'true'
       RUN_MIGRATION: 'false'
+      EMIT_PAYMENT_STATE_TRANSITION_EVENTS: 'true'
 


### PR DESCRIPTION
We want to send payment events to ledger in all environments so set this
to 'true'
