### PR TITLE
PP-6259 Rename GatewayParamsFor3ds to Gateway3dsRequiredParams

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/model/Epdq3dsRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/model/Epdq3dsRequiredParams.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.connector.gateway.epdq.model;
 
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
-public class EpdqParamsFor3ds implements GatewayParamsFor3ds {
+public class Epdq3dsRequiredParams implements Gateway3dsRequiredParams {
 
     private final String htmlOut;
 
-    public EpdqParamsFor3ds(String htmlOut) {
+    public Epdq3dsRequiredParams(String htmlOut) {
         this.htmlOut = htmlOut;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/model/response/EpdqAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/model/response/EpdqAuthorisationResponse.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.epdq.model.response;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
-import uk.gov.pay.connector.gateway.epdq.model.EpdqParamsFor3ds;
+import uk.gov.pay.connector.gateway.epdq.model.Epdq3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
@@ -54,9 +54,9 @@ public class EpdqAuthorisationResponse extends EpdqBaseResponse implements BaseA
     }
 
     @Override
-    public Optional<EpdqParamsFor3ds> getGatewayParamsFor3ds() {
+    public Optional<Epdq3dsRequiredParams> getGatewayParamsFor3ds() {
         if (htmlAnswer != null) {
-            return Optional.of(new EpdqParamsFor3ds(htmlAnswer));
+            return Optional.of(new Epdq3dsRequiredParams(htmlAnswer));
         }
         return Optional.empty();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/Gateway3dsRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/Gateway3dsRequiredParams.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.model;
 
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 
-public interface GatewayParamsFor3ds {
+public interface Gateway3dsRequiredParams {
 
     Auth3dsRequiredEntity toAuth3dsRequiredEntity();
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/BaseAuthoriseResponse.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.model.response;
 
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
 import java.util.Optional;
 
@@ -11,7 +11,7 @@ public interface BaseAuthoriseResponse extends BaseResponse {
 
     AuthoriseStatus authoriseStatus();
 
-    Optional<? extends GatewayParamsFor3ds> getGatewayParamsFor3ds();
+    Optional<? extends Gateway3dsRequiredParams> getGatewayParamsFor3ds();
 
     enum AuthoriseStatus {
         SUBMITTED(ChargeStatus.AUTHORISATION_SUBMITTED),

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxGatewayResponseGenerator.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.GatewayError;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
@@ -59,7 +59,7 @@ public interface SandboxGatewayResponseGenerator {
             }
 
             @Override
-            public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+            public Optional<Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
                 return Optional.empty();
             }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/Smartpay3dsAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/Smartpay3dsAuthorisationResponse.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.smartpay;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import java.util.Optional;
@@ -35,7 +35,7 @@ public class Smartpay3dsAuthorisationResponse extends SmartpayBaseResponse imple
     }
 
     @Override
-    public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+    public Optional<Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/Smartpay3dsRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/Smartpay3dsRequiredParams.java
@@ -1,15 +1,15 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
-public class SmartpayParamsFor3ds implements GatewayParamsFor3ds {
+public class Smartpay3dsRequiredParams implements Gateway3dsRequiredParams {
 
     private final String issuerUrl;
     private final String paRequest;
     private final String md;
 
-    public SmartpayParamsFor3ds(String issuerUrl, String paRequest, String md) {
+    public Smartpay3dsRequiredParams(String issuerUrl, String paRequest, String md) {
         this.issuerUrl = issuerUrl;
         this.paRequest = paRequest;
         this.md = md;

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationResponse.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.smartpay;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import javax.xml.bind.annotation.XmlRootElement;
@@ -53,8 +53,8 @@ public class SmartpayAuthorisationResponse extends SmartpayBaseResponse implemen
     }
 
     @Override
-    public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
-        return Optional.of(new SmartpayParamsFor3ds(issuerUrl, paRequest, md));
+    public Optional<Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
+        return Optional.of(new Smartpay3dsRequiredParams(issuerUrl, paRequest, md));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/Stripe3dsSourceAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/Stripe3dsSourceAuthorisationResponse.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.gateway.stripe;
 
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsSourceResponse;
-import uk.gov.pay.connector.gateway.stripe.response.StripeParamsFor3ds;
 
 import java.util.Optional;
 
@@ -32,8 +32,8 @@ public class Stripe3dsSourceAuthorisationResponse implements BaseAuthoriseRespon
     }
 
     @Override
-    public Optional<? extends GatewayParamsFor3ds> getGatewayParamsFor3ds() {
-        return Optional.of(new StripeParamsFor3ds(jsonResponse.getRedirectUrl()));
+    public Optional<? extends Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
+        return Optional.of(new Stripe3dsRequiredParams(jsonResponse.getRedirectUrl()));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.gateway.stripe;
 
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.stripe.json.StripeCharge;
-import uk.gov.pay.connector.gateway.stripe.response.StripeParamsFor3ds;
+import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.stripe.response.StripePaymentIntentResponse;
 
 import java.util.Objects;
@@ -51,9 +51,9 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
     }
 
     @Override
-    public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+    public Optional<Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
         return Optional.ofNullable(redirectUrl)
-                .map(StripeParamsFor3ds::new);
+                .map(Stripe3dsRequiredParams::new);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe.json;
 
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 
 import java.util.Optional;
@@ -28,7 +28,7 @@ public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse 
     }
 
     @Override
-    public Optional<? extends GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+    public Optional<? extends Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
         return Optional.empty();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/Stripe3dsRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/Stripe3dsRequiredParams.java
@@ -1,13 +1,13 @@
 package uk.gov.pay.connector.gateway.stripe.response;
 
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
-public class StripeParamsFor3ds implements GatewayParamsFor3ds {
+public class Stripe3dsRequiredParams implements Gateway3dsRequiredParams {
 
     private final String issuerUrl;
 
-    public StripeParamsFor3ds(String issuerUrl) {
+    public Stripe3dsRequiredParams(String issuerUrl) {
         this.issuerUrl = issuerUrl;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexRequiredParams.java
@@ -1,21 +1,21 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
 import java.util.Objects;
 
-public class WorldpayParamsFor3dsFlex implements GatewayParamsFor3ds {
+public class Worldpay3dsFlexRequiredParams implements Gateway3dsRequiredParams {
     
     private final String challengeAcsUrl;
     private final String challengeTransactionId;
     private final String challengePayload;
     private final String threeDsVersion;
 
-    public WorldpayParamsFor3dsFlex(String challengeAcsUrl,
-                                    String challengeTransactionId,
-                                    String challengePayload,
-                                    String threeDsVersion) {
+    public Worldpay3dsFlexRequiredParams(String challengeAcsUrl,
+                                         String challengeTransactionId,
+                                         String challengePayload,
+                                         String threeDsVersion) {
         this.challengeAcsUrl = Objects.requireNonNull(challengeAcsUrl);
         this.challengeTransactionId = Objects.requireNonNull(challengeTransactionId);
         this.challengePayload = Objects.requireNonNull(challengePayload);

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsRequiredParams.java
@@ -1,14 +1,14 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
-public class WorldpayParamsFor3ds implements GatewayParamsFor3ds {
+public class Worldpay3dsRequiredParams implements Gateway3dsRequiredParams {
 
     private final String issuerUrl;
     private final String paRequest;
 
-    public WorldpayParamsFor3ds(String issuerUrl, String paRequest) {
+    public Worldpay3dsRequiredParams(String issuerUrl, String paRequest) {
         this.issuerUrl = issuerUrl;
         this.paRequest = paRequest;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.persistence.oxm.annotations.XmlPath;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
@@ -135,12 +135,12 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         return trim(errorMessage);
     }
 
-    public Optional<GatewayParamsFor3ds> getGatewayParamsFor3ds() {
+    public Optional<Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
         if (is3dsVersionOneRequired()) {
-            return Optional.of(new WorldpayParamsFor3ds(issuerUrl, paRequest));
+            return Optional.of(new Worldpay3dsRequiredParams(issuerUrl, paRequest));
         }
         if (is3dsFlexChallengeRequired()) {
-            return Optional.of(new WorldpayParamsFor3dsFlex(
+            return Optional.of(new Worldpay3dsFlexRequiredParams(
                     challengeAcsUrl,
                     challengeTransactionId,
                     challengePayload,

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -16,7 +16,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -146,7 +146,7 @@ public class CardAuthoriseService {
     private Optional<Auth3dsRequiredEntity> extractAuth3dsRequiredDetails(GatewayResponse<BaseAuthoriseResponse> operationResponse) {
         return operationResponse.getBaseResponse()
                 .flatMap(BaseAuthoriseResponse::getGatewayParamsFor3ds)
-                .map(GatewayParamsFor3ds::toAuth3dsRequiredEntity);
+                .map(Gateway3dsRequiredParams::toAuth3dsRequiredEntity);
     }
 
     private PaymentProvider getPaymentProviderFor(ChargeEntity chargeEntity) {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -28,7 +28,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeAuthoriseRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripePaymentIntentRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripePaymentMethodRequest;
-import uk.gov.pay.connector.gateway.stripe.response.StripeParamsFor3ds;
+import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -133,7 +133,7 @@ public class StripePaymentProviderTest {
         assertTrue(response.isSuccessful());
         assertThat(response.getBaseResponse().get().getTransactionId(), is("pi_123")); // id from templates/stripe/create_3ds_sources_response.json
 
-        Optional<StripeParamsFor3ds> stripeParamsFor3ds = (Optional<StripeParamsFor3ds>) response.getBaseResponse().get().getGatewayParamsFor3ds();
+        Optional<Stripe3dsRequiredParams> stripeParamsFor3ds = (Optional<Stripe3dsRequiredParams>) response.getBaseResponse().get().getGatewayParamsFor3ds();
         assertThat(stripeParamsFor3ds.isPresent(), is(true));
         assertThat(stripeParamsFor3ds.get().toAuth3dsRequiredEntity().getIssuerUrl(), containsString("https://hooks.stripe.com"));
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
@@ -27,19 +28,18 @@ import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
-import uk.gov.pay.connector.gateway.model.GatewayParamsFor3ds;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
+import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
+import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayParamsFor3ds;
-import uk.gov.pay.connector.gateway.worldpay.WorldpayParamsFor3dsFlex;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.queue.StateTransitionService;
@@ -342,7 +342,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     public void doAuthorise_shouldRespondWith3dsResponseFor3dsOrders() throws Exception {
         String issuerUrl = "an-issuer-url";
         String paRequest = "a-pa-request";
-        WorldpayParamsFor3ds worldpayParamsFor3ds = new WorldpayParamsFor3ds(issuerUrl, paRequest);
+        Worldpay3dsRequiredParams worldpayParamsFor3ds = new Worldpay3dsRequiredParams(issuerUrl, paRequest);
         worldpayProviderWillRequire3ds(null, worldpayParamsFor3ds);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
@@ -363,7 +363,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         String challengeTransactionId = "a-transaction-id";
         String challengePayload = "a-payload";
         String threeDsVersion = "a-version";
-        WorldpayParamsFor3dsFlex worldpayParamsFor3dsFlex = new WorldpayParamsFor3dsFlex(challengeAcsUrl, challengeTransactionId, challengePayload, threeDsVersion);
+        Worldpay3dsFlexRequiredParams worldpayParamsFor3dsFlex = new Worldpay3dsFlexRequiredParams(challengeAcsUrl, challengeTransactionId, challengePayload, threeDsVersion);
         worldpayProviderWillRequire3ds(null, worldpayParamsFor3dsFlex);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
@@ -400,7 +400,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     public void doAuthorise_shouldRespondWith3dsResponseFor3dsOrdersWithWorldpayMachineCookie() throws Exception {
         String issuerUrl = "an-issuer-url";
         String paRequest = "a-pa-request";
-        WorldpayParamsFor3ds worldpayParamsFor3ds = new WorldpayParamsFor3ds(issuerUrl, paRequest);
+        Worldpay3dsRequiredParams worldpayParamsFor3ds = new Worldpay3dsRequiredParams(issuerUrl, paRequest);
         worldpayProviderWillRequire3ds(SESSION_IDENTIFIER, worldpayParamsFor3ds);
 
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
@@ -709,7 +709,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillRespondToAuthoriseWith(authResponse);
     }
 
-    private void worldpayProviderWillRequire3ds(String sessionIdentifier, GatewayParamsFor3ds worldpayParamsFor3ds) throws GatewayException {
+    private void worldpayProviderWillRequire3ds(String sessionIdentifier, Gateway3dsRequiredParams worldpayParamsFor3ds) throws GatewayException {
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         
         var mockWorldpayResponse = mock(WorldpayOrderStatusResponse.class);


### PR DESCRIPTION
Rename `GatewayParamsFor3ds` to `Gateway3dsRequiredParams` to make it clear that the parameters relate to what the gateway tells us when 3D Secure is required and not anything to do with the 3D Secure result.

with @SandorArpa