### PR TITLE
PP-6194 Add limit for gateway cleanup job

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -71,10 +71,18 @@ The job will move the charge into one of three statuses when it has successfully
 - `AUTHORISATION ERROR REJECTED` - the authorisation was rejected on the gateway and no action needed to be taken to clean up.
 - `AUTHORISATION ERROR CHARGE MISSING` - the charge was not found on the gateway, most likely because the error was before the gateway processed the authorisation.
 
+
+### Request query parameters
+
+| Field   | Required | Description                                                                        |
+|:--------|:--------:|:-----------------------------------------------------------------------------------|
+| `limit` |    X     | The maximum number of charges in an error state that will be processed by the job. |
+
+
 ### Request example
 
 ```
-POST /v1/tasks/gateway-cleanup-sweep
+POST /v1/tasks/gateway-cleanup-sweep?limit=50
 ```
 
 ### Response example

--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -241,11 +241,12 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .executeUpdate();
     }
 
-    public List<ChargeEntity> findWithPaymentProviderAndStatusIn(String provider, List<ChargeStatus> statuses) {
+    public List<ChargeEntity> findWithPaymentProviderAndStatusIn(String provider, List<ChargeStatus> statuses, int limit) {
         return entityManager.get()
                 .createQuery("SELECT c FROM ChargeEntity c WHERE c.gatewayAccount.gatewayName = :provider AND c.status in :statuses", ChargeEntity.class)
                 .setParameter("provider", provider)
                 .setParameter("statuses", statuses)
+                .setMaxResults(limit)
                 .getResultList();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/GatewayCleanupResource.java
@@ -3,12 +3,12 @@ package uk.gov.pay.connector.charge.resource;
 import uk.gov.pay.connector.charge.service.EpdqAuthorisationErrorGatewayCleanupService;
 
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -27,8 +27,8 @@ public class GatewayCleanupResource {
     @POST
     @Path("/v1/tasks/gateway-cleanup-sweep")
     @Produces(APPLICATION_JSON)
-    public Response cleanupChargesInAuthErrorWithGateway(@Context UriInfo uriInfo) {
-        Map<String, Integer> resultMap = cleanupService.sweepAndCleanupAuthorisationErrors();
+    public Response cleanupChargesInAuthErrorWithGateway(@QueryParam("limit") @NotNull(message = "Parameter [limit] is required") Integer limit) {
+        Map<String, Integer> resultMap = cleanupService.sweepAndCleanupAuthorisationErrors(limit);
         return successResponseWithEntity(resultMap);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
@@ -52,12 +52,12 @@ public class EpdqAuthorisationErrorGatewayCleanupService {
         this.providers = providers;
     }
 
-    public Map<String, Integer> sweepAndCleanupAuthorisationErrors() {
+    public Map<String, Integer> sweepAndCleanupAuthorisationErrors(int limit) {
         List<ChargeEntity> chargesToCleanUp = chargeDao.findWithPaymentProviderAndStatusIn(EPDQ.getName(), List.of(
                 AUTHORISATION_ERROR,
                 AUTHORISATION_TIMEOUT,
                 AUTHORISATION_UNEXPECTED_ERROR
-        ));
+        ), limit);
 
         AtomicInteger successes = new AtomicInteger();
         AtomicInteger failures = new AtomicInteger();

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
@@ -1,21 +1,21 @@
 package uk.gov.pay.connector.it.resources;
 
-import io.restassured.http.ContentType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.testcontainers.shaded.org.apache.commons.lang.math.RandomUtils;
 import uk.gov.pay.connector.app.ConnectorApp;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import java.util.List;
-import java.util.Map;
 
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR_CANCELLED;
@@ -42,7 +42,7 @@ public class GatewayCleanupResourceIT extends ChargingITestBase {
         String chargeId2 = addCharge(AUTHORISATION_ERROR);
         String chargeId3 = addCharge(AUTHORISATION_UNEXPECTED_ERROR);
         String chargeId4 = addCharge(AUTHORISATION_TIMEOUT);
-        
+
         // add a non-ePDQ charge that shouldn't be picked up
         var worldpayAccount = withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
@@ -54,14 +54,15 @@ public class GatewayCleanupResourceIT extends ChargingITestBase {
                 .withGatewayAccountId(String.valueOf(worldpayAccount.getAccountId()))
                 .withStatus(AUTHORISATION_ERROR)
                 .build());
-        
+
         epdqMockClient.mockCancelSuccess();
         epdqMockClient.mockAuthorisationQuerySuccess();
-        
-        connectorRestApiClient
-                .postGatewayCleanupTask()
+
+        given().port(testContext.getPort())
+                .post("/v1/tasks/gateway-cleanup-sweep?limit=10")
+                .then()
                 .statusCode(OK.getStatusCode())
-                .contentType(ContentType.JSON)
+                .contentType(JSON)
                 .body("cleanup-success", is(3))
                 .body("cleanup-failed", is(0));
 
@@ -74,5 +75,33 @@ public class GatewayCleanupResourceIT extends ChargingITestBase {
         assertThat(events2, contains(AUTHORISATION_ERROR.getValue(), AUTHORISATION_ERROR_CANCELLED.getValue()));
         assertThat(events3, contains(AUTHORISATION_UNEXPECTED_ERROR.getValue(), AUTHORISATION_ERROR_CANCELLED.getValue()));
         assertThat(events4, contains(AUTHORISATION_TIMEOUT.getValue(), AUTHORISATION_ERROR_CANCELLED.getValue()));
+    }
+
+    @Test
+    public void shouldLimitChargesCleanedUp() {
+        addCharge(AUTHORISATION_ERROR);
+        addCharge(AUTHORISATION_ERROR);
+        addCharge(AUTHORISATION_ERROR);
+
+        epdqMockClient.mockCancelSuccess();
+        epdqMockClient.mockAuthorisationQuerySuccess();
+
+        given().port(testContext.getPort())
+                .post("/v1/tasks/gateway-cleanup-sweep?limit=2")
+                .then()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("cleanup-success", is(2))
+                .body("cleanup-failed", is(0));
+    }
+
+    @Test
+    public void shouldReturn422WhenLimitQueryParamMissing() {
+        given().port(testContext.getPort())
+                .post("/v1/tasks/gateway-cleanup-sweep")
+                .then()
+                .statusCode(422)
+                .contentType(JSON)
+                .body("message", containsInAnyOrder("Parameter [limit] is required"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -116,12 +116,6 @@ public class RestAssuredClient {
                 .post("/v1/tasks/emitted-events-sweep")
                 .then();
     }
-    
-    public ValidatableResponse postGatewayCleanupTask() {
-        return given().port(port)
-                .post("/v1/tasks/gateway-cleanup-sweep")
-                .then();
-    }
 
     public ValidatableResponse putChargeStatus(String putBody) {
         String requestPath = "/v1/frontend/charges/{chargeId}"


### PR DESCRIPTION
Take a mandatory query param, "limit", for the v1/tasks/gateway-cleanup-sweep endpoint, which limits the number of charges that are processed by the job.

The intention of this is to have a safe limit to ensure that we won't end up sending a large number of requests to ePDQ in an out of the ordinary situation that may hit a rate limit.