### PR TITLE
PP-6712 Make the EpdqTemplateData a field of EpdqPayloadDefinition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -53,7 +53,9 @@ public class EpdqCaptureHandler implements CaptureHandler {
         templateData.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         templateData.setTransactionId(request.getTransactionId());
-        
-        return new EpdqPayloadDefinitionForCaptureOrder().createGatewayOrder(templateData);
+
+        var epdqPayloadDefinitionForCaptureOrder = new EpdqPayloadDefinitionForCaptureOrder();
+        epdqPayloadDefinitionForCaptureOrder.setEpdqTemplateData(templateData);
+        return epdqPayloadDefinitionForCaptureOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -278,7 +278,10 @@ public class EpdqPaymentProvider implements PaymentProvider {
         templateData.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
-        return new EpdqPayloadDefinitionForQueryOrder().createGatewayOrder(templateData);
+
+        var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
+        epdqPayloadDefinitionForQueryOrder.setEpdqTemplateData(templateData);
+        return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
     private GatewayOrder buildQueryOrderRequestFor(ChargeEntity charge) {
@@ -288,7 +291,10 @@ public class EpdqPaymentProvider implements PaymentProvider {
         templateData.setShaInPassphrase(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setUserId(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setMerchantCode(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
-        return new EpdqPayloadDefinitionForQueryOrder().createGatewayOrder(templateData);
+
+        var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
+        epdqPayloadDefinitionForQueryOrder.setEpdqTemplateData(templateData);
+        return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
     private GatewayOrder buildAuthoriseOrder(CardAuthorisationGatewayRequest request, String frontendUrl) {
@@ -314,7 +320,8 @@ public class EpdqPaymentProvider implements PaymentProvider {
             epdqPayloadDefinition = new EpdqPayloadDefinitionForNewOrder();
         }
 
-        return epdqPayloadDefinition.createGatewayOrder(templateData);
+        epdqPayloadDefinition.setEpdqTemplateData(templateData);
+        return epdqPayloadDefinition.createGatewayOrder();
     }
 
     private GatewayOrder buildCancelOrder(CancelGatewayRequest request) {
@@ -328,7 +335,9 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 .ifPresentOrElse(
                         templateData::setTransactionId,
                         () -> templateData.setOrderId(request.getExternalChargeId()));
-        
-        return new EpdqPayloadDefinitionForCancelOrder().createGatewayOrder(templateData);
+
+        var epdqPayloadDefinitionForCancelOrder = new EpdqPayloadDefinitionForCancelOrder();
+        epdqPayloadDefinitionForCancelOrder.setEpdqTemplateData(templateData);
+        return epdqPayloadDefinitionForCancelOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -56,7 +56,9 @@ public class EpdqRefundHandler implements RefundHandler {
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         templateData.setTransactionId(request.getTransactionId());
         templateData.setAmount(request.getAmount());
-        
-        return new EpdqPayloadDefinitionForRefundOrder().createGatewayOrder(templateData);
+
+        var epdqPayloadDefinitionForRefundOrder = new EpdqPayloadDefinitionForRefundOrder();
+        epdqPayloadDefinitionForRefundOrder.setEpdqTemplateData(templateData);
+        return epdqPayloadDefinitionForRefundOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
@@ -28,11 +28,14 @@ public abstract class EpdqPayloadDefinition {
      */
     public static final Charset EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET = Charset.forName("windows-1252");
     
-    protected abstract List<NameValuePair> extract(EpdqTemplateData templateData);
+    protected EpdqTemplateData epdqTemplateData;
 
-    public GatewayOrder createGatewayOrder(EpdqTemplateData templateData) {
+    protected abstract List<NameValuePair> extract();
+
+    public GatewayOrder createGatewayOrder() {
+        EpdqTemplateData templateData = getEpdqTemplateData();
         templateData.setOperationType(getOperationType());
-        ArrayList<NameValuePair> params = new ArrayList<>(extract(templateData));
+        ArrayList<NameValuePair> params = new ArrayList<>(extract());
         String signature = SIGNATURE_GENERATOR.sign(params, templateData.getShaInPassphrase());
         params.add(new BasicNameValuePair("SHASIGN", signature));
         String payload = URLEncodedUtils.format(params, EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET);
@@ -46,4 +49,13 @@ public abstract class EpdqPayloadDefinition {
     protected abstract String getOperationType();
 
     protected abstract OrderRequestType getOrderRequestType();
+
+    public void setEpdqTemplateData(EpdqTemplateData epdqTemplateData) {
+        this.epdqTemplateData = epdqTemplateData;
+    }
+
+    public EpdqTemplateData getEpdqTemplateData() {
+        return epdqTemplateData;
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
@@ -2,10 +2,8 @@ package uk.gov.pay.connector.gateway.epdq.payload;
 
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
-import javax.inject.Singleton;
-
-@Singleton
 public class EpdqPayloadDefinitionForCancelOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
+
     @Override
     protected String getOperationType() {
         return "DES";
@@ -15,4 +13,5 @@ public class EpdqPayloadDefinitionForCancelOrder extends EpdqPayloadDefinitionFo
     protected OrderRequestType getOrderRequestType() {
         return OrderRequestType.CANCEL;
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
@@ -2,10 +2,8 @@ package uk.gov.pay.connector.gateway.epdq.payload;
 
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
-import javax.inject.Singleton;
-
-@Singleton
 public class EpdqPayloadDefinitionForCaptureOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
+
     @Override
     protected String getOperationType() {
         return "SAS";
@@ -15,4 +13,5 @@ public class EpdqPayloadDefinitionForCaptureOrder extends EpdqPayloadDefinitionF
     protected OrderRequestType getOrderRequestType() {
         return OrderRequestType.CAPTURE;
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForMaintenanceOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForMaintenanceOrder.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.epdq.payload;
 
 import org.apache.http.NameValuePair;
-import uk.gov.pay.connector.gateway.epdq.EpdqTemplateData;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,8 +10,8 @@ import static uk.gov.pay.connector.gateway.epdq.payload.EpdqParameterBuilder.new
 public abstract class EpdqPayloadDefinitionForMaintenanceOrder extends EpdqPayloadDefinition {
     
     @Override
-    public List<NameValuePair> extract(EpdqTemplateData templateData) {
-
+    public List<NameValuePair> extract() {
+        var templateData = getEpdqTemplateData();
         EpdqParameterBuilder epdqParameterBuilder = newParameterBuilder();
         Optional.ofNullable(templateData.getAmount()).ifPresent(amount -> epdqParameterBuilder.add("AMOUNT", amount));
         Optional.ofNullable(templateData.getTransactionId()).ifPresent(

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2Order.java
@@ -61,8 +61,9 @@ public class EpdqPayloadDefinitionForNew3ds2Order extends EpdqPayloadDefinitionF
     }
 
     @Override
-    public List<NameValuePair> extract(EpdqTemplateData templateData) {
-        List<NameValuePair> nameValuePairs = super.extract(templateData);
+    public List<NameValuePair> extract() {
+        List<NameValuePair> nameValuePairs = super.extract();
+        var templateData = getEpdqTemplateData();
         EpdqParameterBuilder parameterBuilder = newParameterBuilder(nameValuePairs)
                 .add(BROWSER_COLOR_DEPTH, getBrowserColorDepth(templateData))
                 .add(BROWSER_LANGUAGE, getBrowserLanguage(templateData))

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
@@ -35,7 +35,8 @@ public class EpdqPayloadDefinitionForNew3dsOrder extends EpdqPayloadDefinitionFo
     }
 
     @Override
-    public List<NameValuePair> extract(EpdqTemplateData templateData) {
+    public List<NameValuePair> extract() {
+        var templateData = getEpdqTemplateData();
         templateData.setFrontendUrl(frontendUrl);
         String frontend3dsIncomingUrl = String.format("%s/card_details/%s/3ds_required_in/epdq", templateData.getFrontendUrl(), templateData.getOrderId());
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
@@ -3,15 +3,12 @@ package uk.gov.pay.connector.gateway.epdq.payload;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import uk.gov.pay.connector.common.model.domain.Address;
-import uk.gov.pay.connector.gateway.epdq.EpdqTemplateData;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
-import javax.inject.Singleton;
 import java.util.List;
 
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqParameterBuilder.newParameterBuilder;
 
-@Singleton
 public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
 
     public final static String AMOUNT_KEY = "AMOUNT";
@@ -31,8 +28,8 @@ public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
     public final static String USERID_KEY = "USERID";
 
     @Override
-    public List<NameValuePair> extract(EpdqTemplateData templateData) {
-
+    public List<NameValuePair> extract() {
+        var templateData = getEpdqTemplateData();
         EpdqParameterBuilder epdqParameterBuilder = newParameterBuilder()
                 .add(AMOUNT_KEY, templateData.getAmount())
                 .add(CARD_NO_KEY, templateData.getAuthCardDetails().getCardNo())

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
@@ -1,15 +1,12 @@
 package uk.gov.pay.connector.gateway.epdq.payload;
 
 import org.apache.http.NameValuePair;
-import uk.gov.pay.connector.gateway.epdq.EpdqTemplateData;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 
-import javax.inject.Singleton;
 import java.util.List;
 
 import static uk.gov.pay.connector.gateway.epdq.payload.EpdqParameterBuilder.newParameterBuilder;
 
-@Singleton
 public class EpdqPayloadDefinitionForQueryOrder extends EpdqPayloadDefinition {
     
     public final static String ORDER_ID_KEY = "ORDERID";
@@ -18,7 +15,8 @@ public class EpdqPayloadDefinitionForQueryOrder extends EpdqPayloadDefinition {
     public final static String USERID_KEY = "USERID";
 
     @Override
-    public List<NameValuePair> extract(EpdqTemplateData templateData) {
+    public List<NameValuePair> extract() {
+        var templateData = getEpdqTemplateData();
         return newParameterBuilder()
                 .add(ORDER_ID_KEY, templateData.getOrderId())
                 .add(PSPID_KEY, templateData.getMerchantCode())
@@ -36,4 +34,5 @@ public class EpdqPayloadDefinitionForQueryOrder extends EpdqPayloadDefinition {
     protected OrderRequestType getOrderRequestType() {
         return OrderRequestType.AUTHORISE;
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCancelOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCancelOrderTest.java
@@ -20,7 +20,9 @@ public class EpdqPayloadDefinitionForCancelOrderTest {
         templateData.setMerchantCode("merchant-id");
         templateData.setTransactionId("payId");
 
-        GatewayOrder gatewayOrder = new EpdqPayloadDefinitionForCancelOrder().createGatewayOrder(templateData);
+        var epdqPayloadDefinitionForCancelOrder = new EpdqPayloadDefinitionForCancelOrder();
+        epdqPayloadDefinitionForCancelOrder.setEpdqTemplateData(templateData);
+        GatewayOrder gatewayOrder = epdqPayloadDefinitionForCancelOrder.createGatewayOrder();
         assertEquals(TestTemplateResourceLoader.load(EPDQ_CANCEL_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.CANCEL, gatewayOrder.getOrderRequestType());
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCaptureOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCaptureOrderTest.java
@@ -20,7 +20,10 @@ public class EpdqPayloadDefinitionForCaptureOrderTest {
         templateData.setMerchantCode("merchant-id");
         templateData.setTransactionId("payId");
 
-        GatewayOrder gatewayOrder = new EpdqPayloadDefinitionForCaptureOrder().createGatewayOrder(templateData);
+        var epdqPayloadDefinitionForCaptureOrder = new EpdqPayloadDefinitionForCaptureOrder();
+        epdqPayloadDefinitionForCaptureOrder.setEpdqTemplateData(templateData);
+        GatewayOrder gatewayOrder = epdqPayloadDefinitionForCaptureOrder.createGatewayOrder();
+
         assertEquals(TestTemplateResourceLoader.load(EPDQ_CAPTURE_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.CAPTURE, gatewayOrder.getOrderRequestType());
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForMaintenanceOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForMaintenanceOrderTest.java
@@ -48,7 +48,8 @@ public class EpdqPayloadDefinitionForMaintenanceOrderTest {
     @Test
     public void shouldExtractParametersFromTemplate() {
         Set.of(cancelOrder, captureOrder, refundOrder).forEach(order -> {
-            List<NameValuePair> result = order.extract(epdqTemplateData);
+            order.setEpdqTemplateData(epdqTemplateData);
+            List<NameValuePair> result = order.extract();
             assertThat(result, is(ImmutableList.builder().add(
                     new BasicNameValuePair("AMOUNT", "400"),
                     new BasicNameValuePair("OPERATION", OPERATION_TYPE),
@@ -63,7 +64,8 @@ public class EpdqPayloadDefinitionForMaintenanceOrderTest {
     @Test
     public void testOnlyTransactionIdIsSentIfBothTransactionIdAndOrderIdAvailable() {
         epdqTemplateData.setOrderId("Order-Id");
-        List<NameValuePair> extractPairs = captureOrder.extract(epdqTemplateData);
+        captureOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> extractPairs = captureOrder.extract();
         assertThat(extractPairs, hasItem(new BasicNameValuePair("PAYID", PAY_ID)));
     }
 
@@ -71,7 +73,8 @@ public class EpdqPayloadDefinitionForMaintenanceOrderTest {
     public void testThatOrderIdIsSentIfTransactionIsNotAvailable() {
         epdqTemplateData.setTransactionId(null);
         epdqTemplateData.setOrderId("Order-Id");
-        List<NameValuePair> extractPairs = refundOrder.extract(epdqTemplateData);
+        refundOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> extractPairs = refundOrder.extract();
         assertThat(extractPairs, hasItem(new BasicNameValuePair("ORDERID", "Order-Id")));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
@@ -124,8 +124,9 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
         templateData.setDescription("MyDescription");
         templateData.setAmount("500");
         templateData.setAuthCardDetails(authCardDetails);
-        
-        GatewayOrder gatewayOrder = epdqPayloadDefinitionFor3dsNewOrder.createGatewayOrder(templateData);
+
+        epdqPayloadDefinitionFor3dsNewOrder.setEpdqTemplateData(templateData);
+        GatewayOrder gatewayOrder = epdqPayloadDefinitionFor3dsNewOrder.createGatewayOrder();
         assertEquals(TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_3DS_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.AUTHORISE_3DS, gatewayOrder.getOrderRequestType());
     }
@@ -147,7 +148,8 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
     public void shouldExtractParametersFromTemplateWithOneLineStreetAddress() {
         when(mockAddress.getLine1()).thenReturn(ADDRESS_LINE_1);
 
-        List<NameValuePair> result = epdqPayloadDefinitionFor3dsNewOrder.extract(mockTemplateData);
+        epdqPayloadDefinitionFor3dsNewOrder.setEpdqTemplateData(mockTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3dsNewOrder.extract();
 
         String expectedFrontend3dsIncomingUrl = "http://www.frontend.example.com/card_details/OrderId/3ds_required_in/epdq";
 
@@ -183,7 +185,8 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
         when(mockAddress.getLine1()).thenReturn(ADDRESS_LINE_1);
         when(mockAddress.getLine2()).thenReturn(ADDRESS_LINE_2);
 
-        List<NameValuePair> result = epdqPayloadDefinitionFor3dsNewOrder.extract(mockTemplateData);
+        epdqPayloadDefinitionFor3dsNewOrder.setEpdqTemplateData(mockTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3dsNewOrder.extract();
 
         String expectedFrontend3dsIncomingUrl = "http://www.frontend.example.com/card_details/OrderId/3ds_required_in/epdq";
 
@@ -218,7 +221,8 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
     public void shouldOmitAddressWhenInputAddressIsNotPresent() {
         when(mockAuthCardDetails.getAddress()).thenReturn(Optional.empty());
 
-        List<NameValuePair> result = epdqPayloadDefinitionFor3dsNewOrder.extract(mockTemplateData);
+        epdqPayloadDefinitionFor3dsNewOrder.setEpdqTemplateData(mockTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3dsNewOrder.extract();
 
         String expectedFrontend3dsIncomingUrl = "http://www.frontend.example.com/card_details/OrderId/3ds_required_in/epdq";
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
@@ -109,8 +109,9 @@ public class EpdqPayloadDefinitionForNewOrderTest {
         templateData.setDescription("MyDescription");
         templateData.setAmount("500");
         templateData.setAuthCardDetails(authCardDetails);
-        
-        GatewayOrder gatewayOrder = epdqPayloadDefinitionForNewOrder.createGatewayOrder(templateData);
+
+        epdqPayloadDefinitionForNewOrder.setEpdqTemplateData(templateData);
+        GatewayOrder gatewayOrder = epdqPayloadDefinitionForNewOrder.createGatewayOrder();
         assertEquals(TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.AUTHORISE, gatewayOrder.getOrderRequestType());
     }
@@ -132,7 +133,8 @@ public class EpdqPayloadDefinitionForNewOrderTest {
     public void shouldExtractParametersFromTemplateWithOneLineStreetAddress() {
         when(mockAddress.getLine1()).thenReturn(ADDRESS_LINE_1);
 
-        List<NameValuePair> result = epdqPayloadDefinitionForNewOrder.extract(mockTemplateData);
+        epdqPayloadDefinitionForNewOrder.setEpdqTemplateData(mockTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionForNewOrder.extract();
 
         assertThat(result, is(ImmutableList.builder().add(
                 new BasicNameValuePair(AMOUNT_KEY, AMOUNT),
@@ -158,7 +160,8 @@ public class EpdqPayloadDefinitionForNewOrderTest {
         when(mockAddress.getLine1()).thenReturn(ADDRESS_LINE_1);
         when(mockAddress.getLine2()).thenReturn(ADDRESS_LINE_2);
 
-        List<NameValuePair> result = epdqPayloadDefinitionForNewOrder.extract(mockTemplateData);
+        epdqPayloadDefinitionForNewOrder.setEpdqTemplateData(mockTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionForNewOrder.extract();
 
         assertThat(result, is(ImmutableList.builder().add(
                 new BasicNameValuePair(AMOUNT_KEY, AMOUNT),
@@ -183,7 +186,8 @@ public class EpdqPayloadDefinitionForNewOrderTest {
     public void shouldOmitAddressWhenInputAddressIsNotPresent() {
         when(mockAuthCardDetails.getAddress()).thenReturn(Optional.empty());
 
-        List<NameValuePair> result = epdqPayloadDefinitionForNewOrder.extract(mockTemplateData);
+        epdqPayloadDefinitionForNewOrder.setEpdqTemplateData(mockTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionForNewOrder.extract();
 
         assertThat(result, is(ImmutableList.builder().add(
                 new BasicNameValuePair(AMOUNT_KEY, AMOUNT),

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForRefundOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForRefundOrderTest.java
@@ -21,7 +21,10 @@ public class EpdqPayloadDefinitionForRefundOrderTest {
         templateData.setTransactionId("payId");
         templateData.setAmount("400");
 
-        GatewayOrder gatewayOrder = new EpdqPayloadDefinitionForRefundOrder().createGatewayOrder(templateData);
+        var epdqPayloadDefinitionForRefundOrder = new EpdqPayloadDefinitionForRefundOrder();
+        epdqPayloadDefinitionForRefundOrder.setEpdqTemplateData(templateData);
+        GatewayOrder gatewayOrder = epdqPayloadDefinitionForRefundOrder.createGatewayOrder();
+
         assertEquals(TestTemplateResourceLoader.load(EPDQ_REFUND_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.REFUND, gatewayOrder.getOrderRequestType());
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
@@ -104,6 +104,13 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     
     @Before
     public void setup() {
+        authCardDetails.setCardNo(CARD_NO);
+        authCardDetails.setCvc(CVC);
+        authCardDetails.setEndDate(END_DATE);
+        authCardDetails.setCardHolder(CARDHOLDER_NAME);
+        authCardDetails.setAcceptHeader(ACCEPT_HEADER);
+        authCardDetails.setUserAgentHeader(USER_AGENT_HEADER);
+
         epdqTemplateData.setMerchantCode(PSP_ID);
         epdqTemplateData.setPassword(PASSWORD);
         epdqTemplateData.setUserId(USER_ID);
@@ -112,13 +119,8 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
         epdqTemplateData.setAmount(AMOUNT);
         epdqTemplateData.setFrontendUrl(FRONTEND_URL);
         epdqTemplateData.setAuthCardDetails(authCardDetails);
-        
-        authCardDetails.setCardNo(CARD_NO);
-        authCardDetails.setCvc(CVC);
-        authCardDetails.setEndDate(END_DATE);
-        authCardDetails.setCardHolder(CARDHOLDER_NAME);
-        authCardDetails.setAcceptHeader(ACCEPT_HEADER);
-        authCardDetails.setUserAgentHeader(USER_AGENT_HEADER);
+
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
     }
     
     @After
@@ -135,7 +137,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     @Parameters({"0", "999999", "100"})
     public void should_include_browserScreenHeight(String screenHeight) {
         authCardDetails.setJsScreenHeight(screenHeight);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserScreenHeight(screenHeight).build()));
     }
     
@@ -144,7 +146,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_default_browserScreenHeight_when_screen_height_provided_is_invalid
             (@Nullable String screenHeight) {
         authCardDetails.setJsScreenHeight(screenHeight);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().build()));
     }
 
@@ -152,7 +154,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     @Parameters({"0", "999999", "100"})
     public void should_include_browserScreenWidth(String screenWidth) {
         authCardDetails.setJsScreenWidth(screenWidth);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserScreenWidth(screenWidth).build()));
     }
 
@@ -161,14 +163,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_default_browserScreenWidth_when_screen_width_provided_is_invalid
             (@Nullable String screenWidth) {
         authCardDetails.setJsScreenWidth(screenWidth);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().build()));
     }
     
     @Test
     public void should_include_browserLanguage() {
         authCardDetails.setJsNavigatorLanguage("de");
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserLanguage("de").build()));
     }
 
@@ -177,7 +179,8 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_payment_browserLanguage_if_none_provided(SupportedLanguage language, String expectedBrowserLanguage) {
         var epdqPayloadDefinitionFor3ds2NewOrder = new EpdqPayloadDefinitionForNew3ds2Order(FRONTEND_URL, SEND_PAYER_IP_ADDRESS_TO_GATEWAY, language,
                 BRITISH_SUMMER_TIME_OFFSET_CLOCK);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserLanguage(expectedBrowserLanguage).build()));
     }
 
@@ -187,7 +190,8 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
         var epdqPayloadDefinitionFor3ds2NewOrder = new EpdqPayloadDefinitionForNew3ds2Order(FRONTEND_URL, SEND_PAYER_IP_ADDRESS_TO_GATEWAY, language,
                 BRITISH_SUMMER_TIME_OFFSET_CLOCK);
         authCardDetails.setJsNavigatorLanguage("x-this-is-too-long");
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserLanguage(expectedBrowserLanguage).build()));
     }
 
@@ -195,28 +199,28 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     @Parameters({"1", "2", "4", "8", "15", "16", "24", "32"})
     public void should_include_accepted_browserColorDepths(String colorDepthValue) {
         authCardDetails.setJsScreenColorDepth(colorDepthValue);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(BROWSER_COLOR_DEPTH, colorDepthValue)));
     }
     
     @Test
     public void browserColorDepth_should_default_to_24_if_js_screen_color_depth_not_provided() {
         authCardDetails.setJsScreenColorDepth(null);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(BROWSER_COLOR_DEPTH, "24")));
     }
 
     @Test
     public void browserColorDepth_should_default_to_24_if_js_screen_color_depth_is_not_in_the_range_of_accepted_values() {
         authCardDetails.setJsScreenColorDepth("100");
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(BROWSER_COLOR_DEPTH, "24")));
     }
 
     @Test
     public void should_include_browserColorDepth() {
         authCardDetails.setJsScreenColorDepth("1");
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserColorDepth("1").build()));
     }
 
@@ -224,7 +228,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     @Parameters({"-840", "720", "500"})
     public void should_include_browserTimezoneOffSetMins(String timeZoneOffsetMins) {
         authCardDetails.setJsTimezoneOffsetMins(timeZoneOffsetMins);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserTimezoneOffsetMins(timeZoneOffsetMins).build()));
     }
 
@@ -234,7 +238,8 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
             (@Nullable String timeZoneOffsetMins) {
         var epdqPayloadDefinitionFor3ds2NewOrder = new EpdqPayloadDefinitionForNew3ds2Order(FRONTEND_URL, SEND_PAYER_IP_ADDRESS_TO_GATEWAY, SupportedLanguage.ENGLISH, BRITISH_SUMMER_TIME_OFFSET_CLOCK);
         authCardDetails.setJsTimezoneOffsetMins(timeZoneOffsetMins);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserTimezoneOffsetMins("-60").build()));
     }
 
@@ -244,14 +249,15 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
             (@Nullable String timeZoneOffsetMins) {
         var epdqPayloadDefinitionFor3ds2NewOrder = new EpdqPayloadDefinitionForNew3ds2Order(FRONTEND_URL, SEND_PAYER_IP_ADDRESS_TO_GATEWAY, SupportedLanguage.ENGLISH, GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK);
         authCardDetails.setJsTimezoneOffsetMins(timeZoneOffsetMins);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserTimezoneOffsetMins("0").build()));
     }
 
     @Test
     public void should_include_accepted_browserAcceptHeader() {
         authCardDetails.setAcceptHeader("text/html");
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserAcceptHeader("text/html").build()));
     }
     
@@ -259,7 +265,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     @Parameters({"null", ""})
     public void browserAcceptHeader_should_include_default_if_browser_accept_header_not_provided(@Nullable String browserAcceptHeader) {
         authCardDetails.setAcceptHeader(browserAcceptHeader);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserAcceptHeader(DEFAULT_BROWSER_ACCEPT_HEADER).build()));
     }
 
@@ -267,14 +273,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void browserAcceptHeader_should_include_default_when_browser_accept_header_too_long() {
         var veryLongAcceptHeader = randomAlphanumeric(BROWSER_ACCEPT_MAX_LENGTH + 1);
         authCardDetails.setAcceptHeader(veryLongAcceptHeader);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserAcceptHeader(DEFAULT_BROWSER_ACCEPT_HEADER).build()));
     }
 
     @Test
     public void should_include_provided_userAgentHeader() {
         authCardDetails.setUserAgentHeader("Opera/9.8");
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserUserAgent("Opera/9.8").build()));
     }
     
@@ -282,7 +288,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     @Parameters({"null", ""})
     public void browserUserAgentHeader_should_include_default_if_user_agent_header_not_provided(@Nullable String browserAgentHeader) {
         authCardDetails.setUserAgentHeader(browserAgentHeader);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserUserAgent(DEFAULT_BROWSER_USER_AGENT).build()));
     }
 
@@ -290,13 +296,13 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void browserUserAgentHeader_should_include_default_when_user_agent_header_too_long() {
         var veryLongUserAgentHeader = randomAlphanumeric(BROWSER_USER_AGENT_MAX_LENGTH + 1);
         authCardDetails.setUserAgentHeader(veryLongUserAgentHeader);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserUserAgent(DEFAULT_BROWSER_USER_AGENT).build()));
     }
 
     @Test
     public void should_include_browserJavaEnabled_parameter() {
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, is(aParameterBuilder().withBrowserJavaEnabled("false").build()));
     }
     
@@ -304,14 +310,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_ECOM_BILLTO_POSTAL_CITY_if_city_provided() {
         address.setCity(ADDRESS_CITY);
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_CITY, "London")));
     }
 
     @Test
     public void should_not_include_ECOM_BILLTO_POSTAL_CITY_if_city_not_provided() {
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_CITY)));
     }
 
@@ -319,7 +325,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_not_include_ECOM_BILLTO_POSTAL_CITY_if_city_too_long() {
         address.setCity(randomAlphabetic(ECOM_BILLTO_POSTAL_CITY_MAX_LENGTH + 1));
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_CITY)));
     }
 
@@ -327,14 +333,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_ECOM_ECOM_BILLTO_POSTAL_COUNTRYCODE_if_country_provided() {
         address.setCountry(ADDRESS_COUNTRY);
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_COUNTRYCODE, "GB")));
     }
 
     @Test
     public void should_not_include_ECOM_BILLTO_POSTAL_COUNTRYCODE_if_country_not_provided() {
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_COUNTRYCODE)));
     }
 
@@ -342,7 +348,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_not_include_ECOM_BILLTO_POSTAL_COUNTRYCODE_if_country_too_long() {
         address.setLine2(randomAlphabetic( ECOM_BILLTO_POSTAL_COUNTRYCODE_MAX_LENGTH + 1));
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_COUNTRYCODE)));
     }
 
@@ -350,14 +356,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_ECOM_BILLTO_POSTAL_STREET_LINE1_if_address_line1_provided() {
         address.setLine1(ADDRESS_LINE_1);
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE1, "The Money Pool")));
     }
 
     @Test
     public void should_not_include_ECOM_BILLTO_POSTAL_STREET_LINE1_if_address_line1_not_provided() {
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE1)));
     }
 
@@ -365,7 +371,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_not_include_ECOM_BILLTO_POSTAL_STREET_LINE1_if_address_line1_too_long() {
         address.setLine1(randomAlphanumeric(ECOM_BILLTO_POSTAL_STREET_LINE1_MAX_LENGTH + 1));
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE1)));
     }
 
