### PR TITLE
PP-6671 Do not send ePDQ 3DS2 address data that exceeds limits

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
@@ -39,7 +39,12 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
     public static final int BROWSER_ACCEPT_MAX_LENGTH = 2048;
     public static final int BROWSER_USER_AGENT_MAX_LENGTH = 2048;
     public static final int BROWSER_LANGUAGE_MAX_LENGTH = 8;
-    
+    public static final int ECOM_BILLTO_POSTAL_CITY_MAX_LENGTH = 25;
+    public static final int ECOM_BILLTO_POSTAL_COUNTRYCODE_MAX_LENGTH = 2;
+    public static final int ECOM_BILLTO_POSTAL_STREET_LINE1_MAX_LENGTH = 35;
+    public static final int ECOM_BILLTO_POSTAL_STREET_LINE2_MAX_LENGTH = 35;
+    public static final int ECOM_BILLTO_POSTAL_POSTALCODE_MAX_LENGTH = 25;
+
     private final static Pattern NUMBER_FROM_0_TO_999999 = Pattern.compile("0|[1-9][0-9]{0,5}");
     private final static Pattern NUMBER_FROM_MINUS_999_TO_999 = Pattern.compile("-[1-9][0-9]{0,2}|0|[1-9][0-9]{0,2}");
     private final static Set<String> VALID_SCREEN_COLOR_DEPTHS = Set.of("1", "2", "4", "8", "15", "16", "24", "32");
@@ -67,13 +72,27 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
                 .add(BROWSER_ACCEPT_HEADER, getBrowserAcceptHeader(templateData))
                 .add(BROWSER_USER_AGENT, getBrowserUserAgent(templateData))
                 .add(BROWSER_JAVA_ENABLED, "false");
-        
-        templateData.getAuthCardDetails().getAddress().map(Address::getCity).ifPresent(city -> parameterBuilder.add(ECOM_BILLTO_POSTAL_CITY, city));
-        templateData.getAuthCardDetails().getAddress().map(Address::getCountry).ifPresent(country -> parameterBuilder.add(ECOM_BILLTO_POSTAL_COUNTRYCODE, country));
-        templateData.getAuthCardDetails().getAddress().map(Address::getLine1).ifPresent(addressLine1 -> parameterBuilder.add(ECOM_BILLTO_POSTAL_STREET_LINE1, addressLine1));
-        templateData.getAuthCardDetails().getAddress().map(Address::getLine2).ifPresent(addressLine2 -> parameterBuilder.add(ECOM_BILLTO_POSTAL_STREET_LINE2, addressLine2));
-        templateData.getAuthCardDetails().getAddress().map(Address::getPostcode).ifPresent(addressPostCode -> parameterBuilder.add(ECOM_BILLTO_POSTAL_POSTALCODE, addressPostCode));
-        
+
+        templateData.getAuthCardDetails().getAddress().map(Address::getCity)
+                .filter(city -> city.length() <= ECOM_BILLTO_POSTAL_CITY_MAX_LENGTH)
+                .ifPresent(city -> parameterBuilder.add(ECOM_BILLTO_POSTAL_CITY, city));
+
+        templateData.getAuthCardDetails().getAddress().map(Address::getCountry)
+                .filter(country -> country.length() <= ECOM_BILLTO_POSTAL_COUNTRYCODE_MAX_LENGTH)
+                .ifPresent(country -> parameterBuilder.add(ECOM_BILLTO_POSTAL_COUNTRYCODE, country));
+
+        templateData.getAuthCardDetails().getAddress().map(Address::getLine1)
+                .filter(addressLine1 -> addressLine1.length() <= ECOM_BILLTO_POSTAL_STREET_LINE1_MAX_LENGTH)
+                .ifPresent(addressLine1 -> parameterBuilder.add(ECOM_BILLTO_POSTAL_STREET_LINE1, addressLine1));
+
+        templateData.getAuthCardDetails().getAddress().map(Address::getLine2)
+                .filter(addressLine2 -> addressLine2.length() <= ECOM_BILLTO_POSTAL_STREET_LINE2_MAX_LENGTH)
+                .ifPresent(addressLine2 -> parameterBuilder.add(ECOM_BILLTO_POSTAL_STREET_LINE2, addressLine2));
+
+        templateData.getAuthCardDetails().getAddress().map(Address::getPostcode)
+                .filter(addressPostCode -> addressPostCode.length() <= ECOM_BILLTO_POSTAL_POSTALCODE_MAX_LENGTH)
+                .ifPresent(addressPostCode -> parameterBuilder.add(ECOM_BILLTO_POSTAL_POSTALCODE, addressPostCode));
+
         if (sendPayerIpAddressToGateway) {
             templateData.getAuthCardDetails().getIpAddress().ifPresent(ipAddress -> parameterBuilder.add(REMOTE_ADDR, ipAddress));
         }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -39,6 +40,11 @@ import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionFor
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.DEFAULT_BROWSER_COLOR_DEPTH;
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.DEFAULT_BROWSER_SCREEN_HEIGHT;
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.DEFAULT_BROWSER_SCREEN_WIDTH;
+import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_CITY_MAX_LENGTH;
+import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_COUNTRYCODE_MAX_LENGTH;
+import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE_MAX_LENGTH;
+import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE1_MAX_LENGTH;
+import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE2_MAX_LENGTH;
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3ds2OrderTest.ParameterBuilder.aParameterBuilder;
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3dsOrder.ACCEPTURL_KEY;
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3dsOrder.DECLINEURL_KEY;
@@ -310,6 +316,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     }
 
     @Test
