### PR TITLE
PP-6475 Remove swap table for emitted events

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1474,4 +1474,8 @@
         <sql>CREATE TABLE emitted_events_swp (LIKE emitted_events INCLUDING ALL);</sql>
     </changeSet>
 
+    <changeSet id="remove emitted events swap table following use" author="">
+        <dropTable tableName="emitted_events_swp" />
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Following #2347 and
successful work on the live emitted events table, remove the no longer
needed temporary swap table.