### PR TITLE
PP-6194 Add DAO method for getting charges with provider and status

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -240,4 +240,12 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setParameter(1, id)
                 .executeUpdate();
     }
+
+    public List<ChargeEntity> findWithPaymentProviderAndStatusIn(String provider, List<ChargeStatus> statuses) {
+        return entityManager.get()
+                .createQuery("SELECT c FROM ChargeEntity c WHERE c.gatewayAccount.gatewayName = :provider AND c.status in :statuses", ChargeEntity.class)
+                .setParameter("provider", provider)
+                .setParameter("statuses", statuses)
+                .getResultList();
+    }
 }


### PR DESCRIPTION
Want to be able to get all epdq charges in statuses 'AUTHORISATION ERROR',
'AUTHORISATION TIMEOUT' and 'AUTHORISATION UNEXPECTED ERROR' in order to
clean them up with the gateway.

Add this DAO method so we can do that.