### PR TITLE
PP-6469 Add Feature flag to emit payout events

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 | `STRIPE_PLATFORM_ACCOUNT_ID` | - | the account ID for the Stripe Connect GOV.UK Pay platform. |
 | `DISABLE_INTERNAL_HTTPS` | false | disable secure connection for calls to internal APIs |
 | `DEFAULT_DO_NOT_RETRY_EMITTING_EVENT_UNTIL_DURATION_IN_SECONDS` | 7200 | Sets the default duration in seconds for events (emitted by parity checker worker) until which the emitted events sweeper ignores to re-emit. Value can be overridden by passing `do_not_retry_emit_until` query parameter to parity checker worker or historical event emitter tasks |
+| `EMIT_PAYOUT_EVENTS` | false | enable or disable emitting payout specific events to payment queue |
 
 
 ### Queues

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorConfiguration.java
@@ -104,6 +104,9 @@ public class ConnectorConfiguration extends Configuration {
     @NotNull
     private Boolean emitPaymentStateTransitionEvents;
 
+    @NotNull
+    private Boolean emitPayoutEvents;
+
     @Valid
     @NotNull
     @JsonProperty("sqsConfig")
@@ -219,6 +222,10 @@ public class ConnectorConfiguration extends Configuration {
 
     public Boolean getEmitPaymentStateTransitionEvents() {
         return emitPaymentStateTransitionEvents;
+    }
+
+    public Boolean getEmitPayoutEvents() {
+        return emitPayoutEvents;
     }
 
     public RestClientConfig getRestClientConfig() {

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -224,6 +224,7 @@ graphitePort: ${METRICS_PORT:-8092}
 xrayEnabled: ${XRAY_ENABLED:-false}
 
 emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
+emitPayoutEvents: ${EMIT_PAYOUT_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -169,6 +169,7 @@ graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
 emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
+emitPayoutEvents: ${EMIT_PAYOUT_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -168,6 +168,7 @@ graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
 emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
+emitPayoutEvents: ${EMIT_PAYOUT_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -158,6 +158,7 @@ graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
 emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
+emitPayoutEvents: ${EMIT_PAYOUT_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -164,6 +164,7 @@ graphitePort: ${METRICS_PORT:-8092}
 xrayEnabled: false
 
 emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-false}
+emitPayoutEvents: ${EMIT_PAYOUT_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -163,6 +163,7 @@ graphitePort: ${METRICS_PORT:-8092}
 
 xrayEnabled: false
 emitPaymentStateTransitionEvents: ${EMIT_PAYMENT_STATE_TRANSITION_EVENTS:-true}
+emitPayoutEvents: ${EMIT_PAYOUT_EVENTS:-false}
 
 chargesSweepConfig:
   defaultChargeExpiryThreshold: ${CHARGE_EXPIRY_WINDOW_SECONDS:-5400}


### PR DESCRIPTION
## WHAT YOU DID
- Added a feature flag to enable or disable emitting payout specific events (PAYOUT_CREATED,PAYOUT_FAILED...,  PAYMENT_INCLUDED_IN_PAYOUT or refund specific event)
