### PR TITLE
PP-6259 Store machine cookie when Worldpay asks us to do 3DS again

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -49,7 +49,6 @@ import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.common.model.domain.PrefilledAddress;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.events.EventService;
-import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -544,12 +543,14 @@ public class ChargeService {
     public ChargeEntity updateChargePost3dsAuthorisation(String chargeExternalId, ChargeStatus status,
                                                          OperationType operationType,
                                                          String transactionId,
-                                                         Auth3dsRequiredEntity auth3dsRequiredDetails) {
+                                                         Auth3dsRequiredEntity auth3dsRequiredDetails,
+                                                         ProviderSessionIdentifier sessionIdentifier) {
         return chargeDao.findByExternalId(chargeExternalId).map(charge -> {
             try {
                 setTransactionId(charge, transactionId);
                 transitionChargeState(charge, status);
                 Optional.ofNullable(auth3dsRequiredDetails).ifPresent(charge::set3dsRequiredDetails);
+                Optional.ofNullable(sessionIdentifier).map(ProviderSessionIdentifier::toString).ifPresent(charge::setProviderSessionId);
             } catch (InvalidStateTransitionException e) {
                 if (chargeIsInLockedStatus(operationType, charge)) {
                     throw new OperationAlreadyInProgressRuntimeException(operationType.getValue(), charge.getExternalId());

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.model.response;
 
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 
 import java.util.Optional;
 
@@ -13,39 +14,41 @@ public class Gateway3DSAuthorisationResponse {
     private final String transactionId;
     private final String stringified;
     private final Gateway3dsRequiredParams gateway3dsRequiredParams;
+    private final ProviderSessionIdentifier providerSessionIdentifier;
 
     private Gateway3DSAuthorisationResponse(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId, String stringified,
-                                            Gateway3dsRequiredParams gateway3dsRequiredParams) {
+                                            Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier) {
         this.transactionId = transactionId;
         this.authorisationStatus = authorisationStatus;
         this.stringified = stringified;
         this.gateway3dsRequiredParams = gateway3dsRequiredParams;
+        this.providerSessionIdentifier = providerSessionIdentifier;
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
-                                                     Gateway3dsRequiredParams gateway3dsRequiredParams) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified, gateway3dsRequiredParams);
+                                                     Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, stringified, gateway3dsRequiredParams, providerSessionIdentifier);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, String transactionId,
-                                                     Gateway3dsRequiredParams gateway3dsRequiredParams) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", gateway3dsRequiredParams);
+                                                     Gateway3dsRequiredParams gateway3dsRequiredParams, ProviderSessionIdentifier providerSessionIdentifier) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, transactionId, "", gateway3dsRequiredParams, providerSessionIdentifier);
     }
 
     public static Gateway3DSAuthorisationResponse of(String stringified, BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringified, null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, stringified, null, null);
     }
 
     public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus) {
-        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null);
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null, null);
     }
 
     public boolean isSuccessful() {
@@ -67,6 +70,10 @@ public class Gateway3DSAuthorisationResponse {
 
     public Optional<Gateway3dsRequiredParams> getGateway3dsRequiredParams() {
         return Optional.ofNullable(gateway3dsRequiredParams);
+    }
+
+    public Optional<ProviderSessionIdentifier> getProviderSessionIdentifier() {
+        return Optional.ofNullable(providerSessionIdentifier);
     }
 
     public String toString() {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -171,12 +171,14 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
             logger.info(format("Worldpay 3ds authorisation response for %s : %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
 
-            if (gatewayResponse.getBaseResponse().isEmpty()) gatewayResponse.throwGatewayError();
+            if (gatewayResponse.getBaseResponse().isEmpty()) {
+                gatewayResponse.throwGatewayError();
+            }
 
             BaseAuthoriseResponse authoriseResponse = gatewayResponse.getBaseResponse().get();
 
             return Gateway3DSAuthorisationResponse.of(gatewayResponse.toString(), authoriseResponse.authoriseStatus(), authoriseResponse.getTransactionId(),
-                    authoriseResponse.getGatewayParamsFor3ds().orElse(null));
+                    authoriseResponse.getGatewayParamsFor3ds().orElse(null), gatewayResponse.getSessionIdentifier().orElse(null));
         } catch (GatewayException e) {
             return Gateway3DSAuthorisationResponse.of(e.getMessage(), BaseAuthoriseResponse.AuthoriseStatus.EXCEPTION);
         }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -102,7 +102,8 @@ public class Card3dsResponseAuthService {
                 newStatus,
                 AUTHORISATION_3DS,
                 transactionId.orElse(null),
-                operationResponse.getGateway3dsRequiredParams().map(Gateway3dsRequiredParams::toAuth3dsRequiredEntity).orElse(null)
+                operationResponse.getGateway3dsRequiredParams().map(Gateway3dsRequiredParams::toAuth3dsRequiredEntity).orElse(null),
+                operationResponse.getProviderSessionIdentifier().orElse(null)
         );
 
         LOGGER.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -44,6 +44,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paritycheck.LedgerService;
@@ -461,7 +462,8 @@ public class ChargeServiceTest {
         final String chargeEntityExternalId = chargeSpy.getExternalId();
         when(mockedChargeDao.findByExternalId(chargeEntityExternalId)).thenReturn(Optional.of(chargeSpy));
 
-        service.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_REJECTED, AUTHORISATION_3DS, null, null);
+        service.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_REJECTED, AUTHORISATION_3DS, null,
+                null, null);
 
         verify(chargeSpy, never()).setGatewayTransactionId(anyString());
         verify(chargeSpy).setStatus(AUTHORISATION_REJECTED);
@@ -477,7 +479,8 @@ public class ChargeServiceTest {
         final String chargeEntityExternalId = chargeSpy.getExternalId();
         when(mockedChargeDao.findByExternalId(chargeEntityExternalId)).thenReturn(Optional.of(chargeSpy));
         
-        service.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_SUCCESS, AUTHORISATION_3DS, "transaction-id", null);
+        service.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_SUCCESS, AUTHORISATION_3DS, "transaction-id",
+                null, null);
 
         verify(chargeSpy).setGatewayTransactionId("transaction-id");
         verify(chargeSpy).setStatus(AUTHORISATION_SUCCESS);
@@ -496,10 +499,11 @@ public class ChargeServiceTest {
         final Auth3dsRequiredEntity mockedAuth3dsRequiredEntity = mock(Auth3dsRequiredEntity.class);
         
         service.updateChargePost3dsAuthorisation(chargeSpy.getExternalId(), AUTHORISATION_3DS_REQUIRED, AUTHORISATION_3DS, "transaction-id",
-                mockedAuth3dsRequiredEntity);
+                mockedAuth3dsRequiredEntity, ProviderSessionIdentifier.of("provider-session-identifier"));
 
         verify(chargeSpy).setGatewayTransactionId("transaction-id");
         verify(chargeSpy).set3dsRequiredDetails(mockedAuth3dsRequiredEntity);
+        verify(chargeSpy).setProviderSessionId("provider-session-identifier");
         verify(mockedChargeEventDao).persistChargeEventOf(eq(chargeSpy), isNull());
     }
  

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -104,9 +104,11 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     }
 
     private void setupPaymentProviderMock(String transactionId, AuthoriseStatus authoriseStatus, Gateway3dsRequiredParams gateway3dsRequiredParams,
-                                          ArgumentCaptor<Auth3dsResponseGatewayRequest> argumentCaptor) {
-        Gateway3DSAuthorisationResponse authorisationResponse = Gateway3DSAuthorisationResponse.of(authoriseStatus, transactionId, gateway3dsRequiredParams);
-        when(mockedPaymentProvider.authorise3dsResponse(argumentCaptor.capture())).thenReturn(authorisationResponse);
+                                          ProviderSessionIdentifier providerSessionIdentifier,
+                                          ArgumentCaptor<Auth3dsResponseGatewayRequest> auth3dsResponseGatewayRequestArgumentCaptor) {
+        Gateway3DSAuthorisationResponse authorisationResponse = Gateway3DSAuthorisationResponse.of(authoriseStatus, transactionId, gateway3dsRequiredParams,
+                providerSessionIdentifier);
+        when(mockedPaymentProvider.authorise3dsResponse(auth3dsResponseGatewayRequestArgumentCaptor.capture())).thenReturn(authorisationResponse);
     }
 
     @Test
