### PR TITLE
PP-6477 Fix Refund availability for historic payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 import uk.gov.pay.connector.paritycheck.LedgerTransaction;
+import uk.gov.pay.connector.paritycheck.SettlementSummary;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
+
+import static java.util.Optional.ofNullable;
 
 public class Charge {
 
@@ -22,10 +25,14 @@ public class Charge {
     private Long gatewayAccountId;
     private String paymentGatewayName;
     private boolean historic;
+    private String captureSubmitTime;
+    private String capturedDate;
 
     public Charge(String externalId, Long amount, String status, String externalStatus, String gatewayTransactionId,
                   Long corporateSurcharge, String refundAvailabilityStatus, String reference,
-                  String description, ZonedDateTime createdDate, String email, Long gatewayAccountId, String paymentGatewayName, boolean historic) {
+                  String description, ZonedDateTime createdDate, String email, Long gatewayAccountId,
+                  String paymentGatewayName, boolean historic, String captureSubmitTime,
+                  String capturedDate) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
@@ -40,6 +47,8 @@ public class Charge {
         this.gatewayAccountId = gatewayAccountId;
         this.paymentGatewayName = paymentGatewayName;
         this.historic = historic;
+        this.captureSubmitTime = captureSubmitTime;
+        this.capturedDate = capturedDate;
     }
 
     public static Charge from(ChargeEntity chargeEntity) {
@@ -49,24 +58,26 @@ public class Charge {
                 chargeEntity.getExternalId(),
                 chargeEntity.getAmount(),
                 chargeEntity.getStatus(),
-                chargeStatus.toExternal().toString(),
+                chargeStatus.toExternal().getStatus(),
                 chargeEntity.getGatewayTransactionId(),
                 chargeEntity.getCorporateSurcharge().orElse(null),
-                null, 
+                null,
                 chargeEntity.getReference().toString(),
                 chargeEntity.getDescription(),
                 chargeEntity.getCreatedDate(),
                 chargeEntity.getEmail(),
                 chargeEntity.getGatewayAccount().getId(),
                 chargeEntity.getPaymentGatewayName().getName(),
-                false);
+                false,
+                null,
+                null);
     }
 
     public static Charge from(LedgerTransaction transaction) {
         String externalRefundState = null;
         String externalStatus = null;
 
-        if (transaction.getRefundSummary() != null ) {
+        if (transaction.getRefundSummary() != null) {
             externalRefundState = transaction.getRefundSummary().getStatus();
         }
 
@@ -88,7 +99,9 @@ public class Charge {
                 transaction.getEmail(),
                 Long.valueOf(transaction.getGatewayAccountId()),
                 transaction.getPaymentProvider(),
-                true
+                true,
+                ofNullable(transaction.getSettlementSummary()).map(SettlementSummary::getCaptureSubmitTime).orElse(null),
+                ofNullable(transaction.getSettlementSummary()).map(SettlementSummary::getCapturedDate).orElse(null)
         );
     }
 
@@ -173,5 +186,21 @@ public class Charge {
 
     public void setHistoric(boolean historic) {
         this.historic = historic;
+    }
+
+    public String getCaptureSubmitTime() {
+        return captureSubmitTime;
+    }
+
+    public void setCaptureSubmitTime(String captureSubmitTime) {
+        this.captureSubmitTime = captureSubmitTime;
+    }
+
+    public String getCapturedDate() {
+        return capturedDate;
+    }
+
+    public void setCapturedDate(String capturedDate) {
+        this.capturedDate = capturedDate;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -161,13 +161,9 @@ public class EventFactory {
                         List<RefundEntity> refundEntityList = refundDao.findRefundsByChargeExternalId(c.getExternalId());
                         ExternalChargeRefundAvailability refundAvailability;
 
-                        if(charge.isHistoric()) {
-                            refundAvailability = ExternalChargeRefundAvailability.from(charge.getRefundAvailabilityStatus());
-                        } else {
-                            refundAvailability = paymentProviders
-                                    .byName(PaymentGatewayName.valueFrom(charge.getPaymentGatewayName()))
-                                    .getExternalChargeRefundAvailability(charge, refundEntityList);
-                        }
+                        refundAvailability = paymentProviders
+                                .byName(PaymentGatewayName.valueFrom(charge.getPaymentGatewayName()))
+                                .getExternalChargeRefundAvailability(charge, refundEntityList);
 
                         return new RefundAvailabilityUpdated(
                                         c.getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
@@ -2,14 +2,15 @@ package uk.gov.pay.connector.gateway.util;
 
 import com.google.common.collect.ImmutableList;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
@@ -27,6 +28,12 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailabi
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_FULL;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_PENDING;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_CAPTURABLE;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_CREATED;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_STARTED;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUBMITTED;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
+import static uk.gov.pay.connector.common.model.api.ExternalChargeState.fromStatusStringV2;
 
 public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefundAvailabilityCalculator {
 
@@ -46,9 +53,20 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
     );
     private static final List<ChargeStatus> STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL = ImmutableList.of(CAPTURED);
 
+    private static final List<ExternalChargeState> EXTERNAL_STATUSES_THAT_MAP_TO_REFUND_EXTERNAL_PENDING = ImmutableList.of(
+            EXTERNAL_CREATED,
+            EXTERNAL_STARTED,
+            EXTERNAL_SUBMITTED,
+            EXTERNAL_CAPTURABLE,
+            EXTERNAL_SUCCESS);
+
     @Override
     public ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList) {
-        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+        if (charge.isHistoric()) {
+            return calculateForHistoricCharge(charge, refundEntityList, false);
+        } else {
+            return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+        }
     }
 
     protected ExternalChargeRefundAvailability calculate(Charge charge, List<ChargeStatus> statusesThatMapToExternalPending,
@@ -57,13 +75,39 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
         if (chargeIsPending(charge, statusesThatMapToExternalPending)) {
             return EXTERNAL_PENDING;
         } else if (chargeIsAvailableOrFull(charge, statusesThatMapToExternalAvailableOrExternalFull)) {
-            if (RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntityList) > 0) {
-                return EXTERNAL_AVAILABLE;
-            } else {
-                return EXTERNAL_FULL;
-            }
+            return calculateRefundAvailability(charge, refundEntityList);
         }
         return EXTERNAL_UNAVAILABLE;
+    }
+
+    public ExternalChargeRefundAvailability calculateForHistoricCharge(Charge charge,
+                                                                       List<RefundEntity> refundEntityList,
+                                                                       boolean isCaptureSubmittedRefundable) {
+        try {
+            if (isNotEmpty(charge.getExternalStatus())) {
+                List<ExternalChargeState> externalChargeStatuses = fromStatusStringV2(charge.getExternalStatus());
+
+                if (isNotEmpty(charge.getCapturedDate())) {
+                    return calculateRefundAvailability(charge, refundEntityList);
+                } else if (isCaptureSubmittedRefundable && isNotEmpty(charge.getCaptureSubmitTime())) {
+                    return calculateRefundAvailability(charge, refundEntityList);
+                } else if (chargeIsPendingForHistoricPayment(externalChargeStatuses)) {
+                    return EXTERNAL_PENDING;
+                }
+            }
+        } catch (IllegalArgumentException ignored) {
+            // do nothing: returns refund unavailable if historic payment status cannot be mapped to external charge state
+        }
+        return EXTERNAL_UNAVAILABLE;
+    }
+
+    private ExternalChargeRefundAvailability calculateRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
+        long amountAvailableToBeRefunded = RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntityList);
+        if (amountAvailableToBeRefunded > 0) {
+            return EXTERNAL_AVAILABLE;
+        } else {
+            return EXTERNAL_FULL;
+        }
     }
 
     private boolean chargeIsAvailableOrFull(Charge charge, List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull) {
@@ -72,5 +116,14 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
 
     private boolean chargeIsPending(Charge charge, List<ChargeStatus> statusesThatMapToExternalPending) {
         return statusesThatMapToExternalPending.contains(ChargeStatus.fromString(charge.getStatus()));
+    }
+
+    private boolean chargeIsPendingForHistoricPayment(List<ExternalChargeState> externalChargeStatuses) {
+        for (ExternalChargeState externalChargeState : externalChargeStatuses) {
+            if (EXTERNAL_STATUSES_THAT_MAP_TO_REFUND_EXTERNAL_PENDING.contains(externalChargeState)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gateway.util;
 
 import com.google.common.collect.ImmutableList;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
@@ -43,7 +42,11 @@ public class EpdqExternalRefundAvailabilityCalculator extends DefaultExternalRef
 
     @Override
     public ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList) {
-        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+        if (charge.isHistoric()) {
+            return calculateForHistoricCharge(charge, refundEntityList, true);
+        } else {
+            return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+        }
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.util;
 
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
@@ -10,5 +9,4 @@ import java.util.List;
 public interface ExternalRefundAvailabilityCalculator {
 
     ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList);
-
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -236,13 +236,9 @@ public class ChargeRefundService {
                                                      List<RefundEntity> refundEntityList) {
         ExternalChargeRefundAvailability refundAvailability;
 
-        if(charge.isHistoric()) {
-            refundAvailability = ExternalChargeRefundAvailability.from(charge.getRefundAvailabilityStatus());
-        } else {
-            refundAvailability = providers
-                    .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
-                    .getExternalChargeRefundAvailability(charge, refundEntityList);
-        }
+        refundAvailability = providers
+                .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
+                .getExternalChargeRefundAvailability(charge, refundEntityList);
         checkIfChargeIsRefundableOrTerminate(charge, refundAvailability, gatewayAccountEntity);
 
         List<RefundEntity> refundEntities = refundDao.findRefundsByChargeExternalId(charge.getExternalId());

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -90,7 +90,7 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         when(mockGatewayAccountService.getGatewayAccount(charge.getGatewayAccountId())).thenReturn(Optional.of(gatewayAccountEntity));
         when(mockChargeService.findByProviderAndTransactionIdFromDbOrLedger(EPDQ.getName(), payId)).thenReturn(Optional.of(charge));
         notificationService.handleNotificationFor(payload);
-        
+
 
         verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, payId, charge, CAPTURED);
     }
@@ -237,10 +237,10 @@ public class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationSer
         notificationService.handleNotificationFor(payload);
         verifyNoInteractions(mockChargeNotificationProcessor);
     }
-    
-    private Charge getCharge(boolean isHistoric){
+
+    private Charge getCharge(boolean isHistoric) {
         return new Charge("external-id", 10L, null, null, "transaction-id",
                 10L, null, "ref-1", "desc", now(),
-                "test@example.org", 123L, "epdq", isHistoric);
+                "test@example.org", 123L, "epdq", isHistoric, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.connector.service;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -13,8 +15,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static java.time.ZonedDateTime.now;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
@@ -43,9 +47,9 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailabi
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_FULL;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_PENDING;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE;
-import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
 
+@RunWith(JUnitParamsRunner.class)
 public class DefaultExternalRefundAvailabilityCalculatorTest {
 
     private final DefaultExternalRefundAvailabilityCalculator defaultExternalRefundAvailabilityCalculator = new DefaultExternalRefundAvailabilityCalculator();
@@ -110,17 +114,95 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
 
     }
 
-    private static Charge chargeEntity(ChargeStatus status) {
+    @Test
+    @Parameters({"created", "started", "submitted", "capturable", "success"})
+    public void shouldReturnRefundAvailabilityAsPendingIfChargeIsHistoricButNotRefundable(String status) {
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(
+                getCharge(true, status, null, null),
+                List.of()), is(EXTERNAL_PENDING));
+    }
+
+    @Test
+    public void shouldReturnRefundAvailabilityAsAvailableIfChargeIsHistoricAndCaptured() {
+        List<RefundEntity> refunds = Arrays.asList(
+                aValidRefundEntity().withStatus(RefundStatus.CREATED).withAmount(100L).build(),
+                aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(200L).build()
+        );
+        // partially refunded charge
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(
+                getCharge(true, "success", "2019-11-11", "2019-11-11T13:01:40.844Z"),
+                refunds), is(EXTERNAL_AVAILABLE));
+        // charge without any refunds
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(
+                getCharge(true, "success", "2019-11-11", "2019-11-11T13:01:40.844Z"),
+                List.of()), is(EXTERNAL_AVAILABLE));
+    }
+
+    @Test
+    public void shouldReturnRefundAvailabilityAsFullIfChargeIsHistoricAndFullyRefunded() {
+        List<RefundEntity> refunds = Arrays.asList(
+                aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(100L).build(),
+                aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(400L).build()
+        );
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(
+                getCharge(true, "success", null, "2019-11-11T13:01:40.844Z"),
+                refunds), is(EXTERNAL_FULL));
+    }
+
+    @Test
+    public void shouldReturnRefundAvailabilityAsAvailableIfChargeIsHistoricAndRefundableAfterCaptureSubmitted() {
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculateForHistoricCharge(
+                getCharge(true, "success", "2019-11-11", null),
+                List.of(), true), is(EXTERNAL_AVAILABLE));
+    }
+
+    @Test
+    public void shouldReturnRefundAvailabilityAsUnavailableIfChargeIsHistoricAndNotRefundableWhenInCaptureSubmittedState() {
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculateForHistoricCharge(
+                getCharge(true, "success", "2019-11-11", null),
+                List.of(), false), is(EXTERNAL_PENDING));
+    }
+
+    @Test
+    @Parameters({"declined", "timedout", "cancelled", "error"})
+    public void shouldReturnRefundAvailabilityAsUnavailableIfChargeIsHistoricAndFailed(String status) {
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(
+                getCharge(true, status, null, null),
+                List.of()), is(EXTERNAL_UNAVAILABLE));
+    }
+
+    @Test
+    @Parameters({"", "unknown", "undefined"})
+    public void shouldReturnRefundAvailabilityAsUnavailableIfChargeIsHistoricAndExternalStatusIsUnknown(String status) {
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(
+                getCharge(true, status, null, null),
+                List.of()), is(EXTERNAL_UNAVAILABLE));
+    }
+
+    @Test
+    public void shouldReturnRefundAvailabilityAsUnavailableIfChargeIsHistoricAndExternalStatusIsEmpty() {
+        assertThat(defaultExternalRefundAvailabilityCalculator.calculate(
+                getCharge(true, null, null, null),
+                List.of()), is(EXTERNAL_UNAVAILABLE));
+    }
+
+    private Charge chargeEntity(ChargeStatus status) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build()
         );
     }
 
