### PR TITLE
BAU Stripe refund handler sets transfer id for gateway transaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -54,10 +54,10 @@ public class StripeRefundHandler {
             } else {
                 stripeChargeId = request.getTransactionId();
             }
-            StripeRefund refundResponse = refundCharge(request, stripeChargeId);
-            transferFromConnectAccount(request, stripeChargeId);
+            refundCharge(request, stripeChargeId);
+            StripeTransferResponse transferResponse = transferFromConnectAccount(request, stripeChargeId);
 
-            return fromBaseRefundResponse(StripeRefundResponse.of(refundResponse.getId()), GatewayRefundResponse.RefundState.COMPLETE);
+            return fromBaseRefundResponse(StripeRefundResponse.of(transferResponse.getId()), GatewayRefundResponse.RefundState.COMPLETE);
         } catch (GatewayErrorException e) {
 
             if (e.getFamily() == CLIENT_ERROR) {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -87,7 +87,7 @@ public class StripeRefundHandlerTest {
         assertNotNull(refund);
         assertTrue(refund.isSuccessful());
         assertThat(refund.state(), is(GatewayRefundResponse.RefundState.COMPLETE));
-        assertThat(refund.getReference().get(), is("re_1DRiccHj08j21DRiccHj08j2_test"));
+        assertThat(refund.getReference().get(), is("transfer_id"));
     }
 @Test
     public void shouldRefundSuccessfully_usingChargeId() throws Exception {
@@ -99,7 +99,7 @@ public class StripeRefundHandlerTest {
         assertNotNull(refund);
         assertTrue(refund.isSuccessful());
         assertThat(refund.state(), is(GatewayRefundResponse.RefundState.COMPLETE));
-        assertThat(refund.getReference().get(), is("re_1DRiccHj08j21DRiccHj08j2_test"));
+        assertThat(refund.getReference().get(), is("transfer_id"));
     }
 
     @Test


### PR DESCRIPTION
We currently set the ID of the refund against the platform for the
refund `gateway_transaction_id`. The actual refund relative to the
Connect account is the transfer from the Connect account to the
platform.

Store this ID so we can use to relate refund transactions and GOV.UK Pay
refunds during reconcilation.

See `PP-6266`