### PR TITLE
bau: Make epdq order classes singletons

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -25,10 +25,14 @@ public class EpdqCaptureHandler implements CaptureHandler {
 
     private final GatewayClient client;
     private final Map<String, String> gatewayUrlMap;
+    private final EpdqPayloadDefinitionForCaptureOrder epdqPayloadDefinitionForCaptureOrder;
 
-    public EpdqCaptureHandler(GatewayClient client, Map<String, String> gatewayUrlMap) {
+    public EpdqCaptureHandler(GatewayClient client, 
+                              Map<String, String> gatewayUrlMap, 
+                              EpdqPayloadDefinitionForCaptureOrder epdqPayloadDefinitionForCaptureOrder) {
         this.client = client;
         this.gatewayUrlMap = gatewayUrlMap;
+        this.epdqPayloadDefinitionForCaptureOrder = epdqPayloadDefinitionForCaptureOrder;
     }
 
     @Override
@@ -54,6 +58,6 @@ public class EpdqCaptureHandler implements CaptureHandler {
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         templateData.setTransactionId(request.getTransactionId());
         
-        return new EpdqPayloadDefinitionForCaptureOrder().createGatewayOrder(templateData);
+        return epdqPayloadDefinitionForCaptureOrder.createGatewayOrder(templateData);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
@@ -2,6 +2,9 @@ package uk.gov.pay.connector.gateway.epdq.payload;
 
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
+import javax.inject.Singleton;
+
+@Singleton
 public class EpdqPayloadDefinitionForCancelOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
     @Override
     protected String getOperationType() {

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
@@ -2,6 +2,9 @@ package uk.gov.pay.connector.gateway.epdq.payload;
 
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
+import javax.inject.Singleton;
+
+@Singleton
 public class EpdqPayloadDefinitionForCaptureOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
     @Override
     protected String getOperationType() {

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
@@ -6,10 +6,12 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.epdq.EpdqTemplateData;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
+import javax.inject.Singleton;
 import java.util.List;
 
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqParameterBuilder.newParameterBuilder;
 
+@Singleton
 public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
 
     public final static String AMOUNT_KEY = "AMOUNT";

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
@@ -4,10 +4,12 @@ import org.apache.http.NameValuePair;
 import uk.gov.pay.connector.gateway.epdq.EpdqTemplateData;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
+import javax.inject.Singleton;
 import java.util.List;
 
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqParameterBuilder.newParameterBuilder;
 
+@Singleton
 public class EpdqPayloadDefinitionForQueryOrder extends EpdqPayloadDefinition {
     
     public final static String ORDER_ID_KEY = "ORDERID";

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
@@ -2,6 +2,9 @@ package uk.gov.pay.connector.gateway.epdq.payload;
 
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
+import javax.inject.Singleton;
+
+@Singleton
 public class EpdqPayloadDefinitionForRefundOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
     @Override
     protected String getOperationType() {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderTest.java
@@ -17,6 +17,10 @@ import uk.gov.pay.connector.gateway.ClientFactory;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCancelOrder;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCaptureOrder;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNewOrder;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForQueryOrder;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
@@ -111,7 +115,14 @@ public abstract class BaseEpdqPaymentProviderTest {
         when(configuration.getLinks()).thenReturn(linksConfig);
         when(linksConfig.getFrontendUrl()).thenReturn("http://frontendUrl");
 
-        provider = new EpdqPaymentProvider(configuration, gatewayClientFactory, environment);
+        provider = new EpdqPaymentProvider(
+                configuration, 
+                gatewayClientFactory, 
+                environment,
+                new EpdqPayloadDefinitionForCancelOrder(),
+                new EpdqPayloadDefinitionForCaptureOrder(),
+                new EpdqPayloadDefinitionForNewOrder(),
+                new EpdqPayloadDefinitionForQueryOrder());
     }
 
     private Invocation.Builder mockClientInvocationBuilder() {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCaptureOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
@@ -46,7 +47,7 @@ public class EpdqCaptureHandlerTest {
 
     @Before
     public void setup() {
-        epdqCaptureHandler = new EpdqCaptureHandler(client, emptyMap());
+        epdqCaptureHandler = new EpdqCaptureHandler(client, emptyMap(), new EpdqPayloadDefinitionForCaptureOrder());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -26,6 +26,10 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCancelOrder;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCaptureOrder;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNewOrder;
+import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForQueryOrder;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -120,7 +124,14 @@ public class EpdqPaymentProviderTest {
                 any(GatewayOperation.class),
                 any())).thenReturn(gatewayClient);
 
-        paymentProvider = new EpdqPaymentProvider(mockConnectorConfiguration, mockGatewayClientFactory, mockEnvironment);
+        paymentProvider = new EpdqPaymentProvider(
+                mockConnectorConfiguration, 
+                mockGatewayClientFactory, 
+                mockEnvironment,
+                new EpdqPayloadDefinitionForCancelOrder(),
+                new EpdqPayloadDefinitionForCaptureOrder(),
+                new EpdqPayloadDefinitionForNewOrder(),
+                new EpdqPayloadDefinitionForQueryOrder());
     }
 
     @Test


### PR DESCRIPTION
Where subclasses of `EpdqPayloadDefinition` have no state, these can be made singletons.
