### PR TITLE
PP-6199 Add charge statuses for cleanup job

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
@@ -55,7 +55,14 @@ public enum ChargeStatus implements Status {
     USER_CANCEL_READY("USER CANCEL READY", EXTERNAL_FAILED_CANCELLED, false),
     USER_CANCEL_SUBMITTED("USER CANCEL SUBMITTED", EXTERNAL_FAILED_CANCELLED, false),
     USER_CANCELLED("USER CANCELLED", EXTERNAL_FAILED_CANCELLED, true),
-    USER_CANCEL_ERROR("USER CANCEL ERROR", EXTERNAL_FAILED_CANCELLED, true);
+    USER_CANCEL_ERROR("USER CANCEL ERROR", EXTERNAL_FAILED_CANCELLED, true),
+    
+    // Below statuses exist to facilitate cancellation on the gateway for charges that entered the various authorisation
+    // error states. A recurring cleanup job moves charges into these states when it has handled them. This job is only
+    // run for ePDQ charges, so only ePDQ charges will enter these states.
+    AUTHORISATION_ERROR_CANCELLED("AUTHORISATION ERROR CANCELLED", EXTERNAL_ERROR_GATEWAY, true),
+    AUTHORISATION_ERROR_REJECTED("AUTHORISATION ERROR REJECTED", EXTERNAL_ERROR_GATEWAY, true),
+    AUTHORISATION_ERROR_CHARGE_MISSING("AUTHORISATION ERROR CHARGE MISSING", EXTERNAL_ERROR_GATEWAY, true);
 
     private String value;
     private ExternalChargeState externalStatus;

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -8,6 +8,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.UnspecifiedEvent;
 import uk.gov.pay.connector.events.model.charge.AuthorisationCancelled;
+import uk.gov.pay.connector.events.model.charge.AuthorisationErrorCheckedWithGatewayChargeWasMissing;
+import uk.gov.pay.connector.events.model.charge.AuthorisationErrorCheckedWithGatewayChargeWasRejected;
 import uk.gov.pay.connector.events.model.charge.AuthorisationRejected;
 import uk.gov.pay.connector.events.model.charge.AuthorisationSucceeded;
 import uk.gov.pay.connector.events.model.charge.CancelByExpirationFailed;
@@ -19,6 +21,7 @@ import uk.gov.pay.connector.events.model.charge.CancelByUserSubmitted;
 import uk.gov.pay.connector.events.model.charge.CancelledByExpiration;
 import uk.gov.pay.connector.events.model.charge.CancelledByExternalService;
 import uk.gov.pay.connector.events.model.charge.CancelledByUser;
+import uk.gov.pay.connector.events.model.charge.CancelledWithGatewayAfterAuthorisationError;
 import uk.gov.pay.connector.events.model.charge.CaptureAbandonedAfterTooManyRetries;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureErrored;
@@ -48,6 +51,9 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ABORTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CHARGE_MISSING;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUBMITTED;
@@ -195,6 +201,17 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(USER_CANCEL_READY, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
         graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCEL_ERROR, ModelledEvent.of(CancelByUserFailed.class));
         graph.putEdgeValue(USER_CANCEL_SUBMITTED, USER_CANCELLED, ModelledEvent.of(CancelledByUser.class));
+
+        graph.putEdgeValue(AUTHORISATION_ERROR, AUTHORISATION_ERROR_CANCELLED, ModelledEvent.of(CancelledWithGatewayAfterAuthorisationError.class));
+        graph.putEdgeValue(AUTHORISATION_ERROR, AUTHORISATION_ERROR_REJECTED, ModelledEvent.of(AuthorisationErrorCheckedWithGatewayChargeWasRejected.class));
+        graph.putEdgeValue(AUTHORISATION_ERROR, AUTHORISATION_ERROR_CHARGE_MISSING, ModelledEvent.of(AuthorisationErrorCheckedWithGatewayChargeWasMissing.class));
+        graph.putEdgeValue(AUTHORISATION_UNEXPECTED_ERROR, AUTHORISATION_ERROR_CANCELLED, ModelledEvent.of(CancelledWithGatewayAfterAuthorisationError.class));
+        graph.putEdgeValue(AUTHORISATION_UNEXPECTED_ERROR, AUTHORISATION_ERROR_REJECTED, ModelledEvent.of(AuthorisationErrorCheckedWithGatewayChargeWasRejected.class));
+        graph.putEdgeValue(AUTHORISATION_UNEXPECTED_ERROR, AUTHORISATION_ERROR_CHARGE_MISSING, ModelledEvent.of(AuthorisationErrorCheckedWithGatewayChargeWasMissing.class));
+        graph.putEdgeValue(AUTHORISATION_TIMEOUT, AUTHORISATION_ERROR_CANCELLED, ModelledEvent.of(CancelledWithGatewayAfterAuthorisationError.class));
+        graph.putEdgeValue(AUTHORISATION_TIMEOUT, AUTHORISATION_ERROR_REJECTED, ModelledEvent.of(AuthorisationErrorCheckedWithGatewayChargeWasRejected.class));
+        graph.putEdgeValue(AUTHORISATION_TIMEOUT, AUTHORISATION_ERROR_CHARGE_MISSING, ModelledEvent.of(AuthorisationErrorCheckedWithGatewayChargeWasMissing.class));
+        
 
         return ImmutableValueGraph.copyOf(graph);
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasMissing.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import java.time.ZonedDateTime;
+
+public class AuthorisationErrorCheckedWithGatewayChargeWasMissing extends PaymentEventWithoutDetails {
+    public AuthorisationErrorCheckedWithGatewayChargeWasMissing(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/AuthorisationErrorCheckedWithGatewayChargeWasRejected.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import java.time.ZonedDateTime;
+
+public class AuthorisationErrorCheckedWithGatewayChargeWasRejected extends PaymentEventWithoutDetails {
+    public AuthorisationErrorCheckedWithGatewayChargeWasRejected(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledWithGatewayAfterAuthorisationError.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import java.time.ZonedDateTime;
+
+public class CancelledWithGatewayAfterAuthorisationError extends PaymentEventWithoutDetails {
+    public CancelledWithGatewayAfterAuthorisationError(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}


### PR DESCRIPTION
Add charge statuses that represent the outcomes of the cleanup job that will be ran against ePDQ charges to ensure that charges that entered a state of `AUTHORISATION ERROR`, `AUTHORISATION UNEXPECTED ERROR` and `AUTHORISATION TIMEOUT` do not remain in an `AUTHORISATION SUCCESS` state on the gateway.

The statuses are: 

`AUTHORISATION ERROR CANCELLED` - the charge was actually authorised on the gateway, and has now been cancelled  

`AUTHORISATION ERROR REJECTED` - the authorisation was actually  rejected by the gateway and no further action needed to be taken to  clean up.  

`AUTHORISATION ERROR CHARGE MISSING` - the charge was not found on the  gateway. This could happen if there is an error on our end before the  request completes, or if the gateway returns an error and has not processed the charge. An example of this is when a card type is disabled on the gateway's end.


The statuses all map to an external gateway error state, so there will be no difference in the externally reported status after clean-up.

Events are emitted to ledger for the status changes, but as they do not change the external state of a charge, they are not registered on ledger's end as SalientEventTypes.