### PR TITLE
PP-6254: Add Carbon Relay metrics config

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,6 +20,8 @@ applications:
 
       # Provided by the app-catalog service - see src/main/resources/env-map.yml
       FRONTEND_URL: ""
+      METRICS_HOST: ""
+      METRICS_PORT: ""
 
       # Provided by card-connector-secret-service - see src/main/resource/env-map.yml
       SENTRY_DSN: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -5,6 +5,8 @@ env_vars:
   DB_USER:                         '.[][] | select(.name == "card-connector-db") | .credentials.username                       '
   DB_SSL_OPTION:                   '.[][] | select(.name == "card-connector-db") | .credentials.ssl_option        // "ssl=true"'
   FRONTEND_URL:                    '.[][] | select(.name == "app-catalog")       | .credentials.card_frontend_url              '
+  METRICS_HOST:                    '.[][] | select(.name == "app-catalog")       | .credentials.carbon_relay_route             '
+  METRICS_PORT:                    '.[][] | select(.name == "app-catalog")       | .credentials.carbon_relay_port              '
   AWS_SQS_CAPTURE_QUEUE_URL:       '.[][] | select(.name == "sqs")               | .credentials.capture_queue_url              '
   AWS_SQS_ENDPOINT:                '.[][] | select(.name == "sqs")               | .credentials.endpoint                       '
   AWS_SQS_PAYMENT_EVENT_QUEUE_URL: '.[][] | select(.name == "sqs")               | .credentials.event_queue_url                '


### PR DESCRIPTION
Set the `METRICS_HOST` and `METRICS_PORT` from the app-catalog to send
metrics to the carbon-relay app.
