### PR TITLE
PP-6346 Stripe transfer records pay transaction id for reconciliation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -21,9 +21,10 @@ public class StripeTransferInRequest extends StripeTransferRequest {
             String stripeChargeId,
             String idempotencyKey,
             String transferGroup,
-            StripeGatewayConfig stripeGatewayConfig
+            StripeGatewayConfig stripeGatewayConfig,
+            String reconciliationTransactionId
     ) {
-        super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig);
+        super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig, reconciliationTransactionId);
         this.transferGroup = transferGroup;
     }
 
@@ -34,7 +35,8 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 stripeChargeId,
                 request.getRefundExternalId(),
                 request.getChargeExternalId(),
-                stripeGatewayConfig
+                stripeGatewayConfig,
+                request.getRefundExternalId()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -22,9 +22,9 @@ public class StripeTransferInRequest extends StripeTransferRequest {
             String idempotencyKey,
             String transferGroup,
             StripeGatewayConfig stripeGatewayConfig,
-            String reconciliationTransactionId
+            String govukPayTransactionExternalId
     ) {
-        super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig, reconciliationTransactionId);
+        super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig, govukPayTransactionExternalId);
         this.transferGroup = transferGroup;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import java.util.Map;
+
+public class StripeTransferMetadata {
+    public static final String STRIPE_CHARGE_ID_KEY = "stripe_charge_id";
+    public static final String RECONCILIATION_TRANSACTION_ID_KEY = "reconciliation_transaction_id";
+
+    private final String stripeChargeId;
+    private final String reconciliationTransactionId;
+
+    public StripeTransferMetadata(String stripeChargeId, String reconciliationTransactionId) {
+        this.stripeChargeId = stripeChargeId;
+        this.reconciliationTransactionId = reconciliationTransactionId;
+    }
+
+    public static StripeTransferMetadata from(Map<String, String> metadata) {
+        return new StripeTransferMetadata(metadata.get(STRIPE_CHARGE_ID_KEY), metadata.get(RECONCILIATION_TRANSACTION_ID_KEY));
+    }
+
+    public Map<String, String> format() {
+        return Map.of(
+                formatMetadataRequestKey(STRIPE_CHARGE_ID_KEY), this.stripeChargeId,
+                formatMetadataRequestKey(RECONCILIATION_TRANSACTION_ID_KEY), this.reconciliationTransactionId
+        );
+    }
+    
+    private String formatMetadataRequestKey(String key) {
+        return "metadata[" + key + "]";
+    }
+
+    public String getStripeChargeId() {
+        return stripeChargeId;
+    }
+
+    public String getReconciliationTransactionId() {
+        return reconciliationTransactionId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
@@ -18,7 +18,7 @@ public class StripeTransferMetadata {
         return new StripeTransferMetadata(metadata.get(STRIPE_CHARGE_ID_KEY), metadata.get(GOVUK_PAY_TRANSACTION_EXTERNAL_ID));
     }
 
-    public Map<String, String> format() {
+    public Map<String, String> getParams() {
         return Map.of(
                 formatMetadataRequestKey(STRIPE_CHARGE_ID_KEY), this.stripeChargeId,
                 formatMetadataRequestKey(GOVUK_PAY_TRANSACTION_EXTERNAL_ID), this.govukPayTransactionExternalId
@@ -26,7 +26,7 @@ public class StripeTransferMetadata {
     }
     
     private String formatMetadataRequestKey(String key) {
-        return "metadata[" + key + "]";
+        return String.format("metadata[%s]", key);
     }
 
     public String getStripeChargeId() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
@@ -4,24 +4,24 @@ import java.util.Map;
 
 public class StripeTransferMetadata {
     public static final String STRIPE_CHARGE_ID_KEY = "stripe_charge_id";
-    public static final String RECONCILIATION_TRANSACTION_ID_KEY = "reconciliation_transaction_id";
+    public static final String GOVUK_PAY_TRANSACTION_EXTERNAL_ID = "govuk_pay_transaction_external_id";
 
     private final String stripeChargeId;
-    private final String reconciliationTransactionId;
+    private final String govukPayTransactionExternalId;
 
     public StripeTransferMetadata(String stripeChargeId, String reconciliationTransactionId) {
         this.stripeChargeId = stripeChargeId;
-        this.reconciliationTransactionId = reconciliationTransactionId;
+        this.govukPayTransactionExternalId = reconciliationTransactionId;
     }
 
     public static StripeTransferMetadata from(Map<String, String> metadata) {
-        return new StripeTransferMetadata(metadata.get(STRIPE_CHARGE_ID_KEY), metadata.get(RECONCILIATION_TRANSACTION_ID_KEY));
+        return new StripeTransferMetadata(metadata.get(STRIPE_CHARGE_ID_KEY), metadata.get(GOVUK_PAY_TRANSACTION_EXTERNAL_ID));
     }
 
     public Map<String, String> format() {
         return Map.of(
                 formatMetadataRequestKey(STRIPE_CHARGE_ID_KEY), this.stripeChargeId,
-                formatMetadataRequestKey(RECONCILIATION_TRANSACTION_ID_KEY), this.reconciliationTransactionId
+                formatMetadataRequestKey(GOVUK_PAY_TRANSACTION_EXTERNAL_ID), this.govukPayTransactionExternalId
         );
     }
     
@@ -33,7 +33,7 @@ public class StripeTransferMetadata {
         return stripeChargeId;
     }
 
-    public String getReconciliationTransactionId() {
-        return reconciliationTransactionId;
+    public String getGovukPayTransactionExternalId() {
+        return govukPayTransactionExternalId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -15,9 +15,9 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
                                      String sourceTransactionId,
                                      String idempotencyKey,
                                      StripeGatewayConfig stripeGatewayConfig,
-                                     String reconciliationTransactionId
+                                     String govukPayTransactionExternalId
     ) {
-        super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig, reconciliationTransactionId);
+        super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig, govukPayTransactionExternalId);
     }
 
     public static StripeTransferOutRequest of(String amount, String stripeChargeId, CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -14,9 +14,10 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
                                      GatewayAccountEntity gatewayAccount,
                                      String sourceTransactionId,
                                      String idempotencyKey,
-                                     StripeGatewayConfig stripeGatewayConfig
+                                     StripeGatewayConfig stripeGatewayConfig,
+                                     String reconciliationTransactionId
     ) {
-        super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig);
+        super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig, reconciliationTransactionId);
     }
 
     public static StripeTransferOutRequest of(String amount, String stripeChargeId, CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
@@ -25,7 +26,8 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
                 request.getGatewayAccount(),
                 stripeChargeId,
                 request.getExternalId(),
-                stripeGatewayConfig
+                stripeGatewayConfig,
+                request.getExternalId()
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.stripe.request;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -31,12 +32,12 @@ public abstract class StripeTransferRequest extends StripeRequest {
 
     @Override
     protected Map<String, String> params() {
-        return Map.of(
-                "amount", amount,
-                "currency", "GBP",
-                "metadata[stripe_charge_id]", stripeChargeId,
-                "metadata[reconciliation_transaction_id]", reconciliationTransactionId
-        );
+        StripeTransferMetadata stripeTransferMetadata = new StripeTransferMetadata(this.stripeChargeId, this.reconciliationTransactionId);
+        Map<String, String> baseParams = new HashMap<>();
+        baseParams.put("amount", amount);
+        baseParams.put("currency", "GBP");
+        baseParams.putAll(stripeTransferMetadata.format());
+        return baseParams;
     }
     
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -10,7 +10,7 @@ import java.util.Map;
 public abstract class StripeTransferRequest extends StripeRequest {
     protected String amount;
     protected String stripeChargeId;
-    protected String reconciliationTransactionId;
+    protected String govukPayTransactionExternalId;
 
     protected StripeTransferRequest(
             String amount,
@@ -18,12 +18,12 @@ public abstract class StripeTransferRequest extends StripeRequest {
             String stripeChargeId,
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
-            String reconciliationTransactionId
+            String govukPayTransactionExternalId
     ) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
         this.stripeChargeId = stripeChargeId;
         this.amount = amount;
-        this.reconciliationTransactionId = reconciliationTransactionId;
+        this.govukPayTransactionExternalId = govukPayTransactionExternalId;
     }
 
     public String urlPath() {
@@ -32,7 +32,7 @@ public abstract class StripeTransferRequest extends StripeRequest {
 
     @Override
     protected Map<String, String> params() {
-        StripeTransferMetadata stripeTransferMetadata = new StripeTransferMetadata(this.stripeChargeId, this.reconciliationTransactionId);
+        StripeTransferMetadata stripeTransferMetadata = new StripeTransferMetadata(this.stripeChargeId, this.govukPayTransactionExternalId);
         Map<String, String> baseParams = new HashMap<>();
         baseParams.put("amount", amount);
         baseParams.put("currency", "GBP");

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -36,7 +36,7 @@ public abstract class StripeTransferRequest extends StripeRequest {
         Map<String, String> baseParams = new HashMap<>();
         baseParams.put("amount", amount);
         baseParams.put("currency", "GBP");
-        baseParams.putAll(stripeTransferMetadata.format());
+        baseParams.putAll(stripeTransferMetadata.getParams());
         return baseParams;
     }
     

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -9,17 +9,20 @@ import java.util.Map;
 public abstract class StripeTransferRequest extends StripeRequest {
     protected String amount;
     protected String stripeChargeId;
+    protected String reconciliationTransactionId;
 
     protected StripeTransferRequest(
             String amount,
             GatewayAccountEntity gatewayAccount,
             String stripeChargeId,
             String idempotencyKey,
-            StripeGatewayConfig stripeGatewayConfig
+            StripeGatewayConfig stripeGatewayConfig,
+            String reconciliationTransactionId
     ) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
         this.stripeChargeId = stripeChargeId;
         this.amount = amount;
+        this.reconciliationTransactionId = reconciliationTransactionId;
     }
 
     public String urlPath() {
@@ -31,7 +34,8 @@ public abstract class StripeTransferRequest extends StripeRequest {
         return Map.of(
                 "amount", amount,
                 "currency", "GBP",
-                "metadata[stripe_charge_id]", stripeChargeId
+                "metadata[stripe_charge_id]", stripeChargeId,
+                "metadata[reconciliation_transaction_id]", reconciliationTransactionId
         );
     }
     

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -82,6 +82,7 @@ public class StripeTransferInRequestTest {
         assertThat(payload, containsString("expand%5B%5D=destination_payment"));
         assertThat(payload, containsString("currency=GBP"));
         assertThat(payload, containsString("metadata%5Bstripe_charge_id%5D=" + stripeChargeId));
+        assertThat(payload, containsString("metadata%5Bgovuk_pay_transaction_external_id%5D=" + refundExternalId));
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
@@ -26,7 +26,7 @@ public class StripeTransferMetadataTest {
     @Test
     public void shouldSeraliseToMetadata() {
         var stripeTransferMetadata = new StripeTransferMetadata("some-charge-id", "some-reconciliation-transaction-id");
-        var requestMap = stripeTransferMetadata.format();
+        var requestMap = stripeTransferMetadata.getParams();
         assertThat(requestMap.get("metadata[stripe_charge_id]"), is("some-charge-id"));
         assertThat(requestMap.get("metadata[govuk_pay_transaction_external_id]"), is("some-reconciliation-transaction-id"));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StripeTransferMetadataTest {
+
+    @Test
+    public void shouldDeserialiseFromMetadata() {
+        Map<String, String> stripeObjectMetadata = Map.of(
+                "stripe_charge_id", "some-charge-id",
+                "reconciliation_transaction_id", "some-reconciliation-transaction-id"
+        );
+        var stripeTransferMetadata = StripeTransferMetadata.from(stripeObjectMetadata);
+        assertThat(stripeTransferMetadata.getStripeChargeId(), is("some-charge-id"));
+        assertThat(stripeTransferMetadata.getReconciliationTransactionId(),is("some-reconciliation-transaction-id"));
+    }
+
+    @Test
+    public void shouldSeraliseToMetadata() {
+        var stripeTransferMetadata = new StripeTransferMetadata("some-charge-id", "some-reconciliation-transaction-id");
+        var requestMap = stripeTransferMetadata.format();
+        assertThat(requestMap.get("metadata[stripe_charge_id]"), is("some-charge-id"));
+        assertThat(requestMap.get("metadata[reconciliation_transaction_id]"), is("some-reconciliation-transaction-id"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
@@ -16,11 +16,11 @@ public class StripeTransferMetadataTest {
     public void shouldDeserialiseFromMetadata() {
         Map<String, String> stripeObjectMetadata = Map.of(
                 "stripe_charge_id", "some-charge-id",
-                "reconciliation_transaction_id", "some-reconciliation-transaction-id"
+                "govuk_pay_transaction_external_id", "some-reconciliation-transaction-id"
         );
         var stripeTransferMetadata = StripeTransferMetadata.from(stripeObjectMetadata);
         assertThat(stripeTransferMetadata.getStripeChargeId(), is("some-charge-id"));
-        assertThat(stripeTransferMetadata.getReconciliationTransactionId(),is("some-reconciliation-transaction-id"));
+        assertThat(stripeTransferMetadata.getGovukPayTransactionExternalId(),is("some-reconciliation-transaction-id"));
     }
 
     @Test
@@ -28,6 +28,6 @@ public class StripeTransferMetadataTest {
         var stripeTransferMetadata = new StripeTransferMetadata("some-charge-id", "some-reconciliation-transaction-id");
         var requestMap = stripeTransferMetadata.format();
         assertThat(requestMap.get("metadata[stripe_charge_id]"), is("some-charge-id"));
-        assertThat(requestMap.get("metadata[reconciliation_transaction_id]"), is("some-reconciliation-transaction-id"));
+        assertThat(requestMap.get("metadata[govuk_pay_transaction_external_id]"), is("some-reconciliation-transaction-id"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
@@ -70,6 +70,7 @@ public class StripeTransferOutRequestTest {
         assertThat(payload, containsString("currency=GBP"));
         assertThat(payload, containsString("expand%5B%5D=balance_transaction"));
         assertThat(payload, containsString("expand%5B%5D=destination_payment"));
+        assertThat(payload, containsString("metadata%5Bgovuk_pay_transaction_external_id%5D=" + chargeExternalId));
     }
 
     @Test


### PR DESCRIPTION
Require a `charge` or `refund` external ID when making a Stripe
transfer so that these can be used to simply and clearly reconcile
transactions with bank payouts.