@@ -119,7 +121,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
                 .thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, null,
+                argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -163,7 +166,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
                 .thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.AUTHORISED, null, null, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -221,7 +224,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         Gateway3dsRequiredParams gateway3dsRequiredParams = new Worldpay3dsRequiredParams(REQUIRES_3DS_ISSUER_URL, REQUIRES_3DS_PA_REQUEST);
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams,
+                ProviderSessionIdentifier.of("provider-session-identifier"),
+                argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -232,6 +237,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         assertThat(charge.getGatewayTransactionId(), is(GENERATED_TRANSACTION_ID));
         assertThat(charge.get3dsRequiredDetails().getIssuerUrl(), is(REQUIRES_3DS_ISSUER_URL));
         assertThat(charge.get3dsRequiredDetails().getPaRequest(), is(REQUIRES_3DS_PA_REQUEST));
+        assertThat(charge.getProviderSessionId(), is("provider-session-identifier"));
 
         assertTrue(argumentCaptor.getValue().getTransactionId().isPresent());
         assertThat(argumentCaptor.getValue().getTransactionId().get(), is(GENERATED_TRANSACTION_ID));
@@ -250,7 +256,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
                 REQUIRES_3DS_WORLDPAY_3DS_FLEX_3DS_VERSION);
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams,
+                ProviderSessionIdentifier.of("provider-session-identifier"), argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -263,6 +270,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         assertThat(charge.get3dsRequiredDetails().getWorldpayChallengeTransactionId(), is(REQUIRES_3DS_WORLDPAY_3DS_FLEX_CHALLENGE_TRANSACTION_ID));
         assertThat(charge.get3dsRequiredDetails().getWorldpayChallengePayload(), is(REQUIRES_3DS_WORLDPAY_3DS_FLEX_CHALLENGE_PAYLOAD));
         assertThat(charge.get3dsRequiredDetails().getThreeDsVersion(), is(REQUIRES_3DS_WORLDPAY_3DS_FLEX_3DS_VERSION));
