### PR TITLE
PP-6194 Allow force transition to auth error and rejected states

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationErrorToMatchGatewayStatus.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import java.time.ZonedDateTime;
+
+public class StatusCorrectedToAuthorisationErrorToMatchGatewayStatus extends PaymentEventWithoutDetails {
+    public StatusCorrectedToAuthorisationErrorToMatchGatewayStatus(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import java.time.ZonedDateTime;
+
+public class StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus extends PaymentEventWithoutDetails {
+    public StatusCorrectedToAuthorisationRejectedToMatchGatewayStatus(String resourceExternalId, ZonedDateTime timestamp) {
+        super(resourceExternalId, timestamp);
+    }
+}


### PR DESCRIPTION
The charge could be in a terminal state corresponding to AUTHORISATION
ERROR or AUTHORISATION REJECTED with the gateway. Currently when we come
across charges in these states as part of the expiry job we don't expire
them and leave them to be picked up continuously by the job.

Instead we should transition them to the terminal state they are in on
the gateway.