### PR TITLE
PP-6712 Remove SHA-IN passphrase from EpdqTemplateData

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -50,12 +50,12 @@ public class EpdqCaptureHandler implements CaptureHandler {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         templateData.setTransactionId(request.getTransactionId());
 
         var epdqPayloadDefinitionForCaptureOrder = new EpdqPayloadDefinitionForCaptureOrder();
         epdqPayloadDefinitionForCaptureOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForCaptureOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForCaptureOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -275,12 +275,13 @@ public class EpdqPaymentProvider implements PaymentProvider {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setOrderId(request.getChargeExternalId());
         templateData.setPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
 
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
         epdqPayloadDefinitionForQueryOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
@@ -288,12 +289,12 @@ public class EpdqPaymentProvider implements PaymentProvider {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setOrderId(charge.getExternalId());
         templateData.setPassword(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setShaInPassphrase(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setUserId(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setMerchantCode(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
 
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
         epdqPayloadDefinitionForQueryOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
@@ -301,7 +302,6 @@ public class EpdqPaymentProvider implements PaymentProvider {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setOrderId(request.getChargeExternalId());
         templateData.setPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         templateData.setDescription(request.getDescription());
@@ -321,6 +321,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
         }
 
         epdqPayloadDefinition.setEpdqTemplateData(templateData);
+        epdqPayloadDefinition.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinition.createGatewayOrder();
     }
 
@@ -328,7 +329,6 @@ public class EpdqPaymentProvider implements PaymentProvider {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
 
         Optional.ofNullable(request.getTransactionId())
@@ -338,6 +338,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
 
         var epdqPayloadDefinitionForCancelOrder = new EpdqPayloadDefinitionForCancelOrder();
         epdqPayloadDefinitionForCancelOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForCancelOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForCancelOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -52,13 +52,13 @@ public class EpdqRefundHandler implements RefundHandler {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
         templateData.setPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         templateData.setTransactionId(request.getTransactionId());
         templateData.setAmount(request.getAmount());
 
         var epdqPayloadDefinitionForRefundOrder = new EpdqPayloadDefinitionForRefundOrder();
         epdqPayloadDefinitionForRefundOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForRefundOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqTemplateData.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqTemplateData.java
@@ -7,7 +7,6 @@ public class EpdqTemplateData extends OrderRequestBuilder.TemplateData {
     private String orderId;
     private String password;
     private String userId;
-    private String shaInPassphrase;
     private String amount;
     private String frontendBaseUrl;
 
@@ -33,14 +32,6 @@ public class EpdqTemplateData extends OrderRequestBuilder.TemplateData {
 
     public void setUserId(String userId) {
         this.userId = userId;
-    }
-
-    public String getShaInPassphrase() {
-        return shaInPassphrase;
-    }
-
-    public void setShaInPassphrase(String shaInPassphrase) {
-        this.shaInPassphrase = shaInPassphrase;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
@@ -29,13 +29,14 @@ public abstract class EpdqPayloadDefinition {
     public static final Charset EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET = Charset.forName("windows-1252");
     
     protected EpdqTemplateData epdqTemplateData;
+    
+    protected String shaInPassphrase;
 
     protected abstract List<NameValuePair> extract();
 
     public GatewayOrder createGatewayOrder() {
-        EpdqTemplateData templateData = getEpdqTemplateData();
         ArrayList<NameValuePair> params = new ArrayList<>(extract());
-        String signature = SIGNATURE_GENERATOR.sign(params, templateData.getShaInPassphrase());
+        String signature = SIGNATURE_GENERATOR.sign(params, getShaInPassphrase());
         params.add(new BasicNameValuePair("SHASIGN", signature));
         String payload = URLEncodedUtils.format(params, EPDQ_APPLICATION_X_WWW_FORM_URLENCODED_CHARSET);
         return new GatewayOrder(
@@ -53,8 +54,16 @@ public abstract class EpdqPayloadDefinition {
         this.epdqTemplateData = epdqTemplateData;
     }
 
-    public EpdqTemplateData getEpdqTemplateData() {
+    protected EpdqTemplateData getEpdqTemplateData() {
         return epdqTemplateData;
+    }
+
+    public void setShaInPassphrase(String shaInPassphrase) {
+        this.shaInPassphrase = shaInPassphrase;
+    }
+
+    public String getShaInPassphrase() {
+        return shaInPassphrase;
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCancelOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCancelOrderTest.java
@@ -16,13 +16,14 @@ public class EpdqPayloadDefinitionForCancelOrderTest {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setPassword("password");
         templateData.setUserId("username");
-        templateData.setShaInPassphrase("sha-passphrase");
         templateData.setMerchantCode("merchant-id");
         templateData.setTransactionId("payId");
 
         var epdqPayloadDefinitionForCancelOrder = new EpdqPayloadDefinitionForCancelOrder();
         epdqPayloadDefinitionForCancelOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForCancelOrder.setShaInPassphrase("sha-passphrase");
         GatewayOrder gatewayOrder = epdqPayloadDefinitionForCancelOrder.createGatewayOrder();
+
         assertEquals(TestTemplateResourceLoader.load(EPDQ_CANCEL_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.CANCEL, gatewayOrder.getOrderRequestType());
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCaptureOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForCaptureOrderTest.java
@@ -16,12 +16,12 @@ public class EpdqPayloadDefinitionForCaptureOrderTest {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setPassword("password");
         templateData.setUserId("username");
-        templateData.setShaInPassphrase("sha-passphrase");
         templateData.setMerchantCode("merchant-id");
         templateData.setTransactionId("payId");
 
         var epdqPayloadDefinitionForCaptureOrder = new EpdqPayloadDefinitionForCaptureOrder();
         epdqPayloadDefinitionForCaptureOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForCaptureOrder.setShaInPassphrase("sha-passphrase");
         GatewayOrder gatewayOrder = epdqPayloadDefinitionForCaptureOrder.createGatewayOrder();
 
         assertEquals(TestTemplateResourceLoader.load(EPDQ_CAPTURE_REQUEST), gatewayOrder.getPayload());

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
@@ -118,14 +118,15 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
         templateData.setOrderId("mq4ht90j2oir6am585afk58kml");
         templateData.setPassword("password");
         templateData.setUserId("username");
-        templateData.setShaInPassphrase("sha-passphrase");
         templateData.setMerchantCode("merchant-id");
         templateData.setDescription("MyDescription");
         templateData.setAmount("500");
         templateData.setAuthCardDetails(authCardDetails);
 
         epdqPayloadDefinitionFor3dsNewOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionFor3dsNewOrder.setShaInPassphrase("sha-passphrase");
         GatewayOrder gatewayOrder = epdqPayloadDefinitionFor3dsNewOrder.createGatewayOrder();
+
         assertEquals(TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_3DS_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.AUTHORISE_3DS, gatewayOrder.getOrderRequestType());
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
@@ -103,14 +103,15 @@ public class EpdqPayloadDefinitionForNewOrderTest {
         templateData.setOrderId("mq4ht90j2oir6am585afk58kml");
         templateData.setPassword("password");
         templateData.setUserId("username");
-        templateData.setShaInPassphrase("sha-passphrase");
         templateData.setMerchantCode("merchant-id");
         templateData.setDescription("MyDescription");
         templateData.setAmount("500");
         templateData.setAuthCardDetails(authCardDetails);
 
         epdqPayloadDefinitionForNewOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForNewOrder.setShaInPassphrase("sha-passphrase");
         GatewayOrder gatewayOrder = epdqPayloadDefinitionForNewOrder.createGatewayOrder();
+
         assertEquals(TestTemplateResourceLoader.load(EPDQ_AUTHORISATION_REQUEST), gatewayOrder.getPayload());
         assertEquals(OrderRequestType.AUTHORISE, gatewayOrder.getOrderRequestType());
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForRefundOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForRefundOrderTest.java
@@ -16,13 +16,13 @@ public class EpdqPayloadDefinitionForRefundOrderTest {
         EpdqTemplateData templateData = new EpdqTemplateData();
         templateData.setPassword("password");
         templateData.setUserId("username");
-        templateData.setShaInPassphrase("sha-passphrase");
         templateData.setMerchantCode("merchant-id");
         templateData.setTransactionId("payId");
         templateData.setAmount("400");
 
         var epdqPayloadDefinitionForRefundOrder = new EpdqPayloadDefinitionForRefundOrder();
         epdqPayloadDefinitionForRefundOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase("sha-passphrase");
         GatewayOrder gatewayOrder = epdqPayloadDefinitionForRefundOrder.createGatewayOrder();
 
         assertEquals(TestTemplateResourceLoader.load(EPDQ_REFUND_REQUEST), gatewayOrder.getPayload());


### PR DESCRIPTION
Move the SHA-IN passphrase from being a field of `EpdqTemplateData` to being a field of `EpdqPayloadDefinition`.

This means that only the `extract()` method on `EpdqPayloadDefinition` now accesses the `EpdqTemplateData` inside the `EpdqPayloadDefinition`.