### PR TITLE
PP-6259 Worldpay: store 3DS required data if asked to do 3DS again

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -543,11 +543,13 @@ public class ChargeService {
     @Transactional
     public ChargeEntity updateChargePost3dsAuthorisation(String chargeExternalId, ChargeStatus status,
                                                          OperationType operationType,
-                                                         String transactionId) {
+                                                         String transactionId,
+                                                         Auth3dsRequiredEntity auth3dsRequiredDetails) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             try {
                 setTransactionId(charge, transactionId);
                 transitionChargeState(charge, status);
+                Optional.ofNullable(auth3dsRequiredDetails).ifPresent(charge::set3dsRequiredDetails);
             } catch (InvalidStateTransitionException e) {
                 if (chargeIsInLockedStatus(operationType, charge)) {
                     throw new OperationAlreadyInProgressRuntimeException(operationType.getValue(), charge.getExternalId());

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -1,36 +1,51 @@
 package uk.gov.pay.connector.gateway.model.response;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 
 import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION;
 
 public class Gateway3DSAuthorisationResponse {
+
     private final BaseAuthoriseResponse.AuthoriseStatus authorisationStatus;
     private final String transactionId;
     private final String stringified;
+    private final Gateway3dsRequiredParams gateway3dsRequiredParams;
 
-    private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, String stringified) {
+    private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, String stringified,
+                                            Gateway3dsRequiredParams gateway3dsRequiredParams) {
         this.transactionId = transactionId;
         this.authorisationStatus = authorisationStatus;
         this.stringified = stringified;
+        this.gateway3dsRequiredParams = gateway3dsRequiredParams;
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified, null);
+    }
+
+    public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
+                                                     Gateway3dsRequiredParams gateway3dsRequiredParams) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified, gateway3dsRequiredParams);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "");
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", null);
+    }
+
+    public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
+                                                     Gateway3dsRequiredParams gateway3dsRequiredParams) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", gateway3dsRequiredParams);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringified);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringified, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "");
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null);
     }
 
     public boolean isSuccessful() {
@@ -49,7 +64,11 @@ public class Gateway3DSAuthorisationResponse {
     public Optional<String> getTransactionId() {
         return Optional.ofNullable(transactionId);
     }
-    
+
+    public Optional<Gateway3dsRequiredParams> getGateway3dsRequiredParams() {
+        return Optional.ofNullable(gateway3dsRequiredParams);
+    }
+
     public String toString() {
         return stringified;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -175,7 +175,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
             BaseAuthoriseResponse authoriseResponse = gatewayResponse.getBaseResponse().get();
 
-            return Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), authoriseResponse.authoriseStatus(), authoriseResponse.getTransactionId());
+            return Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), authoriseResponse.authoriseStatus(), authoriseResponse.getTransactionId(),
+                    authoriseResponse.getGatewayParamsFor3ds().orElse(null));
         } catch (GatewayException e) {
             return Gateway3DSAuthorisationResponse.of(e.getMessage(), BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION);
         }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 
@@ -90,7 +91,8 @@ public class Card3dsResponseAuthService {
                 chargeExternalId,
                 operationResponse.getMappedChargeStatus(),
                 AUTHORISATION_3DS,
-                transactionId.orElse(null)
+                transactionId.orElse(null),
+                operationResponse.getGateway3dsRequiredParams().map(Gateway3dsRequiredParams::toAuth3dsRequiredEntity).orElse(null)
         );
 
         LOGGER.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",


### PR DESCRIPTION
If attempting to authorise a 3D Secure result with Worldpay leads to Worldpay sending back a response that contains details required to complete 3D Secure again (e.g. a `paRequest`), store these on the charge.

Note that this won’t actually change any behaviour because a transition from `AUTHORISATION 3DS READY` to `AUTHORISATION 3DS REQUIRED` is still considered invalid and we’re also not yet indicating to frontend that the operation was successful.

with @SandorArpa 