### PR TITLE
PP-6470 Lookup gateway account by generic credentials value

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -34,6 +34,16 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
                 .getResultList().stream().findFirst();
     }
 
+    public Optional<GatewayAccountEntity> findByCredentialsKeyValue(String key, String value) {
+        String query = "SELECT * FROM gateway_accounts where credentials->>?1 = ?2";
+
+        return entityManager.get()
+                .createNativeQuery(query, GatewayAccountEntity.class)
+                .setParameter(1, key)
+                .setParameter(2, value)
+                .getResultList().stream().findFirst();
+    }
+
     public List<GatewayAccountEntity> search(GatewayAccountSearchParams params) {
         List<String> filterTemplates = params.getFilterTemplates();
         String whereClause = filterTemplates.isEmpty() ?

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -29,7 +29,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
@@ -133,6 +132,22 @@ public class GatewayAccountDaoIT extends DaoITestBase {
                         hasProperty("type", is(visaCardDebit.getType())),
                         hasProperty("brand", is(visaCardDebit.getBrand()))
                 )));
+    }
+
+    @Test
+    public void findByCredentialsKeyValue_shouldFindGatewayAccount() {
+        var credMap = Map.of("some_payment_provider_account_id", "accountid");
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId))
+                .withPaymentGateway("test provider")
+                .withServiceName("service name")
+                .withCredentials(credMap)
+                .build());
+        
+        Optional<GatewayAccountEntity> maybeGatewayAccount = gatewayAccountDao.findByCredentialsKeyValue("some_payment_provider_account_id", "accountid");
+        assertThat(maybeGatewayAccount.isPresent(), is(true));
+        Map<String, String> credentialsMap = maybeGatewayAccount.get().getCredentials();
+        assertThat(credentialsMap, hasEntry("some_payment_provider_account_id", "accountid"));
     }
 
     @Test


### PR DESCRIPTION
Utility method to lookup gateway account entity by values inside the
credentials `JSONB` field. This method assumes credentials for a given
account are unique across accounts.