### PR TITLE
PP-6472 Emit events for transactions included in payout

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/TransactionIncludedInPayoutEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/TransactionIncludedInPayoutEventDetails.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.events.eventdetails;
+
+import java.util.Objects;
+
+public class TransactionIncludedInPayoutEventDetails extends EventDetails {
+    private final String gatewayPayoutId;
+
+    public TransactionIncludedInPayoutEventDetails(String gatewayPayoutId) {
+        this.gatewayPayoutId = gatewayPayoutId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TransactionIncludedInPayoutEventDetails that = (TransactionIncludedInPayoutEventDetails) o;
+        return Objects.equals(gatewayPayoutId, that.gatewayPayoutId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(gatewayPayoutId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayout.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayout.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.events.eventdetails.TransactionIncludedInPayoutEventDetails;
+
+import java.time.ZonedDateTime;
+
+public class PaymentIncludedInPayout extends PaymentEvent {
+    public PaymentIncludedInPayout(String paymentExternalId, String gatewayPayoutId, ZonedDateTime payoutCreatedDate) {
+        super(paymentExternalId, new TransactionIncludedInPayoutEventDetails(gatewayPayoutId), payoutCreatedDate);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
@@ -15,6 +15,10 @@ public abstract class RefundEvent extends Event {
         this.parentResourceExternalId = parentResourceExternalId;
     }
 
+    public RefundEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+    }
+
     public RefundEvent(String resourceExternalId, String parentResourceExternalId, ZonedDateTime timestamp) {
         super(resourceExternalId, timestamp);
         this.parentResourceExternalId = parentResourceExternalId;

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayout.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayout.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import uk.gov.pay.connector.events.eventdetails.TransactionIncludedInPayoutEventDetails;
+
+import java.time.ZonedDateTime;
+
+public class RefundIncludedInPayout extends RefundEvent {
+    public RefundIncludedInPayout(String refundExternalId, String gatewayPayoutId, ZonedDateTime payoutCreatedDate) {
+        super(refundExternalId, new TransactionIncludedInPayoutEventDetails(gatewayPayoutId), payoutCreatedDate);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -1,19 +1,26 @@
 package uk.gov.pay.connector.payout;
 
+import com.stripe.exception.StripeException;
 import com.stripe.model.BalanceTransaction;
 import com.stripe.model.Charge;
 import com.stripe.model.Transfer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.model.charge.PaymentIncludedInPayout;
+import uk.gov.pay.connector.events.model.refund.RefundIncludedInPayout;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
+import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
 import uk.gov.pay.connector.queue.payout.Payout;
 import uk.gov.pay.connector.queue.payout.PayoutReconcileMessage;
@@ -21,13 +28,18 @@ import uk.gov.pay.connector.queue.payout.PayoutReconcileQueue;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadata.GOVUK_PAY_TRANSACTION_EXTERNAL_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -41,63 +53,71 @@ public class PayoutReconcileProcessTest {
 
     @Mock
     private StripeGatewayConfig stripeGatewayConfig;
+    
+    @Mock
+    private ConnectorConfiguration connectorConfiguration;
 
     @Mock
     private StripeAuthTokens stripeAuthTokens;
 
     @Mock
     private GatewayAccountDao gatewayAccountDao;
+    
+    @Mock
+    private EventService eventService;
 
     @InjectMocks
     private PayoutReconcileProcess payoutReconcileProcess;
 
     private final String stripeAccountId = "acct_2RDpWRLXEC2XwBWp";
     private final String stripeApiKey = "a-fake-api-key";
+    private final String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
+    private final ZonedDateTime payoutCreatedDate = ZonedDateTime.parse("2020-05-01T10:30:00.000Z");
+    private final String paymentExternalId = "payment-id";
+    private final String refundExternalId = "refund-id";
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
         GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(GatewayAccountEntity.Type.TEST).build();
         when(gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID_KEY, stripeAccountId))
                 .thenReturn(Optional.of(gatewayAccountEntity));
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeAuthTokens.getTest()).thenReturn(stripeApiKey);
+
+        setupMockBalanceTransactions();
     }
 
     @Test
-    public void shouldMarkMessageAsProcessedIfPayoutIsProcessedSuccessfully() throws Exception {
-        String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
-        Payout payout = new Payout(payoutId, stripeAccountId, ZonedDateTime.parse("2020-05-01T10:30:00.000Z"));
-        QueueMessage mockQueueMessage = mock(QueueMessage.class);
-        PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
-        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
+    public void shouldEmitEventsForMessageAndMarkAsProcessed() throws Exception {
+        when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
 
-        BalanceTransaction paymentBalanceTransaction = mock(BalanceTransaction.class);
-        Charge paymentSource = mock(Charge.class);
-        Transfer paymentTransferSource = mock(Transfer.class);
-        when(paymentBalanceTransaction.getType()).thenReturn("payment");
-        when(paymentBalanceTransaction.getSourceObject()).thenReturn(paymentSource);
-        when(paymentSource.getSourceTransferObject()).thenReturn(paymentTransferSource);
-        when(paymentTransferSource.getTransferGroup()).thenReturn("payment-id");
-
-        BalanceTransaction refundBalanceTransaction = mock(BalanceTransaction.class);
-        when(refundBalanceTransaction.getType()).thenReturn("transfer");
-        when(refundBalanceTransaction.getSource()).thenReturn("refund-transfer-id");
-
-        when(stripeClientWrapper.getBalanceTransactionsForPayout(eq(payoutId), eq(stripeAccountId), eq(stripeApiKey)))
-                .thenReturn(List.of(paymentBalanceTransaction, refundBalanceTransaction));
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
 
         payoutReconcileProcess.processPayouts();
+        
+        var paymentEvent = new PaymentIncludedInPayout(paymentExternalId, payoutId, payoutCreatedDate);
+        var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate);
+        
+        verify(eventService).emitEvent(eq(paymentEvent), eq(false));
+        verify(eventService).emitEvent(eq(refundEvent), eq(false));
+        verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
+    }
 
+    @Test
+    public void shouldNotEmitEventsIfConnectorConfigurationDisabled() throws Exception {
+        when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(false);
+
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
+
+        payoutReconcileProcess.processPayouts();
+        
+        verify(eventService, never()).emitEvent(any(), anyBoolean());
         verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
 
     @Test
     public void shouldNotMarkMessageAsSuccessfullyProcessedIfNoPaymentsOrRefundsFound() throws Exception {
-        String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
-        Payout payout = new Payout(payoutId, stripeAccountId, ZonedDateTime.parse("2020-05-01T10:30:00.000Z"));
-        QueueMessage mockQueueMessage = mock(QueueMessage.class);
-        PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
-        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
 
         when(stripeClientWrapper.getBalanceTransactionsForPayout(eq(payoutId), eq(stripeAccountId), eq(stripeApiKey)))
                 .thenReturn(List.of());
@@ -108,15 +128,51 @@ public class PayoutReconcileProcessTest {
     }
 
     @Test
-    public void shouldNotMarkMessageAsSuccessfullyProcessedIfExceptionThrown() throws Exception {
-        String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
-        Payout payout = new Payout(payoutId, "non-existent-connect-account-id", ZonedDateTime.parse("2020-05-01T10:30:00.000Z"));
-        QueueMessage mockQueueMessage = mock(QueueMessage.class);
-        PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
-        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
+    public void shouldNotMarkMessageAsSuccessfullyProcessedIfGatewayAccountNotFound() throws Exception {
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage("non-existent-connect-account-id");
 
         payoutReconcileProcess.processPayouts();
 
         verify(payoutReconcileQueue, never()).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
+    }
+
+    @Test
+    public void shouldNotMarkMessageAsSuccessfullyProcessedIfEventEmissionFails() throws Exception {
+        when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
+
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
+
+        doThrow(new QueueException()).when(eventService).emitEvent(any(), anyBoolean());
+
+        payoutReconcileProcess.processPayouts();
+
+        verify(payoutReconcileQueue, never()).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
+    }
+
+    private PayoutReconcileMessage setupQueueMessage(String stripeAccountId) throws QueueException {
+        Payout payout = new Payout(payoutId, stripeAccountId, payoutCreatedDate);
+        QueueMessage mockQueueMessage = mock(QueueMessage.class);
+        PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
+        when(payoutReconcileQueue.retrievePayoutMessages()).thenReturn(List.of(payoutReconcileMessage));
+        return payoutReconcileMessage;
+    }
+
+    private void setupMockBalanceTransactions() throws StripeException {
+        BalanceTransaction paymentBalanceTransaction = mock(BalanceTransaction.class);
+        Charge paymentSource = mock(Charge.class);
+        Transfer paymentTransferSource = mock(Transfer.class);
+        when(paymentBalanceTransaction.getType()).thenReturn("payment");
+        when(paymentBalanceTransaction.getSourceObject()).thenReturn(paymentSource);
+        when(paymentSource.getSourceTransferObject()).thenReturn(paymentTransferSource);
+        when(paymentTransferSource.getMetadata()).thenReturn(Map.of(GOVUK_PAY_TRANSACTION_EXTERNAL_ID, paymentExternalId));
+
+        BalanceTransaction refundBalanceTransaction = mock(BalanceTransaction.class);
+        Transfer refundTransferSource = mock(Transfer.class);
+        when(refundBalanceTransaction.getType()).thenReturn("transfer");
+        when(refundBalanceTransaction.getSourceObject()).thenReturn(refundTransferSource);
+        when(refundTransferSource.getMetadata()).thenReturn(Map.of(GOVUK_PAY_TRANSACTION_EXTERNAL_ID, refundExternalId));
+
+        when(stripeClientWrapper.getBalanceTransactionsForPayout(eq(payoutId), eq(stripeAccountId), eq(stripeApiKey)))
+                .thenReturn(List.of(paymentBalanceTransaction, refundBalanceTransaction));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -169,7 +169,7 @@ public class PayoutReconcileProcessTest {
         payoutReconcileProcess.processPayouts();
 
         verify(logAppender).doAppend(loggingEventArgumentCaptor.capture());
-        assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("Error sending event"));
+        assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("Error sending PAYMENT_INCLUDED_IN_PAYOUT event"));
 
         verify(payoutReconcileQueue, never()).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
@@ -191,7 +191,7 @@ public class PayoutReconcileProcessTest {
 
         verify(logAppender).doAppend(loggingEventArgumentCaptor.capture());
         assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("Transaction external ID missing in metadata"));
-        
+
         verify(payoutReconcileQueue, never()).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
 


### PR DESCRIPTION
When we process PayoutReconcileMessages from the SQS queue, emit events to ledger for each payment and refund included in a payout.

Events we emit are PAYMENT_INCLUDED_IN_PAYOUT and REFUND_INCLUDED_IN_PAYOUT. These both contain a `gateway_payout_id` field.

Only emit events if the feature flag is switched on using the existing EMIT_PAYOUT_EVENTS environment variable.