### PR TITLE
zd3934900: Don't throw exception if the response is successful

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static javax.ws.rs.core.Response.Status.Family.familyOf;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.OK;
 
@@ -68,7 +70,7 @@ public class GatewayClient {
             response = requestBuilder.post(Entity.entity(request.getPayload(), request.getMediaType()));
             int statusCode = response.getStatus();
             Response gatewayResponse = new Response(response);
-            if (statusCode == OK.getStatusCode()) {
+            if (familyOf(statusCode) == SUCCESSFUL) {
                 return gatewayResponse;
             } else {
                 if (statusCode >= INTERNAL_SERVER_ERROR.getStatusCode()) {


### PR DESCRIPTION
A capture of a charge failed because a 202 was returned. This led to the error

```
Error capturing charge from SQS message [queueMessageId=a4f345d9-c063-4a87-ad35-c31503a031f7] [errorMessage=HTTP 202 Accepted]
```

See the ticket for more details. I'm not actually sure how `errorMessage=HTTP
202 Accepted` came about; following the code path, a 202 should throw a
GatewayErrorException which gets rethrown as a runtime exception in
StripeCaptureHandler (`new RuntimeException("Unrecognised response status
during capture.")`). But it's still worth checking the response is successful,
rather than just a 200 OK.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
