### PR TITLE
PP-6259 Return charge status to frontend when 3DS auth declined

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
@@ -110,17 +111,21 @@ public class CardResource {
     @Produces(APPLICATION_JSON)
     public Response authorise3dsCharge(@PathParam("chargeId") String chargeId, Auth3dsResult auth3DsResult) {
         Gateway3DSAuthorisationResponse response = card3dsResponseAuthService.process3DSecureAuthorisation(chargeId, auth3DsResult);
-        
+
         if (response.isSuccessful()) {
             return ResponseUtil.successResponseWithEntity(
-                    ImmutableMap.of(
+                    Map.of(
                             "status", response.getMappedChargeStatus().toString()
                     ));
         }
         if (response.isException()) {
             return serviceErrorResponse("There was an error when attempting to authorise the transaction.");
         }
-        return badRequestResponse("This transaction was declined.");
+        return ResponseUtil.badRequestResponseWithEntity(
+                Map.of(
+                        "status", response.getMappedChargeStatus().toString()
+                )
+        );
     }
 
     @POST

--- a/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
+++ b/src/main/java/uk/gov/pay/connector/util/ResponseUtil.java
@@ -99,6 +99,10 @@ public class ResponseUtil {
         return responseWithEntity(OK, entity);
     }
 
+    public static Response badRequestResponseWithEntity(Object entity) {
+        return responseWithEntity(BAD_REQUEST, entity);
+    }
+
     private static Response responseWithEntity(Status status, Object entity) {
         return status(status).entity(entity).build();
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -258,7 +258,6 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
     public void shouldReturnStatus400_WhenAuthorisationFails() {
         String chargeId = createNewCharge(AUTHORISATION_3DS_REQUIRED);
 
-        String expectedErrorMessage = "This transaction was declined.";
         worldpayMockClient.mockAuthorisationFailure();
 
         givenSetup()
@@ -267,8 +266,7 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .contentType(JSON)
-                .body("message", contains(expectedErrorMessage))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+                .body("status", is(AUTHORISATION_REJECTED.toString()));
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_REJECTED.getValue());
     }


### PR DESCRIPTION
When a call to `/v1/frontend/charges/{chargeId}/3ds` results in the payment’s authorisation being rejected, return a 400 with a body containing the response, rather than just a generic error message.

Before:

```json
{
  "error_identifier": "GENERIC",
  "message": "This transaction was declined."
}
```

After:

```json
{
  "status": "AUTHORISATION REJECTED"
}
```

This makes 400 responses consistent with 200 responses. Only frontend uses this endpoint.

with @SandorArpa