### PR TITLE
PP-6458 Reduce time before charge is expunged to 7 days

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -241,7 +241,7 @@ restClientConfig:
 ledgerBaseURL: ${LEDGER_URL}
 
 expungeConfig:
-  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-7}
   excludeChargesParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_PARITY_CHECKED_WITHIN_DAYS:-7}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGE_PER_TASK_RUN:-25000}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}


### PR DESCRIPTION
We initially kept charges for 90 days so we could monitor that updates
to ledger were working as expected. The 3 month time limit came about to
ensure safety around making refunds, as 96% of refunds happened within
3 months of the payment being created. As we haven’t had any issues
around refunds we feel safe reducing this time.

Reduce the time charges are kept in connector to 7 days. This is an
initial step towards expunging charges as soon as they are terminal.