### PR TITLE
PP-6712 Remove operation type from EpdqTemplateData

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqTemplateData.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqTemplateData.java
@@ -3,21 +3,13 @@ package uk.gov.pay.connector.gateway.epdq;
 import uk.gov.pay.connector.gateway.OrderRequestBuilder;
 
 public class EpdqTemplateData extends OrderRequestBuilder.TemplateData {
-    private String operationType;
+
     private String orderId;
     private String password;
     private String userId;
     private String shaInPassphrase;
     private String amount;
     private String frontendBaseUrl;
-
-    public String getOperationType() {
-        return operationType;
-    }
-
-    public void setOperationType(String operationType) {
-        this.operationType = operationType;
-    }
 
     public String getOrderId() {
         return orderId;

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
@@ -34,7 +34,6 @@ public abstract class EpdqPayloadDefinition {
 
     public GatewayOrder createGatewayOrder() {
         EpdqTemplateData templateData = getEpdqTemplateData();
-        templateData.setOperationType(getOperationType());
         ArrayList<NameValuePair> params = new ArrayList<>(extract());
         String signature = SIGNATURE_GENERATOR.sign(params, templateData.getShaInPassphrase());
         params.add(new BasicNameValuePair("SHASIGN", signature));
@@ -46,7 +45,7 @@ public abstract class EpdqPayloadDefinition {
         );
     }
 
-    protected abstract String getOperationType();
+    public abstract String getOperationType();
 
     protected abstract OrderRequestType getOrderRequestType();
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 public class EpdqPayloadDefinitionForCancelOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
 
     @Override
-    protected String getOperationType() {
+    public String getOperationType() {
         return "DES";
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 public class EpdqPayloadDefinitionForCaptureOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
 
     @Override
-    protected String getOperationType() {
+    public String getOperationType() {
         return "SAS";
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForMaintenanceOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForMaintenanceOrder.java
@@ -22,7 +22,7 @@ public abstract class EpdqPayloadDefinitionForMaintenanceOrder extends EpdqPaylo
         );
         
         return epdqParameterBuilder
-                .add("OPERATION", templateData.getOperationType())
+                .add("OPERATION", getOperationType())
                 .add("PSPID", templateData.getMerchantCode())
                 .add("PSWD", templateData.getPassword())
                 .add("USERID", templateData.getUserId())

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
@@ -55,7 +55,7 @@ public class EpdqPayloadDefinitionForNew3dsOrder extends EpdqPayloadDefinitionFo
                 .add(HTTPACCEPT_KEY, getBrowserAcceptHeader(templateData))
                 .add(HTTPUSER_AGENT_KEY, getBrowserUserAgent(templateData))
                 .add(LANGUAGE_URL, "en_GB")
-                .add(OPERATION_KEY, templateData.getOperationType())
+                .add(OPERATION_KEY, getOperationType())
                 .add(ORDER_ID_KEY, templateData.getOrderId());
         
         if (templateData.getAuthCardDetails().getAddress().isPresent()) {
@@ -82,7 +82,7 @@ public class EpdqPayloadDefinitionForNew3dsOrder extends EpdqPayloadDefinitionFo
     }
 
     @Override
-    protected String getOperationType() {
+    public String getOperationType() {
         return "RES";
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
@@ -37,7 +37,7 @@ public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
                 .add(CURRENCY_KEY, "GBP")
                 .add(CVC_KEY, templateData.getAuthCardDetails().getCvc())
                 .add(EXPIRY_DATE_KEY, templateData.getAuthCardDetails().getEndDate())
-                .add(OPERATION_KEY, templateData.getOperationType())
+                .add(OPERATION_KEY, getOperationType())
                 .add(ORDER_ID_KEY, templateData.getOrderId());
 
         if (templateData.getAuthCardDetails().getAddress().isPresent()) {
@@ -58,7 +58,7 @@ public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
     }
 
     @Override
-    protected String getOperationType() {
+    public String getOperationType() {
         return "RES";
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
@@ -26,7 +26,7 @@ public class EpdqPayloadDefinitionForQueryOrder extends EpdqPayloadDefinition {
     }
 
     @Override
-    protected String getOperationType() {
+    public String getOperationType() {
         return "RES";
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
@@ -5,7 +5,7 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 public class EpdqPayloadDefinitionForRefundOrder extends EpdqPayloadDefinitionForMaintenanceOrder {
 
     @Override
-    protected String getOperationType() {
+    public String getOperationType() {
         return "RFD";
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForMaintenanceOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForMaintenanceOrderTest.java
@@ -21,7 +21,6 @@ import static org.hamcrest.core.Is.is;
 @RunWith(MockitoJUnitRunner.class)
 public class EpdqPayloadDefinitionForMaintenanceOrderTest {
 
-    private static final String OPERATION_TYPE = "RES";
     private static final String PAY_ID = "PayId";
     private static final String PSP_ID = "PspId";
     private static final String PASSWORD = "password";
@@ -36,8 +35,6 @@ public class EpdqPayloadDefinitionForMaintenanceOrderTest {
     @Before
     public void setup() {
         epdqTemplateData = new EpdqTemplateData();
-
-        epdqTemplateData.setOperationType(OPERATION_TYPE);
         epdqTemplateData.setTransactionId(PAY_ID);
         epdqTemplateData.setMerchantCode(PSP_ID);
         epdqTemplateData.setPassword(PASSWORD);
@@ -50,14 +47,14 @@ public class EpdqPayloadDefinitionForMaintenanceOrderTest {
         Set.of(cancelOrder, captureOrder, refundOrder).forEach(order -> {
             order.setEpdqTemplateData(epdqTemplateData);
             List<NameValuePair> result = order.extract();
-            assertThat(result, is(ImmutableList.builder().add(
+            assertThat(result, is(List.of(
                     new BasicNameValuePair("AMOUNT", "400"),
-                    new BasicNameValuePair("OPERATION", OPERATION_TYPE),
+                    new BasicNameValuePair("OPERATION", order.getOperationType()),
                     new BasicNameValuePair("PAYID", PAY_ID),
                     new BasicNameValuePair("PSPID", PSP_ID),
                     new BasicNameValuePair("PSWD", PASSWORD),
-                    new BasicNameValuePair("USERID", USER_ID))
-                    .build()));
+                    new BasicNameValuePair("USERID", USER_ID)
+                    )));
         });
     }
 
@@ -77,4 +74,5 @@ public class EpdqPayloadDefinitionForMaintenanceOrderTest {
         List<NameValuePair> extractPairs = refundOrder.extract();
         assertThat(extractPairs, hasItem(new BasicNameValuePair("ORDERID", "Order-Id")));
     }
+    
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
@@ -92,7 +92,6 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
         when(mockTemplateData.getMerchantCode()).thenReturn(PSP_ID);
         when(mockTemplateData.getPassword()).thenReturn(PASSWORD);
         when(mockTemplateData.getUserId()).thenReturn(USER_ID);
-        when(mockTemplateData.getOperationType()).thenReturn(OPERATION_TYPE);
         when(mockTemplateData.getOrderId()).thenReturn(ORDER_ID);
         when(mockTemplateData.getAmount()).thenReturn(AMOUNT);
         when(mockTemplateData.getFrontendUrl()).thenReturn(FRONTEND_URL);

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
@@ -80,7 +80,6 @@ public class EpdqPayloadDefinitionForNewOrderTest {
         when(mockTemplateData.getMerchantCode()).thenReturn(PSP_ID);
         when(mockTemplateData.getPassword()).thenReturn(PASSWORD);
         when(mockTemplateData.getUserId()).thenReturn(USER_ID);
-        when(mockTemplateData.getOperationType()).thenReturn(OPERATION_TYPE);
         when(mockTemplateData.getOrderId()).thenReturn(ORDER_ID);
         when(mockTemplateData.getAmount()).thenReturn(AMOUNT);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
@@ -114,7 +114,6 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
         epdqTemplateData.setMerchantCode(PSP_ID);
         epdqTemplateData.setPassword(PASSWORD);
         epdqTemplateData.setUserId(USER_ID);
-        epdqTemplateData.setOperationType(OPERATION_TYPE);
         epdqTemplateData.setOrderId(ORDER_ID);
         epdqTemplateData.setAmount(AMOUNT);
         epdqTemplateData.setFrontendUrl(FRONTEND_URL);


### PR DESCRIPTION
We were reading the operation type from a subclass of `EpdqPayloadDefinition`, storing it in `EpdqTemplateData`, then having that same subclass of `EpdqPayloadDefinition` read it from `EpdqTemplateData`. This is silly because the subclass of `EpdqPayloadDefinition` already knew the operation type.