-    private static Charge chargeEntity(ChargeStatus status, long amount) {
+    private Charge chargeEntity(ChargeStatus status, long amount) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build()
         );
+    }
+
+    private Charge getCharge(boolean isHistoric, String externalStatus, String captureSubmitTime, String capturedDate) {
+        return new Charge("external-id", 500L, null, externalStatus, "transaction-id",
+                0L, null, "ref-1", "desc", now(),
+                "test@example.org", 123L, "epdq", isHistoric, captureSubmitTime, capturedDate);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
@@ -2,8 +2,8 @@ package uk.gov.pay.connector.service;
 
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -14,8 +14,10 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static java.time.ZonedDateTime.now;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
@@ -44,13 +46,12 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailabi
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_FULL;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_PENDING;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_UNAVAILABLE;
-import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
 
 public class EpdqExternalRefundAvailabilityCalculatorTest {
 
     private final ExternalRefundAvailabilityCalculator epdqExternalRefundAvailabilityCalculator = new EpdqExternalRefundAvailabilityCalculator();
-    
+
     @Test
     public void testGetChargeRefundAvailabilityReturnsPending() {
         assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CREATED), List.of()), is(EXTERNAL_PENDING));
@@ -132,17 +133,53 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
         assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L), refunds), is(EXTERNAL_FULL));
     }
 
