### PR TITLE
PP-6259 Stop using Optional params for some authorisation methods

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -90,7 +90,7 @@ public class Card3dsResponseAuthService {
                 chargeExternalId,
                 operationResponse.getMappedChargeStatus(),
                 AUTHORISATION_3DS,
-                transactionId
+                transactionId.orElse(null)
         );
 
         LOGGER.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -81,9 +81,9 @@ public class CardAuthoriseService {
             ChargeEntity updatedCharge = chargeService.updateChargePostCardAuthorisation(
                     charge.getExternalId(),
                     newStatus,
-                    transactionId,
-                    auth3dsDetailsEntity,
-                    sessionIdentifier,
+                    transactionId.orElse(null),
+                    auth3dsDetailsEntity.orElse(null),
+                    sessionIdentifier.orElse(null),
                     authCardDetails);
 
             boolean billingAddressSubmitted = updatedCharge.getCardDetails().getBillingAddress().isPresent();

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -89,8 +89,8 @@ public class WalletAuthoriseService {
                     ChargeStatus.fromString(charge.getStatus()),
                     walletAuthorisationData,
                     responseFromPaymentGateway,
-                    transactionId,
-                    sessionIdentifier,
+                    transactionId.orElse(null),
+                    sessionIdentifier.orElse(null),
                     chargeStatus);
 
             // Used by Sumo Logic saved search
@@ -133,8 +133,8 @@ public class WalletAuthoriseService {
             ChargeStatus oldChargeStatus,
             WalletAuthorisationData walletAuthorisationData,
             String responseFromGateway,
-            Optional<String> transactionId,
-            Optional<ProviderSessionIdentifier> sessionIdentifier,
+            String transactionId,
+            ProviderSessionIdentifier sessionIdentifier,
             ChargeStatus status) {
 
         logger.info("Processing gateway auth response for {}", walletAuthorisationData.getWalletType().toString());
@@ -150,7 +150,7 @@ public class WalletAuthoriseService {
 
         logger.info("Authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
                 updatedCharge.getExternalId(), updatedCharge.getPaymentGatewayName().getName(),
-                transactionId.orElse("missing transaction ID"),
+                transactionId != null ? transactionId : "missing transaction ID",
                 updatedCharge.getGatewayAccount().getAnalyticsId(), updatedCharge.getGatewayAccount().getId(),
                 responseFromGateway, oldChargeStatus, status);
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -371,7 +371,7 @@ public class ChargeServiceTest {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo("1234567890");
         service.updateChargeAndEmitEventPostAuthorisation(chargeSpy.getExternalId(), ENTERING_CARD_DETAILS,
-                authCardDetails, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
+                authCardDetails, null, null, null, null, null);
 
         verify(mockEventService).emitAndRecordEvent(PaymentDetailsEntered.from(chargeSpy));
     }


### PR DESCRIPTION
Having `Optional`s as method parameters is generally frowned upon, so replace some of them in authorisation-related methods with just regular might-be-null objects.

with @SandorArpa