### PR TITLE
PP-6194 Fix charge status transition not persisted for cleanup job

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupServiceTest.java
@@ -110,7 +110,7 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
         assertThat(result.get(CLEANUP_SUCCESS), is(1));
         assertThat(result.get(CLEANUP_FAILED), is(0));
 
-        verify(mockChargeService).transitionChargeState(eq(charge), eq(AUTHORISATION_ERROR_CANCELLED));
+        verify(mockChargeService).transitionChargeState(eq(charge.getExternalId()), eq(AUTHORISATION_ERROR_CANCELLED));
     }
 
     @Test
@@ -124,7 +124,7 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
         assertThat(result.get(CLEANUP_SUCCESS), is(1));
         assertThat(result.get(CLEANUP_FAILED), is(0));
 
-        verify(mockChargeService).transitionChargeState(eq(charge), eq(AUTHORISATION_ERROR_REJECTED));
+        verify(mockChargeService).transitionChargeState(eq(charge.getExternalId()), eq(AUTHORISATION_ERROR_REJECTED));
         verify(mockPaymentProvider, never()).cancel(any());
     }
 
@@ -139,7 +139,7 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
         assertThat(result.get(CLEANUP_SUCCESS), is(1));
         assertThat(result.get(CLEANUP_FAILED), is(0));
 
-        verify(mockChargeService).transitionChargeState(eq(charge), eq(AUTHORISATION_ERROR_CHARGE_MISSING));
+        verify(mockChargeService).transitionChargeState(eq(charge.getExternalId()), eq(AUTHORISATION_ERROR_CHARGE_MISSING));
         verify(mockPaymentProvider, never()).cancel(any());
     }
 
@@ -154,7 +154,7 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
         assertThat(result.get(CLEANUP_SUCCESS), is(1));
         assertThat(result.get(CLEANUP_FAILED), is(0));
 
-        verify(mockChargeService).transitionChargeState(eq(charge), eq(AUTHORISATION_ERROR_CANCELLED));
+        verify(mockChargeService).transitionChargeState(eq(charge.getExternalId()), eq(AUTHORISATION_ERROR_CANCELLED));
         verify(mockPaymentProvider, never()).cancel(any());
     }
 
@@ -173,7 +173,7 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
         assertThat(result.get(CLEANUP_SUCCESS), is(0));
         assertThat(result.get(CLEANUP_FAILED), is(1));
 
-        verify(mockChargeService, never()).transitionChargeState(eq(charge), any());
+        verify(mockChargeService, never()).transitionChargeState(eq(charge.getExternalId()), any());
     }
 
     @Test
@@ -188,7 +188,7 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
         assertThat(result.get(CLEANUP_FAILED), is(1));
 
         verify(mockPaymentProvider, never()).cancel(any());
-        verify(mockChargeService, never()).transitionChargeState(eq(charge), any());
+        verify(mockChargeService, never()).transitionChargeState(eq(charge.getExternalId()), any());
     }
 
     @Test
@@ -203,6 +203,6 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
         assertThat(result.get(CLEANUP_FAILED), is(1));
 
         verify(mockPaymentProvider, never()).cancel(any());
-        verify(mockChargeService, never()).transitionChargeState(eq(charge), any());
+        verify(mockChargeService, never()).transitionChargeState(eq(charge.getExternalId()), any());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayCleanupResourceIT.java
@@ -66,6 +66,16 @@ public class GatewayCleanupResourceIT extends ChargingITestBase {
                 .body("cleanup-success", is(3))
                 .body("cleanup-failed", is(0));
 
+        String chargeStatus1 = databaseTestHelper.getChargeStatusByExternalId(chargeId1);
+        String chargeStatus2 = databaseTestHelper.getChargeStatusByExternalId(chargeId2);
+        String chargeStatus3 = databaseTestHelper.getChargeStatusByExternalId(chargeId3);
+        String chargeStatus4 = databaseTestHelper.getChargeStatusByExternalId(chargeId4);
+        
+        assertThat(chargeStatus1, is(AUTHORISATION_REJECTED.getValue()));
+        assertThat(chargeStatus2, is(AUTHORISATION_ERROR_CANCELLED.getValue()));
+        assertThat(chargeStatus3, is(AUTHORISATION_ERROR_CANCELLED.getValue()));
+        assertThat(chargeStatus4, is(AUTHORISATION_ERROR_CANCELLED.getValue()));
+
         List<String> events1 = databaseTestHelper.getInternalEvents(chargeId1);
         List<String> events2 = databaseTestHelper.getInternalEvents(chargeId2);
         List<String> events3 = databaseTestHelper.getInternalEvents(chargeId3);

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -515,6 +515,15 @@ public class DatabaseTestHelper {
         );
     }
 
+    public String getChargeStatusByExternalId(String externalId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("SELECT status from charges where external_id = :externalId")
+                        .bind("externalId", externalId)
+                        .mapTo(String.class)
+                        .first()
+        );
+    }
+
     public String getChargeCardBrand(Long chargeId) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT card_brand from charges WHERE id = :charge_id")


### PR DESCRIPTION
The update to the charge status was not being persisted because the
ChargeEntity was not part of the transaction opened for the
ChargeService method.

Switch to using the ChargeService method that takes the charge external
id as a parameter so that the ChargeEntity is loaded into the transaction
that it is updated in.