+        assertThat(charge.getProviderSessionId(), is("provider-session-identifier"));
 
         assertTrue(argumentCaptor.getValue().getTransactionId().isPresent());
         assertThat(argumentCaptor.getValue().getTransactionId().get(), is(GENERATED_TRANSACTION_ID));
@@ -280,7 +288,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         Gateway3dsRequiredParams gateway3dsRequiredParams = new Worldpay3dsRequiredParams(REQUIRES_3DS_ISSUER_URL, REQUIRES_3DS_PA_REQUEST);
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams,
+                ProviderSessionIdentifier.of("provider-session-identifier"), argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -302,7 +311,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         Gateway3dsRequiredParams gateway3dsRequiredParams = new Worldpay3dsRequiredParams(REQUIRES_3DS_ISSUER_URL, REQUIRES_3DS_PA_REQUEST);
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams, argumentCaptor);
+        setupPaymentProviderMock(charge.getGatewayTransactionId(), AuthoriseStatus.REQUIRES_3DS, gateway3dsRequiredParams,
+                ProviderSessionIdentifier.of("provider-session-identifier"), argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -392,7 +402,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(transactionId, authoriseStatus, null, argumentCaptor);
+        setupPaymentProviderMock(transactionId, authoriseStatus, null, null, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 
@@ -404,7 +414,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));
 
         setupMockExecutorServiceMock();
-        setupPaymentProviderMock(null, AuthoriseStatus.REJECTED, null, argumentCaptor);
+        setupPaymentProviderMock(null, AuthoriseStatus.REJECTED, null, null, argumentCaptor);
 
         when(mockedProviders.byName(charge.getPaymentGatewayName())).thenReturn(mockedPaymentProvider);
 


### PR DESCRIPTION
Store the `machine` cookie sent by Worldpay with the response an attempt to authorise a 3D Secure result, if there is one. This means that if Worldpay asks us to do 3DS again, our attempt to authorise this subsequent 3DS result will use the new cookie and not the old one, which won’t work.

with @SandorArpa