### PR TITLE
PP-6259 Create specific types for session IDs

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -54,6 +54,7 @@ import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paritycheck.LedgerService;
@@ -477,7 +478,7 @@ public class ChargeService {
                                                           ChargeStatus status,
                                                           Optional<String> transactionId,
                                                           Optional<Auth3dsRequiredEntity> auth3dsRequiredDetails,
-                                                          Optional<String> sessionIdentifier,
+                                                          Optional<ProviderSessionIdentifier> sessionIdentifier,
                                                           AuthCardDetails authCardDetails) {
         return updateChargeAndEmitEventPostAuthorisation(chargeExternalId, status, authCardDetails, transactionId, auth3dsRequiredDetails, sessionIdentifier,
                 Optional.empty(), Optional.empty());
@@ -487,7 +488,7 @@ public class ChargeService {
     public ChargeEntity updateChargePostWalletAuthorisation(String chargeExternalId,
                                                             ChargeStatus status,
                                                             Optional<String> transactionId,
-                                                            Optional<String> sessionIdentifier,
+                                                            Optional<ProviderSessionIdentifier> sessionIdentifier,
                                                             AuthCardDetails authCardDetails,
                                                             WalletType walletType,
                                                             String emailAddress) {
@@ -500,7 +501,7 @@ public class ChargeService {
                                                                   AuthCardDetails authCardDetails,
                                                                   Optional<String> transactionId,
                                                                   Optional<Auth3dsRequiredEntity> auth3dsRequiredDetails,
-                                                                  Optional<String> sessionIdentifier,
+                                                                  Optional<ProviderSessionIdentifier> sessionIdentifier,
                                                                   Optional<WalletType> walletType,
                                                                   Optional<String> emailAddress) {
         updateChargePostAuthorisation(chargeExternalId, status, authCardDetails, transactionId,
@@ -519,12 +520,12 @@ public class ChargeService {
                                                       AuthCardDetails authCardDetails,
                                                       Optional<String> transactionId,
                                                       Optional<Auth3dsRequiredEntity> auth3dsRequiredDetails,
-                                                      Optional<String> sessionIdentifier,
+                                                      Optional<ProviderSessionIdentifier> sessionIdentifier,
                                                       Optional<WalletType> walletType,
                                                       Optional<String> emailAddress) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             setTransactionId(charge, transactionId);
-            sessionIdentifier.ifPresent(charge::setProviderSessionId);
+            sessionIdentifier.map(ProviderSessionIdentifier::toString).ifPresent(charge::setProviderSessionId);
             auth3dsRequiredDetails.ifPresent(charge::set3dsRequiredDetails);
             walletType.ifPresent(charge::setWalletType);
             emailAddress.ifPresent(charge::setEmail);

--- a/src/main/java/uk/gov/pay/connector/gateway/model/ProviderSessionIdentifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/ProviderSessionIdentifier.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.gateway.model;
+
+import uk.gov.pay.commons.model.WrappedStringValue;
+
+/**
+ * A session identifier that a payment provider requires us to store
+ * and send to back to them, for example Worldpay’s “machine” cookie,
+ * which we receive when Worldpay tells us 3D Secure is required and
+ * send back to them with the 3D Secure result
+ */
+public class ProviderSessionIdentifier extends WrappedStringValue {
+
+    private ProviderSessionIdentifier(String value) {
+        super(value);
+    }
+    
+    public static ProviderSessionIdentifier of(String providerSessionIdentifier) {
+        return new ProviderSessionIdentifier(providerSessionIdentifier);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.util.Optional;
@@ -30,8 +31,8 @@ public class Auth3dsResponseGatewayRequest implements GatewayRequest {
         return String.valueOf(charge.getExternalId());
     }
 
-    public Optional<String> getProviderSessionId() {
-        return Optional.ofNullable(charge.getProviderSessionId());
+    public Optional<ProviderSessionIdentifier> getProviderSessionId() {
+        return Optional.ofNullable(charge.getProviderSessionId()).map(ProviderSessionIdentifier::of);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/GatewayResponse.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 
 import java.util.Optional;
 
@@ -18,9 +19,9 @@ public class GatewayResponse<T extends BaseResponse> {
     private GatewayError gatewayError;
     private T baseResponse;
 
-    private String sessionIdentifier;
+    private ProviderSessionIdentifier sessionIdentifier;
 
-    private GatewayResponse(T baseResponse, String sessionIdentifier) {
+    private GatewayResponse(T baseResponse, ProviderSessionIdentifier sessionIdentifier) {
         this.baseResponse = baseResponse;
         this.sessionIdentifier = sessionIdentifier;
     }
@@ -39,7 +40,7 @@ public class GatewayResponse<T extends BaseResponse> {
         return gatewayError != null;
     }
 
-    public Optional<String> getSessionIdentifier() {
+    public Optional<ProviderSessionIdentifier> getSessionIdentifier() {
         return Optional.ofNullable(sessionIdentifier);
     }
 
@@ -73,7 +74,7 @@ public class GatewayResponse<T extends BaseResponse> {
 
     public static class GatewayResponseBuilder<T extends BaseResponse> {
         private T response;
-        private String sessionIdentifier;
+        private ProviderSessionIdentifier sessionIdentifier;
         private GatewayError gatewayError;
 
         private GatewayResponseBuilder() {
@@ -88,7 +89,7 @@ public class GatewayResponse<T extends BaseResponse> {
             return this;
         }
 
-        public GatewayResponseBuilder withSessionIdentifier(String responseIdentifier) {
+        public GatewayResponseBuilder withSessionIdentifier(ProviderSessionIdentifier responseIdentifier) {
             this.sessionIdentifier = responseIdentifier;
             return this;
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseOrderSessionId.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseOrderSessionId.java
@@ -1,0 +1,18 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import uk.gov.pay.commons.model.WrappedStringValue;
+
+/**
+ * A unique session ID that Worldpay requires us to send with a request to
+ * authorise a payment (we usually use the payment’s own external ID)
+ */
+public class WorldpayAuthoriseOrderSessionId extends WrappedStringValue {
+    
+    private WorldpayAuthoriseOrderSessionId(String worldpayAuthoriseOrderSessionId) {
+        super(worldpayAuthoriseOrderSessionId);
+    }
+    
+    public static WorldpayAuthoriseOrderSessionId of(String worldpayAuthoriseOrderSessionId) {
+        return new WorldpayAuthoriseOrderSessionId(worldpayAuthoriseOrderSessionId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 
@@ -23,8 +24,9 @@ public interface WorldpayGatewayResponseGenerator {
     default <T extends BaseResponse> GatewayResponse<T> getWorldpayGatewayResponse(GatewayClient.Response response, Class<T> target) throws GatewayErrorException {
         GatewayResponse.GatewayResponseBuilder<T> responseBuilder = GatewayResponse.GatewayResponseBuilder.responseBuilder();
         responseBuilder.withResponse(unmarshallResponse(response, target));
-        Optional.ofNullable(response.getResponseCookies().get(WORLDPAY_MACHINE_COOKIE_NAME))
-                .ifPresent(responseBuilder::withSessionIdentifier);
+        Optional.ofNullable(response.getResponseCookies().get(
+                WORLDPAY_MACHINE_COOKIE_NAME))
+                .map(ProviderSessionIdentifier::of).ifPresent(responseBuilder::withSessionIdentifier);
         return responseBuilder.build();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -57,8 +57,8 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
             return sessionId;
         }
 
-        public void setSessionId(String sessionId) {
-            this.sessionId = sessionId;
+        public void setSessionId(WorldpayAuthoriseOrderSessionId sessionId) {
+            this.sessionId = sessionId.toString();
         }
 
         public String getAcceptHeader() {
@@ -161,7 +161,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         return this;
     }
 
-    public WorldpayOrderRequestBuilder withSessionId(String sessionId) {
+    public WorldpayOrderRequestBuilder withSessionId(WorldpayAuthoriseOrderSessionId sessionId) {
         worldpayTemplateData.setSessionId(sessionId);
         return this;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -158,7 +158,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
         try {
             List<HttpCookie> cookies = request.getProviderSessionId()
-                    .map(providerSessionId -> singletonList(new HttpCookie(WORLDPAY_MACHINE_COOKIE_NAME, providerSessionId)))
+                    .map(providerSessionId -> singletonList(new HttpCookie(WORLDPAY_MACHINE_COOKIE_NAME, providerSessionId.toString())))
                     .orElse(emptyList());
 
             GatewayClient.Response response = authoriseClient.postRequestFor(

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -216,7 +216,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 request.getGatewayAccount().isRequires3ds();
 
         var builder = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(request.getChargeExternalId())
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
                 .with3dsRequired(is3dsRequired)
                 .withDate(DateTime.now(DateTimeZone.UTC));
 
@@ -244,7 +244,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     private GatewayOrder build3dsResponseAuthOrder(Auth3dsResponseGatewayRequest request) {
         return aWorldpay3dsResponseAuthOrderRequestBuilder()
                 .withPaResponse3ds(request.getAuth3dsResult().getPaResponse())
-                .withSessionId(request.getChargeExternalId())
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
                 .withTransactionId(request.getTransactionId().orElse(""))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthoriseOrderSessionId;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayGatewayResponseGenerator;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.WalletAuthorisationHandler;
@@ -41,7 +42,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
     private GatewayOrder buildWalletAuthoriseOrder(WalletAuthorisationGatewayRequest request) {
         return aWorldpayAuthoriseWalletOrderRequestBuilder(request.getWalletAuthorisationData().getWalletType())
                 .withWalletTemplateData(request.getWalletAuthorisationData())
-                .withSessionId(request.getChargeExternalId())
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
                 .withTransactionId(request.getTransactionId().orElse(""))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withDescription(request.getDescription())

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -59,7 +60,7 @@ public class CardAuthoriseService {
             GatewayResponse<BaseAuthoriseResponse> operationResponse;
             ChargeStatus newStatus;
             Optional<String> transactionId = Optional.empty();
-            Optional<String> sessionIdentifier = Optional.empty();
+            Optional<ProviderSessionIdentifier> sessionIdentifier = Optional.empty();
             Optional<Auth3dsRequiredEntity> auth3dsDetailsEntity = Optional.empty();
 
             try {

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
@@ -49,7 +50,7 @@ public class WalletAuthoriseService {
             final ChargeEntity charge = prepareChargeForAuthorisation(chargeId);
             GatewayResponse<BaseAuthoriseResponse> operationResponse;
             Optional<String> transactionId = Optional.empty();
-            Optional<String> sessionIdentifier = Optional.empty();
+            Optional<ProviderSessionIdentifier> sessionIdentifier = Optional.empty();
             ChargeStatus chargeStatus = null;
             String responseFromPaymentGateway = null;
             String requestStatus = "failure";
@@ -133,7 +134,7 @@ public class WalletAuthoriseService {
             WalletAuthorisationData walletAuthorisationData,
             String responseFromGateway,
             Optional<String> transactionId,
-            Optional<String> sessionIdentifier,
+            Optional<ProviderSessionIdentifier> sessionIdentifier,
             ChargeStatus status) {
 
         logger.info("Processing gateway auth response for {}", walletAuthorisationData.getWalletType().toString());

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -152,8 +152,6 @@ public class WorldpayOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidAuth3dsResponseOrderRequest() throws Exception {
-
-        String providerSessionId = "provider-session-id";
         GatewayOrder actualRequest = aWorldpay3dsResponseAuthOrderRequestBuilder()
                 .withPaResponse3ds("I am an opaque 3D Secure PA response from the card issuer")
                 .withSessionId("uniqueSessionId")

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -50,7 +50,7 @@ public class WorldpayOrderRequestBuilderTest {
         AuthCardDetails authCardDetails = getValidTestCard(minAddress);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
                 .withTransactionId("MyUniqueTransactionId!")
@@ -72,7 +72,7 @@ public class WorldpayOrderRequestBuilderTest {
         AuthCardDetails authCardDetails = getValidTestCard(minAddress);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .with3dsRequired(true)
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
@@ -95,7 +95,7 @@ public class WorldpayOrderRequestBuilderTest {
         AuthCardDetails authCardDetails = getValidTestCard(fullAddress);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
                 .withTransactionId("MyUniqueTransactionId!")
@@ -117,7 +117,7 @@ public class WorldpayOrderRequestBuilderTest {
         AuthCardDetails authCardDetails = getValidTestCard(address);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
                 .withTransactionId("MyUniqueTransactionId!")
@@ -136,7 +136,7 @@ public class WorldpayOrderRequestBuilderTest {
         AuthCardDetails authCardDetails = getValidTestCard(null);
 
         GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
                 .withTransactionId("MyUniqueTransactionId!")
@@ -154,7 +154,7 @@ public class WorldpayOrderRequestBuilderTest {
     public void shouldGenerateValidAuth3dsResponseOrderRequest() throws Exception {
         GatewayOrder actualRequest = aWorldpay3dsResponseAuthOrderRequestBuilder()
                 .withPaResponse3ds("I am an opaque 3D Secure PA response from the card issuer")
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .withTransactionId("MyUniqueTransactionId!")
                 .withMerchantCode("MERCHANTCODE")
                 .build();
@@ -167,7 +167,7 @@ public class WorldpayOrderRequestBuilderTest {
     public void shouldGenerateValidAuthoriseApplePayOrderRequest() throws Exception {
         GatewayOrder actualRequest = aWorldpayAuthoriseWalletOrderRequestBuilder(WalletType.APPLE_PAY)
                 .withWalletTemplateData(validData)
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
                 .withTransactionId("MyUniqueTransactionId!")
@@ -192,7 +192,7 @@ public class WorldpayOrderRequestBuilderTest {
                         .build();
         GatewayOrder actualRequest = aWorldpayAuthoriseWalletOrderRequestBuilder(WalletType.APPLE_PAY)
                 .withWalletTemplateData(validData)
-                .withSessionId("uniqueSessionId")
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
                 .withAcceptHeader("text/html")
                 .withUserAgentHeader("Mozilla/5.0")
                 .withTransactionId("MyUniqueTransactionId!")

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeEx
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
@@ -133,8 +134,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     public void doAuthorise_shouldPopulateTheProviderSessionId() {
 
         Auth3dsResult auth3dsResult = AuthUtils.buildAuth3dsResult();
-        String providerSessionId = "provider-session-id";
-        charge.setProviderSessionId(providerSessionId);
+        ProviderSessionIdentifier providerSessionId = ProviderSessionIdentifier.of("provider-session-id");
+        charge.setProviderSessionId(providerSessionId.toString());
 
         ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor = ArgumentCaptor.forClass(Auth3dsResponseGatewayRequest.class);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
@@ -85,7 +86,7 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 @RunWith(MockitoJUnitRunner.class)
 public class CardAuthoriseServiceTest extends CardServiceTest {
     
-    private static final String SESSION_IDENTIFIER = "session-identifier";
+    private static final ProviderSessionIdentifier SESSION_IDENTIFIER = ProviderSessionIdentifier.of("session-identifier");
     private static final String TRANSACTION_ID = "transaction-id";
 
     private final ChargeEntity charge = createNewChargeWith(1L, ENTERING_CARD_DETAILS);
@@ -187,7 +188,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertTrue(response.getAuthoriseStatus().isPresent());
         assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -206,7 +207,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertTrue(response.getAuthoriseStatus().isPresent());
         assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -228,7 +229,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertTrue(response.getAuthoriseStatus().isPresent());
         assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -254,7 +255,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertTrue(response.getAuthoriseStatus().isPresent());
         assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -279,7 +280,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertTrue(response.getAuthoriseStatus().isPresent());
         assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -304,7 +305,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertTrue(response.getAuthoriseStatus().isPresent());
         assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -330,7 +331,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         assertTrue(response.getAuthoriseStatus().isPresent());
         assertThat(response.getAuthoriseStatus().get(), is(AuthoriseStatus.AUTHORISED));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         assertThat(charge.get3dsRequiredDetails(), is(nullValue()));
@@ -600,7 +601,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails().build();
         cardAuthorisationService.doAuthorise(charge.getExternalId(), authCardDetails);
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
     }
 
     @Test
@@ -709,7 +710,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         providerWillRespondToAuthoriseWith(authResponse);
     }
 
-    private void worldpayProviderWillRequire3ds(String sessionIdentifier, Gateway3dsRequiredParams worldpayParamsFor3ds) throws GatewayException {
+    private void worldpayProviderWillRequire3ds(ProviderSessionIdentifier sessionIdentifier, Gateway3dsRequiredParams worldpayParamsFor3ds) throws GatewayException {
         mockExecutorServiceWillReturnCompletedResultWithSupplierReturnValue();
         
         var mockWorldpayResponse = mock(WorldpayOrderStatusResponse.class);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
@@ -86,7 +87,7 @@ import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.
 @RunWith(MockitoJUnitRunner.class)
 public class WalletAuthoriseServiceTest extends CardServiceTest {
 
-    private static final String SESSION_IDENTIFIER = "session-identifier";
+    private static final ProviderSessionIdentifier SESSION_IDENTIFIER = ProviderSessionIdentifier.of("session-identifier");
     private static final String TRANSACTION_ID = "transaction-id";
 
     private final ChargeEntity charge = createNewChargeWith(1L, ENTERING_CARD_DETAILS);
@@ -181,7 +182,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -214,7 +215,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         assertThat(response.getSessionIdentifier().isPresent(), is(true));
         assertThat(response.getSessionIdentifier().get(), is(SESSION_IDENTIFIER));
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
         assertThat(charge.getStatus(), is(AUTHORISATION_SUCCESS.getValue()));
         assertThat(charge.getGatewayTransactionId(), is(TRANSACTION_ID));
         verify(mockedChargeEventDao).persistChargeEventOf(eq(charge), isNull());
@@ -311,7 +312,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
         walletAuthoriseService.doAuthorise(charge.getExternalId(), validApplePayDetails);
 
-        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER));
+        assertThat(charge.getProviderSessionId(), is(SESSION_IDENTIFIER.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayServiceTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
@@ -56,7 +57,7 @@ public class ApplePayServiceTest {
         WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
         GatewayResponse gatewayResponse = responseBuilder()
                 .withResponse(worldpayResponse)
-                .withSessionIdentifier("234")
+                .withSessionIdentifier(ProviderSessionIdentifier.of("234"))
                 .build();
         when(worldpayResponse.authoriseStatus()).thenReturn(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
         when(mockedApplePayDecrypter.performDecryptOperation(applePayAuthRequest)).thenReturn(validData);
@@ -76,7 +77,7 @@ public class ApplePayServiceTest {
         GatewayError gatewayError = mock(GatewayError.class);
         GatewayResponse gatewayResponse = responseBuilder()
                 .withGatewayError(gatewayError)
-                .withSessionIdentifier("234")
+                .withSessionIdentifier(ProviderSessionIdentifier.of("234"))
                 .build();
         when(gatewayError.getErrorType()).thenReturn(GATEWAY_ERROR);
         when(gatewayError.getMessage()).thenReturn("oops");

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/GooglePayServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gateway.model.GatewayError;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
@@ -50,7 +51,7 @@ public class GooglePayServiceTest {
         WorldpayOrderStatusResponse worldpayResponse = mock(WorldpayOrderStatusResponse.class);
         GatewayResponse<BaseAuthoriseResponse> gatewayResponse = responseBuilder()
                 .withResponse(worldpayResponse)
-                .withSessionIdentifier("234")
+                .withSessionIdentifier(ProviderSessionIdentifier.of("234"))
                 .build();
         when(worldpayResponse.authoriseStatus()).thenReturn(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
         when(mockedWalletAuthoriseService.doAuthorise(externalChargeId, googlePayAuthRequest)).thenReturn(gatewayResponse);
@@ -68,7 +69,7 @@ public class GooglePayServiceTest {
         GatewayError gatewayError = mock(GatewayError.class);
         GatewayResponse gatewayResponse = responseBuilder()
                 .withGatewayError(gatewayError)
-                .withSessionIdentifier("234")
+                .withSessionIdentifier(ProviderSessionIdentifier.of("234"))
                 .build();
         when(gatewayError.getErrorType()).thenReturn(GATEWAY_ERROR);
         when(gatewayError.getMessage()).thenReturn("oops");


### PR DESCRIPTION
We have a couple of different things called session identifiers or IDs:

* A thing that a payment provider sends to us and requires us to store and send back to them. This includes Worldpay’s `machine` cookie, which is used as part of 3D Secure.
* A unique identifier Worldpay requires us to generate and send to them when authorising a payment.

To avoid confusion, introduce specific types for these two things, rather than having them both be strings with confusingly similar names.

with @SandorArpa