### PR TITLE
PP-6224: Don't expunge epdq charges in select states

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeStatus.java
@@ -78,7 +78,7 @@ public enum ChargeStatus implements Status {
         return value;
     }
 
-    public boolean  isExpungeable() {
+    public boolean isExpungeable() {
         return expungeable;
     }
 


### PR DESCRIPTION
Don't expunge if in AUTHORISATION ERROR, AUTHORISATION TIMEOUT and
AUTHORISATION UNEXPECTED ERROR states.
The reason we're doing this is because we don't trust that epdq charges in
these states match the states at the epdq end. On the epdq side, these charges
can be:
  - missing
  - captured
  - authorised
  - rejected

By making these not expungable, the EpdqAuthorisationErrorGatewayCleanupService
will be able to pick these charges up and clean them up.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