@@ -373,14 +379,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_ECOM_ECOM_BILLTO_POSTAL_STREET_LINE_2_if_address_line2_provided() {
         address.setLine2(ADDRESS_LINE_2);
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE2, "1 Gold Way")));
     }
 
     @Test
     public void should_not_include_ECOM_ECOM_BILLTO_POSTAL_STREET_LINE_2_if_address_line2_not_provided() {
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE2)));
     }
 
@@ -388,7 +394,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_not_include_ECOM_BILLTO_POSTAL_STREET_LINE2_if_address_line2_too_long() {
         address.setLine2(randomAlphanumeric(ECOM_BILLTO_POSTAL_STREET_LINE2_MAX_LENGTH + 1));
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_STREET_LINE2)));
     }
 
@@ -396,14 +402,14 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_provided() {
         address.setPostcode(ADDRESS_POSTCODE);
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE, "DO11 4RS")));
     }
 
     @Test
     public void should_not_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_not_provided() {
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE)));
     }
 
@@ -411,7 +417,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_not_include_ECOM_BILLTO_POSTAL_POSTALCODE_if_address_postcode_too_long() {
         address.setPostcode(randomAlphanumeric(ECOM_BILLTO_POSTAL_POSTALCODE_MAX_LENGTH + 1));
         authCardDetails.setAddress(address);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.ECOM_BILLTO_POSTAL_POSTALCODE)));
     }
 