-    private static Charge chargeEntity(ChargeStatus status) {
+    @Test
+    public void shouldCalculateRefundAvailabilityAsFullIfChargeIsHistoricAndFullyRefunded() {
+        List<RefundEntity> refunds = Arrays.asList(
+                aValidRefundEntity().withStatus(RefundStatus.CREATED).withAmount(100L).build(),
+                aValidRefundEntity().withStatus(RefundStatus.REFUND_SUBMITTED).withAmount(200L).build(),
+                aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(200L).build()
+        );
+
+        Charge charge = getCharge(true, "success", "2019-11-11", "2019-11-11");
+
+        ExternalChargeRefundAvailability refundAvailability = epdqExternalRefundAvailabilityCalculator.calculate(charge, refunds);
+        assertThat(refundAvailability, is(EXTERNAL_FULL));
+    }
+
+    @Test
+    public void shouldCalculateRefundAvailabilityAsAvailableIfChargeIsHistoricAndCaptureSubmitted() {
+        Charge charge = getCharge(true, "success", "2019-11-11", null);
+
+        ExternalChargeRefundAvailability refundAvailability = epdqExternalRefundAvailabilityCalculator.calculate(charge, List.of());
+        assertThat(refundAvailability, is(EXTERNAL_AVAILABLE));
+    }
+
+    @Test
+    public void shouldCalculateRefundAvailabilityAsPendingIfChargeIsHistoricAndNotAvailableForRefund() {
+        Charge charge = getCharge(true, "success", null, null);
+
+        ExternalChargeRefundAvailability refundAvailability = epdqExternalRefundAvailabilityCalculator.calculate(charge, List.of());
+        assertThat(refundAvailability, is(EXTERNAL_PENDING));
+    }
+
+    private Charge chargeEntity(ChargeStatus status) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build()
         );
     }
 