+    public void should_not_include_ECOM_BILLTO_POSTAL_CITY_if_city_too_long() {
+        address.setCity(randomAlphabetic(ECOM_BILLTO_POSTAL_CITY_MAX_LENGTH + 1));
+        authCardDetails.setAddress(address);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_CITY)));
+    }
+
+    @Test
     public void should_include_ECOM_ECOM_BILLTO_POSTAL_COUNTRYCODE_if_country_provided() {
         address.setCountry(ADDRESS_COUNTRY);
         authCardDetails.setAddress(address);
@@ -319,6 +333,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
 
     @Test
     public void should_not_include_ECOM_BILLTO_POSTAL_COUNTRYCODE_if_country_not_provided() {
+        authCardDetails.setAddress(address);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_COUNTRYCODE)));
+    }
+
+    @Test
+    public void should_not_include_ECOM_BILLTO_POSTAL_COUNTRYCODE_if_country_too_long() {
+        address.setLine2(randomAlphabetic( ECOM_BILLTO_POSTAL_COUNTRYCODE_MAX_LENGTH + 1));
         authCardDetails.setAddress(address);
         List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_COUNTRYCODE)));
@@ -340,6 +362,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     }
 
     @Test
+    public void should_not_include_ECOM_BILLTO_POSTAL_STREET_LINE1_if_address_line1_too_long() {
+        address.setLine1(randomAlphanumeric(ECOM_BILLTO_POSTAL_STREET_LINE1_MAX_LENGTH + 1));
+        authCardDetails.setAddress(address);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE1)));
+    }
+
+    @Test
     public void should_include_ECOM_ECOM_BILLTO_POSTAL_STREET_LINE_2_if_address_line2_provided() {
         address.setLine2(ADDRESS_LINE_2);
         authCardDetails.setAddress(address);
@@ -353,7 +383,15 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
         List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE2)));
     }
-    
+
+    @Test
+    public void should_not_include_ECOM_BILLTO_POSTAL_STREET_LINE2_if_address_line2_too_long() {
+        address.setLine2(randomAlphanumeric(ECOM_BILLTO_POSTAL_STREET_LINE2_MAX_LENGTH + 1));
+        authCardDetails.setAddress(address);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE2)));
+    }
+
     @Test
     public void should_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_provided() {
         address.setPostcode(ADDRESS_POSTCODE);
@@ -364,6 +402,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
 
     @Test
     public void should_not_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_not_provided() {
+        authCardDetails.setAddress(address);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE)));
+    }
+
+    @Test
+    public void should_not_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_too_long() {
+        address.setPostcode(randomAlphanumeric(ECOM_BILLTO_POSTAL_POSTALCODE_MAX_LENGTH + 1));
         authCardDetails.setAddress(address);
         List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE)));


### PR DESCRIPTION
Do not send `ECOM_BILLTO_POSTAL_STREET_LINE1`, `ECOM_BILLTO_POSTAL_STREET_LINE2`, `ECOM_BILLTO_POSTAL_CITY`, `ECOM_BILLTO_POSTAL_POSTALCODE` and `ECOM_BILLTO_POSTAL_COUNTRYCODE` parameters to ePDQ when authorising a 3D Secure 2 payment if they exceed ePDQ’s prescribed limits of 35, 35, 25, 10 and 2 characters respectively because some of our own limits our longer than these. Don’t send a parameter at all if its limit is exceeded (these parameters are optional but recommended).

No changes to the equivalent `OWNERADDRESS`, `OWNERTOWN`, `OWNERZIP` and `OWNERCTY` parameters sent to ePDQ for all requests where the user supplies an address because the limits don’t seem to be enforced there and we really don’t want to mess with the user-supplied address we send unless we have to have to. (An exception is the `OWNERZIP` parameter, which holds the postcode and seems to have its 10-character limit enforced, but this already matches our own 10-character limit for the postcode.)

Similarly, the `CN` (cardholder name) parameter we already send for all requests (and is mandated by ePDQ for 3DS2) theoretically has a 35 character limit but it doesn’t seem to be enforced (and neither does the rule that quotes must be avoided) so no changes there.