### PR TITLE
PP-6194 Add resource for ePDQ cleanup job

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ The [API Specification](docs/api_specification.md) provides more detail on the p
 
 ### Tasks namespace
 
-| Path                          | Supported Methods | Description                        |
-| ----------------------------- | ----------------- | ---------------------------------- |
-|[```/v1/tasks/expired-charges-sweep```](docs/api_specification.md#post-v1tasksexpired-charges-sweep)  | POST    |  Spawns a task to expire charges with a default window of 90 minutes|
-|[```/v1/tasks/emitted-events-sweep```](docs/api_specification.md#post-v1tasksemitted-events-sweep)  | POST    |  Spawns a task to verify whether all the events from the state transition in-memory queue have been processed|
+| Path                                                                                                 | Supported Methods | Description                                                                                                                      |
+|:-----------------------------------------------------------------------------------------------------|:------------------|:---------------------------------------------------------------------------------------------------------------------------------|
+| [```/v1/tasks/expired-charges-sweep```](docs/api_specification.md#post-v1tasksexpired-charges-sweep) | POST              | Spawns a task to expire charges with a default window of 90 minutes                                                              |
+| [```/v1/tasks/emitted-events-sweep```](docs/api_specification.md#post-v1tasksemitted-events-sweep)   | POST              | Spawns a task to verify whether all the events from the state transition in-memory queue have been processed                     |
+| [```/v1/tasks/gateway-cleanup-sweep```](docs/api_specification.md#post-v1tasksgateway-cleanup-sweep) | POST              | Spawns a task to check ePDQ charges in an authorisation error state with the gateway and cancel them on the gateway if necessary |
+
 
 ### Command line tasks
 

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -59,6 +59,37 @@ curl -v -XPOST '127.0.0.1:9300/v1/tasks/emitted-events-sweep'
 ```
 -----------------------------------------------------------------------------------------------------------
 
+## POST /v1/tasks/gateway-cleanup-sweep
+
+Finds all ePDQ charges which have a status of `AUTHORISATION ERROR`, `AUTHORISATION UNEXPECTED ERROR`,
+`AUTHORISATION TIMEOUT` and checks what their status is with the payment gateway. If the charges exist on the gateway
+and are in a non-terminal state, e.g. `AUTHORISATION SUCCESS`, a request is sent to cancel the charge on the gateway.
+
+The job will move the charge into one of three statuses when it has successfully handled it:
+
+- `AUTHORISATION ERROR CANCELLED` - the charge was authorised on the gateway but has now been cancelled.
+- `AUTHORISATION ERROR REJECTED` - the authorisation was rejected on the gateway and no action needed to be taken to clean up.
+- `AUTHORISATION ERROR CHARGE MISSING` - the charge was not found on the gateway, most likely because the error was before the gateway processed the authorisation.
+
+### Request example
+
+```
+POST /v1/tasks/gateway-cleanup-sweep
+```
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+"cleanup-success": 0
+"cleanup-failed": 0
+}
+```
+
+-----------------------------------------------------------------------------------------------------------
+
 ## POST /v1/api/accounts
 
 This endpoint creates a new account in this connector.

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAcco
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.resource.ChargesFrontendResource;
+import uk.gov.pay.connector.charge.resource.GatewayCleanupResource;
 import uk.gov.pay.connector.chargeevent.resource.ChargeEventsResource;
 import uk.gov.pay.connector.command.RenderStateTransitionGraphCommand;
 import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
@@ -141,6 +142,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(DiscrepancyResource.class));
         environment.jersey().register(injector.getInstance(EmittedEventResource.class));
         environment.jersey().register(injector.getInstance(GatewayAccount3dsFlexCredentialsResource.class));
+        environment.jersey().register(injector.getInstance(GatewayCleanupResource.class));
         environment.jersey().register(injector.getInstance(LoggingMDCRequestFilter.class));
         environment.jersey().register(injector.getInstance(LoggingMDCResponseFilter.class));
 

--- a/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.charge.resource;
+
+import uk.gov.pay.connector.charge.service.EpdqAuthorisationErrorGatewayCleanupService;
+
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.Map;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.connector.util.ResponseUtil.successResponseWithEntity;
+
+@Path("/")
+public class GatewayCleanupResource {
+
+    private EpdqAuthorisationErrorGatewayCleanupService cleanupService;
+
+    @Inject 
+    public GatewayCleanupResource(EpdqAuthorisationErrorGatewayCleanupService cleanupService) {
+        this.cleanupService = cleanupService;
+    }
+
+    @POST
+    @Path("/v1/tasks/gateway-cleanup-sweep")
+    @Produces(APPLICATION_JSON)
+    public Response cleanupChargesInAuthErrorWithGateway(@Context UriInfo uriInfo) {
+        Map<String, Integer> resultMap = cleanupService.sweepAndCleanupAuthorisationErrors();
+        return successResponseWithEntity(resultMap);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.rules.EpdqMockClient;
 import uk.gov.pay.connector.rules.SmartpayMockClient;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.RestAssuredClient;
 
 import java.time.ZonedDateTime;
@@ -328,6 +329,10 @@ public class ChargingITestBase {
         return addChargeAndCardDetails(nextLong(), status, reference, fromDate, cardBrand);
     }
 
+    protected String addCharge(ChargeStatus status) {
+        return addCharge(status, "ref", ZonedDateTime.now(), RandomIdGenerator.newId());
+    }
+    
     protected String addCharge(ChargeStatus status, String reference, ZonedDateTime fromDate, String transactionId) {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge" + chargeId;

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
@@ -1,0 +1,78 @@
+package uk.gov.pay.connector.it.resources;
+
+import io.restassured.http.ContentType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.testcontainers.shaded.org.apache.commons.lang.math.RandomUtils;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+
+import java.util.List;
+import java.util.Map;
+
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.it.dao.DatabaseFixtures.withDatabaseTestHelper;
+import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class GatewayCleanupResourceIT extends ChargingITestBase {
+
+    private static final String PROVIDER_NAME = "epdq";
+
+    public GatewayCleanupResourceIT() {
+        super(PROVIDER_NAME);
+    }
+
+    @Test
+    public void shouldCleanUpChargesInAuthorisationErrorStates() {
+        String chargeId1 = addCharge(AUTHORISATION_REJECTED);
+        String chargeId2 = addCharge(AUTHORISATION_ERROR);
+        String chargeId3 = addCharge(AUTHORISATION_UNEXPECTED_ERROR);
+        String chargeId4 = addCharge(AUTHORISATION_TIMEOUT);
+        
+        // add a non-ePDQ charge that shouldn't be picked up
+        var worldpayAccount = withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withAccountId(RandomUtils.nextLong())
+                .withPaymentProvider(WORLDPAY.getName())
+                .insert();
+
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withGatewayAccountId(String.valueOf(worldpayAccount.getAccountId()))
+                .withStatus(AUTHORISATION_ERROR)
+                .build());
+        
+        epdqMockClient.mockCancelSuccess();
+        epdqMockClient.mockAuthorisationQuerySuccess();
+        
+        connectorRestApiClient
+                .postGatewayCleanupTask()
+                .statusCode(OK.getStatusCode())
+                .contentType(ContentType.JSON)
+                .body("cleanup-success", is(3))
+                .body("cleanup-failed", is(0));
+
+        List<String> events1 = databaseTestHelper.getInternalEvents(chargeId1);
+        List<String> events2 = databaseTestHelper.getInternalEvents(chargeId2);
+        List<String> events3 = databaseTestHelper.getInternalEvents(chargeId3);
+        List<String> events4 = databaseTestHelper.getInternalEvents(chargeId4);
+
+        assertThat(events1, contains(AUTHORISATION_REJECTED.getValue()));
+        assertThat(events2, contains(AUTHORISATION_ERROR.getValue(), AUTHORISATION_ERROR_CANCELLED.getValue()));
+        assertThat(events3, contains(AUTHORISATION_UNEXPECTED_ERROR.getValue(), AUTHORISATION_ERROR_CANCELLED.getValue()));
+        assertThat(events4, contains(AUTHORISATION_TIMEOUT.getValue(), AUTHORISATION_ERROR_CANCELLED.getValue()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -116,6 +116,12 @@ public class RestAssuredClient {
                 .post("/v1/tasks/emitted-events-sweep")
                 .then();
     }
+    
+    public ValidatableResponse postGatewayCleanupTask() {
+        return given().port(port)
+                .post("/v1/tasks/gateway-cleanup-sweep")
+                .then();
+    }
 
     public ValidatableResponse putChargeStatus(String putBody) {
         String requestPath = "/v1/frontend/charges/{chargeId}"


### PR DESCRIPTION
Add resource which will be called by a recurring task to sweep and
cleanup ePDQ payments that are in authorisation error states.

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
