### PR TITLE
PP-6475 Record when exceptions are thrown during backfill process

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EmittedEventsBackfillService.java
@@ -98,6 +98,16 @@ public class EmittedEventsBackfillService {
             charge.ifPresent(c -> MDC.put("chargeId", c.getExternalId()));
             charge.ifPresent(historicalEventEmitter::processPaymentAndRefundEvents);
             event.setEmittedDate(now(ZoneId.of("UTC")));
+        } catch (Exception e) {
+            logger.error(
+                    "Failed to process backfill for event {} due to {} [externalId={}] [event_type={}] [event_date={}]",
+                    event.getId(),
+                    e.getMessage(),
+                    event.getResourceExternalId(),
+                    event.getEventType(),
+                    event.getEventDate()
+            );
+            throw e;
         } finally {
             MDC.remove("chargeId");
         }


### PR DESCRIPTION
We are silently consuming any exceptions thrown during the backfill
process when sweeping non-emitted events. Generally exceptions are
handled at the actual point of event emission (an unrelated process)
but there are a number of cases where this would happen before that 
(charge doesn't exist given inconsistent data etc.)