### PR TITLE
PP-6363 - Send IP address parameter to ePDQ 3DS2

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -322,7 +322,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
         
         if (request.getGatewayAccount().isRequires3ds()) {
             if (request.getGatewayAccount().getIntegrationVersion3ds() == 2) {
-                epdqPayloadDefinition = new EpdqPayloadDefinitionForNew3ds2Order(frontendUrl, request.getCharge().getLanguage(), clock);
+                epdqPayloadDefinition = new EpdqPayloadDefinitionForNew3ds2Order(frontendUrl, request.getGatewayAccount().isSendPayerIpAddressToGateway(), request.getCharge().getLanguage(), clock);
             } else {
                 epdqPayloadDefinition = new EpdqPayloadDefinitionForNew3dsOrder(frontendUrl);
             }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
@@ -30,6 +30,7 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
     public final static String ECOM_BILLTO_POSTAL_CITY = "ECOM_BILLTO_POSTAL_CITY";
     public final static String ECOM_BILLTO_POSTAL_COUNTRYCODE = "ECOM_BILLTO_POSTAL_COUNTRYCODE";
     public final static String ECOM_BILLTO_POSTAL_POSTALCODE = "ECOM_BILLTO_POSTAL_POSTALCODE";
+    public final static String REMOTE_ADDR = "REMOTE_ADDR";
     public final static String DEFAULT_BROWSER_COLOR_DEPTH = "24";
     public final static String DEFAULT_BROWSER_SCREEN_HEIGHT = "480";
     public final static String DEFAULT_BROWSER_SCREEN_WIDTH = "320";
@@ -38,11 +39,13 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
     private final static Pattern NUMBER_FROM_MINUS_999_TO_999 = Pattern.compile("-[1-9][0-9]{0,2}|0|[1-9][0-9]{0,2}");
     private final static Set<String> VALID_SCREEN_COLOR_DEPTHS = Set.of("1", "2", "4", "8", "15", "16", "24", "32");
     
+    private final boolean sendPayerIpAddressToGateway;
     private final SupportedLanguage paymentLanguage;
     private final Clock clock;
 
-    public EpdqPayloadDefinitionForNew3ds2Order(String frontendUrl, SupportedLanguage paymentLanguage, Clock clock) {
+    public EpdqPayloadDefinitionForNew3ds2Order(String frontendUrl, boolean sendPayerIpAddressToGateway, SupportedLanguage paymentLanguage, Clock clock) {
         super(frontendUrl);
+        this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
         this.paymentLanguage = paymentLanguage;
         this.clock = clock;
     }
@@ -66,6 +69,10 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
         templateData.getAuthCardDetails().getAddress().map(Address::getLine2).ifPresent(addressLine2 -> parameterBuilder.add(ECOM_BILLTO_POSTAL_STREET_LINE2, addressLine2));
         templateData.getAuthCardDetails().getAddress().map(Address::getPostcode).ifPresent(addressPostCode -> parameterBuilder.add(ECOM_BILLTO_POSTAL_POSTALCODE, addressPostCode));
         
+        if (sendPayerIpAddressToGateway) {
+            templateData.getAuthCardDetails().getIpAddress().ifPresent(ipAddress -> parameterBuilder.add(REMOTE_ADDR, ipAddress));
+        }
+
         return parameterBuilder.build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
@@ -29,6 +29,7 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
     public final static String ECOM_BILLTO_POSTAL_STREET_LINE2 = "ECOM_BILLTO_POSTAL_STREET_LINE2";
     public final static String ECOM_BILLTO_POSTAL_CITY = "ECOM_BILLTO_POSTAL_CITY";
     public final static String ECOM_BILLTO_POSTAL_COUNTRYCODE = "ECOM_BILLTO_POSTAL_COUNTRYCODE";
+    public final static String ECOM_BILLTO_POSTAL_POSTALCODE = "ECOM_BILLTO_POSTAL_POSTALCODE";
     public final static String DEFAULT_BROWSER_COLOR_DEPTH = "24";
     public final static String DEFAULT_BROWSER_SCREEN_HEIGHT = "480";
     public final static String DEFAULT_BROWSER_SCREEN_WIDTH = "320";
@@ -63,6 +64,7 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
         templateData.getAuthCardDetails().getAddress().map(Address::getCountry).ifPresent(country -> parameterBuilder.add(ECOM_BILLTO_POSTAL_COUNTRYCODE, country));
         templateData.getAuthCardDetails().getAddress().map(Address::getLine1).ifPresent(addressLine1 -> parameterBuilder.add(ECOM_BILLTO_POSTAL_STREET_LINE1, addressLine1));
         templateData.getAuthCardDetails().getAddress().map(Address::getLine2).ifPresent(addressLine2 -> parameterBuilder.add(ECOM_BILLTO_POSTAL_STREET_LINE2, addressLine2));
+        templateData.getAuthCardDetails().getAddress().map(Address::getPostcode).ifPresent(addressPostCode -> parameterBuilder.add(ECOM_BILLTO_POSTAL_POSTALCODE, addressPostCode));
         
         return parameterBuilder.build();
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
@@ -73,6 +73,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     private static final String ADDRESS_LINE_1 = "The Money Pool";
     private static final String ADDRESS_LINE_2 = "1 Gold Way";
     private static final String ADDRESS_CITY = "London";
+    private static final String ADDRESS_POSTCODE = "DO11 4RS";
     private static final String ADDRESS_COUNTRY = "GB";
     private static final String PSP_ID = "PspId";
     private static final String PASSWORD = "password";
@@ -115,6 +116,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
         address.setCountry(null);
         address.setLine1(null);
         address.setLine2(null);
+        address.setPostcode(null);
     }
 
     @Test
@@ -319,6 +321,21 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
         authCardDetails.setAddress(address);
         List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE2)));
+    }
+    
+    @Test
+    public void should_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_provided() {
+        address.setPostcode(ADDRESS_POSTCODE);
+        authCardDetails.setAddress(address);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        assertThat(result, hasItem(new BasicNameValuePair(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE, "DO11 4RS")));
+    }
+
+    @Test
+    public void should_not_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_not_provided() {
+        authCardDetails.setAddress(address);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE)));
     }
     
     static class ParameterBuilder {


### PR DESCRIPTION
## WHAT YOU DID
Description:
    - Sends the IP address to ePDQ 3DS2 when it is provided by frontend and the setting is enabled on the gateway account
    - There will need to be a service-level integration test as the parameter is passed in from the EpdqPaymentProvider a follow up PR will address this

