### PR TITLE
PP-6712 EpdqSha512SignatureGenerator: be smarter with streams

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGenerator.java
@@ -7,10 +7,9 @@ import org.apache.http.message.BasicNameValuePair;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.StringJoiner;
 
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.joining;
 
 public class EpdqSha512SignatureGenerator implements SignatureGenerator {
 
@@ -20,15 +19,14 @@ public class EpdqSha512SignatureGenerator implements SignatureGenerator {
             throw new IllegalArgumentException("Passphrase must not be blank.");
         }
 
-        List<NameValuePair> normalisedParams = params.stream()
+        String stringToBeHashed = params.stream()
                 .filter(param -> StringUtils.isNotEmpty(param.getValue()))
                 .map(param -> new BasicNameValuePair(param.getName().toUpperCase(Locale.ENGLISH), param.getValue()))
-                .sorted(comparing(BasicNameValuePair::getName))
-                .collect(toList());
+                .sorted(comparing(NameValuePair::getName))
+                .map(param -> param.getName() + "=" + param.getValue())
+                .collect(joining(passphrase, "", passphrase));
 
-        StringJoiner input = new StringJoiner(passphrase, "", passphrase);
-        normalisedParams.forEach(param -> input.add(param.getName() + "=" + param.getValue()));
-        return DigestUtils.sha512Hex(input.toString());
+        return DigestUtils.sha512Hex(stringToBeHashed);
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGeneratorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGeneratorTest.java
@@ -8,8 +8,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class EpdqSha512SignatureGeneratorTest {
 


### PR DESCRIPTION
Be smarter with streams in `EpdqSha512SignatureGenerator` to avoid both an intermediate list and an intermediate `StringJoiner`.