### PR TITLE
PP-6267 Added PayoutReconciliation background job

### DIFF
--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.payout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.queue.QueueException;
+import uk.gov.pay.connector.queue.payout.PayoutReconcileMessage;
+import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
+
+import javax.inject.Inject;
+import java.util.List;
+
+public class PayoutReconcileProcess {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayoutReconcileProcess.class);
+    private PayoutReconcileQueue payoutReconcileQueue;
+
+    @Inject
+    public PayoutReconcileProcess(PayoutReconcileQueue payoutReconcileQueue) {
+        this.payoutReconcileQueue = payoutReconcileQueue;
+    }
+
+    public void processPayouts() throws QueueException {
+        List<PayoutReconcileMessage> payoutReconcileMessages = payoutReconcileQueue.retrievePayoutMessages();
+        for (PayoutReconcileMessage payoutReconcileMessage : payoutReconcileMessages) {
+            try {
+                LOGGER.info("Processing payout [{}] for connect account [{}]",
+                        payoutReconcileMessage.getGatewayPayoutId(),
+                        payoutReconcileMessage.getConnectAccountId());
+
+                //TODO: Payout reconciliation - Algorithm described in PP-6266
+
+                LOGGER.info("Finished processing payout [{}] for connect account [{}]",
+                        payoutReconcileMessage.getGatewayPayoutId(),
+                        payoutReconcileMessage.getConnectAccountId());
+
+                payoutReconcileQueue.markMessageAsProcessed(payoutReconcileMessage);
+            } catch (Exception e) {
+                LOGGER.warn("Error processing payout from SQS message [queueMessageId={}] [errorMessage={}]",
+                        payoutReconcileMessage.getQueueMessageId(),
+                        e.getMessage()
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/managed/PayoutReconcileMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/PayoutReconcileMessageReceiver.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.connector.queue.managed;
+
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.setup.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.payout.PayoutReconcileProcess;
+
+import javax.inject.Inject;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class PayoutReconcileMessageReceiver implements Managed {
+
+    private static final String PAYOUT_RECONCILE_MESSAGE_RECEIVER_THREAD_NAME = "sqs-message-payoutReconcileMessageReceiver";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PayoutReconcileMessageReceiver.class);
+
+    private final int queueSchedulerThreadDelayInSeconds;
+    private final PayoutReconcileProcess payoutReconcileProcess;
+    private final boolean payoutReconcileQueueEnabled;
+    private ScheduledExecutorService payoutReconcileMessageExecutorService;
+
+    @Inject
+    public PayoutReconcileMessageReceiver(PayoutReconcileProcess payoutReconcileProcess, Environment environment,
+                                          ConnectorConfiguration connectorConfiguration) {
+        this.payoutReconcileProcess = payoutReconcileProcess;
+
+        int queueScheduleNumberOfThreads = connectorConfiguration.getPayoutReconcileProcessConfig()
+                .getQueueSchedulerNumberOfThreads();
+
+        payoutReconcileMessageExecutorService = environment
+                .lifecycle()
+                .scheduledExecutorService(PAYOUT_RECONCILE_MESSAGE_RECEIVER_THREAD_NAME)
+                .threads(queueScheduleNumberOfThreads)
+                .build();
+
+        queueSchedulerThreadDelayInSeconds = connectorConfiguration.getPayoutReconcileProcessConfig().getQueueSchedulerThreadDelayInSeconds();
+        payoutReconcileQueueEnabled = connectorConfiguration.getPayoutReconcileProcessConfig().getPayoutReconcileQueueEnabled();
+    }
+
+    @Override
+    public void start() {
+        if (payoutReconcileQueueEnabled) {
+            int initialDelay = queueSchedulerThreadDelayInSeconds;
+            payoutReconcileMessageExecutorService.scheduleWithFixedDelay(
+                    this::processPayouts,
+                    initialDelay,
+                    queueSchedulerThreadDelayInSeconds,
+                    TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public void stop() {
+        payoutReconcileMessageExecutorService.shutdown();
+    }
+
+    private void processPayouts() {
+        try {
+            payoutReconcileProcess.processPayouts();
+        } catch (Exception e) {
+            LOGGER.error("Queue message payoutReconcileMessageReceiver thread exception [message={}]", e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -138,7 +138,7 @@ eventQueue:
   paymentStateTransitionPollerNumberOfThreads: ${PAYMENT_STATE_TRANSITION_POLLER_NUMBER_OF_THREADS:-1}
 
 payoutReconcileProcessConfig:
-  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-true}
+  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-false}
   failedPayoutReconcileMessageRetryDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -1,0 +1,42 @@
+package uk.gov.pay.connector.payout;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.queue.QueueException;
+import uk.gov.pay.connector.queue.payout.PayoutReconcileMessage;
+import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PayoutReconcileProcessTest {
+
+    @Mock
+    PayoutReconcileQueue payoutReconcileQueue;
+    @Mock
+    PayoutReconcileMessage payoutReconcileMessage;
+
+    PayoutReconcileProcess payoutReconcileProcess;
+
+    @Before
+    public void setUp() throws Exception {
+        List<PayoutReconcileMessage> messages = Arrays.asList(payoutReconcileMessage);
+        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(messages);
+
+        payoutReconcileProcess = new PayoutReconcileProcess(payoutReconcileQueue);
+    }
+
+    @Test
+    public void shouldMarkMessageAsProcessedIfPayoutIsProcessedSuccessfully() throws QueueException {
+        payoutReconcileProcess.processPayouts();
+
+        verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage);
+    }
+}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -115,7 +115,7 @@ eventQueue:
   paymentStateTransitionPollerNumberOfThreads: ${PAYMENT_STATE_TRANSITION_POLLER_NUMBER_OF_THREADS:-1}
 
 payoutReconcileProcessConfig:
-  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-true}
+  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-false}
   failedPayoutReconcileMessageRetryDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -114,7 +114,7 @@ eventQueue:
   paymentStateTransitionPollerNumberOfThreads: ${PAYMENT_STATE_TRANSITION_POLLER_NUMBER_OF_THREADS:-1}
 
 payoutReconcileProcessConfig:
-  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-true}
+  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-false}
   failedPayoutReconcileMessageRetryDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -104,7 +104,7 @@ eventQueue:
   paymentStateTransitionPollerNumberOfThreads: ${PAYMENT_STATE_TRANSITION_POLLER_NUMBER_OF_THREADS:-1}
 
 payoutReconcileProcessConfig:
-  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-true}
+  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-false}
   failedPayoutReconcileMessageRetryDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -95,7 +95,7 @@ eventQueue:
   paymentStateTransitionPollerNumberOfThreads: ${PAYMENT_STATE_TRANSITION_POLLER_NUMBER_OF_THREADS:-1}
 
 payoutReconcileProcessConfig:
-  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-true}
+  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-false}
   failedPayoutReconcileMessageRetryDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -82,7 +82,7 @@ eventQueue:
   paymentStateTransitionPollerNumberOfThreads: ${PAYMENT_STATE_TRANSITION_POLLER_NUMBER_OF_THREADS:-1}
 
 payoutReconcileProcessConfig:
-  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-true}
+  payoutReconcileQueueEnabled: ${PAYOUT_RECONCILE_QUEUE_ENABLED:-false}
   failedPayoutReconcileMessageRetryDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${PAYOUT_RECONCILE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}


### PR DESCRIPTION
## WHAT 
- Added background job `PayoutReconcileMessageReceiver` that is scheduled at fixed internal, and which process payout messages from SQS queue.
- Sets `payoutReconcileQueueEnabled` to false to disable background processing until payout reconcile SQS queue is available and also payout reconciliation algorithm added
- Added `PayoutReconcileProcess` to receive & remove messages from queue. Payout reconciliation algorithm defined in PP-6266 to be added in future
