### PR TITLE
PP-6267 Abstract queue functions and common fields

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcess.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcess.java
@@ -62,7 +62,7 @@ public class CardCaptureProcess {
             CaptureResponse gatewayResponse = cardCaptureService.doCapture(externalChargeId);
 
             if (gatewayResponse.isSuccessful()) {
-                captureQueue.markMessageAsProcessed(captureMessage);
+                captureQueue.markMessageAsProcessed(captureMessage.getQueueMessage());
             } else {
                 LOGGER.info(
                         "Failed to capture [externalChargeId={}] due to: {}",
@@ -81,10 +81,10 @@ public class CardCaptureProcess {
 
         if (shouldRetry) {
             LOGGER.info("Charge capture message [{}] scheduled for retry.", captureMessage.getChargeId());
-            captureQueue.scheduleMessageForRetry(captureMessage);
+            captureQueue.scheduleMessageForRetry(captureMessage.getQueueMessage());
         } else {
             cardCaptureService.markChargeAsCaptureError(captureMessage.getChargeId());
-            captureQueue.markMessageAsProcessed(captureMessage);
+            captureQueue.markMessageAsProcessed(captureMessage.getQueueMessage());
         }
     }
 
@@ -94,7 +94,7 @@ public class CardCaptureProcess {
                     "Charge capture message [{}] already captured - marking as processed. [chargeId={}]",
                     captureMessage.getQueueMessageId(),
                     captureMessage.getChargeId());
-            captureQueue.markMessageAsProcessed(captureMessage);
+            captureQueue.markMessageAsProcessed(captureMessage.getQueueMessage());
             return;
         }
 

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -33,7 +33,7 @@ public class PayoutReconcileProcess {
                         payoutReconcileMessage.getGatewayPayoutId(),
                         payoutReconcileMessage.getConnectAccountId());
 
-                payoutReconcileQueue.markMessageAsProcessed(payoutReconcileMessage);
+                payoutReconcileQueue.markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
             } catch (Exception e) {
                 LOGGER.warn("Error processing payout from SQS message [queueMessageId={}] [errorMessage={}]",
                         payoutReconcileMessage.getQueueMessageId(),

--- a/src/main/java/uk/gov/pay/connector/queue/AbstractQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/AbstractQueue.java
@@ -1,0 +1,41 @@
+package uk.gov.pay.connector.queue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.connector.queue.sqs.SqsQueueService;
+
+import java.util.List;
+
+public abstract class AbstractQueue {
+
+    private static final String MESSAGE_ATTRIBUTES_TO_RECEIVE = "All";
+    protected ObjectMapper objectMapper;
+    private String queueUrl;
+    private int failedMessageRetryDelayInSeconds;
+    private SqsQueueService sqsQueueService;
+
+    public AbstractQueue(SqsQueueService sqsQueueService, ObjectMapper objectMapper,
+                         String queueUrl, int failedMessageRetryDelayInSeconds) {
+        this.sqsQueueService = sqsQueueService;
+        this.queueUrl = queueUrl;
+        this.failedMessageRetryDelayInSeconds = failedMessageRetryDelayInSeconds;
+        this.objectMapper = objectMapper;
+    }
+
+    public QueueMessage sendMessageToQueue(String message) throws QueueException {
+        return sqsQueueService.sendMessage(queueUrl, message);
+    }
+
+    public List<QueueMessage> retrieveMessages() throws QueueException {
+        return sqsQueueService
+                .receiveMessages(this.queueUrl, MESSAGE_ATTRIBUTES_TO_RECEIVE);
+    }
+
+    public void markMessageAsProcessed(QueueMessage queueMessage) throws QueueException {
+        sqsQueueService.deleteMessage(this.queueUrl, queueMessage.getReceiptHandle());
+    }
+
+    public void scheduleMessageForRetry(QueueMessage queueMessage) throws QueueException {
+        sqsQueueService.deferMessage(this.queueUrl, queueMessage.getReceiptHandle(), failedMessageRetryDelayInSeconds);
+    }
+}
+

--- a/src/main/java/uk/gov/pay/connector/queue/ChargeCaptureMessage.java
+++ b/src/main/java/uk/gov/pay/connector/queue/ChargeCaptureMessage.java
@@ -4,7 +4,6 @@ public class ChargeCaptureMessage {
     private CaptureCharge captureCharge;
     private QueueMessage queueMessage;
 
-
     private ChargeCaptureMessage(CaptureCharge captureCharge, QueueMessage queueMessage) {
         this.captureCharge = captureCharge;
         this.queueMessage = queueMessage;
@@ -24,5 +23,9 @@ public class ChargeCaptureMessage {
 
     public Object getQueueMessageId() {
         return queueMessage.getMessageId();
+    }
+
+    public QueueMessage getQueueMessage() {
+        return queueMessage;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileMessage.java
+++ b/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileMessage.java
@@ -30,4 +30,8 @@ public class PayoutReconcileMessage {
     public Object getQueueMessageId() {
         return queueMessage.getMessageId();
     }
+
+    public QueueMessage getQueueMessage() {
+        return queueMessage;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileQueue.java
+++ b/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileQueue.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.queue.AbstractQueue;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
 import uk.gov.pay.connector.queue.sqs.SqsQueueService;
@@ -15,37 +16,29 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class PayoutReconcileQueue {
+public class PayoutReconcileQueue extends AbstractQueue {
 
-    private static final String MESSAGE_ATTRIBUTES_TO_RECEIVE = "All";
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final ObjectMapper objectMapper;
-    private final String payoutReconcileQueueUrl;
-    private final int failedPayoutReconcileRetryDelayInSeconds;
-    private SqsQueueService sqsQueueService;
 
     @Inject
-    public PayoutReconcileQueue(
-            SqsQueueService sqsQueueService,
-            ConnectorConfiguration connectorConfiguration, ObjectMapper objectMapper) {
-        this.sqsQueueService = sqsQueueService;
-        this.payoutReconcileQueueUrl = connectorConfiguration.getSqsConfig().getPayoutReconcileQueueUrl();
-        this.failedPayoutReconcileRetryDelayInSeconds = connectorConfiguration.getPayoutReconcileProcessConfig()
-                .getFailedPayoutReconcileMessageRetryDelayInSeconds();
-        this.objectMapper = objectMapper;
+    public PayoutReconcileQueue(SqsQueueService sqsQueueService,
+                                ConnectorConfiguration connectorConfiguration,
+                                ObjectMapper objectMapper) {
+        super(sqsQueueService, objectMapper,
+                connectorConfiguration.getSqsConfig().getPayoutReconcileQueueUrl(),
+                connectorConfiguration.getPayoutReconcileProcessConfig()
+                        .getFailedPayoutReconcileMessageRetryDelayInSeconds());
     }
 
     public void sendPayout(Payout payout) throws QueueException, JsonProcessingException {
         String message = objectMapper.writeValueAsString(payout);
-
-        QueueMessage queueMessage = sqsQueueService.sendMessage(payoutReconcileQueueUrl, message);
-
-        logger.info("Payout [{}] added to queue. Message ID [{}]", payout.getGatewayPayoutId(), queueMessage.getMessageId());
+        QueueMessage queueMessage = sendMessageToQueue(message);
+        logger.info("Payout [{}] added to queue. Message ID [{}]",
+                payout.getGatewayPayoutId(), queueMessage.getMessageId());
     }
 
     public List<PayoutReconcileMessage> retrievePayoutMessages() throws QueueException {
-        List<QueueMessage> queueMessages = sqsQueueService
-                .receiveMessages(this.payoutReconcileQueueUrl, MESSAGE_ATTRIBUTES_TO_RECEIVE);
+        List<QueueMessage> queueMessages = retrieveMessages();
 
         return queueMessages
                 .stream()
@@ -60,16 +53,9 @@ public class PayoutReconcileQueue {
 
             return PayoutReconcileMessage.of(payout, qm);
         } catch (IOException e) {
-            logger.warn("Error parsing payout message [message={}] from queue [error={}]", qm.getMessageBody(), e.getMessage());
+            logger.warn("Error parsing payout message [message={}] from queue [error={}]",
+                    qm.getMessageBody(), e.getMessage());
             return null;
         }
-    }
-
-    public void markMessageAsProcessed(PayoutReconcileMessage message) throws QueueException {
-        sqsQueueService.deleteMessage(this.payoutReconcileQueueUrl, message.getQueueMessageReceiptHandle());
-    }
-
-    public void scheduleMessageForRetry(PayoutReconcileMessage message) throws QueueException {
-        sqsQueueService.deferMessage(this.payoutReconcileQueueUrl, message.getQueueMessageReceiptHandle(), failedPayoutReconcileRetryDelayInSeconds);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureProcessTest.java
@@ -23,26 +23,19 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class CardCaptureProcessTest {
 
+    private static final String chargeExternalId = "some-charge-id";
     @Mock
     CaptureQueue captureQueue;
-
     @Mock
     CardCaptureService cardCaptureService;
-
     @Mock
     CaptureResponse captureResponse;
-
     @Mock
     ChargeCaptureMessage chargeCaptureMessage;
-
     @Mock
     ChargeService chargeService;
-
     @Mock
     ChargesAwaitingCaptureMetricEmitter chargesAwaitingCaptureMetricEmitter;
-
-    private static final String chargeExternalId = "some-charge-id";
-
     CardCaptureProcess cardCaptureProcess;
 
     @Before
@@ -63,7 +56,7 @@ public class CardCaptureProcessTest {
 
         cardCaptureProcess.handleCaptureMessages();
 
-        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage);
+        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage.getQueueMessage());
     }
 
     @Test
@@ -73,7 +66,7 @@ public class CardCaptureProcessTest {
 
         cardCaptureProcess.handleCaptureMessages();
 
-        verify(captureQueue).scheduleMessageForRetry(chargeCaptureMessage);
+        verify(captureQueue).scheduleMessageForRetry(chargeCaptureMessage.getQueueMessage());
     }
 
     @Test
@@ -84,7 +77,7 @@ public class CardCaptureProcessTest {
         cardCaptureProcess.handleCaptureMessages();
 
         verify(cardCaptureService).markChargeAsCaptureError(chargeExternalId);
-        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage);
+        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage.getQueueMessage());
     }
 
     @Test
@@ -94,6 +87,6 @@ public class CardCaptureProcessTest {
 
         cardCaptureProcess.handleCaptureMessages();
 
-        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage);
+        verify(captureQueue).markMessageAsProcessed(chargeCaptureMessage.getQueueMessage());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -37,6 +37,6 @@ public class PayoutReconcileProcessTest {
     public void shouldMarkMessageAsProcessedIfPayoutIsProcessedSuccessfully() throws QueueException {
         payoutReconcileProcess.processPayouts();
 
-        verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage);
+        verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
 }


### PR DESCRIPTION
## WHAT
- Move SQS queue specific functionality to abstract class which makes it easier to replace with different queue technology if needed and reuse functionality if new queues are added
- Also extracts common fields to parent class

