### PR TITLE
PP-6302 Add language to PAYMENT_NOTIFICATION_CREATED event details

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
@@ -25,6 +25,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     private final boolean live;
     private final String paymentProvider;
     private final Map<String, Object> externalMetadata;
+    private final String language;
     private Source source;
 
     private PaymentNotificationCreatedEventDetails(Long gatewayAccountId, Long amount, String reference,
@@ -33,7 +34,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                                                    String cardholderName, String email, String expiryDate,
                                                    String cardBrand, String cardBrandLabel, boolean live,
                                                    String paymentProvider, Map<String, Object> externalMetadata,
-                                                   Source source) {
+                                                   Source source, String language) {
         this.gatewayAccountId = gatewayAccountId;
         this.amount = amount;
         this.reference = reference;
@@ -50,6 +51,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
         this.externalMetadata = externalMetadata;
         this.paymentProvider = paymentProvider;
         this.source = source;
+        this.language = language;
     }
 
     public static PaymentNotificationCreatedEventDetails from(ChargeEntity charge) {
@@ -89,7 +91,8 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                     charge.getGatewayAccount().isLive(),
                     charge.getGatewayAccount().getGatewayName(),
                     charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null),
-                    charge.getSource());
+                    charge.getSource(),
+                    charge.getLanguage().toString());
     }
 
     @Override
@@ -111,14 +114,15 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                 Objects.equals(cardBrandLabel, that.cardBrandLabel) &&
                 Objects.equals(live, that.live) &&
                 Objects.equals(externalMetadata, that.externalMetadata) &&
-                Objects.equals(source, that.source);
+                Objects.equals(source, that.source) &&
+                Objects.equals(language, that.language);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(gatewayAccountId, amount, reference, description, gatewayTransactionId,
                 firstDigitsCardNumber, lastDigitsCardNumber, cardholderName, email, expiryDate,
-                cardBrand, cardBrandLabel, live, externalMetadata, source);
+                cardBrand, cardBrandLabel, live, externalMetadata, source, language);
     }
 
     public Long getGatewayAccountId() {
@@ -183,5 +187,9 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
 
     public Source getSource() {
         return source;
+    }
+
+    public String getLanguage() {
+        return language;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -17,8 +17,8 @@ import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.PAYMENT_NOTIFICATION_CREATED;
@@ -127,6 +127,8 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
         DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
         Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId);
         Long chargeId = Long.parseLong(chargeDetails.get("id").toString());
+        assertThat(chargeDetails.get("language"), is("en"));
+
         List<Map<String, Object>> chargeEvents = testHelper.getChargeEvents(chargeId);
 
         assertThat(chargeEvents, hasEvent(PAYMENT_NOTIFICATION_CREATED));


### PR DESCRIPTION
## WHAT YOU DID
- Payment notification end point doesn't receive `language` in the request body, but connector
DB column defaults to 'en' and parity check fails as language is not included in details sent to Ledger.
Added language to payment notification event details.