@@ -419,7 +425,8 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_include_REMOTE_ADDR_if_Ip_address_provided_and_sending_Ip_enabled_on_gateway() {
         var epdqPayloadDefinitionFor3ds2NewOrder = new EpdqPayloadDefinitionForNew3ds2Order(FRONTEND_URL, true, SupportedLanguage.ENGLISH, GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK);
         authCardDetails.setIpAddress(IP_ADDRESS);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, hasItem(new BasicNameValuePair(EpdqPayloadDefinitionForNew3ds2Order.REMOTE_ADDR, "8.8.8.8")));
     }
 
@@ -427,7 +434,8 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_not_include_REMOTE_ADDR_if_Ip_address_not_provided_and_sending_Ip_enabled_on_gateway() {
         var epdqPayloadDefinitionFor3ds2NewOrder = new EpdqPayloadDefinitionForNew3ds2Order(FRONTEND_URL, true, SupportedLanguage.ENGLISH, GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK);
         authCardDetails.setIpAddress(null);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.REMOTE_ADDR)));
     }
 
@@ -435,7 +443,8 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     public void should_not_include_REMOTE_ADDR_if_Ip_address_provided_and_sending_Ip_not_enabled_on_gateway() {
         var epdqPayloadDefinitionFor3ds2NewOrder = new EpdqPayloadDefinitionForNew3ds2Order(FRONTEND_URL, SEND_PAYER_IP_ADDRESS_TO_GATEWAY, SupportedLanguage.ENGLISH, GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK);
         authCardDetails.setIpAddress(IP_ADDRESS);
-        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract(epdqTemplateData);
+        epdqPayloadDefinitionFor3ds2NewOrder.setEpdqTemplateData(epdqTemplateData);
+        List<NameValuePair> result = epdqPayloadDefinitionFor3ds2NewOrder.extract();
         assertThat(result, not(containsNameValuePairWithName(EpdqPayloadDefinitionForNew3ds2Order.REMOTE_ADDR)));
     }
     


### PR DESCRIPTION
Make`EpdqTemplateData` a field of `EpdqPayloadDefinition`.

The purpose of this is to allow the various subclasses of `EpdqPayloadDefinition` to gradually migrate to using different
internal data structures to store the data currently held in `EpdqTemplateData`.