### PR TITLE
PP-6265 Handle Payout Notifications

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
@@ -10,6 +10,7 @@ public enum StripeNotificationType {
     SOURCE_FAILED("source.failed"),
     PAYMENT_INTENT_AMOUNT_CAPTURABLE_UPDATED("payment_intent.amount_capturable_updated"),
     PAYMENT_INTENT_PAYMENT_FAILED("payment_intent.payment_failed"),
+    PAYOUT_CREATED("payout.created"),
     UNKNOWN("");
 
     private final String type;

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -142,6 +142,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
     public static final String STRIPE_REFUND_FULL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_charge.json";
     public static final String STRIPE_TRANSFER_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/transfer_success_response.json";
+    public static final String STRIPE_PAYOUT_CREATED = TEMPLATE_BASE_NAME + "/stripe/payout_created.json";
 
     public static final String STRIPE_NOTIFICATION_3DS_SOURCE = TEMPLATE_BASE_NAME + "/stripe/notification_3ds_source.json";
     public static final String STRIPE_NOTIFICATION_PAYMENT_INTENT = TEMPLATE_BASE_NAME + "/stripe/notification_payment_intent.json";

--- a/src/test/resources/templates/stripe/payout_created.json
+++ b/src/test/resources/templates/stripe/payout_created.json
@@ -1,0 +1,32 @@
+{
+  "id": "evt_aaaaaaaaaaaaaaaaaaaaa",
+  "type": "payout.created",
+  "object": "event",
+  "api_version": "2019-02-19",
+  "created": 1567622603,
+  "data": {
+    "object": {
+      "id": "po_aaaaaaaaaaaaaaaaaaaaa",
+      "object": "payout",
+      "amount": 1337702,
+      "arrival_date": 1585094400,
+      "automatic": true,
+      "balance_transaction": "txn_aaaaaaaaaaaaaaaaaaaaa",
+      "created": 1585013446,
+      "currency": "gbp",
+      "description": "STRIPE PAYOUT",
+      "destination": "ba_aaaaaaaaaaaaaaaaaaaaa",
+      "failure_balance_transaction": null,
+      "failure_code": null,
+      "failure_message": null,
+      "livemode": true,
+      "metadata": {
+      },
+      "method": "standard",
+      "source_type": "card",
+      "statement_descriptor": null,
+      "status": "in_transit",
+      "type": "bank_account"
+    }
+  }
+}


### PR DESCRIPTION
- Connector now handles `payout.created` notifications from Stripe,
parsing them and outputting logs that show information about the event.

- It also includes a test that ensures that the payout event is
correctly deserialised.

- This will be adapted later to trigger more meaningful actions when
such an event is received.
