### PR TITLE
PP-6199 - Force state transitions for capture notifications for charges in errored states

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.common.exception.InvalidForceStateTransitionException;
 import uk.gov.pay.connector.common.exception.InvalidStateTransitionException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
@@ -32,21 +33,26 @@ public class ChargeNotificationProcessor {
         ChargeEntity chargeEntity = chargeService.findChargeByExternalId(charge.getExternalId());
         GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
         String oldStatus = chargeEntity.getStatus();
+        
+        if (newStatus.equals(oldStatus)) {
+            return;
+        }
 
         try {
             chargeService.transitionChargeState(chargeEntity, newStatus, gatewayEventDate);
         } catch (InvalidStateTransitionException e) {
-            // don't log an error if we're trying to transition to the same state as this can happen if we've already
-            // processed the notification
-            if (!e.getCurrentState().equals(e.getTargetState())) {
-                logger.error(String.format("%s (%s) notification '%s' could not be used to update charge: %s",
-                        gatewayAccount.getGatewayName(), gatewayAccount.getId(), gatewayTransactionId, e.getMessage()),
-                        kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
-                        kv(PROVIDER_PAYMENT_ID, gatewayTransactionId),
-                        kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
-                        kv(PROVIDER, gatewayAccount.getGatewayName()));
+            logger.error(String.format("%s (%s) notification '%s' could not be used to update charge: %s",
+                    gatewayAccount.getGatewayName(), gatewayAccount.getId(), gatewayTransactionId, e.getMessage()),
+                    kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
+                    kv(PROVIDER_PAYMENT_ID, gatewayTransactionId),
+                    kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
+                    kv(PROVIDER, gatewayAccount.getGatewayName()));
+            
+            boolean success = forceTransitionChargeState(gatewayAccount, gatewayTransactionId, chargeEntity, oldStatus, newStatus);
+            
+            if (!success) {
+                return;
             }
-            return;
         }
 
         logger.info("Notification received. Updating charge - " +
@@ -64,5 +70,20 @@ public class ChargeNotificationProcessor {
                 gatewayAccount.getId(),
                 gatewayAccount.getGatewayName(),
                 gatewayAccount.getType());
+    }
+    
+    private boolean forceTransitionChargeState(GatewayAccountEntity gatewayAccount, String gatewayTransactionId, ChargeEntity chargeEntity, String oldStatus, ChargeStatus newStatus) {
+        try {
+            chargeService.forceTransitionChargeState(chargeEntity, newStatus);
+            return true;
+        } catch (InvalidForceStateTransitionException ie) {
+            logger.error(String.format("%s (%s) notification '%s' could not force transition from %s to %s",
+                    gatewayAccount.getGatewayName(), gatewayAccount.getId(), gatewayTransactionId, oldStatus, newStatus),
+                    kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
+                    kv(PROVIDER_PAYMENT_ID, gatewayTransactionId),
+                    kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
+                    kv(PROVIDER, gatewayAccount.getGatewayName()));
+            return false;
+        }
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
@@ -70,6 +70,36 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
     }
 
     @Test
+    public void shouldForceCaptureForChargeInErrorState() {
+        String transactionId = "transaction-id";
+        String chargeId = createNewChargeWith(ChargeStatus.AUTHORISATION_ERROR, transactionId);
+
+        String response = notifyConnector(transactionId, "1", "9", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+                .statusCode(200)
+                .extract().body()
+                .asString();
+
+        assertThat(response, is(RESPONSE_EXPECTED_BY_EPDQ));
+
+        assertFrontendChargeStatusIs(chargeId, CAPTURED.getValue());
+    }
+
+    @Test
+    public void shouldNotForceCaptureForChargeForOtherNotification() {
+        String transactionId = "transaction-id";
+        String chargeId = createNewChargeWith(USER_CANCELLED, transactionId);
+
+        String response = notifyConnector(transactionId, "1", "6", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
+                .statusCode(200)
+                .extract().body()
+                .asString();
+
+        assertThat(response, is(RESPONSE_EXPECTED_BY_EPDQ));
+
+        assertFrontendChargeStatusIs(chargeId, USER_CANCELLED.getValue());
+    }
+    
+    @Test
     public void shouldHandleAnAuthorisedNotification_whenChargeIsInAuthorisationSubmittedState() {
         String transactionId = "transaction-id";
         String chargeId = createNewChargeWith(AUTHORISATION_SUBMITTED, transactionId);


### PR DESCRIPTION
Description:
- Reuses ChargeService.forceTransitionChargeState and placed in catch clause so that it only attempts to force if it has already tried to update using the normal flow
- I'm unsure of the logging messages here. It will initially log at ERROR level that it couldn't be transitioned the normal way then attempt to force capture. If this fails then it will log at ERROR level.

Any thoughts on the exact wording for the error message and the placement of the force transition code?


