### PR TITLE
PP-6671 ePDQ 3DS2: send default browser data if provided too long

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
@@ -31,9 +31,14 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
     public final static String ECOM_BILLTO_POSTAL_COUNTRYCODE = "ECOM_BILLTO_POSTAL_COUNTRYCODE";
     public final static String ECOM_BILLTO_POSTAL_POSTALCODE = "ECOM_BILLTO_POSTAL_POSTALCODE";
     public final static String REMOTE_ADDR = "REMOTE_ADDR";
+
     public final static String DEFAULT_BROWSER_COLOR_DEPTH = "24";
     public final static String DEFAULT_BROWSER_SCREEN_HEIGHT = "480";
     public final static String DEFAULT_BROWSER_SCREEN_WIDTH = "320";
+
+    public static final int BROWSER_ACCEPT_MAX_LENGTH = 2048;
+    public static final int BROWSER_USER_AGENT_MAX_LENGTH = 2048;
+    public static final int BROWSER_LANGUAGE_MAX_LENGTH = 8;
     
     private final static Pattern NUMBER_FROM_0_TO_999999 = Pattern.compile("0|[1-9][0-9]{0,5}");
     private final static Pattern NUMBER_FROM_MINUS_999_TO_999 = Pattern.compile("-[1-9][0-9]{0,2}|0|[1-9][0-9]{0,2}");
@@ -82,7 +87,7 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
                 .map(Integer::parseInt)
                 .filter(timezoneOffsetMins -> timezoneOffsetMins >= -840 && timezoneOffsetMins <= 720)
                 .map(timezoneOffsetMins -> Integer.toString(timezoneOffsetMins))
-                .orElseGet(() -> getDefaultBrowserOffsetInMinutes());
+                .orElseGet(this::getDefaultBrowserOffsetInMinutes);
     }
 
     private String getBrowserScreenWidth(EpdqTemplateData templateData) {
@@ -109,6 +114,7 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
                 .getJsNavigatorLanguage()
                 .map(Locale::forLanguageTag)
                 .map(Locale::toLanguageTag)
+                .filter(languageTag -> languageTag.length() <= BROWSER_LANGUAGE_MAX_LENGTH)
                 .orElse(getDefaultBrowserLanguage());
     }
 
@@ -132,10 +138,12 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
     }
     
     String getBrowserAcceptHeader(EpdqTemplateData templateData) {
-        return super.getBrowserAcceptHeader(templateData);
+        String acceptHeader = super.getBrowserAcceptHeader(templateData);
+        return acceptHeader.length() > BROWSER_ACCEPT_MAX_LENGTH ? DEFAULT_BROWSER_ACCEPT_HEADER : acceptHeader;
     }
 
     String getBrowserUserAgent(EpdqTemplateData templateData) {
-        return super.getBrowserUserAgent(templateData);
+        String userAgent = super.getBrowserUserAgent(templateData);
+        return userAgent.length() > BROWSER_USER_AGENT_MAX_LENGTH ? DEFAULT_BROWSER_USER_AGENT : userAgent;
     }
 }


### PR DESCRIPTION
When sending an authorisation request for a 3DS2 payment to ePDQ, don’t exceed the character limits of the `browserAcceptHeader`, `browserLanguage` and `browserUserAgent` parameters of 2048, 8 and 2048 characters respectively because ePDQ seems to enforce these limits for `browserAcceptHeader` and `browserUserAgent`, causing
failures (the limit doesn’t seem to be enforced for `browserLanguage` but let’s enforce the limit there too in case it starts being enforced in the future).

Where the provided data exceeds the limit, send the existing default value we use if the data isn’t provided i.e. `*/*` for `browserAcceptHeader`, `en-GB` or `cy` for `browserLanguage` (depending on the language of the payment) and `Mozilla/5.0` for `browserUserAgent`.

For the `browserAcceptHeader`, we could try to do something fancy like remove content types with lower `q` values until we get under limit but this is a lot of effort for an edge case and would violate ePDQ’s requirement to send the exact value of the HTTP Accept header. Similarly, we could trim subtags from the `browserLanguage` but again this would be a lot of effort for an edge case.

Don’t enforce the limits for the `HTTP_ACCEPT` and `HTTP_USER_AGENT` parameters (sent for both 3DS1 and 3DS2 authorisations), which normally match the `browserAcceptHeader` and `browserUserAgent` parameters respectively, because the limits don’t seem to be enforced there. While this creates an inconsistency, ePDQ’s docs suggest that `HTTP_ACCEPT `and `HTTP_USER_AGENT` are used to determine if the user’s browser is compatible with issuer identification system, so we want them to be accurate rather than defaults.