### PR TITLE
PP-6564 refactor emitting payout event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -136,16 +136,16 @@ public class StripeNotificationService {
             if (PAYOUT_CREATED.equals(stripeNotificationType)) {
                 Payout payout = new Payout(stripePayout.getId(), notification.getAccount(), stripePayout.getCreated());
                 sendToPayoutReconcileQueue(notification.getAccount(), payout);
-            }
-
-            Optional<Class<? extends PayoutEvent>> mayBeEventClass = stripeNotificationType.getEventClass();
-
-            if (mayBeEventClass.isEmpty()) {
-                logger.warn("Event class is not assigned for Stripe payout type [{}] - payout [{}]",
-                        notification.getType(), stripePayout.getId());
             } else {
-                payoutEmitterService.emitPayoutEvent(mayBeEventClass.get(), notification.getCreated(),
-                        notification.getAccount(), stripePayout);
+                Optional<Class<? extends PayoutEvent>> mayBeEventClass = stripeNotificationType.getEventClass();
+
+                if (mayBeEventClass.isEmpty()) {
+                    logger.warn("Event class is not assigned for Stripe payout type [{}] - payout [{}]",
+                            notification.getType(), stripePayout.getId());
+                } else {
+                    payoutEmitterService.emitPayoutEvent(mayBeEventClass.get(), notification.getCreated(),
+                            notification.getAccount(), stripePayout);
+                }
             }
         } catch (StripeParseException e) {
             logger.error("{} payout notification parsing failed for connect account [{}]: {}",

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.stripe.json;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.stripe.model.Payout;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -42,6 +43,13 @@ public class StripePayout {
         this.failureCode = failureCode;
         this.failureBalanceTransaction = failureBalanceTransaction;
         this.failureMessage = failureMessage;
+    }
+
+    public static StripePayout from(Payout payoutObject) {
+        return new StripePayout(payoutObject.getId(), payoutObject.getAmount(),
+                payoutObject.getArrivalDate(), payoutObject.getCreated(),
+                payoutObject.getStatus(), payoutObject.getType(),
+                payoutObject.getStatementDescriptor());
     }
 
     public String getId() {

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -159,6 +159,8 @@ public class StripeNotificationServiceTest {
                 "evt_id", PAYOUT_CREATED);
         notificationService.handleNotificationFor(payload, signPayload(payload));
 
+        verify(mockPayoutEmitterService, never()).emitPayoutEvent(any(), any(), any(), any());
+
         verify(mockPayoutReconcileQueue).sendPayout(payoutArgumentCaptor.capture());
         Payout payout = payoutArgumentCaptor.getValue();
         assertThat(payout.getGatewayPayoutId(), is("po_aaaaaaaaaaaaaaaaaaaaa"));
@@ -167,8 +169,8 @@ public class StripeNotificationServiceTest {
     }
 
     @Test
-    public void shouldSendAllPayoutEventsToEventQueue() {
-        List<String> types = List.of("payout.created", "payout.updated", "payout.paid", "payout.failed");
+    public void shouldSendAllExceptPayoutCreatedEventToEventQueue() {
+        List<String> types = List.of("payout.updated", "payout.paid", "payout.failed");
         StripePayout payout = new StripePayout("po_aaaaaaaaaaaaaaaaaaaaa", 1337702L, 1585094400L,
                 1585013446L, "in_transit", "bank_account", null);
 


### PR DESCRIPTION
## WHAT
- refactor PayoutReconcileProcess, add emitPayoutCreatedEvent method
- refactor PayoutEmitterService, extend sendToEventQueue method to
  include connect account
- refactor log messages to a more meaningful logline
- refactor StripeNotificationService to handle missing event class
- refactor StripePayout, add from Payout method
- add/refactor relevant tests

authors: @sandorarpa, @kbottla