-    private static Charge chargeEntity(ChargeStatus status, long amount) {
+    private Charge chargeEntity(ChargeStatus status, long amount) {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build()
         );
+    }
+
+    private Charge getCharge(boolean isHistoric, String externalStatus, String captureSubmitTime, String capturedDate) {
+        return new Charge("external-id", 500L, null, externalStatus, "transaction-id",
+                0L, null, "ref-1", "desc", now(),
+                "test@example.org", 123L, "epdq", isHistoric, captureSubmitTime, capturedDate);
     }
 }


### PR DESCRIPTION
## WHAT 
- We currently calculate refund available in 2 ways
  1. For in-flight (charge still in connector) payments, refund availability is calculated based on     internal charge status. Internal statuses considered are also slightly to EPDQ compared to the      rest of the payment providers. i.e., for EPDQ, CAPTURED_SUBMITTED is refundable and pending for others
  2. Historic payments (payments expunged and only exists in ledger)
     So far, for historic payments `refundAvailability` is set based on ledger refund availability which is always `available` (or the latest `refundAvailability` that Ledger holds),  but this should be calculated based on charge status and current list of refunds.

Changes addresses the issue with historic payments and aims to match the functionality of calculating refundAvailability of in-flight payments

As ledger doesn't store equivalent of connector internal status, we are now relying on
 1. `captured_date` from Ledger : (for all payment providers) to calculate amount refundable. This matches current functionality of `CAPTURED` state
 2. `capture_submitted_date` : For EPDQ, refunds are allowed immediately when charge is 
 submitted for capture. So refundable amount is calculated for EPDQ if capture submitted date is available.
 3. For any in-progress external states, refundAvailability is `pending`. We should not have any historic payments that are expunged from connector but still in progress

All other states or if connector couldn't map external state from Ledger for any reason, refundAvailability will be `unavailable`
