### PR TITLE
PP-6201 - Fix timestamp for historic charge event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationService.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -118,7 +119,7 @@ public class EpdqNotificationService {
         if (newChargeStatus.isPresent()) {
             if(charge.isHistoric()){
                 if (CAPTURED.equals(newChargeStatus.get())) {
-                    chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccountEntity, notification.getTransactionId(), charge, newChargeStatus.get(), null);
+                    chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccountEntity, notification.getTransactionId(), charge, newChargeStatus.get());
                     return;
                 }
                 

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -97,8 +97,7 @@ public class ChargeNotificationProcessor {
     public void processCaptureNotificationForExpungedCharge(GatewayAccountEntity gatewayAccount, 
                                                             String gatewayTransactionId, 
                                                             Charge charge, 
-                                                            ChargeStatus newStatus, 
-                                                            ZonedDateTime gatewayEventDate) {
+                                                            ChargeStatus newStatus) {
         logger.info(format("Received capture notification for charge that was already expunged from Connector. " +
                         "Transitioning state from [%s] to [%s].", charge.getStatus(), newStatus.getValue()),
                 kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
@@ -106,7 +105,7 @@ public class ChargeNotificationProcessor {
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
                 kv(PROVIDER, gatewayAccount.getGatewayName()));
         
-        Event event = new CaptureConfirmedByGatewayNotification(charge.getExternalId(), gatewayEventDate);
+        Event event = new CaptureConfirmedByGatewayNotification(charge.getExternalId(), ZonedDateTime.now());
         eventService.emitEvent(event);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gateway.epdq;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.eclipse.persistence.exceptions.QueryException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,7 +11,6 @@ import org.mockito.junit.MockitoRule;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.queue.QueueException;
 
 import java.util.Optional;
@@ -92,8 +90,9 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         when(mockGatewayAccountService.getGatewayAccount(charge.getGatewayAccountId())).thenReturn(Optional.of(gatewayAccountEntity));
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(EPDQ.getName(), payId)).thenReturn(Optional.of(charge));
         notificationService.handleNotificationFor(payload);
+        
 
-        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, payId, charge, CAPTURED, null);
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, payId, charge, CAPTURED);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
@@ -7,7 +7,6 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.util.Optional;
@@ -59,7 +58,8 @@ public class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest
         notificationService.handleNotificationFor(payload);
 
         verifyNoInteractions(mockRefundNotificationProcessor);
-        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, payId, charge, CAPTURED, null);
+        
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, payId, charge, CAPTURED);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.processor;
 
 import junitparams.JUnitParamsRunner;
+import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,6 +20,8 @@ import uk.gov.pay.connector.events.model.ResourceType;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Optional;
 
@@ -64,7 +67,7 @@ public class ChargeNotificationProcessorTest {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().withStatus(AUTHORISATION_ERROR).build();
         Charge charge = Charge.from(chargeEntity);
         
-        chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccount, charge.getGatewayTransactionId(), charge,  CAPTURED, null);
+        chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccount, charge.getGatewayTransactionId(), charge,  CAPTURED);
         
         ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         
@@ -72,7 +75,7 @@ public class ChargeNotificationProcessorTest {
         Event event = eventArgumentCaptor.getValue();
 
         assertThat(event.getEventType(), is("CAPTURE_CONFIRMED_BY_GATEWAY_NOTIFICATION"));
-        assertThat(event.getTimestamp(), is(nullValue()));
+        assertThat(event.getTimestamp(), ZonedDateTimeMatchers.within(5, ChronoUnit.SECONDS, ZonedDateTime.now()));
         assertThat(event.getResourceType(), is(ResourceType.PAYMENT));
     }
 }


### PR DESCRIPTION
Description:
- Ledger cannot process the CAPTURE_CONFIRMED_BY_GATEWAY_NOTIFICATION event as there is no timestamp when Connector sends the event