### PR TITLE
PP-6712 Make subclasses of EpdqPayloadDefinition not be singletons

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -25,14 +25,10 @@ public class EpdqCaptureHandler implements CaptureHandler {
 
     private final GatewayClient client;
     private final Map<String, String> gatewayUrlMap;
-    private final EpdqPayloadDefinitionForCaptureOrder epdqPayloadDefinitionForCaptureOrder;
 
-    public EpdqCaptureHandler(GatewayClient client, 
-                              Map<String, String> gatewayUrlMap, 
-                              EpdqPayloadDefinitionForCaptureOrder epdqPayloadDefinitionForCaptureOrder) {
+    public EpdqCaptureHandler(GatewayClient client, Map<String, String> gatewayUrlMap) {
         this.client = client;
         this.gatewayUrlMap = gatewayUrlMap;
-        this.epdqPayloadDefinitionForCaptureOrder = epdqPayloadDefinitionForCaptureOrder;
     }
 
     @Override
@@ -58,6 +54,6 @@ public class EpdqCaptureHandler implements CaptureHandler {
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         templateData.setTransactionId(request.getTransactionId());
         
-        return epdqPayloadDefinitionForCaptureOrder.createGatewayOrder(templateData);
+        return new EpdqPayloadDefinitionForCaptureOrder().createGatewayOrder(templateData);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
@@ -2,10 +2,8 @@ package uk.gov.pay.connector.gateway.epdq.payload;
 
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
-import javax.inject.Singleton;
-
-@Singleton
 public class EpdqPayloadDefinitionForRefundOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
+
     @Override
     protected String getOperationType() {
         return "RFD";
@@ -15,4 +13,5 @@ public class EpdqPayloadDefinitionForRefundOrder extends EpdqPayloadDefinitionFo
     protected OrderRequestType getOrderRequestType() {
         return OrderRequestType.REFUND;
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -17,10 +17,6 @@ import uk.gov.pay.connector.gateway.ClientFactory;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCancelOrder;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCaptureOrder;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNewOrder;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForQueryOrder;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.GatewayError;
@@ -123,10 +119,6 @@ public abstract class BaseEpdqPaymentProviderIT {
                 configuration, 
                 gatewayClientFactory, 
                 environment,
-                new EpdqPayloadDefinitionForCancelOrder(),
-                new EpdqPayloadDefinitionForCaptureOrder(),
-                new EpdqPayloadDefinitionForNewOrder(),
-                new EpdqPayloadDefinitionForQueryOrder(),
                 Clock.fixed(Instant.parse("2020-01-01T10:10:10.100Z"), ZoneOffset.UTC));
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -12,7 +12,6 @@ import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCaptureOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
@@ -26,13 +25,13 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
-import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -47,7 +46,7 @@ public class EpdqCaptureHandlerTest {
 
     @Before
     public void setup() {
-        epdqCaptureHandler = new EpdqCaptureHandler(client, emptyMap(), new EpdqPayloadDefinitionForCaptureOrder());
+        epdqCaptureHandler = new EpdqCaptureHandler(client, emptyMap());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -27,10 +27,6 @@ import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCancelOrder;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForCaptureOrder;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNewOrder;
-import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForQueryOrder;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
@@ -137,10 +133,6 @@ public class EpdqPaymentProviderTest {
                 mockConnectorConfiguration, 
                 mockGatewayClientFactory, 
                 mockEnvironment,
-                new EpdqPayloadDefinitionForCancelOrder(),
-                new EpdqPayloadDefinitionForCaptureOrder(),
-                new EpdqPayloadDefinitionForNewOrder(),
-                new EpdqPayloadDefinitionForQueryOrder(),
                 Clock.fixed(Instant.parse("2020-01-01T10:10:10.100Z"), ZoneOffset.UTC));
     }
 


### PR DESCRIPTION
Make subclasses of `EpdqPayloadDefinition` not be singletons for they will soon hold state (except for
`EpdqPayloadDefinitionForNew3dsOrder` and `EpdqPayloadDefinitionForNew3ds2Order`, which already aren’t singletons and hold state).

Fun fact: despite being annotated with `@Singleton`, `EpdqPayloadDefinitionForRefundOrder` wasn’t a singleton.