### PR TITLE
PP-6217 Fix stringification for Worldpay payment query response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayQueryResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayQueryResponse.java
@@ -90,7 +90,7 @@ public class WorldpayQueryResponse implements BaseInquiryResponse {
 
     @Override
     public String toString() {
-        StringJoiner joiner = new StringJoiner(", ", "Worldpay authorisation response (", ")");
+        StringJoiner joiner = new StringJoiner(", ", "Worldpay query response (", ")");
         if (StringUtils.isNotBlank(getTransactionId())) {
             joiner.add("orderCode: " + getTransactionId());
         }


### PR DESCRIPTION
When stringifying a Worldpay payment query response, describe it as a “Worldpay query response” rather than a “Worldpay authorisation response” because it was making our logs confusing.