### PR TITLE
PP-6688 Remove VAT_NUMBER_COMPANY_NUMBER task

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetup.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetup.java
@@ -14,9 +14,6 @@ public class StripeAccountSetup {
     @JsonProperty("responsible_person")
     private boolean responsiblePersonCompleted = false;
 
-    @JsonProperty("vat_number_company_number")
-    private boolean vatNumberCompanyNumberCompleted = false;
-
     @JsonProperty("vat_number")
     private boolean vatNumberCompleted = false;
 
@@ -37,14 +34,6 @@ public class StripeAccountSetup {
 
     public void setResponsiblePersonCompleted(boolean responsiblePersonCompleted) {
         this.responsiblePersonCompleted = responsiblePersonCompleted;
-    }
-
-    public boolean isVatNumberCompanyNumberCompleted() {
-        return vatNumberCompanyNumberCompleted;
-    }
-
-    public void setVatNumberCompanyNumberCompleted(boolean vatNumberCompanyNumberCompleted) {
-        this.vatNumberCompanyNumberCompleted = vatNumberCompanyNumberCompleted;
     }
 
     public void setVatNumberCompleted(boolean vatNumberCompleted) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeAccountSetupTask.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.gatewayaccount.model;
 public enum StripeAccountSetupTask {
     BANK_ACCOUNT,
     RESPONSIBLE_PERSON,
-    VAT_NUMBER_COMPANY_NUMBER,
     VAT_NUMBER,
     COMPANY_NUMBER
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupService.java
@@ -31,9 +31,6 @@ public class StripeAccountSetupService {
                         case RESPONSIBLE_PERSON:
                             stripeAccountSetup.setResponsiblePersonCompleted(true);
                             break;
-                        case VAT_NUMBER_COMPANY_NUMBER:
-                            stripeAccountSetup.setVatNumberCompanyNumberCompleted(true);
-                            break;
                         case VAT_NUMBER:
                             stripeAccountSetup.setVatNumberCompleted(true);
                             break;

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
@@ -31,8 +31,6 @@ public class StripeAccountSetupRequestValidatorTest {
             "replace, bank_account, false",
             "replace, responsible_person, true",
             "replace, responsible_person, false",
-            "replace, vat_number_company_number, true",
-            "replace, vat_number_company_number, false",
             "replace, vat_number, true",
             "replace, vat_number, false",
             "replace, company_number, true",
@@ -53,7 +51,7 @@ public class StripeAccountSetupRequestValidatorTest {
                 Map.of("operation", "add", "path", "bank_account", "value", true,
                         "expectedErrorMessage", "Operation [add] not supported for path [bank_account]"),
                 Map.of("operation", "add", "path", "blood_sample_deposited", "value", true,
-                        "expectedErrorMessage", "Field [path] must be one of [bank_account, company_number, responsible_person, vat_number, vat_number_company_number]"),
+                        "expectedErrorMessage", "Field [path] must be one of [bank_account, company_number, responsible_person, vat_number]"),
 
                 Map.of("expectedErrorMessage", "Field [path] is required", "operation", "replace", "value", true),
                 Map.of("expectedErrorMessage", "Field [path] is required", "operation", "replace", "path", "", "value", true),
@@ -110,7 +108,7 @@ public class StripeAccountSetupRequestValidatorTest {
                         "value", false),
                 ImmutableMap.of(
                         "op", "replace",
-                        "path", "vat_number_company_number",
+                        "path", "vat_number",
                         "value", true)
         ));
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountSetupServiceTest.java
@@ -27,7 +27,6 @@ import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.B
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.COMPANY_NUMBER;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.RESPONSIBLE_PERSON;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER;
-import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeAccountSetupServiceTest {
@@ -45,8 +44,6 @@ public class StripeAccountSetupServiceTest {
     @Mock
     private StripeAccountSetupTaskEntity mockResponsiblePersonCompletedTaskEntity;
     @Mock
-    private StripeAccountSetupTaskEntity mockOrganisationDetailsCompletedTaskEntity;
-    @Mock
     private StripeAccountSetupTaskEntity mockVatNumberCompletedTaskEntity;
     @Mock
     private StripeAccountSetupTaskEntity mockCompanyNumberCompletedTaskEntity;
@@ -59,7 +56,6 @@ public class StripeAccountSetupServiceTest {
 
         given(mockBankDetailsCompletedTaskEntity.getTask()).willReturn(BANK_ACCOUNT);
         given(mockResponsiblePersonCompletedTaskEntity.getTask()).willReturn(RESPONSIBLE_PERSON);
-        given(mockOrganisationDetailsCompletedTaskEntity.getTask()).willReturn(VAT_NUMBER_COMPANY_NUMBER);
         given(mockVatNumberCompletedTaskEntity.getTask()).willReturn(VAT_NUMBER);
         given(mockCompanyNumberCompletedTaskEntity.getTask()).willReturn(COMPANY_NUMBER);
 
@@ -75,7 +71,6 @@ public class StripeAccountSetupServiceTest {
 
         assertThat(tasks.isBankAccountCompleted(), is(false));
         assertThat(tasks.isResponsiblePersonCompleted(), is(false));
-        assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(false));
         assertThat(tasks.isVatNumberCompleted(), is(false));
         assertThat(tasks.isCompanyNumberCompleted(), is(false));
     }
@@ -83,14 +78,13 @@ public class StripeAccountSetupServiceTest {
     @Test
     public void shouldReturnStripeAccountSetupWithAllTasksCompleted() {
         given(mockStripeAccountSetupDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID))
-                .willReturn(Arrays.asList(mockOrganisationDetailsCompletedTaskEntity, mockResponsiblePersonCompletedTaskEntity,
+                .willReturn(Arrays.asList(mockResponsiblePersonCompletedTaskEntity,
                         mockBankDetailsCompletedTaskEntity, mockVatNumberCompletedTaskEntity, mockCompanyNumberCompletedTaskEntity));
 
         StripeAccountSetup tasks = stripeAccountSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
 
         assertThat(tasks.isBankAccountCompleted(), is(true));
         assertThat(tasks.isResponsiblePersonCompleted(), is(true));
-        assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(true));
         assertThat(tasks.isVatNumberCompleted(), is(true));
         assertThat(tasks.isCompanyNumberCompleted(), is(true));
     }
@@ -98,13 +92,13 @@ public class StripeAccountSetupServiceTest {
     @Test
     public void shouldReturnStripeAccountSetupWithSomeTasksCompleted() {
         given(mockStripeAccountSetupDao.findByGatewayAccountId(GATEWAY_ACCOUNT_ID))
-                .willReturn(Arrays.asList(mockOrganisationDetailsCompletedTaskEntity, mockResponsiblePersonCompletedTaskEntity));
+                .willReturn(Arrays.asList(mockResponsiblePersonCompletedTaskEntity, mockVatNumberCompletedTaskEntity));
 
         StripeAccountSetup tasks = stripeAccountSetupService.getCompletedTasks(GATEWAY_ACCOUNT_ID);
 
         assertThat(tasks.isBankAccountCompleted(), is(false));
         assertThat(tasks.isResponsiblePersonCompleted(), is(true));
-        assertThat(tasks.isVatNumberCompanyNumberCompleted(), is(true));
+        assertThat(tasks.isVatNumberCompleted(), is(true));
     }
 
     @Test
@@ -148,11 +142,11 @@ public class StripeAccountSetupServiceTest {
         List<StripeAccountSetupUpdateRequest> patchRequests = Arrays.asList(
                 new StripeAccountSetupUpdateRequest(BANK_ACCOUNT, true),
                 new StripeAccountSetupUpdateRequest(RESPONSIBLE_PERSON, true),
-                new StripeAccountSetupUpdateRequest(VAT_NUMBER_COMPANY_NUMBER, true));
+                new StripeAccountSetupUpdateRequest(VAT_NUMBER, true));
 
         given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, BANK_ACCOUNT)).willReturn(false);
         given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, RESPONSIBLE_PERSON)).willReturn(false);
-        given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, VAT_NUMBER_COMPANY_NUMBER)).willReturn(false);
+        given(mockStripeAccountSetupDao.isTaskCompletedForGatewayAccount(GATEWAY_ACCOUNT_ID, VAT_NUMBER)).willReturn(false);
 
         stripeAccountSetupService.update(mockGatewayAccountEntity, patchRequests);
 
@@ -170,6 +164,6 @@ public class StripeAccountSetupServiceTest {
         assertThat(entities.get(1).getTask(), is(RESPONSIBLE_PERSON));
 
         assertThat(entities.get(2).getGatewayAccount(), is(mockGatewayAccountEntity));
-        assertThat(entities.get(2).getTask(), is(VAT_NUMBER_COMPANY_NUMBER));
+        assertThat(entities.get(2).getTask(), is(VAT_NUMBER));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/StripeAccountSetupDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/StripeAccountSetupDaoIT.java
@@ -8,14 +8,13 @@ import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTaskEntity;
 
 import java.util.List;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.BANK_ACCOUNT;
-import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER;
 import static uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask.RESPONSIBLE_PERSON;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 
@@ -51,7 +50,6 @@ public class StripeAccountSetupDaoIT extends DaoITestBase {
         databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, BANK_ACCOUNT);
         databaseTestHelper.addGatewayAccountsStripeSetupTask(gatewayAccountId, RESPONSIBLE_PERSON);
         databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, BANK_ACCOUNT);
-        databaseTestHelper.addGatewayAccountsStripeSetupTask(anotherGatewayAccountId, VAT_NUMBER_COMPANY_NUMBER);
 
         List<StripeAccountSetupTaskEntity> tasks = stripeAccountSetupDao.findByGatewayAccountId(gatewayAccountId);
         assertThat(tasks, hasSize(2));

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -37,7 +37,6 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                 .statusCode(200)
                 .body("bank_account", is(false))
                 .body("responsible_person", is(false))
-                .body("vat_number_company_number", is(false))
                 .body("vat_number", is(false))
                 .body("company_number", is(false));
     }
