### PR TITLE
PP-6194 Catch IllegalArgumentException in cleanup job

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupService.java
@@ -74,7 +74,7 @@ public class EpdqAuthorisationErrorGatewayCleanupService {
                 } else {
                     failures.getAndIncrement();
                 }
-            } catch (WebApplicationException | GatewayException e) {
+            } catch (WebApplicationException | GatewayException | IllegalArgumentException e) {
                 logger.info("Error when querying charge status with gateway: " + e.getMessage(),
                         chargeEntity.getStructuredLoggingArgs());
                 failures.getAndIncrement();


### PR DESCRIPTION
Catch an IllegalArgumentException thrown when querying epdq and allow
the job to continue cleaning up other charges.

This exception can be thrown when the credentials aren't configured
correctly for an ePDQ account.

Example is:
java.lang.IllegalArgumentException: Passphrase must not be blank.