### PR TITLE
PP-6238 Enable prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -502,6 +502,22 @@
             <artifactId>dropwizard-db</artifactId>
             <version>${dropwizard.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_dropwizard</artifactId>
+            <version>0.0.23</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>0.8.1</version>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -86,6 +86,10 @@ public class ConnectorConfiguration extends Configuration {
     private String graphiteHost;
 
     @NotNull
+    @JsonProperty("prometheusConfig")
+    private PrometheusConfig prometheusConfig;
+
+    @NotNull
     private String graphitePort;
 
     @NotNull
@@ -225,5 +229,9 @@ public class ConnectorConfiguration extends Configuration {
 
     public ExpungeConfig getExpungeConfig() {
         return expungeConfig;
+    }
+
+    public PrometheusConfig getPrometheusConfig() {
+        return prometheusConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/PrometheusConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/PrometheusConfig.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.app;
+
+
+import io.dropwizard.Configuration;
+
+import javax.validation.constraints.NotNull;
+
+public class PrometheusConfig extends Configuration {
+
+    @NotNull private boolean prometheusEnabled;
+    @NotNull private String path;
+
+    public boolean isPrometheusEnabled() {
+        return prometheusEnabled;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -239,3 +239,7 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+prometheusConfig:
+  prometheusEnabled: ${PROMETHEUS_ENABLED:-false}
+  path: ${PROMETHEUS_PATH:-/prometheus-metrics}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -179,3 +179,7 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+prometheusConfig:
+  prometheusEnabled: ${PROMETHEUS_ENABLED:-false}
+  path: ${PROMETHEUS_PATH:-/prometheus-metrics}


### PR DESCRIPTION
If `PROMETHEUS_ENABLED` is `true` add a `DropwizardExports` to process
the default `MetricsRegistry` into the format required by Prometheus and
add it to the default Prometheus `CollectorRegistry`. To provide an
end-point which Prometheus can scrape, add a `MetricsServlet` exposed on
a configurable path and add serve it via the admin port.

The default settings are to not enable Prometheus.

This is for a spike and will not be moved to prod. Please do not merge and no need to review. Creating a draft PR to add to the jira ticket.