### PR TITLE
PP-6475 Add swap table to take over for emitted events

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1470,4 +1470,8 @@
         <dropColumn tableName="refunds_history" columnName="charge_id"/>
     </changeSet>
 
+    <changeSet id="add swap table in order to truncate emitted events safely" author="">
+        <sql>CREATE TABLE emitted_events_swp (LIKE emitted_events INCLUDING ALL);</sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
An issue with expunging emitted events from Connector was recently
addressed in https://github.com/alphagov/pay-connector/pull/2340. This
issue means that the `emitted_events` table has a large number of rows
that need to be safely removed.

The first step in the process outlined in this ticket is to create an
identical table that live Connector nodes can use to track emitted
events for in-flight payments.