### PR TITLE
PP-6470 Retrieve balance transfers for payout from Stripe

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountNotFoundException.java
@@ -9,4 +9,8 @@ public class GatewayAccountNotFoundException extends WebApplicationException {
     public GatewayAccountNotFoundException(Long accountId) {
         super(notFoundResponse(format("Gateway Account with id [%s] not found.", accountId)));
     }
+    
+    public GatewayAccountNotFoundException(String message) {
+        super(notFoundResponse(format(message)));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 public class StripeCredentials {
 
+    public static final String STRIPE_ACCOUNT_ID = "stripe_account_id";
     private String accountId;
 
     public StripeCredentials(@JsonProperty("stripe_account_id") String accountId) {
@@ -14,6 +15,6 @@ public class StripeCredentials {
     }
 
     public Map<String, String> toMap() {
-        return ImmutableMap.of("stripe_account_id", accountId);
+        return ImmutableMap.of(STRIPE_ACCOUNT_ID, accountId);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeCredentials.java
@@ -7,14 +7,14 @@ import java.util.Map;
 
 public class StripeCredentials {
 
-    public static final String STRIPE_ACCOUNT_ID = "stripe_account_id";
+    public static final String STRIPE_ACCOUNT_ID_KEY = "stripe_account_id";
     private String accountId;
 
-    public StripeCredentials(@JsonProperty("stripe_account_id") String accountId) {
+    public StripeCredentials(@JsonProperty(STRIPE_ACCOUNT_ID_KEY) String accountId) {
         this.accountId = accountId;
     }
 
     public Map<String, String> toMap() {
-        return ImmutableMap.of(STRIPE_ACCOUNT_ID, accountId);
+        return ImmutableMap.of(STRIPE_ACCOUNT_ID_KEY, accountId);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -100,7 +100,7 @@ public class PayoutReconcileProcess {
     }
 
     private String getStripeApiKey(String stripeAccountId) {
-        return gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID, stripeAccountId)
+        return gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID_KEY, stripeAccountId)
                 .map(gatewayAccountEntity ->
                         gatewayAccountEntity.isLive() ? stripeGatewayConfig.getAuthTokens().getLive() : stripeGatewayConfig.getAuthTokens().getTest())
                 .orElseThrow(() -> new GatewayAccountNotFoundException(format("Gateway account with Stripe connect account ID %s not found.", stripeAccountId)));

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -1,22 +1,39 @@
 package uk.gov.pay.connector.payout;
 
+import com.stripe.model.Charge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileMessage;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.String.format;
 
 public class PayoutReconcileProcess {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PayoutReconcileProcess.class);
     private PayoutReconcileQueue payoutReconcileQueue;
+    private StripeClientWrapper stripeClientWrapper;
+    private StripeGatewayConfig stripeGatewayConfig;
+    private GatewayAccountDao gatewayAccountDao;
 
     @Inject
-    public PayoutReconcileProcess(PayoutReconcileQueue payoutReconcileQueue) {
+    public PayoutReconcileProcess(PayoutReconcileQueue payoutReconcileQueue,
+                                  StripeClientWrapper stripeClientWrapper,
+                                  StripeGatewayConfig stripeGatewayConfig,
+                                  GatewayAccountDao gatewayAccountDao) {
         this.payoutReconcileQueue = payoutReconcileQueue;
+        this.stripeClientWrapper = stripeClientWrapper;
+        this.stripeGatewayConfig = stripeGatewayConfig;
+        this.gatewayAccountDao = gatewayAccountDao;
     }
 
     public void processPayouts() throws QueueException {
@@ -27,11 +44,50 @@ public class PayoutReconcileProcess {
                         payoutReconcileMessage.getGatewayPayoutId(),
                         payoutReconcileMessage.getConnectAccountId());
 
-                //TODO: Payout reconciliation - Algorithm described in PP-6266
+                String apiKey = getStripeApiKey(payoutReconcileMessage.getConnectAccountId());
 
-                LOGGER.info("Finished processing payout [{}] for connect account [{}]",
+                AtomicInteger payments = new AtomicInteger();
+                AtomicInteger refunds = new AtomicInteger();
+                
+                stripeClientWrapper.getBalanceTransactionsForPayout(payoutReconcileMessage.getGatewayPayoutId(), payoutReconcileMessage.getConnectAccountId(), apiKey)
+                        .forEach(balanceTransaction -> {
+                            switch (balanceTransaction.getType()) {
+                                case "payment":
+                                    var paymentSource = (Charge) balanceTransaction.getSourceObject();
+                                    var paymentSourceTransfer = paymentSource.getSourceTransferObject();
+                                    String paymentExternalId = paymentSourceTransfer.getTransferGroup();
+                                    
+                                    // TODO emit transaction event
+                                    LOGGER.info("Payout [{}] includes payment [{}]", payoutReconcileMessage.getGatewayPayoutId(), paymentExternalId);
+                                    payments.getAndIncrement();
+                                    break;
+                                // Refunds have a balance transaction of type "transfer" as refunds are made from our 
+                                // Platform Stripe account, and then a transfer is made for the amount from the connect
+                                // account.
+                                case "transfer":
+                                    String transferId = balanceTransaction.getSource();
+                                    
+                                    // TODO emit transaction event
+                                    LOGGER.info("Payout [{}] includes transfer (refund) [{}]", payoutReconcileMessage.getGatewayPayoutId(), transferId);
+                                    refunds.getAndIncrement();
+                                    break;
+                                // There is a balance transaction for the payout itself, ignore this.
+                                case "payout":
+                                    break;
+                                default:
+                                    LOGGER.warn("Payout [{}] for connect account [{}] contains balance transfer of type [{}], which is unexpected",
+                                            payoutReconcileMessage.getGatewayPayoutId(),
+                                            payoutReconcileMessage.getConnectAccountId(),
+                                            balanceTransaction.getType());
+                                    break;
+                            }
+                        });
+
+                LOGGER.info("Finished processing payout [{}] for connect account [{}]. Emitted events for {} payments and {} refunds.",
                         payoutReconcileMessage.getGatewayPayoutId(),
-                        payoutReconcileMessage.getConnectAccountId());
+                        payoutReconcileMessage.getConnectAccountId(),
+                        payments,
+                        refunds);
 
                 payoutReconcileQueue.markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
             } catch (Exception e) {
@@ -41,5 +97,12 @@ public class PayoutReconcileProcess {
                 );
             }
         }
+    }
+
+    private String getStripeApiKey(String stripeAccountId) {
+        return gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID, stripeAccountId)
+                .map(gatewayAccountEntity ->
+                        gatewayAccountEntity.isLive() ? stripeGatewayConfig.getAuthTokens().getLive() : stripeGatewayConfig.getAuthTokens().getTest())
+                .orElseThrow(() -> new GatewayAccountNotFoundException(format("Gateway account with Stripe connect account ID %s not found.", stripeAccountId)));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/payout/StripeClientWrapper.java
+++ b/src/main/java/uk/gov/pay/connector/payout/StripeClientWrapper.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.payout;
+
+import com.stripe.exception.StripeException;
+import com.stripe.model.BalanceTransaction;
+import com.stripe.net.RequestOptions;
+
+import java.util.List;
+import java.util.Map;
+
+class StripeClientWrapper {
+
+    Iterable<BalanceTransaction> getBalanceTransactionsForPayout(String payoutId, String stripeAccountId, String apiKey) throws StripeException {
+        RequestOptions requestOptions = RequestOptions.builder()
+                .setApiKey(apiKey)
+                .setStripeAccount(stripeAccountId)
+                .build();
+
+        Map<String, Object> params = Map.of(
+                "payout", payoutId,
+                "expand", List.of("data.source", "data.source.source_transfer"));
+        
+        return BalanceTransaction.list(params, requestOptions).autoPagingIterable();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -1,42 +1,107 @@
 package uk.gov.pay.connector.payout;
 
+import com.stripe.model.BalanceTransaction;
+import com.stripe.model.Charge;
+import com.stripe.model.Transfer;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.queue.QueueException;
+import uk.gov.pay.connector.app.StripeAuthTokens;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
+import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
+import uk.gov.pay.connector.queue.QueueMessage;
+import uk.gov.pay.connector.queue.payout.Payout;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileMessage;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PayoutReconcileProcessTest {
 
     @Mock
-    PayoutReconcileQueue payoutReconcileQueue;
+    private PayoutReconcileQueue payoutReconcileQueue;
+    
     @Mock
-    PayoutReconcileMessage payoutReconcileMessage;
+    private StripeClientWrapper stripeClientWrapper;
+    
+    @Mock
+    private StripeGatewayConfig stripeGatewayConfig;
+    
+    @Mock
+    private StripeAuthTokens stripeAuthTokens;
+    
+    @Mock
+    private GatewayAccountDao gatewayAccountDao;
 
-    PayoutReconcileProcess payoutReconcileProcess;
+    @InjectMocks
+    private PayoutReconcileProcess payoutReconcileProcess;
+    
+    private final String stripeAccountId = "acct_2RDpWRLXEC2XwBWp";
+    private final String stripeApiKey = "a-fake-api-key";
 
     @Before
-    public void setUp() throws Exception {
-        List<PayoutReconcileMessage> messages = Arrays.asList(payoutReconcileMessage);
-        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(messages);
-
-        payoutReconcileProcess = new PayoutReconcileProcess(payoutReconcileQueue);
+    public void setUp() {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(GatewayAccountEntity.Type.TEST).build();
+        when(gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID, stripeAccountId))
+                .thenReturn(Optional.of(gatewayAccountEntity));
+        when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
+        when(stripeAuthTokens.getTest()).thenReturn(stripeApiKey);
     }
 
     @Test
-    public void shouldMarkMessageAsProcessedIfPayoutIsProcessedSuccessfully() throws QueueException {
+    public void shouldMarkMessageAsProcessedIfPayoutIsProcessedSuccessfully() throws Exception {
+        String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
+        Payout payout = new Payout(payoutId, stripeAccountId);
+        QueueMessage mockQueueMessage = mock(QueueMessage.class);
+        PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
+        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
+        
+        BalanceTransaction paymentBalanceTransaction = mock(BalanceTransaction.class);
+        Charge paymentSource = mock(Charge.class);
+        Transfer paymentTransferSource = mock(Transfer.class);
+        when(paymentBalanceTransaction.getType()).thenReturn("payment");
+        when(paymentBalanceTransaction.getSourceObject()).thenReturn(paymentSource);
+        when(paymentSource.getSourceTransferObject()).thenReturn(paymentTransferSource);
+        when(paymentTransferSource.getTransferGroup()).thenReturn("payment-id");
+        
+        BalanceTransaction refundBalanceTransaction = mock(BalanceTransaction.class);
+        when(refundBalanceTransaction.getType()).thenReturn("transfer");
+        when(refundBalanceTransaction.getSource()).thenReturn("refund-transfer-id");
+        
+        when(stripeClientWrapper.getBalanceTransactionsForPayout(eq(payoutId), eq(stripeAccountId), eq(stripeApiKey)))
+                .thenReturn(List.of(paymentBalanceTransaction, refundBalanceTransaction));
+        
         payoutReconcileProcess.processPayouts();
 
         verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
+    }
+    
+    @Test
+    public void shouldNotMarkMessageAsSuccessfullyProcessedIfExceptionThrown() throws Exception {
+        String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
+        Payout payout = new Payout(payoutId, "non-existent-connect-account-id");
+        QueueMessage mockQueueMessage = mock(QueueMessage.class);
+        PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
+        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
+
+        payoutReconcileProcess.processPayouts();
+
+        verify(payoutReconcileQueue, never()).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -13,7 +13,6 @@ import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.queue.QueueMessage;
 import uk.gov.pay.connector.queue.payout.Payout;
@@ -58,7 +57,7 @@ public class PayoutReconcileProcessTest {
     @Before
     public void setUp() {
         GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(GatewayAccountEntity.Type.TEST).build();
-        when(gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID, stripeAccountId))
+        when(gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID_KEY, stripeAccountId))
                 .thenReturn(Optional.of(gatewayAccountEntity));
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeAuthTokens.getTest()).thenReturn(stripeApiKey);


### PR DESCRIPTION
When we process a PayoutReconcileMessage, make a request to Stripe to
retrieve all BalanceTransactions for the payout.

Add skeleton structure for processing of Payments and Refunds included
in the transfer. We will reconcile these and emit events to ledger in
PP-6472.

Add mocks to the existing happy path test to verify the payout is
processed as expected.