@@ -46,7 +45,7 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
     public void getStripeSetupWithSomeTasksCompletedReturnsAppropriateFlags() {
         long gatewayAccountId = Long.valueOf(createAGatewayAccountFor("stripe"));
         addCompletedTask(gatewayAccountId, StripeAccountSetupTask.BANK_ACCOUNT);
-        addCompletedTask(gatewayAccountId, StripeAccountSetupTask.VAT_NUMBER_COMPANY_NUMBER);
+        addCompletedTask(gatewayAccountId, StripeAccountSetupTask.VAT_NUMBER);
 
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
@@ -54,7 +53,7 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                 .statusCode(200)
                 .body("bank_account", is(true))
                 .body("responsible_person", is(false))
-                .body("vat_number_company_number", is(true));
+                .body("vat_number", is(true));
     }
 
     @Test
@@ -94,7 +93,8 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                 .statusCode(200)
                 .body("bank_account", is(true))
                 .body("responsible_person", is(false))
-                .body("vat_number_company_number", is(false));
+                .body("vat_number", is(false))
+                .body("company_number", is(false));
     }
 
     @Test
@@ -109,10 +109,6 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                         ImmutableMap.of(
                                 "op", "replace",
                                 "path", "responsible_person",
-                                "value", true),
-                        ImmutableMap.of(
-                                "op", "replace",
-                                "path", "vat_number_company_number",
                                 "value", true),
                         ImmutableMap.of(
                                 "op", "replace",
@@ -133,7 +129,6 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                 .statusCode(200)
                 .body("bank_account", is(true))
                 .body("responsible_person", is(true))
-                .body("vat_number_company_number", is(true))
                 .body("vat_number", is(true))
                 .body("company_number", is(true));
     }


### PR DESCRIPTION
## WHAT YOU DID
- Removed VatNumberCompanyNumber task from Stripe onboarding tasks as it is now split into individual tasks (VAT_NUMBER, COMPANY_NUMBER)
 
depends on https://github.com/alphagov/pay-selfservice/pull/2104