### PR TITLE
PP-6444 Do not stop shared postgres container during IT

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/HealthCheckResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/HealthCheckResourceIT.java
@@ -2,8 +2,11 @@ package uk.gov.pay.connector.it.resources;
 
 import org.junit.Rule;
 import org.junit.Test;
-import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.rules.DropwizardAppRule;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.Matchers.is;
@@ -11,11 +14,11 @@ import static org.hamcrest.Matchers.is;
 public class HealthCheckResourceIT {
 
     @Rule
-    public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule();
+    public DropwizardAppRule<ConnectorConfiguration> app = new DropwizardAppRule<>(
+            ConnectorApp.class, resourceFilePath("config/test-it-config.yaml"));
 
     @Test
     public void healthcheckShouldIdentifyUnhealthyDBAndQueue() {
-        app.stopPostgres();
         given().port(app.getLocalPort())
                 .contentType(JSON)
                 .get("healthcheck")

--- a/src/test/java/uk/gov/pay/connector/rules/AppWithPostgresRule.java
+++ b/src/test/java/uk/gov/pay/connector/rules/AppWithPostgresRule.java
@@ -109,10 +109,6 @@ abstract public class AppWithPostgresRule implements TestRule {
         return databaseTestHelper;
     }
 
-    public void stopPostgres() {
-        postgres.stop();
-    }
-
     private ConfigOverride[] overrideDatabaseConfig(ConfigOverride[] configOverrides, PostgresDockerRule postgresDockerRule) {
         List<ConfigOverride> newConfigOverride = newArrayList(configOverrides);
         newConfigOverride.add(config("database.url", postgresDockerRule.getConnectionUrl()));

--- a/src/test/java/uk/gov/pay/connector/rules/PostgresDockerRule.java
+++ b/src/test/java/uk/gov/pay/connector/rules/PostgresDockerRule.java
@@ -47,11 +47,6 @@ public class PostgresDockerRule implements TestRule {
         return container.getPassword();
     }
 
-    public void stop() {
-        container.stop();
-        container = null;
-    }
-
     public String getDriverClass() {
         return "org.postgresql.Driver";
     }


### PR DESCRIPTION
`PostgresDockerRule` effectively has a singleton postgres container which
is shared between  all IT tests using that rule. `HealthCheckResourceIT` was
calling the public stop method which in turn stopped the container and
set it to null after other tests had initialised and proceeded beyond
the container null check (which would start the postgres container if
necessary). We saw this on Concourse and perhaps the different
environment effected the running order and or timing.

Rather than use an app with postgres and then stop postgres to get the
desired result from the health check endpoint, just run the test with a
standard DropwizardAppRule which will not have postgres or sqs.

with @mrlumbu

## WHAT YOU DID
First saw this consistently when running IT on Concourse. 