### PR TITLE
PP-6194 Fix charge status transition not persisted for expiry job

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -210,7 +210,7 @@ public class ChargeExpiryService {
                             // first try to transition to the terminal state gracefully if allowed, otherwise force the
                             // transition
                             try {
-                                chargeService.transitionChargeState(chargeEntity, status);
+                                chargeService.transitionChargeState(chargeEntity.getExternalId(), status);
                                 expireCancelled.getAndIncrement();
                             } catch (InvalidStateTransitionException e) {
                                 if (forceTransitionChargeState(chargeEntity, status)) {
@@ -247,7 +247,7 @@ public class ChargeExpiryService {
     
     private boolean forceTransitionChargeState(ChargeEntity chargeEntity, ChargeStatus status) {
         try {
-            chargeService.forceTransitionChargeState(chargeEntity, status);
+            chargeService.forceTransitionChargeState(chargeEntity.getExternalId(), status);
             return true;
         } catch (InvalidForceStateTransitionException e) {
             logger.error(format("Cannot expire charge as it is in a terminal state of [%s] with " +

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -641,14 +641,21 @@ public class ChargeService {
     }
 
     @Transactional
-    public ChargeEntity transitionChargeState(String chargeId, ChargeStatus targetChargeState) {
-        return chargeDao.findByExternalId(chargeId).map(chargeEntity ->
+    public ChargeEntity transitionChargeState(String chargeExternalId, ChargeStatus targetChargeState) {
+        return chargeDao.findByExternalId(chargeExternalId).map(chargeEntity ->
                 transitionChargeState(chargeEntity, targetChargeState)
-        ).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
+        ).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
+    }
+
+    @Transactional
+    public ChargeEntity forceTransitionChargeState(String chargeExternalId, ChargeStatus targetChargeState) {
+        return chargeDao.findByExternalId(chargeExternalId).map(chargeEntity -> 
+                forceTransitionChargeState(chargeEntity, targetChargeState))
+                .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
     }
     
     @Transactional
-    public <T extends Event> ChargeEntity forceTransitionChargeState(ChargeEntity charge, ChargeStatus targetChargeState) {
+    public ChargeEntity forceTransitionChargeState(ChargeEntity charge, ChargeStatus targetChargeState) {
         ChargeStatus fromChargeState = ChargeStatus.fromString(charge.getStatus());
 
         return PaymentGatewayStateTransitions.getEventForForceUpdate(targetChargeState).map(eventClass -> {

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -272,8 +272,8 @@ public class ChargeExpiryServiceTest {
 
         ChargeEntity updatedCharge = mock(ChargeEntity.class);
         when(updatedCharge.getStatus()).thenReturn(CAPTURED.toString());
-        when(mockChargeService.transitionChargeState(chargeEntity, CAPTURED)).thenThrow(InvalidStateTransitionException.class);
-        when(mockChargeService.forceTransitionChargeState(chargeEntity, CAPTURED)).thenReturn(updatedCharge);
+        when(mockChargeService.transitionChargeState(chargeEntity.getExternalId(), CAPTURED)).thenThrow(InvalidStateTransitionException.class);
+        when(mockChargeService.forceTransitionChargeState(chargeEntity.getExternalId(), CAPTURED)).thenReturn(updatedCharge);
 
         Map<String, Integer> sweepResult = chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -281,7 +281,7 @@ public class ChargeExpiryServiceTest {
         assertThat(sweepResult.get("expiry-failed"), is(0));
 
         verify(mockPaymentProvider, never()).cancel(any());
-        verify(mockChargeService).forceTransitionChargeState(chargeEntity, CAPTURED);
+        verify(mockChargeService).forceTransitionChargeState(chargeEntity.getExternalId(), CAPTURED);
     }
 
     @Test
@@ -298,7 +298,7 @@ public class ChargeExpiryServiceTest {
 
         ChargeEntity updatedCharge = mock(ChargeEntity.class);
         when(updatedCharge.getStatus()).thenReturn(AUTHORISATION_REJECTED.toString());
-        when(mockChargeService.transitionChargeState(chargeEntity, AUTHORISATION_REJECTED)).thenReturn(updatedCharge);
+        when(mockChargeService.transitionChargeState(chargeEntity.getExternalId(), AUTHORISATION_REJECTED)).thenReturn(updatedCharge);
 
         Map<String, Integer> sweepResult = chargeExpiryService.expire(singletonList(chargeEntity));
 
@@ -306,7 +306,7 @@ public class ChargeExpiryServiceTest {
         assertThat(sweepResult.get("expiry-failed"), is(0));
 
         verify(mockPaymentProvider, never()).cancel(any());
-        verify(mockChargeService).transitionChargeState(chargeEntity, AUTHORISATION_REJECTED);
+        verify(mockChargeService).transitionChargeState(chargeEntity.getExternalId(), AUTHORISATION_REJECTED);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
@@ -18,6 +18,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_MAINTENANCE_ORDER;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_QUERY_ORDER;
@@ -77,6 +79,31 @@ public class ChargeExpiryResourceEpdqIT extends ChargingITestBase {
                 .contentType(JSON)
                 .body("charge_id", is(chargeId))
                 .body("state.status", is(EXPIRED.toExternal().getStatus()));
+
+        verifyPostToPath(String.format("/epdq/%s", ROUTE_FOR_QUERY_ORDER));
+    }
+
+    @Test
+    public void shouldUpdateChargeStatusToMatchTerminalStateOnGateway() {
+        String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+        
+        epdqMockClient.mockAuthorisationQuerySuccessCaptured();
+
+        connectorRestApiClient
+                .postChargeExpiryTask()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("expiry-success", is(1))
+                .body("expiry-failed", is(0));
+
+        connectorRestApiClient
+                .withAccountId(accountId)
+                .withChargeId(chargeId)
+                .getCharge()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("charge_id", is(chargeId))
+                .body("state.status", is(CAPTURED.toExternal().getStatus()));
 
         verifyPostToPath(String.format("/epdq/%s", ROUTE_FOR_QUERY_ORDER));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceIT.java
@@ -73,6 +73,20 @@ public class ChargeExpiryResourceIT extends ChargingITestBase {
                         .body(JSON_CHARGE_KEY, is(chargeId))
                         .body(JSON_STATE_KEY, is(EXPIRED.toExternal().getStatus())));
 
+        String chargeStatus1 = databaseTestHelper.getChargeStatusByExternalId(extChargeId1);
+        String chargeStatus2 = databaseTestHelper.getChargeStatusByExternalId(extChargeId2);
+        String chargeStatus3 = databaseTestHelper.getChargeStatusByExternalId(extChargeId3);
+        String chargeStatus4 = databaseTestHelper.getChargeStatusByExternalId(extChargeId4);
+        String chargeStatus5 = databaseTestHelper.getChargeStatusByExternalId(extChargeId5);
+        String chargeStatus6 = databaseTestHelper.getChargeStatusByExternalId(extChargeId6);
+        
+        assertThat(chargeStatus1, is(EXPIRED.getValue()));
+        assertThat(chargeStatus2, is(EXPIRED.getValue()));
+        assertThat(chargeStatus3, is(EXPIRED.getValue()));
+        assertThat(chargeStatus4, is(EXPIRED.getValue()));
+        assertThat(chargeStatus5, is(EXPIRED.getValue()));
+        assertThat(chargeStatus6, is(EXPIRED.getValue()));
+
         List<String> events1 = databaseTestHelper.getInternalEvents(extChargeId1);
         List<String> events2 = databaseTestHelper.getInternalEvents(extChargeId2);
         List<String> events3 = databaseTestHelper.getInternalEvents(extChargeId3);

--- a/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
@@ -30,6 +30,10 @@ public class EpdqMockClient {
     public void mockAuthorisationQuerySuccessAuthFailed() {
         paymentServiceResponse(ROUTE_FOR_QUERY_ORDER, TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_FAILED_RESPONSE));
     }
+    
+    public void mockAuthorisationQuerySuccessCaptured() {
+        paymentServiceResponse(ROUTE_FOR_QUERY_ORDER, TestTemplateResourceLoader.load(EPDQ_CAPTURE_SUCCESS_RESPONSE));
+    }
 
     public void mockCancelQuerySuccess() {
         paymentServiceResponse(ROUTE_FOR_QUERY_ORDER, TestTemplateResourceLoader.load(EPDQ_CANCEL_SUCCESS_RESPONSE));


### PR DESCRIPTION
When updating the charge status to match the gateway status, the change was not being persisted because the ChargeEntity being modified was not part of the current transaction.

Ensure we are loading the ChargeEntity into the transaction and add a test for this.

Improve the tests for the expiry service to ensure we are persisting the status change.