### PR TITLE
PP-6469 Send PayoutCreated event to event queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/EventService.java
+++ b/src/main/java/uk/gov/pay/connector/events/EventService.java
@@ -22,22 +22,41 @@ public class EventService {
         this.emittedEventDao = emittedEventDao;
     }
 
-    /**
-     * This method is used principally for emitting events for expunged entities. As the entities are no longer in the
-     * connector database it does not record the event using the EmittedEventDao.
-     */
     public void emitEvent(Event event) {
+        try {
+            this.emitEvent(event, true);
+        } catch (QueueException e) {
+            // this exception won't be reached
+        }
+    }
+
+    /**
+     * This method is used principally for emitting events when the records (expunged charges, stripe payout and similar)
+     * does not exist in connector database and does not record the event in EmittedEventDao.
+     *
+     * <u>QueueException</u>
+     * In the event of a QueueException we have taken the decision not to retry the emitted event in some cases because:
+     * - the likelihood of failing to send a message to the highly available SQS service is very low.
+     * - emitted events are tightly coupled to entities in the database and doing the work to re-send an event for
+     * event related to expunged entity is more work that doesn't justify the problem we're trying to solve, namely
+     * processing notifications from ePDQ where a state transition has to be forced (PP-6201).
+     * <br>
+     * To achieve this, set <b>swallowException</b> to true so QueueException will be ignored.
+     *
+     * @param event
+     * @param swallowException set to true to not throw QueueException to calling methods.
+     * @throws QueueException
+     */
+    public void emitEvent(Event event, boolean swallowException) throws QueueException {
         try {
             eventQueue.emitEvent(event);
         } catch (QueueException e) {
-            /* 
-            In the event of a QueueException we have taken the decision not to retry the emitted event because:
-            - the likelihood of failing to send a message to the highly available SQS service is very low.
-            - emitted events are tightly coupled to entities in the database and doing the work to re-send an event for 
-              an expunged entity is more work that doesn't justify the problem we're trying to solve, namely processing 
-              notifications from ePDQ where a state transition has to be forced (PP-6201)
-            */
-            logger.error("Failed to emit event {} due to {} [externalId={}]", event.getEventType(), e.getMessage(), event.getResourceExternalId());
+            logger.error("Failed to emit event {} due to {} [externalId={}]", event.getEventType(),
+                    e.getMessage(),
+                    event.getResourceExternalId());
+            if (!swallowException) {
+                throw e;
+            }
         }
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.time.ZonedDateTime;
+import java.util.Objects;
 
 import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
@@ -58,5 +59,24 @@ public class StripePayout {
 
     public String getStatementDescriptor() {
         return statementDescriptor;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StripePayout payout = (StripePayout) o;
+        return id.equals(payout.id) &&
+                amount.equals(payout.amount) &&
+                Objects.equals(arrivalDate, payout.arrivalDate) &&
+                created.equals(payout.created) &&
+                Objects.equals(status, payout.status) &&
+                Objects.equals(type, payout.type) &&
+                Objects.equals(statementDescriptor, payout.statementDescriptor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, amount, arrivalDate, created, status, type, statementDescriptor);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/payout/PayoutEmitterService.java
+++ b/src/main/java/uk/gov/pay/connector/payout/PayoutEmitterService.java
@@ -1,0 +1,58 @@
+package uk.gov.pay.connector.payout;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.events.model.payout.PayoutCreated;
+import uk.gov.pay.connector.events.model.payout.PayoutEvent;
+import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
+import uk.gov.pay.connector.queue.QueueException;
+
+import java.util.Optional;
+
+public class PayoutEmitterService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final EventService eventService;
+    private final Boolean shouldEmitPayoutEvents;
+
+    @Inject
+    public PayoutEmitterService(EventService eventService,
+                                ConnectorConfiguration connectorConfiguration) {
+
+        this.eventService = eventService;
+        shouldEmitPayoutEvents = connectorConfiguration.getEmitPayoutEvents();
+    }
+
+    public void emitPayoutEvent(Class<? extends PayoutEvent> eventClass, String connectAccount, StripePayout payout) {
+        Event event = getPayoutEvent(eventClass, connectAccount, payout);
+
+        Optional.ofNullable(event)
+                .ifPresent(this::sendToEventQueue);
+    }
+
+    private void sendToEventQueue(Event event) {
+        try {
+            if (shouldEmitPayoutEvents) {
+                eventService.emitEvent(event, false);
+            }
+        } catch (QueueException e) {
+            logger.error("Error sending payout event to event queue: event type [{}], payout id [{}] : exception [{}]",
+                    event.getEventType(), event.getResourceExternalId(), e);
+        }
+    }
+
+    private Event getPayoutEvent(Class eventClass, String connectAccount, StripePayout payout) {
+        if (eventClass == PayoutCreated.class) {
+            Event event = PayoutCreated.from(payout);
+            return event;
+        }
+        logger.warn("Unsupported payout event class [{}] for payout [{}] ", eventClass,
+                payout.getId());
+        return null;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EventServiceTest.java
@@ -29,11 +29,34 @@ public class EventServiceTest {
 
     @InjectMocks
     EventService eventService;
-    
+
     @Test
     public void emitEvent() throws QueueException {
         Event event = new PaymentEvent("external-id", now());
         eventService.emitEvent(event);
+        verify(eventQueue).emitEvent(event);
+    }
+
+    @Test
+    public void emitEventShouldRecordEvent() throws QueueException {
+        Event event = new PaymentEvent("external-id", now());
+        eventService.emitEvent(event, false);
+
+        verify(eventQueue).emitEvent(event);
+    }
+
+    @Test(expected = QueueException.class)
+    public void emitEventShouldThrowExceptionIfSwallowExceptionIsFalse() throws QueueException {
+        Event event = new PaymentEvent("external-id", now());
+        doThrow(QueueException.class).when(eventQueue).emitEvent(event);
+        eventService.emitEvent(event, false);
+    }
+
+    @Test
+    public void emitEventShouldNotThrowExceptionIfSwallowExceptionIsFalse() throws QueueException {
+        Event event = new PaymentEvent("external-id", now());
+        doThrow(QueueException.class).when(eventQueue).emitEvent(event);
+        eventService.emitEvent(event, true);
         verify(eventQueue).emitEvent(event);
     }
 

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutEmitterServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutEmitterServiceTest.java
@@ -1,0 +1,84 @@
+package uk.gov.pay.connector.payout;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.eventdetails.payout.PayoutCreatedEventDetails;
+import uk.gov.pay.connector.events.model.payout.PayoutCreated;
+import uk.gov.pay.connector.events.model.payout.PayoutEvent;
+import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
+import uk.gov.pay.connector.queue.QueueException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.events.model.ResourceType.PAYOUT;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PayoutEmitterServiceTest {
+
+    @Mock
+    EventService mockEventService;
+    @Mock
+    ConnectorConfiguration mockConnectorConfiguration;
+
+    private PayoutEmitterService payoutEmitterService;
+    private StripePayout payout;
+    @Captor
+    private ArgumentCaptor<PayoutCreated> payoutArgumentCaptor;
+
+    @Before
+    public void setUp() {
+        when(mockConnectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
+        payoutEmitterService = new PayoutEmitterService(mockEventService, mockConnectorConfiguration);
+        payout = new StripePayout("po_123", 1213L, 1589395533L,
+                null, "pending", "card", null);
+    }
+
+    @Test
+    public void emitPayoutEventForPayoutCreatedShouldEmitCorrectEvent() throws QueueException {
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, "connect-account", payout);
+
+        verify(mockEventService).emitEvent(payoutArgumentCaptor.capture(), anyBoolean());
+
+        PayoutCreated payoutEvent = payoutArgumentCaptor.getValue();
+        PayoutCreatedEventDetails details = (PayoutCreatedEventDetails) payoutEvent.getEventDetails();
+
+        assertThat(payoutEvent.getEventType(), is("PAYOUT_CREATED"));
+        assertThat(payoutEvent.getResourceExternalId(), is("po_123"));
+        assertThat(payoutEvent.getResourceType(), is(PAYOUT));
+        assertThat(details.getAmount(), is(1213L));
+        assertThat(details.getGatewayStatus(), is("pending"));
+    }
+
+    @Test
+    public void emitPayoutEventShouldEmitEventIfFeatureFlagToEmitEventsIsEnabled() throws QueueException {
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, "connect-account", payout);
+        verify(mockEventService).emitEvent(any(), anyBoolean());
+    }
+
+    @Test
+    public void emitPayoutEventShouldNotEmitEventIfFeatureFlagToEmitEventsIsDisabled() throws QueueException {
+        when(mockConnectorConfiguration.getEmitPayoutEvents()).thenReturn(false);
+        payoutEmitterService = new PayoutEmitterService(mockEventService, mockConnectorConfiguration);
+
+        payoutEmitterService.emitPayoutEvent(PayoutCreated.class, null, payout);
+        verify(mockEventService, never()).emitEvent(any(), anyBoolean());
+    }
+
+    @Test
+    public void emitPayoutEventShouldNotEmitEventForAnUnknownPayoutEvent() throws QueueException {
+        payoutEmitterService.emitPayoutEvent(PayoutEvent.class, null, payout);
+        verify(mockEventService, never()).emitEvent(any(), anyBoolean());
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Sends PayoutCreated event to payment event queue behind a feature flag.
- Added `PayoutEmitterService` to process payout related events and emit the same to queue which also limits StripeNotificationService responsibilities
- Refactored EventService so upstream services can emitEvents with a choice of handling queue exceptions themselves or ignoring the same.
  Queue exceptions can be ignored if retrying events is not possible.
