### PR TITLE
PP-6475 Fix: use `ResourceType` enum when removing emitted events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.common.dao.JpaDao;
+import uk.gov.pay.connector.events.model.ResourceType;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -239,7 +240,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
         entityManager.get()
                 .createNativeQuery("delete from emitted_events where resource_type = ?1 AND resource_external_id = ?2")
-                .setParameter(1, "PAYMENT")
+                .setParameter(1, ResourceType.PAYMENT.getLowercase())
                 .setParameter(2, externalId)
                 .executeUpdate();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
@@ -307,7 +307,7 @@ public class ExpungeResourceIT {
         insertChargeEvent(expungeableCharge1);
         emittedEventDao.persist(anEmittedEventEntity()
                 .withResourceExternalId(expungeableCharge1.getExternalChargeId())
-                .withResourceType("PAYMENT")
+                .withResourceType("payment")
                 .withId(RandomUtils.nextLong())
                 .build());
 


### PR DESCRIPTION
Previous code removed emitted events during the expunge process with the
condition `resource_type='PAYMENT'`. Records are written to the database
with the values `payment` or `refund` and so this criteria was never met
and emitted events were not removed as part of the expunge process.

This was covered by a test and story review but these also used `"PAYMENT"`
in line with the code change (resulting in a false positive as no
results didn't mean anything had been deleted).

Use the `ResourceType` enum that is used for writing to the database to
ensure consistency.