### PR TITLE
PP-6688 Split VatNumberCompanyNumber task

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetup.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetup.java
@@ -17,6 +17,12 @@ public class StripeAccountSetup {
     @JsonProperty("vat_number_company_number")
     private boolean vatNumberCompanyNumberCompleted = false;
 
+    @JsonProperty("vat_number")
+    private boolean vatNumberCompleted = false;
+
+    @JsonProperty("company_number")
+    private boolean companyNumberCompleted = false;
+
     public boolean isBankAccountCompleted() {
         return bankAccountCompleted;
     }
@@ -39,6 +45,22 @@ public class StripeAccountSetup {
 
     public void setVatNumberCompanyNumberCompleted(boolean vatNumberCompanyNumberCompleted) {
         this.vatNumberCompanyNumberCompleted = vatNumberCompanyNumberCompleted;
+    }
+
+    public void setVatNumberCompleted(boolean vatNumberCompleted) {
+        this.vatNumberCompleted = vatNumberCompleted;
+    }
+
+    public boolean isVatNumberCompleted() {
+        return vatNumberCompleted;
+    }
+
+    public void setCompanyNumberCompleted(boolean companyNumberCompleted) {
+        this.companyNumberCompleted = companyNumberCompleted;
+    }
+
+    public boolean isCompanyNumberCompleted() {
+        return companyNumberCompleted;
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
@@ -1,9 +1,9 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 public enum StripeAccountSetupTask {
-
     BANK_ACCOUNT,
     RESPONSIBLE_PERSON,
-    VAT_NUMBER_COMPANY_NUMBER
-
+    VAT_NUMBER_COMPANY_NUMBER,
+    VAT_NUMBER,
+    COMPANY_NUMBER
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
@@ -34,6 +34,12 @@ public class StripeAccountSetupService {
                         case VAT_NUMBER_COMPANY_NUMBER:
                             stripeAccountSetup.setVatNumberCompanyNumberCompleted(true);
                             break;
+                        case VAT_NUMBER:
+                            stripeAccountSetup.setVatNumberCompleted(true);
+                            break;
+                        case COMPANY_NUMBER:
+                            stripeAccountSetup.setCompanyNumberCompleted(true);
+                            break;
                         default:
                             // Code doesn’t handle this task
                     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
@@ -33,6 +33,10 @@ public class StripeAccountSetupRequestValidatorTest {
             "replace, responsible_person, false",
             "replace, vat_number_company_number, true",
             "replace, vat_number_company_number, false",
+            "replace, vat_number, true",
+            "replace, vat_number, false",
+            "replace, company_number, true",
+            "replace, company_number, false"
     })
     @Test
     public void shouldAllowReplaceOperationForValidPathsAndValues(String operation, String path, boolean value) {
@@ -49,7 +53,7 @@ public class StripeAccountSetupRequestValidatorTest {
                 Map.of("operation", "add", "path", "bank_account", "value", true,
                         "expectedErrorMessage", "Operation [add] not supported for path [bank_account]"),
                 Map.of("operation", "add", "path", "blood_sample_deposited", "value", true,
-                        "expectedErrorMessage", "Field [path] must be one of [bank_account, responsible_person, vat_number_company_number]"),
+                        "expectedErrorMessage", "Field [path] must be one of [bank_account, company_number, responsible_person, vat_number, vat_number_company_number]"),
 
                 Map.of("expectedErrorMessage", "Field [path] is required", "operation", "replace", "value", true),
                 Map.of("expectedErrorMessage", "Field [path] is required", "operation", "replace", "path", "", "value", true),

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gatewayaccount.dao.StripeAccountSetupDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetup;
-import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTaskEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupUpdateRequest;
 
@@ -17,15 +16,17 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.BANK_ACCOUNT;
+import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.COMPANY_NUMBER;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.RESPONSIBLE_PERSON;
+import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -45,6 +46,10 @@ public class StripeAccountSetupServiceTest {
     private StripeAccountSetupTaskEntity mockResponsiblePersonCompletedTaskEntity;
     @Mock
     private StripeAccountSetupTaskEntity mockOrganisationDetailsCompletedTaskEntity;
+    @Mock
+    private StripeAccountSetupTaskEntity mockVatNumberCompletedTaskEntity;
+    @Mock
+    private StripeAccountSetupTaskEntity mockCompanyNumberCompletedTaskEntity;
 
     private StripeAccountSetupService stripeAccountSetupService;
 
@@ -53,8 +58,10 @@ public class StripeAccountSetupServiceTest {
         given(mockGatewayAccountEntity.getId()).willReturn(GATEWAY_ACCOUNT_ID);
 
         given(mockBankDetailsCompletedTaskEntity.getTask()).willReturn(BANK_ACCOUNT);
-        given(mockResponsiblePersonCompletedTaskEntity.getTask()).willReturn(StripeAccountSetupTask.RESPONSIBLE_PERSON);
-        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER);
+        given(mockResponsiblePersonCompletedTaskEntity.getTask()).willReturn(RESPONSIBLE_PERSON);
+        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(VAT_NUMBER_COMPANY_NUMBER);
+        given(mockVatNumberCompletedTaskEntity.getTask()).willReturn(VAT_NUMBER);
+        given(mockCompanyNumberCompletedTaskEntity.getTask()).willReturn(COMPANY_NUMBER);
 
         this.stripeAccountSetupService = new StripeAccountSetupService(mockStripeAccountSetupDao);
     }
@@ -69,19 +76,23 @@ public class StripeAccountSetupServiceTest {
         assertThat(tasks.isBankAccountCompleted(), is(false));
         assertThat(tasks.isResponsiblePersonCompleted(), is(false));
         assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(false));
+        assertThat(tasks.isVatNumberCompleted(), is(false));
+        assertThat(tasks.isCompanyNumberCompleted(), is(false));
     }
 
     @Test
     public void shouldReturnStripeAccountSetupWithAllTasksCompleted() {
         given(mockStripeAccountSetupDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID))
                 .willReturn(Arrays.asList(mockOrganisationDetailsCompletedTaskEntity, mockResponsiblePersonCompletedTaskEntity,
-                        mockBankDetailsCompletedTaskEntity));
+                        mockBankDetailsCompletedTaskEntity, mockVatNumberCompletedTaskEntity, mockCompanyNumberCompletedTaskEntity));
 
         StripeAccountSetup tasks = stripeAccountSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
 
         assertThat(tasks.isBankAccountCompleted(), is(true));
         assertThat(tasks.isResponsiblePersonCompleted(), is(true));
         assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(true));
+        assertThat(tasks.isVatNumberCompleted(), is(true));
+        assertThat(tasks.isCompanyNumberCompleted(), is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -37,7 +37,9 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                 .statusCode(200)
                 .body("bank_account", is(false))
                 .body("responsible_person", is(false))
-                .body("vat_number_company_number", is(false));
+                .body("vat_number_company_number", is(false))
+                .body("vat_number", is(false))
+                .body("company_number", is(false));
     }
 
     @Test
@@ -111,6 +113,14 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                         ImmutableMap.of(
                                 "op", "replace",
                                 "path", "vat_number_company_number",
+                                "value", true),
+                        ImmutableMap.of(
+                                "op", "replace",
+                                "path", "vat_number",
+                                "value", true),
+                        ImmutableMap.of(
+                                "op", "replace",
+                                "path", "company_number",
                                 "value", true)
                 )))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
@@ -123,7 +133,9 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                 .statusCode(200)
                 .body("bank_account", is(true))
                 .body("responsible_person", is(true))
-                .body("vat_number_company_number", is(true));
+                .body("vat_number_company_number", is(true))
+                .body("vat_number", is(true))
+                .body("company_number", is(true));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
 - Splits `VAT_NUMBER_COMPANY_NUMBER` to individual tasks `VAT_NUMBER` and `COMPANY_NUMBER` as we will be removing `check your answers` page in selfservice. By removing check your answers page we are intending to submit `vat_number` as soon as form is submitted and `company_number` separately.

   This change will enable us to direct service users to specific task due (vat_number or company_number) during their onboarding flow.
- `VAT_NUMBER_COMPANY_NUMBER` task still remains and to be removed once selfservice stops using this task