### PR TITLE
PP-6145 Bump fixed stripe API version to 2020-03-02

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -15,7 +15,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 
 public class AuthUtil {
     private static final String STRIPE_VERSION_HEADER = "Stripe-Version";
-    private static final String STRIPE_API_VERSION = "2019-05-16";
+    private static final String STRIPE_API_VERSION = "2020-03-02";
 
     private static String encode(String username, String password) {
         return "Basic " + Base64.getEncoder().encodeToString(new String(username + ":" + password).getBytes());


### PR DESCRIPTION
The stripe account and API structures have undergone changes as
specified in the referenced Jira ticket. Bump our fixed payment
processing API version to make sure we aren't using outdated flows.

No major changes to the charge creation/ payment intent API should be
included in the version bump but the change should be verified in
staging environments before going to production.