### PR TITLE
PP-6244 Add ChargeID Logging During Expunging And Remove Validation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -144,7 +144,6 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     @Column(name = "external_metadata", columnDefinition = "jsonb")
     @Convert(converter = ExternalMetadataConverter.class)
-    @Valid
     private ExternalMetadata externalMetadata;
 
     @Column(name = "parity_check_status")

--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.IntStream;
 
+import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.SKIPPED;
 import static uk.gov.pay.connector.filters.RestClientLoggingFilter.HEADER_REQUEST_ID;
@@ -63,6 +64,7 @@ public class ChargeExpungeService {
                 chargeDao.findChargeToExpunge(minimumAgeOfChargeInDays, createdWithinLast)
                         .ifPresent(chargeEntity -> {
                             MDC.put(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId());
+                            logger.info(format("Attempting to expunge charge %s", chargeEntity.getExternalId()));
                             try {
                                 parityCheckAndExpungeIfMet(chargeEntity);
                             } catch (OptimisticLockException error) {

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -246,23 +246,6 @@ public class ChargeDaoIT extends DaoITestBase {
     }
 
     @Test
-    public void shouldNotSaveChargeWithInvalidExternalMetadata() {
-        var metaDataWithAnObject = new ExternalMetadata(
-                Map.of("key_1", Map.of("key_1_a", "some value")));
-
-        ChargeEntity chargeEntity = aValidChargeEntity()
-                .withExternalMetadata(metaDataWithAnObject)
-                .build();
-        try {
-            chargeDao.persist(chargeEntity);
-            fail("Persist should throw a ConstraintViolationException");
-        } catch (ConstraintViolationException ex) {
-            assertThat(ex.getConstraintViolations().size(), is(1));
-            assertThat(ex.getConstraintViolations().iterator().next().getMessage(), is("Field [metadata] values must be of type String, Boolean or Number"));
-        }
-    }
-
-    @Test
     public void shouldCreateNewChargeWithParityCheckStatus() {
         GatewayAccountEntity gatewayAccount = new GatewayAccountEntity(defaultTestAccount.getPaymentProvider(), new HashMap<>(), TEST);
         gatewayAccount.setId(defaultTestAccount.getAccountId());


### PR DESCRIPTION
- Removes @Valid on ChargeEntity temporarily

- Removes test that required @Valid

- Now logs the chargeId during the expunging process.
