### PR TITLE
BAU — Simply method to check if card brand requires 3DS

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -133,11 +133,7 @@ public class CardAuthoriseService {
     }
 
     private boolean cardBrandRequires3ds(String cardBrand) {
-        List<CardTypeEntity> cardTypes = cardTypeDao.findByBrand(cardBrand).stream()
-                .filter(cardTypeEntity -> cardTypeEntity.getBrand().equals(cardBrand))
-                .collect(Collectors.toList());
-
-        return cardTypes.stream().anyMatch(CardTypeEntity::isRequires3ds);
+        return cardTypeDao.findByBrand(cardBrand).stream().anyMatch(CardTypeEntity::isRequires3ds);
     }
 
     private GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, AuthCardDetails authCardDetails) throws GatewayException {


### PR DESCRIPTION
- Remove code that filters all returned `CardBrandEntity` objects so that we’re only left with ones where the brand matches the argument: the DAO already does this for us.
- Don’t unnecessarily collect the stream into a list only to immediately create another stream from that.