### PR TITLE
PP-6259 Reduce maximum number of 3D Secure attempts from 3 to 1

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -241,4 +241,4 @@ expungeConfig:
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 
 authorisation3dsConfig:
-  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -186,4 +186,4 @@ expungeConfig:
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 
 authorisation3dsConfig:
-  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -185,4 +185,4 @@ expungeConfig:
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 
 authorisation3dsConfig:
-  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -175,4 +175,4 @@ expungeConfig:
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 
 authorisation3dsConfig:
-  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -181,4 +181,4 @@ expungeConfig:
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 
 authorisation3dsConfig:
-  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -180,4 +180,4 @@ expungeConfig:
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 
 authorisation3dsConfig:
-  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-3}
+  maximumNumberOfTimesToAllowUserToAttempt3ds: ${MAXIMUM_NO_USER_3DS_ATTEMPTS:-1}


### PR DESCRIPTION
Reduce the maximum number of times a user is allowed to attempt 3D Secure from 3 to 1 for gateways we allow retries (only Worldpay). After their 1 attempt, if the gateway asks us to do 3DS again, we’ll consider the payment to be `AUTHORISATION REJECTED`.

We’re doing this because the majority of times when the user retries 3DS results in Worldpay sending an error code 7 with the message “verification of PaRes failed” when we tried to authorise the second result. This means we’re making users do 3DS twice and they’re still not able to pay, which is a worse experience than when we just gave them an error after the first attempt.

with @sandorarpa