### PR TITLE
PP-6186 Log at info level when gateway status unknown

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -228,7 +228,7 @@ public class ChargeExpiryService {
                         }
                     },
                     () -> {
-                        logger.error(format("Gateway status does not map to any charge " +
+                        logger.info(format("Gateway status does not map to any charge " +
                                         "status in %s, expiring without cancelling on the gateway.",
                                 ChargeStatus.class.getCanonicalName()),
                                 kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()));


### PR DESCRIPTION
This is BAU, as the gateway will not return a status if the charge has not yet been authorised. Log at info rather than error level.