### PR TITLE
PP-6712 Don’t use EpdqTemplateData for query requests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -272,28 +272,21 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     private GatewayOrder buildQueryOrderRequestFor(Auth3dsResponseGatewayRequest request) {
-        EpdqTemplateData templateData = new EpdqTemplateData();
-        templateData.setOrderId(request.getChargeExternalId());
-        templateData.setPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
-        templateData.setMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
-
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
-        epdqPayloadDefinitionForQueryOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForQueryOrder.setOrderId(request.getChargeExternalId());
+        epdqPayloadDefinitionForQueryOrder.setPassword(request.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinitionForQueryOrder.setUserId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinitionForQueryOrder.setPspId(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
-
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
     private GatewayOrder buildQueryOrderRequestFor(ChargeEntity charge) {
-        EpdqTemplateData templateData = new EpdqTemplateData();
-        templateData.setOrderId(charge.getExternalId());
-        templateData.setPassword(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        templateData.setUserId(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
-        templateData.setMerchantCode(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
-
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
-        epdqPayloadDefinitionForQueryOrder.setEpdqTemplateData(templateData);
+        epdqPayloadDefinitionForQueryOrder.setOrderId(charge.getExternalId());
+        epdqPayloadDefinitionForQueryOrder.setPassword(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinitionForQueryOrder.setUserId(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinitionForQueryOrder.setPspId(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
         epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
@@ -14,15 +14,35 @@ public class EpdqPayloadDefinitionForQueryOrder extends EpdqPayloadDefinition {
     public final static String PSWD_KEY = "PSWD";
     public final static String USERID_KEY = "USERID";
 
+    private String orderId;
+    private String pspId;
+    private String userId;
+    private String password;
+
     @Override
     public List<NameValuePair> extract() {
-        var templateData = getEpdqTemplateData();
         return newParameterBuilder()
-                .add(ORDER_ID_KEY, templateData.getOrderId())
-                .add(PSPID_KEY, templateData.getMerchantCode())
-                .add(PSWD_KEY, templateData.getPassword())
-                .add(USERID_KEY, templateData.getUserId())
+                .add(ORDER_ID_KEY, orderId)
+                .add(PSPID_KEY, pspId)
+                .add(PSWD_KEY, password)
+                .add(USERID_KEY, userId)
                 .build();
+    }
+
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    public void setPspId(String pspId) {
+        this.pspId = pspId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
 
     @Override


### PR DESCRIPTION
When building a payload to query the status of an ePDQ payment, don’t use `EpdqTemplateData`. Instead, set the data directly on the `EpdqPayloadDefinitionForQueryOrder` object.