### PR TITLE
PP-6472 Include payout created date in SQS message

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureConfirmedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureConfirmedEventDetails.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.events.eventdetails.charge;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
-import uk.gov.pay.connector.events.MicrosecondPrecisionDateTimeSerializer;
+import uk.gov.pay.connector.events.serializer.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureSubmittedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CaptureSubmittedEventDetails.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.events.eventdetails.charge;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
-import uk.gov.pay.connector.events.MicrosecondPrecisionDateTimeSerializer;
+import uk.gov.pay.connector.events.serializer.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 import java.time.ZonedDateTime;

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/payout/PayoutCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/payout/PayoutCreatedEventDetails.java
@@ -1,8 +1,8 @@
 package uk.gov.pay.connector.events.eventdetails.payout;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import uk.gov.pay.connector.events.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.events.serializer.MicrosecondPrecisionDateTimeSerializer;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.dropwizard.jackson.Jackson;
-import uk.gov.pay.connector.events.MicrosecondPrecisionDateTimeSerializer;
+import uk.gov.pay.connector.events.serializer.MicrosecondPrecisionDateTimeSerializer;
 import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 

--- a/src/main/java/uk/gov/pay/connector/events/serializer/MicrosecondPrecisionDateTimeDeserializer.java
+++ b/src/main/java/uk/gov/pay/connector/events/serializer/MicrosecondPrecisionDateTimeDeserializer.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.events.serializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class MicrosecondPrecisionDateTimeDeserializer extends StdDeserializer<ZonedDateTime> {
+
+    public static final DateTimeFormatter MICROSECOND_FORMATTER =
+            MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
+
+    public MicrosecondPrecisionDateTimeDeserializer() {
+        this(null);
+    }
+
+    @Override
+    public ZonedDateTime deserialize(JsonParser p, DeserializationContext ctxt) {
+        try {
+            return ZonedDateTime.from(MICROSECOND_FORMATTER.parse(p.getText()));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MicrosecondPrecisionDateTimeDeserializer(Class<ZonedDateTime> t) {
+        super(t);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/serializer/MicrosecondPrecisionDateTimeSerializer.java
+++ b/src/main/java/uk/gov/pay/connector/events/serializer/MicrosecondPrecisionDateTimeSerializer.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.events;
+package uk.gov.pay.connector.events.serializer;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -122,7 +122,7 @@ public class StripeNotificationService {
                 PAYMENT_GATEWAY_NAME, notification.getId(), notification.getAccount());
         try {
             StripePayout stripePayout = toPayout(notification.getObject());
-            Payout payout = new Payout(stripePayout.getId(), notification.getAccount());
+            Payout payout = new Payout(stripePayout.getId(), notification.getAccount(), stripePayout.getCreated());
 
             sendToPayoutReconcileQueue(notification.getAccount(), payout);
         } catch (StripeParseException e ) {

--- a/src/main/java/uk/gov/pay/connector/queue/payout/Payout.java
+++ b/src/main/java/uk/gov/pay/connector/queue/payout/Payout.java
@@ -2,7 +2,13 @@ package uk.gov.pay.connector.queue.payout;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.connector.events.serializer.MicrosecondPrecisionDateTimeDeserializer;
+import uk.gov.pay.connector.events.serializer.MicrosecondPrecisionDateTimeSerializer;
+
+import java.time.ZonedDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
@@ -11,12 +17,17 @@ public class Payout {
     private String gatewayPayoutId;
     private String connectAccountId;
 
+    @JsonSerialize(using = MicrosecondPrecisionDateTimeSerializer.class)
+    @JsonDeserialize(using = MicrosecondPrecisionDateTimeDeserializer.class)
+    private ZonedDateTime createdDate;
+
     public Payout() {
     }
 
-    public Payout(String gatewayPayoutId, String connectAccountId) {
+    public Payout(String gatewayPayoutId, String connectAccountId, ZonedDateTime createdDate) {
         this.gatewayPayoutId = gatewayPayoutId;
         this.connectAccountId = connectAccountId;
+        this.createdDate = createdDate;
     }
 
     public String getGatewayPayoutId() {
@@ -25,5 +36,9 @@ public class Payout {
 
     public String getConnectAccountId() {
         return connectAccountId;
+    }
+
+    public ZonedDateTime getCreatedDate() {
+        return createdDate;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileMessage.java
+++ b/src/main/java/uk/gov/pay/connector/queue/payout/PayoutReconcileMessage.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.queue.payout;
 
 import uk.gov.pay.connector.queue.QueueMessage;
 
+import java.time.ZonedDateTime;
+
 public class PayoutReconcileMessage {
     private Payout payout;
     private QueueMessage queueMessage;
@@ -22,6 +24,8 @@ public class PayoutReconcileMessage {
     public String getConnectAccountId() {
         return payout.getConnectAccountId();
     }
+    
+    public ZonedDateTime getCreatedDate() { return payout.getCreatedDate(); }
 
     public String getQueueMessageReceiptHandle() {
         return queueMessage.getReceiptHandle();

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.queue.payout.Payout;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileMessage;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -65,7 +66,7 @@ public class PayoutReconcileProcessTest {
     @Test
     public void shouldMarkMessageAsProcessedIfPayoutIsProcessedSuccessfully() throws Exception {
         String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
-        Payout payout = new Payout(payoutId, stripeAccountId);
+        Payout payout = new Payout(payoutId, stripeAccountId, ZonedDateTime.parse("2020-05-01T10:30:00.000Z"));
         QueueMessage mockQueueMessage = mock(QueueMessage.class);
         PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
         when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
@@ -93,7 +94,7 @@ public class PayoutReconcileProcessTest {
     @Test
     public void shouldNotMarkMessageAsSuccessfullyProcessedIfNoPaymentsOrRefundsFound() throws Exception {
         String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
-        Payout payout = new Payout(payoutId, stripeAccountId);
+        Payout payout = new Payout(payoutId, stripeAccountId, ZonedDateTime.parse("2020-05-01T10:30:00.000Z"));
         QueueMessage mockQueueMessage = mock(QueueMessage.class);
         PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
         when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
@@ -109,7 +110,7 @@ public class PayoutReconcileProcessTest {
     @Test
     public void shouldNotMarkMessageAsSuccessfullyProcessedIfExceptionThrown() throws Exception {
         String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
-        Payout payout = new Payout(payoutId, "non-existent-connect-account-id");
+        Payout payout = new Payout(payoutId, "non-existent-connect-account-id", ZonedDateTime.parse("2020-05-01T10:30:00.000Z"));
         QueueMessage mockQueueMessage = mock(QueueMessage.class);
         PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
         when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));


### PR DESCRIPTION
Include the created date of a Stripe payout in the SQS message we create to be processed by the connector task to reconcile transactions involved in a payout.

We need this to use as the EventDate for the PAYMENT_INCLUDED_IN_PAYOUT and REFUND_INCLUDED_IN_PAYOUT events. We want to use the payout created for this to allow for idempotency for the events.

Add a new `MicrosecondPrecisionDateTimeDeserializer` class for deserializing the ZonedDateTime in the message, and move  `MicrosecondPrecisionDateTimeSerializer` into a `serializer` package alongside this.