### PR TITLE
PP-6194 Add service for ePDQ gateway cleanup

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
@@ -33,13 +33,13 @@ public class EpdqAuthorisationErrorGatewayCleanupService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public static final String CLEANUP_SUCCESS = "cleanup-success";
-    public static final String CLEANUP_FAILED = "cleanup-failed";
+    static final String CLEANUP_SUCCESS = "cleanup-success";
+    static final String CLEANUP_FAILED = "cleanup-failed";
 
-    private ChargeDao chargeDao;
-    private ChargeService chargeService;
-    private QueryService queryService;
-    private PaymentProviders providers;
+    private final ChargeDao chargeDao;
+    private final ChargeService chargeService;
+    private final QueryService queryService;
+    private final PaymentProviders providers;
 
     @Inject
     public EpdqAuthorisationErrorGatewayCleanupService(ChargeDao chargeDao,
@@ -137,7 +137,7 @@ public class EpdqAuthorisationErrorGatewayCleanupService {
                 return true;
             }).orElseGet(() -> {
                 cancelResponse.getGatewayError().ifPresent(
-                        e -> logger.info(format("Could not cancel charge. Gateway error: %s", e.getMessage()), 
+                        e -> logger.info(format("Could not cancel charge. Gateway error: %s", e.getMessage()),
                                 chargeEntity.getStructuredLoggingArgs()));
                 return false;
             });

--- a/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
@@ -1,0 +1,151 @@
+package uk.gov.pay.connector.charge.service;
+
+import com.google.common.collect.ImmutableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
+import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.paymentprocessor.service.QueryService;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CHARGE_MISSING;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
+
+public class EpdqAuthorisationErrorGatewayCleanupService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public static final String CLEANUP_SUCCESS = "cleanup-success";
+    public static final String CLEANUP_FAILED = "cleanup-failed";
+
+    private ChargeDao chargeDao;
+    private ChargeService chargeService;
+    private QueryService queryService;
+    private PaymentProviders providers;
+
+    @Inject
+    public EpdqAuthorisationErrorGatewayCleanupService(ChargeDao chargeDao,
+                                                       ChargeService chargeService,
+                                                       QueryService queryService,
+                                                       PaymentProviders providers) {
+        this.chargeDao = chargeDao;
+        this.chargeService = chargeService;
+        this.queryService = queryService;
+        this.providers = providers;
+    }
+
+    public Map<String, Integer> sweepAndCleanupAuthorisationErrors() {
+        List<ChargeEntity> chargesToCleanUp = chargeDao.findWithPaymentProviderAndStatusIn(EPDQ.getName(), List.of(
+                AUTHORISATION_ERROR,
+                AUTHORISATION_TIMEOUT,
+                AUTHORISATION_UNEXPECTED_ERROR
+        ));
+
+        AtomicInteger successes = new AtomicInteger();
+        AtomicInteger failures = new AtomicInteger();
+
+        chargesToCleanUp.forEach(chargeEntity -> {
+            try {
+                ChargeQueryResponse chargeQueryResponse = queryService.getChargeGatewayStatus(chargeEntity);
+                boolean success = cleanUpChargeWithGateway(chargeEntity, chargeQueryResponse);
+                if (success) {
+                    successes.getAndIncrement();
+                } else {
+                    failures.getAndIncrement();
+                }
+            } catch (WebApplicationException | GatewayException e) {
+                logger.info("Error when querying charge status with gateway: " + e.getMessage(),
+                        chargeEntity.getStructuredLoggingArgs());
+                failures.getAndIncrement();
+            }
+        });
+
+        return ImmutableMap.of(
+                CLEANUP_SUCCESS, successes.intValue(),
+                CLEANUP_FAILED, failures.intValue()
+        );
+    }
+
+    private boolean cleanUpChargeWithGateway(ChargeEntity chargeEntity, ChargeQueryResponse chargeQueryResponse) {
+        if (!chargeQueryResponse.foundCharge()) {
+            // The charge might not be found with the gateway when the authorisation failed due to an error with ePDQ
+            // before they tried to process the payment. One example of this is when the card type is not enabled in ePDQ.
+            logger.info("Charge was not found on the gateway. Gateway response was: " +
+                            chargeQueryResponse.getRawGatewayResponseString(),
+                    chargeEntity.getStructuredLoggingArgs());
+            chargeService.transitionChargeState(chargeEntity, AUTHORISATION_ERROR_CHARGE_MISSING);
+            return true;
+        }
+
+        return chargeQueryResponse.getMappedStatus().map(mappedStatus -> {
+            // Attempt to cancel the charge with the gateway if it is not in a terminal state with them
+            if (!mappedStatus.toExternal().isFinished()) {
+                if (attemptCancelWithGateway(chargeEntity)) {
+                    chargeService.transitionChargeState(chargeEntity, AUTHORISATION_ERROR_CANCELLED);
+                    return true;
+                }
+                return false;
+            }
+
+            // These are terminal states with the gateway for which no cleanup is required
+            if (mappedStatus == AUTHORISATION_REJECTED || mappedStatus == AUTHORISATION_ERROR) {
+                chargeService.transitionChargeState(chargeEntity, AUTHORISATION_ERROR_REJECTED);
+                return true;
+            }
+
+            logger.error(format("Charge is in a mapped status of [%s] with the gateway, which is " +
+                            "unexpected and we do not handle. If the gateway status is CAPTURED, it " +
+                            "suggests the service has incorrect gateway settings.",
+                    mappedStatus.getValue()),
+                    chargeEntity.getStructuredLoggingArgs());
+            return false;
+        }).orElseGet(() -> {
+            logger.error("Charge does not map to an internal charge state. Raw query response was: " +
+                            chargeQueryResponse.getRawGatewayResponseString(),
+                    chargeEntity.getStructuredLoggingArgs());
+            return false;
+        });
+    }
+
+    private boolean attemptCancelWithGateway(ChargeEntity chargeEntity) {
+        try {
+            logger.info("Attempting gateway cleanup for charge.", chargeEntity.getStructuredLoggingArgs());
+            GatewayResponse<BaseCancelResponse> cancelResponse = providers.byName(chargeEntity.getPaymentGatewayName()).cancel(CancelGatewayRequest.valueOf(chargeEntity));
+            return cancelResponse.getBaseResponse().map(baseCancelResponse -> {
+                if (baseCancelResponse.cancelStatus() == BaseCancelResponse.CancelStatus.ERROR) {
+                    logger.info("Could not cancel charge, gateway returned an error.", chargeEntity.getStructuredLoggingArgs());
+                    return false;
+                }
+                return true;
+            }).orElseGet(() -> {
+                cancelResponse.getGatewayError().ifPresent(
+                        e -> logger.info(format("Could not cancel charge. Gateway error: %s", e.getMessage()), 
+                                chargeEntity.getStructuredLoggingArgs()));
+                return false;
+            });
+        } catch (GatewayException e) {
+            logger.info(format("Gateway error when attempting to cancel charge with the gateway: %s",
+                    e.getMessage()),
+                    chargeEntity.getStructuredLoggingArgs());
+            return false;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -161,7 +161,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                     ChargeStatus mappedStatus = EpdqStatusMapper.map(epdqQueryResponse.getStatus());
                     return new ChargeQueryResponse(mappedStatus, epdqQueryResponse);
                 })
-                .orElseThrow(() -> 
+                .orElseThrow(() ->
                         new WebApplicationException(String.format(
                                 "Unable to query charge %s - an error occurred: %s",
                                 charge.getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqStatusMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqStatusMapper.java
@@ -15,6 +15,7 @@ public class EpdqStatusMapper {
     
     static {
         Map<String, ChargeStatus> aMap = new HashMap<>();
+        aMap.put("0", ChargeStatus.AUTHORISATION_ERROR);
         aMap.put("2", ChargeStatus.AUTHORISATION_REJECTED);
 
         aMap.put("46", ChargeStatus.AUTHORISATION_3DS_REQUIRED);

--- a/src/test/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupServiceTest.java
@@ -1,0 +1,187 @@
+package uk.gov.pay.connector.charge.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
+import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.epdq.model.response.EpdqCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
+import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentprocessor.service.QueryService;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CHARGE_MISSING;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+import static uk.gov.pay.connector.charge.service.EpdqAuthorisationErrorGatewayCleanupService.CLEANUP_FAILED;
+import static uk.gov.pay.connector.charge.service.EpdqAuthorisationErrorGatewayCleanupService.CLEANUP_SUCCESS;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
+    
+    @Mock
+    private ChargeDao mockChargeDao;
+
+    @Mock
+    private ChargeService mockChargeService;
+
+    @Mock
+    private PaymentProviders mockPaymentProviders;
+
+    @Mock
+    private PaymentProvider mockPaymentProvider;
+
+    @Mock
+    private QueryService mockQueryService;
+    
+    @Mock
+    private BaseInquiryResponse mockQueryResponse;
+    
+    @Mock
+    private EpdqCancelResponse epdqCancelResponse;
+    
+    @InjectMocks
+    private EpdqAuthorisationErrorGatewayCleanupService cleanupService;
+    private ChargeEntity charge;
+
+    @Before
+    public void setUp() {
+        when(mockPaymentProviders.byName(EPDQ)).thenReturn(mockPaymentProvider);
+
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withGatewayName(EPDQ.getName())
+                .build();
+        charge = aValidChargeEntity()
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withStatus(ChargeStatus.AUTHORISATION_ERROR)
+                .build();
+
+        when(mockChargeDao.findWithPaymentProviderAndStatusIn(EPDQ.getName(), List.of(
+                AUTHORISATION_ERROR,
+                AUTHORISATION_TIMEOUT,
+                AUTHORISATION_UNEXPECTED_ERROR
+        ))).thenReturn(List.of(charge));
+    }
+
+    @Test
+    public void shouldCleanupChargeThatIsAuthorisedOnTheGateway() throws Exception {
+        when(mockQueryResponse.getTransactionId()).thenReturn("order-code");
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, mockQueryResponse);
+        when(mockQueryService.getChargeGatewayStatus(eq(charge))).thenReturn(chargeQueryResponse);
+        
+        when(epdqCancelResponse.cancelStatus()).thenReturn(BaseCancelResponse.CancelStatus.CANCELLED);
+        GatewayResponse cancelResponse = responseBuilder().withResponse(epdqCancelResponse).build();
+        when(mockPaymentProvider.cancel(any())).thenReturn(cancelResponse);
+
+        Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors();
+        
+        assertThat(result.get(CLEANUP_SUCCESS), is(1));
+        assertThat(result.get(CLEANUP_FAILED), is(0));
+        
+        verify(mockChargeService).transitionChargeState(eq(charge), eq(AUTHORISATION_ERROR_CANCELLED));
+    }
+
+    @Test
+    public void shouldTransitionChargeStateToErrorRejectedWhenFailedOnGateway() throws Exception {
+        when(mockQueryResponse.getTransactionId()).thenReturn("order-code");
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_REJECTED, mockQueryResponse);
+        when(mockQueryService.getChargeGatewayStatus(eq(charge))).thenReturn(chargeQueryResponse);
+
+        Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors();
+
+        assertThat(result.get(CLEANUP_SUCCESS), is(1));
+        assertThat(result.get(CLEANUP_FAILED), is(0));
+
+        verify(mockChargeService).transitionChargeState(eq(charge), eq(AUTHORISATION_ERROR_REJECTED));
+    }
+
+    @Test
+    public void shouldTransitionChargeStateToErrorChargeMissingWhenNotFoundOnGateway() throws Exception {
+        when(mockQueryResponse.getTransactionId()).thenReturn("");
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(null, mockQueryResponse);
+        when(mockQueryService.getChargeGatewayStatus(eq(charge))).thenReturn(chargeQueryResponse);
+
+        Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors();
+
+        assertThat(result.get(CLEANUP_SUCCESS), is(1));
+        assertThat(result.get(CLEANUP_FAILED), is(0));
+
+        verify(mockChargeService).transitionChargeState(eq(charge), eq(AUTHORISATION_ERROR_CHARGE_MISSING));
+    }
+
+    @Test
+    public void shouldReportFailureWhenGatewayCancelFails() throws Exception {
+        when(mockQueryResponse.getTransactionId()).thenReturn("order-code");
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, mockQueryResponse);
+        when(mockQueryService.getChargeGatewayStatus(eq(charge))).thenReturn(chargeQueryResponse);
+
+        when(epdqCancelResponse.cancelStatus()).thenReturn(BaseCancelResponse.CancelStatus.ERROR);
+        GatewayResponse cancelResponse = responseBuilder().withResponse(epdqCancelResponse).build();
+        when(mockPaymentProvider.cancel(any())).thenReturn(cancelResponse);
+
+        Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors();
+
+        assertThat(result.get(CLEANUP_SUCCESS), is(0));
+        assertThat(result.get(CLEANUP_FAILED), is(1));
+
+        verify(mockChargeService, never()).transitionChargeState(eq(charge), any());
+    }
+
+    @Test
+    public void shouldReportFailureWhenGatewayStatusMapsToUnhandledStatus() throws Exception {
+        when(mockQueryResponse.getTransactionId()).thenReturn("order-code");
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_UNEXPECTED_ERROR, mockQueryResponse);
+        when(mockQueryService.getChargeGatewayStatus(eq(charge))).thenReturn(chargeQueryResponse);
+
+        Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors();
+
+        assertThat(result.get(CLEANUP_SUCCESS), is(0));
+        assertThat(result.get(CLEANUP_FAILED), is(1));
+
+        verify(mockPaymentProvider, never()).cancel(any());
+        verify(mockChargeService, never()).transitionChargeState(eq(charge), any());
+    }
+    
+    @Test
+    public void shouldReportFailureWhenGatewayStatusDoesNotMapToInternalStatus() throws Exception {
+        when(mockQueryResponse.getTransactionId()).thenReturn("order-code");
+        ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(null, mockQueryResponse);
+        when(mockQueryService.getChargeGatewayStatus(eq(charge))).thenReturn(chargeQueryResponse);
+
+        Map<String, Integer> result = cleanupService.sweepAndCleanupAuthorisationErrors();
+
+        assertThat(result.get(CLEANUP_SUCCESS), is(0));
+        assertThat(result.get(CLEANUP_FAILED), is(1));
+
+        verify(mockPaymentProvider, never()).cancel(any());
+        verify(mockChargeService, never()).transitionChargeState(eq(charge), any());
+    }
+}


### PR DESCRIPTION
Add service for the recurring job to cleanup ePDQ charges that are in "AUTHORISATION ERROR", "AUTHORISATION UNEXPECTED ERROR" or "AUTHORISATION TIMEOUT" statuses.

This job is required as when we enter into one of these statuses we are unsure whether the charge was actually authorised with the gateway. If it was authorised, we need to cancel it on the gateway to ensure that funds are released in the paying users' bank account.

The job will move the charge into one of three statuses when it has successfully handled it:
"AUTHORISATION ERROR CANCELLED" - the charge was authorised on the gateway but has now been cancelled.
"AUTHORISATION ERROR REJECTED" - the authorisation was rejected on the gateway and no action needed to be taken to clean up.
"AUTHORISATION ERROR CHARGE MISSING" - the charge was not found on the gateway, most likely because the error was before the gateway processed the authorisation.

Map ePDQ status code "0" to "AUTHORISATION ERROR" status when querying the charge status, as this represents an authorisation response that we would have handled by moving the charge into this state.