### PR TITLE
PP-6201 - Force capture notifications for expunged charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -679,7 +679,7 @@ public class ChargeService {
     public Optional<ChargeEntity> findByProviderAndTransactionId(String paymentGatewayName, String transactionId) {
         return chargeDao.findByProviderAndTransactionId(paymentGatewayName, transactionId);
     }
-
+    
     @Transactional
     public ChargeEntity markChargeAsEligibleForCapture(String externalId) {
         return chargeDao.findByExternalId(externalId).map(charge -> {

--- a/src/main/java/uk/gov/pay/connector/events/EventService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventService.java
@@ -21,7 +21,15 @@ public class EventService {
         this.eventQueue = eventQueue;
         this.emittedEventDao = emittedEventDao;
     }
-
+    
+    public void emitEvent(Event event) {
+        try {
+            eventQueue.emitEvent(event);
+        } catch (QueueException e) {
+            logger.error("Failed to emit event {} due to {} [externalId={}]", event.getEventType(), e.getMessage(), event.getResourceExternalId());
+        }
+    }
+    
     public void emitAndRecordEvent(Event event, ZonedDateTime doNotRetryEmitUntilDate) {
         try {
             eventQueue.emitEvent(event);

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import java.time.ZonedDateTime;
+
+public class CaptureConfirmedByGatewayNotification extends PaymentEventWithoutDetails {
+    public CaptureConfirmedByGatewayNotification(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
+++ b/src/main/java/uk/gov/pay/connector/webhook/resource/NotificationResource.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.gateway.epdq.EpdqNotificationService;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayNotificationService;
 import uk.gov.pay.connector.gateway.stripe.StripeNotificationService;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayNotificationService;
+import uk.gov.pay.connector.queue.QueueException;
 
 import javax.annotation.security.PermitAll;
 import javax.inject.Inject;

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -29,6 +29,13 @@ public class EventServiceTest {
 
     @InjectMocks
     EventService eventService;
+    
+    @Test
+    public void emitEvent() throws QueueException {
+        Event event = new PaymentEvent("external-id", now());
+        eventService.emitEvent(event);
+        verify(eventQueue).emitEvent(event);
+    }
 
     @Test
     public void emitAndRecordEvent_shouldRecordEmission() throws QueueException {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.util.Optional;
@@ -41,9 +42,9 @@ public class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest
         verifyNoInteractions(mockRefundNotificationProcessor);
         verify(mockChargeNotificationProcessor).invoke(payId, charge, CAPTURED, null);
     }
-
+    
     @Test
-    public void givenAChargeCapturedNotification_chargeNotificationProcessorShouldNotBeInvokedIfChargeIsHistoric() {
+    public void givenChargeCapturedNotification_chargeNotificationProcessorShouldBeInvokedIfChargeIsHistoric() {
         final String payload = notificationPayloadForTransaction(
                 payId,
                 EPDQ_PAYMENT_REQUESTED);
@@ -52,12 +53,13 @@ public class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest
                 .build());
         charge.setHistoric(true);
 
+        when(mockGatewayAccountService.getGatewayAccount(charge.getGatewayAccountId())).thenReturn(Optional.of(gatewayAccountEntity));
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(EPDQ.getName(), payId)).thenReturn(Optional.of(charge));
 
         notificationService.handleNotificationFor(payload);
 
         verifyNoInteractions(mockRefundNotificationProcessor);
-        verifyNoInteractions(mockChargeNotificationProcessor);
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, payId, charge, CAPTURED, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
@@ -1,0 +1,80 @@
+package uk.gov.pay.connector.gateway.processor;
+
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.ResourceType;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+
+@RunWith(JUnitParamsRunner.class)
+public class ChargeNotificationProcessorTest {
+    
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    protected static final long GATEWAY_ACCOUNT_ID = 10L;
+    
+    protected ChargeNotificationProcessor chargeNotificationProcessor;
+    protected GatewayAccountEntity gatewayAccount;
+
+    @Mock
+    protected GatewayAccountDao mockedGatewayAccountDao;
+
+    @Mock
+    protected ChargeService chargeService;
+    
+    @Mock
+    protected EventService eventService;
+    
+    @Before
+    public void setUp() {
+        gatewayAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), TEST);
+        gatewayAccount.setId(GATEWAY_ACCOUNT_ID);
+        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        chargeNotificationProcessor = new ChargeNotificationProcessor(chargeService, eventService);
+    }
+    
+    @Test
+    public void receivedCaptureNotification_shouldEmitEvent() {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AUTHORISATION_ERROR).build();
+        Charge charge = Charge.from(chargeEntity);
+        
+        chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccount, charge.getGatewayTransactionId(), charge,  CAPTURED, null);
+        
+        ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+        
+        verify(eventService).emitEvent(eventArgumentCaptor.capture());
+        Event event = eventArgumentCaptor.getValue();
+
+        assertThat(event.getEventType(), is("CAPTURE_CONFIRMED_BY_GATEWAY_NOTIFICATION"));
+        assertThat(event.getTimestamp(), is(nullValue()));
+        assertThat(event.getResourceType(), is(ResourceType.PAYMENT));
+    }
+}


### PR DESCRIPTION
Description:
- Corresponds to PP-6201-Add CAPTURE_NOTIFICATION_FOR_EXPUNGED_CHARGE event to Ledger
- Since the charge doesn't exist in the database (as it is expunged) when we process capture notification we send it directly to the Event SQS queue without persisting
