### PR TITLE
PP-6472 Add pact states for transaction payout events

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/TransactionIncludedInPayoutEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/TransactionIncludedInPayoutEventDetails.java
@@ -9,6 +9,11 @@ public class TransactionIncludedInPayoutEventDetails extends EventDetails {
         this.gatewayPayoutId = gatewayPayoutId;
     }
 
+    // for jackson
+    public String getGatewayPayoutId() {
+        return gatewayPayoutId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayoutTest.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class PaymentIncludedInPayoutTest {
+
+    @Test
+    public void serializesEventDetailsGivenPaymentIncludedInPayoutTest() throws Exception {
+        var paymentExternalId = "payment-id";
+        var gatewayPayoutId = "payout-id";
+        String eventDateStr = "2020-05-10T10:30:00.000000Z";
+        var event = new PaymentIncludedInPayout(paymentExternalId, gatewayPayoutId, ZonedDateTime.parse(eventDateStr));
+        
+        var json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.event_type", equalTo("PAYMENT_INCLUDED_IN_PAYOUT")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(paymentExternalId)));
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(eventDateStr)));
+
+        assertThat(json, hasJsonPath("$.event_details.gateway_payout_id", equalTo(gatewayPayoutId)));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayoutTest.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class RefundIncludedInPayoutTest {
+
+    @Test
+    public void serializesEventDetailsGivenPaymentIncludedInPayoutTest() throws Exception {
+        var paymentExternalId = "payment-id";
+        var gatewayPayoutId = "payout-id";
+        String eventDateStr = "2020-05-10T10:30:00.000000Z";
+        var event = new RefundIncludedInPayout(paymentExternalId, gatewayPayoutId, ZonedDateTime.parse(eventDateStr));
+
+        var json = event.toJsonString();
+
+        assertThat(json, hasJsonPath("$.event_type", equalTo("REFUND_INCLUDED_IN_PAYOUT")));
+        assertThat(json, hasJsonPath("$.resource_type", equalTo("refund")));
+        assertThat(json, hasJsonPath("$.resource_external_id", equalTo(paymentExternalId)));
+        assertThat(json, hasJsonPath("$.timestamp", equalTo(eventDateStr)));
+
+        assertThat(json, hasJsonPath("$.event_details.gateway_payout_id", equalTo(gatewayPayoutId)));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -26,9 +26,11 @@ import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
+import uk.gov.pay.connector.events.model.charge.PaymentIncludedInPayout;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 import uk.gov.pay.connector.events.model.payout.PayoutCreated;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
+import uk.gov.pay.connector.events.model.refund.RefundIncludedInPayout;
 import uk.gov.pay.connector.events.model.refund.RefundSubmitted;
 import uk.gov.pay.connector.events.model.refund.RefundSucceeded;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
@@ -189,5 +191,19 @@ public class QueueMessageContractTest {
         PayoutCreated payoutCreated = from(123456789L, payout);
 
         return payoutCreated.toJsonString();
+    }
+    
+    @PactVerifyProvider("a payment included in payout message")
+    public String verifyPaymentIncludedInPayoutEvent() throws JsonProcessingException {
+        PaymentIncludedInPayout event = new PaymentIncludedInPayout(resourceId, "po_1234567890", ZonedDateTime.now());
+        
+        return event.toJsonString();
+    }
+
+    @PactVerifyProvider("a refund included in payout message")
+    public String verifyRefundIncludedInPayoutEvent() throws JsonProcessingException {
+        RefundIncludedInPayout event = new RefundIncludedInPayout(resourceId, "po_1234567890", ZonedDateTime.now());
+
+        return event.toJsonString();
     }
 }


### PR DESCRIPTION
2 small things in the same PR to save time:

-  Add provider states for PAYMENT_INCLUDED_IN_PAYOUT and REFUND_INCLUDED_IN_PAYOUT events.

- Add a public getter on the event details class for the PAYMENT_INCLUDED_IN_PAYOUT and REFUND_INCLUDED_IN_PAYOUT events so that the eventDetails are serialized.
