### PR TITLE
PP-6470 Log an error if no payments/refunds found for payout

### DIFF
--- a/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutReconcileProcess.java
@@ -75,7 +75,7 @@ public class PayoutReconcileProcess {
                                 case "payout":
                                     break;
                                 default:
-                                    LOGGER.warn("Payout [{}] for connect account [{}] contains balance transfer of type [{}], which is unexpected",
+                                    LOGGER.error("Payout [{}] for connect account [{}] contains balance transfer of type [{}], which is unexpected.",
                                             payoutReconcileMessage.getGatewayPayoutId(),
                                             payoutReconcileMessage.getConnectAccountId(),
                                             balanceTransaction.getType());
@@ -83,13 +83,18 @@ public class PayoutReconcileProcess {
                             }
                         });
 
-                LOGGER.info("Finished processing payout [{}] for connect account [{}]. Emitted events for {} payments and {} refunds.",
-                        payoutReconcileMessage.getGatewayPayoutId(),
-                        payoutReconcileMessage.getConnectAccountId(),
-                        payments,
-                        refunds);
+                if (payments.intValue() == 0 && refunds.intValue() == 0) {
+                    LOGGER.error("No payments or refunds retrieved for payout [{}] for connect account [{}]. Requires investigation.", 
+                            payoutReconcileMessage.getGatewayPayoutId(), payoutReconcileMessage.getConnectAccountId());
+                } else {
+                    LOGGER.info("Finished processing payout [{}] for connect account [{}]. Emitted events for {} payments and {} refunds.",
+                            payoutReconcileMessage.getGatewayPayoutId(),
+                            payoutReconcileMessage.getConnectAccountId(),
+                            payments.intValue(),
+                            refunds.intValue());
 
-                payoutReconcileQueue.markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
+                    payoutReconcileQueue.markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
+                }
             } catch (Exception e) {
                 LOGGER.warn("Error processing payout from SQS message [queueMessageId={}] [errorMessage={}]",
                         payoutReconcileMessage.getQueueMessageId(),


### PR DESCRIPTION
Log an error if the BalanceTransactions retrieved for a payout does not contain any payments or refunds.

We want to ensure that if the Stripe API changes in a way that we do not notice when upgrading the SDK, we are alerted by Sentry if we stop successfully retrieving transactions for the payout.

In this case, we also don't want to mark the message as processed. So we can fix and retry if necessary.

Also change the log level to error when we process a BalanceTransaction of an unexpected type so these reach Sentry.