### PR TITLE
PP-6259 Allow users to retry 3DS again if the gateway asks

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
+import uk.gov.pay.connector.app.config.Authorisation3dsConfig;
 import uk.gov.pay.connector.app.config.EmittedEventSweepConfig;
 import uk.gov.pay.connector.app.config.EventEmitterConfig;
 import uk.gov.pay.connector.app.config.ExpungeConfig;
@@ -81,6 +82,10 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     @JsonProperty("expungeConfig")
     private ExpungeConfig expungeConfig;
+
+    @NotNull
+    @JsonProperty("authorisation3dsConfig")
+    private Authorisation3dsConfig authorisation3dsConfig;
 
     @NotNull
     private String graphiteHost;
@@ -225,5 +230,9 @@ public class ConnectorConfiguration extends Configuration {
 
     public ExpungeConfig getExpungeConfig() {
         return expungeConfig;
+    }
+
+    public Authorisation3dsConfig getAuthorisation3dsConfig() {
+        return authorisation3dsConfig;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/Authorisation3dsConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/Authorisation3dsConfig.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.app.config;
+
+import io.dropwizard.Configuration;
+
+public class Authorisation3dsConfig extends Configuration {
+
+    private int maximumNumberOfTimesToAllowUserToAttempt3ds;
+
+    public int getMaximumNumberOfTimesToAllowUserToAttempt3ds() {
+        return maximumNumberOfTimesToAllowUserToAttempt3ds;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
 
@@ -160,6 +161,18 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setParameter("externalId", externalId)
                 .setParameter("captureApprovedStatus", CAPTURE_APPROVED)
                 .setParameter("captureApprovedRetryStatus", CAPTURE_APPROVED_RETRY)
+                .getSingleResult()).intValue();
+    }
+
+    public int count3dsRequiredEventsForChargeExternalId(String externalId) {
+        String query = "SELECT count(ce) FROM ChargeEventEntity ce WHERE " +
+                "    ce.chargeEntity.externalId = :externalId AND " +
+                "    (ce.status = :authorisation3dsRequiredStatus)";
+
+        return ((Number) entityManager.get()
+                .createQuery(query)
+                .setParameter("externalId", externalId)
+                .setParameter("authorisation3dsRequiredStatus", AUTHORISATION_3DS_REQUIRED)
                 .getSingleResult()).intValue();
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -732,6 +732,10 @@ public class ChargeService {
         return status == CAPTURED || status == CAPTURE_SUBMITTED;
     }
 
+    public int count3dsRequiredEvents(String externalId) {
+        return chargeDao.count3dsRequiredEventsForChargeExternalId(externalId);
+    }
+
     private CardDetailsEntity buildCardDetailsEntity(AuthCardDetails authCardDetails) {
         CardDetailsEntity detailsEntity = new CardDetailsEntity();
         detailsEntity.setCardBrand(sanitize(authCardDetails.getCardBrand()));

--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -153,6 +153,7 @@ public class PaymentGatewayStateTransitions {
         graph.putEdgeValue(AUTHORISATION_3DS_REQUIRED, SYSTEM_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_SUCCESS, ModelledEvent.of(AuthorisationSucceeded.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_REJECTED, ModelledEvent.of(AuthorisationRejected.class));
+        graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_3DS_REQUIRED, ModelledEvent.of(GatewayRequires3dsAuthorisation.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, AUTHORISATION_ERROR, ModelledEvent.of(GatewayErrorDuringAuthorisation.class));
         graph.putEdgeValue(AUTHORISATION_3DS_READY, EXPIRE_CANCEL_READY, ModelledEvent.none());
         graph.putEdgeValue(AUTHORISATION_3DS_READY, SYSTEM_CANCELLED, ModelledEvent.of(CancelledByExternalService.class));

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -239,3 +239,6 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+authorisation3dsConfig:
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -78,6 +78,7 @@ import static uk.gov.pay.connector.charge.model.ChargeResponse.ChargeResponseBui
 import static uk.gov.pay.connector.charge.model.ChargeResponse.aChargeResponseBuilder;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
@@ -387,6 +388,15 @@ public class ChargeServiceTest {
     }
 
     @Test
+    public void shouldReturnNumberOf3dsRequiredEvents() {
+        when(mockedChargeDao.count3dsRequiredEventsForChargeExternalId(EXTERNAL_CHARGE_ID[0])).thenReturn(42);
+
+        int authorisation3dsRequiredEvents = service.count3dsRequiredEvents(EXTERNAL_CHARGE_ID[0]);
+
+        assertThat(authorisation3dsRequiredEvents, is(42));
+    }
+
+    @Test
     public void shouldUpdateChargeEntityAndPersistChargeEventForAValidStateTransition() {
         ChargeEntity chargeSpy = spy(ChargeEntityFixture.aValidChargeEntity().build());
 
@@ -485,7 +495,7 @@ public class ChargeServiceTest {
 
         final Auth3dsRequiredEntity mockedAuth3dsRequiredEntity = mock(Auth3dsRequiredEntity.class);
         
-        service.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_REJECTED, AUTHORISATION_3DS, "transaction-id",
+        service.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_3DS_REQUIRED, AUTHORISATION_3DS, "transaction-id",
                 mockedAuth3dsRequiredEntity);
 
         verify(chargeSpy).setGatewayTransactionId("transaction-id");

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -43,8 +43,9 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED_RETRY;
@@ -577,6 +578,37 @@ public class ChargeDaoIT extends DaoITestBase {
                 .insert();
 
         assertThat(chargeDao.countCaptureRetriesForChargeExternalId(externalChargeId), is(2));
+    }
+
+    @Test
+    public void count3dsRequiredEventsForChargeExternalId() {
+        long chargeId = nextLong();
+        String externalChargeId = RandomIdGenerator.newId();
+
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withCreatedDate(now().minusHours(2))
+                .withChargeStatus(AUTHORISATION_3DS_READY)
+                .insert();
+
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestChargeEvent()
+                .withChargeId(chargeId)
+                .withChargeStatus(AUTHORISATION_3DS_REQUIRED)
+                .insert();
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestChargeEvent()
+                .withChargeId(chargeId)
+                .withChargeStatus(AUTHORISATION_3DS_REQUIRED)
+                .insert();
+
+        assertThat(chargeDao.count3dsRequiredEventsForChargeExternalId(externalChargeId), is(2));
     }
 
     @Test

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -184,3 +184,6 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+authorisation3dsConfig:
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -183,3 +183,6 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+authorisation3dsConfig:
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -173,3 +173,6 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+authorisation3dsConfig:
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -179,3 +179,6 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+authorisation3dsConfig:
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -178,3 +178,6 @@ expungeConfig:
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-10}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-true}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
+
+authorisation3dsConfig:
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}


### PR DESCRIPTION
When we authorise the 3D Secure result, if the gateway response says to do 3D Secure again, transition to payment status to `AUTHORISATION 3DS REQUIRED` and send this in the response to frontend, which will make frontend show the 3DS page again. However, only do this if this means the user will be able to attempt 3DS at most three times in total (measured by counting how many times an `AUTHORISATION 3DS REQUIRED` event appears in the charge events for the payment); otherwise set to payment status to `AUTHORISATION REJECTED`.

While this change is not specific to one payment gateway, in reality we only allow Worldpay to ask us to do 3DS again (due to the way gateway responses to 3DS result authorisations are handled). If there is a desire for another gateway to exhibit the same behaviour, we will have to update how we determine the new status from the response and also replace the data required to do 3DS (which is stored on the charge entity) as it may be different for the second and subsequent attempts.

An important part of this change is that it allows a state transition from `AUTHORISATION 3DS READY` to `AUTHORISATION 3DS REQUIRED`, though as described above, this can only happen in limited circumstances.

The limit of three attempts at 3DS is in place to stop the user repeatedly attempting 3DS again and again. It’s controlled by the `MAXIMUM_NO_USER_3DS_ATTEMPTS` environment variable and defaults to 3 if not explicitly set.

with @SandorArpa