### PR TITLE
PP-6712 Remove getOperationType() from EpdqPayloadDefinition

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinition.java
@@ -43,8 +43,6 @@ public abstract class EpdqPayloadDefinition {
         );
     }
 
-    public abstract String getOperationType();
-
     protected abstract OrderRequestType getOrderRequestType();
 
     public void setShaInPassphrase(String shaInPassphrase) {

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCancelOrder.java
@@ -39,18 +39,13 @@ public class EpdqPayloadDefinitionForCancelOrder extends EpdqPayloadDefinition {
     @Override
     public List<NameValuePair> extract() {
         EpdqParameterBuilder parameterBuilder = newParameterBuilder()
-                .add("OPERATION", getOperationType())
+                .add("OPERATION", "DES")
                 .add("PSPID", pspId)
                 .add("PSWD", password)
                 .add("USERID", userId);
         Optional.ofNullable(payId).ifPresent(payId -> parameterBuilder.add("PAYID", payId));
         Optional.ofNullable(orderId).ifPresent(orderId -> parameterBuilder.add("ORDERID", orderId));
         return parameterBuilder.build();
-    }
-
-    @Override
-    public String getOperationType() {
-        return "DES";
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForCaptureOrder.java
@@ -33,17 +33,12 @@ public class EpdqPayloadDefinitionForCaptureOrder extends EpdqPayloadDefinition 
     @Override
     public List<NameValuePair> extract() {
         return newParameterBuilder()
-                .add("OPERATION", getOperationType())
+                .add("OPERATION", "SAS")
                 .add("PSPID", pspId)
                 .add("PSWD", password)
                 .add("USERID", userId)
                 .add("PAYID", payId)
                 .build();
-    }
-
-    @Override
-    public String getOperationType() {
-        return "SAS";
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
@@ -50,7 +50,7 @@ public class EpdqPayloadDefinitionForNew3dsOrder extends EpdqPayloadDefinitionFo
                 .add(HTTPACCEPT_KEY, getBrowserAcceptHeader())
                 .add(HTTPUSER_AGENT_KEY, getBrowserUserAgent())
                 .add(LANGUAGE_URL, "en_GB")
-                .add(OPERATION_KEY, getOperationType())
+                .add(OPERATION_KEY, "RES")
                 .add(ORDER_ID_KEY, getOrderId());
 
         getAuthCardDetails().getAddress().ifPresent(address -> {
@@ -68,11 +68,6 @@ public class EpdqPayloadDefinitionForNew3dsOrder extends EpdqPayloadDefinitionFo
                 .add(WIN3DS_URL, "MAINW");
 
         return epdqParameterBuilder.build();
-    }
-
-    @Override
-    public String getOperationType() {
-        return "RES";
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
@@ -91,7 +91,7 @@ public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
                 .add(CURRENCY_KEY, "GBP")
                 .add(CVC_KEY, authCardDetails.getCvc())
                 .add(EXPIRY_DATE_KEY, authCardDetails.getEndDate())
-                .add(OPERATION_KEY, getOperationType())
+                .add(OPERATION_KEY, "RES")
                 .add(ORDER_ID_KEY, orderId);
 
         authCardDetails.getAddress().ifPresent(address -> {
@@ -107,11 +107,6 @@ public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
                 .add(USERID_KEY, userId);
 
         return epdqParameterBuilder.build();
-    }
-
-    @Override
-    public String getOperationType() {
-        return "RES";
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForQueryOrder.java
@@ -46,11 +46,6 @@ public class EpdqPayloadDefinitionForQueryOrder extends EpdqPayloadDefinition {
     }
 
     @Override
-    public String getOperationType() {
-        return "RES";
-    }
-
-    @Override
     protected OrderRequestType getOrderRequestType() {
         return OrderRequestType.AUTHORISE;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForRefundOrder.java
@@ -38,18 +38,13 @@ public class EpdqPayloadDefinitionForRefundOrder extends EpdqPayloadDefinition {
     @Override
     public List<NameValuePair> extract() {
         return newParameterBuilder()
-                .add("OPERATION", getOperationType())
+                .add("OPERATION", "RFD")
                 .add("PSPID", pspId)
                 .add("PSWD", password)
                 .add("USERID", userId)
                 .add("PAYID", payId)
                 .add("AMOUNT", amount)
                 .build();
-    }
-    
-    @Override
-    public String getOperationType() {
-        return "RFD";
     }
 
     @Override


### PR DESCRIPTION
Remove `getOperationType()` from `EpdqPayloadDefinition` and its subclasses because it’s only used internally by the same class and doesn’t need to exposed.