### PR TITLE
PP-6186 Cancel charge if has unknown status with gateway

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -73,7 +73,7 @@ public class ChargeCancelService {
         validateChargeStatus(statusFlow, chargeEntity);
         ChargeStatus currentChargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
         var authorisationStage = ExpirableChargeStatus.of(currentChargeStatus).getAuthorisationStage();
-        
+
         if ((authorisationStage == DURING_AUTHORISATION || authorisationStage == POST_AUTHORISATION)
                 && queryService.canQueryChargeGatewayStatus(chargeEntity.getPaymentGatewayName())) {
             cancelChargeOrPotentiallyForceTransitionState(chargeEntity, statusFlow);
@@ -86,40 +86,39 @@ public class ChargeCancelService {
 
     private void cancelChargeOrPotentiallyForceTransitionState(ChargeEntity chargeEntity, StatusFlow statusFlow) {
         Optional<ChargeStatus> gatewayStatus = queryService.getMappedGatewayStatus(chargeEntity);
-        if (gatewayStatus.isPresent()) {
-            if (gatewayStatus.get().toExternal().isFinished()) {
-                var message = format("Cancelling charge aborted as charge is in a terminal state on the gateway " +
-                        "provider. Attempting to force state on charge to [%s]", gatewayStatus.get().getValue());
-                logger.info(message, List.of(kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
-                        kv(GATEWAY_ACCOUNT_ID, chargeEntity.getGatewayAccount().getId()),
-                        kv(PROVIDER, chargeEntity.getGatewayAccount().getGatewayName())));
-                
-                try {
-                    chargeService.forceTransitionChargeState(chargeEntity, gatewayStatus.get());
-                } catch (InvalidForceStateTransitionException e) {
-                    throw new CancelConflictException(
-                            format("Cannot cancel charge as it is in a terminal state of [%s] with the gateway " +
-                                            "provider and it is not possible to transition the charge into this " +
-                                            "state. Current state: [%s].", 
-                                    gatewayStatus.get().getValue(), chargeEntity.getStatus()),
-                            CancelConflictException.ConflictResult.CHARGE_NOT_TRANSITIONED);
-                }
-                throw new CancelConflictException(
-                        format("Cannot cancel charge as it is in a terminal state of [%s] with the gateway provider. " +
-                                        "The charge's state was transitioned to [%s].", 
-                                gatewayStatus.get().getValue(), gatewayStatus.get().getValue()),
-                        CancelConflictException.ConflictResult.CHARGE_FORCIBLY_TRANSITIONED);
-            } else {
-                cancelChargeWithGatewayCleanup(chargeEntity, statusFlow);
-            }
-        } else {
-            //should never happen
-            var message = format("Cancelling charge aborted as gateway status does not map to any charge status in " +
-                    "%s. ", ChargeStatus.class.getCanonicalName());
-            logger.info(message, List.of(kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId())));
-            throw new CancelConflictException("Cannot cancel charge as it is in some unknown state with the " +
-                    "gateway provider.", CancelConflictException.ConflictResult.CHARGE_NOT_TRANSITIONED);
-        }
+        gatewayStatus.ifPresentOrElse(status -> {
+                    if (status.toExternal().isFinished()) {
+                        var message = format("Cancelling charge aborted as charge is in a terminal state on the gateway " +
+                                "provider. Attempting to force state on charge to [%s]", status.getValue());
+                        logger.info(message, List.of(kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
+                                kv(GATEWAY_ACCOUNT_ID, chargeEntity.getGatewayAccount().getId()),
+                                kv(PROVIDER, chargeEntity.getGatewayAccount().getGatewayName())));
+
+                        try {
+                            chargeService.forceTransitionChargeState(chargeEntity, status);
+                        } catch (InvalidForceStateTransitionException e) {
+                            throw new CancelConflictException(
+                                    format("Cannot cancel charge as it is in a terminal state of [%s] with the gateway " +
+                                                    "provider and it is not possible to transition the charge into this " +
+                                                    "state. Current state: [%s].",
+                                            status.getValue(), chargeEntity.getStatus()),
+                                    CancelConflictException.ConflictResult.CHARGE_NOT_TRANSITIONED);
+                        }
+                        throw new CancelConflictException(
+                                format("Cannot cancel charge as it is in a terminal state of [%s] with the gateway provider. " +
+                                                "The charge's state was transitioned to [%s].",
+                                        status.getValue(), status.getValue()),
+                                CancelConflictException.ConflictResult.CHARGE_FORCIBLY_TRANSITIONED);
+                    } else {
+                        cancelChargeWithGatewayCleanup(chargeEntity, statusFlow);
+                    }
+                },
+                () -> {
+                    logger.info(format("Gateway status does not map to any charge status in %s, cancelling without " +
+                                    "cancelling on the gateway", ChargeStatus.class.getCanonicalName()),
+                            kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()));
+                    nonGatewayCancel(chargeEntity, statusFlow);
+                });
     }
 
     private void cancelChargeWithGatewayCleanup(ChargeEntity chargeEntity, StatusFlow statusFlow) {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeCancelServiceTest.java
@@ -304,6 +304,25 @@ public class ChargeCancelServiceTest {
     }
 
     @Test
+    public void doUserCancel_needToCheckWithGateway_hasUnknownStateWithProvider_cancelledWithoutProvider() throws Exception {
+        String externalChargeId = "external-charge-id";
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withExternalId(externalChargeId)
+                .withTransactionId("transaction-id")
+                .withStatus(ChargeStatus.AUTHORISATION_3DS_REQUIRED)
+                .build();
+
+        when(mockQueryService.canQueryChargeGatewayStatus(any(PaymentGatewayName.class))).thenReturn(true);
+        when(mockQueryService.getMappedGatewayStatus(chargeEntity)).thenReturn(Optional.empty());
+        when(mockChargeDao.findByExternalId(externalChargeId)).thenReturn(Optional.of(chargeEntity));
+
+        chargeCancelService.doUserCancel(externalChargeId);
+
+        verify(mockPaymentProvider, never()).cancel(any());
+        verify(chargeService).transitionChargeState(externalChargeId, USER_CANCELLED);
+    }
+
+    @Test
     public void doUserCancel_shouldFail_whenChargeNotFound() {
         String externalChargeId = "external-charge-id";
 


### PR DESCRIPTION
Querying the gateway and not getting a response back is BAU, as this
occurs e.g. when a charge is in AUTHORISATION_3DS_READY state with
Worldpay.

Therefore when this happens, cancel the charge locally without
cancelling with the gateway.