### PR TITLE
PP-6564 Emit additional payout events for payouts with terminal status

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
@@ -46,10 +46,15 @@ public class StripePayout {
     }
 
     public static StripePayout from(Payout payoutObject) {
-        return new StripePayout(payoutObject.getId(), payoutObject.getAmount(),
+        StripePayout stripePayout = new StripePayout(payoutObject.getId(), payoutObject.getAmount(),
                 payoutObject.getArrivalDate(), payoutObject.getCreated(),
                 payoutObject.getStatus(), payoutObject.getType(),
                 payoutObject.getStatementDescriptor());
+        stripePayout.failureMessage = payoutObject.getFailureMessage();
+        stripePayout.failureCode = payoutObject.getFailureCode();
+        stripePayout.failureBalanceTransaction = payoutObject.getFailureBalanceTransaction();
+
+        return stripePayout;
     }
 
     public String getId() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatus.java
@@ -1,0 +1,53 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.events.model.payout.PayoutEvent;
+import uk.gov.pay.connector.events.model.payout.PayoutFailed;
+import uk.gov.pay.connector.events.model.payout.PayoutPaid;
+
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+public enum StripePayoutStatus {
+    PENDING("pending", false),
+    IN_TRANSIT("in_transit", false),
+    CANCELLED("canceled", true),
+    PAID("paid", true, PayoutPaid.class),
+    FAILED("failed", true, PayoutFailed.class);
+
+    private final String status;
+    private final boolean isTerminal;
+    private final Class<? extends PayoutEvent> eventClass;
+
+    StripePayoutStatus(final String status, boolean isTerminal) {
+        this(status, isTerminal, null);
+    }
+
+    <T extends PayoutEvent> StripePayoutStatus(final String status, boolean isTerminal, Class<T> eventClass) {
+        this.status = status;
+        this.eventClass = eventClass;
+        this.isTerminal = isTerminal;
+    }
+
+    public static StripePayoutStatus fromString(String status) {
+        for (StripePayoutStatus stat : values()) {
+            if (StringUtils.equals(stat.getStatus(), status)) {
+                return stat;
+            }
+        }
+        throw new IllegalArgumentException(format("Stripe payout status not recognized: [{}]", status));
+    }
+
+    public Optional<Class<? extends PayoutEvent>> getEventClass() {
+        return Optional.ofNullable(eventClass);
+    }
+
+    public boolean isTerminal() {
+        return isTerminal;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatusTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatusTest.java
@@ -1,0 +1,40 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import org.junit.Test;
+import uk.gov.pay.connector.events.model.payout.PayoutFailed;
+import uk.gov.pay.connector.events.model.payout.PayoutPaid;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.gateway.stripe.json.StripePayoutStatus.CANCELLED;
+import static uk.gov.pay.connector.gateway.stripe.json.StripePayoutStatus.FAILED;
+import static uk.gov.pay.connector.gateway.stripe.json.StripePayoutStatus.IN_TRANSIT;
+import static uk.gov.pay.connector.gateway.stripe.json.StripePayoutStatus.PAID;
+import static uk.gov.pay.connector.gateway.stripe.json.StripePayoutStatus.PENDING;
+
+public class StripePayoutStatusTest {
+
+    @Test
+    public void shouldHaveCorrectEventClassAndTerminalStatusAssignedToPayoutStatus() {
+        assertThat(PENDING.getEventClass().isPresent(), is(false));
+        assertThat(IN_TRANSIT.getEventClass().isPresent(), is(false));
+        assertThat(CANCELLED.getEventClass().isPresent(), is(false));
+
+        assertThat(PAID.getEventClass().get(), is(PayoutPaid.class));
+        assertThat(PAID.isTerminal(), is(true));
+        assertThat(FAILED.getEventClass().get(), is(PayoutFailed.class));
+        assertThat(FAILED.isTerminal(), is(true));
+    }
+
+    @Test
+    public void fromStringShouldReturnCorrectStripePayoutStatus() {
+        StripePayoutStatus stripePayoutStatus = StripePayoutStatus.fromString("paid");
+
+        assertThat(stripePayoutStatus, is(PAID));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromStringShouldThrowExceptionForInvalidPayoutStatus() {
+        StripePayoutStatus.fromString("unknown");
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- StripeNotificationService emits all (except PAYOUT_CREATED) payout events to payment event queue as soon as webhook notification is received from Stripe. So if for any reason event cannot be emitted StripeNotificationService, a webhook need to be triggered manually from Stripe dashboard.
- This change adds a mechanism to also emit additional events (when emitting PAYOUT_CREATED event) if payout status is terminal.
  So instead of using Stripe dashboard to resend notifications, we can emit an event to
  PayoutReconcileQueue which will complete the payout lifecycle (with emitting additional payout events) in ledger