### PR TITLE
PP-6475 Point Connector to emitted events swap table

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -239,7 +239,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .executeUpdate();
 
         entityManager.get()
-                .createNativeQuery("delete from emitted_events where resource_type = ?1 AND resource_external_id = ?2")
+                .createNativeQuery("delete from emitted_events_swp where resource_type = ?1 AND resource_external_id = ?2")
                 .setParameter(1, ResourceType.PAYMENT.getLowercase())
                 .setParameter(2, externalId)
                 .executeUpdate();

--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventEntity.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventEntity.java
@@ -13,7 +13,7 @@ import javax.persistence.Table;
 import java.time.ZonedDateTime;
 
 @Entity
-@Table(name = "emitted_events")
+@Table(name = "emitted_events_swp")
 @SequenceGenerator(name = "emitted_events_id_seq",
         sequenceName = "emitted_events_id_seq", allocationSize = 1)
 public class EmittedEventEntity {

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -379,7 +379,7 @@ public class DatabaseTestHelper {
 
     public boolean containsEmittedEventWithExternalId(String externalId) {
         var result = jdbi.withHandle(h ->
-                h.createQuery("SELECT count(*) FROM emitted_events WHERE resource_external_id = :external_id")
+                h.createQuery("SELECT count(*) FROM emitted_events_swp WHERE resource_external_id = :external_id")
                         .bind("external_id", externalId)
                         .mapTo(Integer.class)
                         .first());
@@ -747,12 +747,12 @@ public class DatabaseTestHelper {
     }
 
     public void truncateEmittedEvents() {
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events").execute());
+        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events_swp").execute());
     }
 
     public void truncateAllData() {
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE gateway_accounts CASCADE").execute());
-        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events CASCADE").execute());
+        jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE emitted_events_swp CASCADE").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE tokens").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds").execute());
         jdbi.withHandle(h -> h.createUpdate("TRUNCATE TABLE refunds_history").execute());
@@ -798,7 +798,7 @@ public class DatabaseTestHelper {
                                 Instant emittedDate, Instant doNotRetryEmitUntil) {
         jdbi.withHandle(handle ->
                 handle
-                        .createUpdate("INSERT INTO emitted_events(resource_type, resource_external_id, event_date, " +
+                        .createUpdate("INSERT INTO emitted_events_swp(resource_type, resource_external_id, event_date, " +
                                 " event_type, emitted_date, do_not_retry_emit_until) VALUES (:resourceType, :externalId, :eventDate, " +
                                 " :eventType, :emittedDate, :doNotRetryEmitUntil)")
                         .bind("resourceType", resourceType)
@@ -813,7 +813,7 @@ public class DatabaseTestHelper {
 
     public Map<String, Object> readEmittedEvent(Long id) {
         return jdbi.withHandle(handle ->
-                handle.createQuery("SELECT * from emitted_events WHERE id = :id")
+                handle.createQuery("SELECT * from emitted_events_swp WHERE id = :id")
                         .bind("id", id)
                         .mapToMap()
                         .first()
@@ -822,7 +822,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> readEmittedEvents() {
         return jdbi.withHandle(handle ->
-                handle.createQuery("SELECT * from emitted_events")
+                handle.createQuery("SELECT * from emitted_events_swp")
                         .mapToMap()
                         .list()
         );


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-connector/pull/2346. Moves
all live Connector nodes to point to swap table to allow `ACCESS
EXCLUSIVE` on the `emitted_events` table.

This pull request will be reverted once work has been completed on the
original table.

This is the second step in process outlined on this ticket.