### PR TITLE
PP-6756 Add gateway_transaction_id to refunds payload

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundEventWithReferenceDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundEventWithReferenceDetails.java
@@ -5,12 +5,18 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 public class RefundEventWithReferenceDetails extends EventDetails {
 
     private String reference;
+    private String gatewayTransactionId;
 
-    public RefundEventWithReferenceDetails(String reference) {
+    public RefundEventWithReferenceDetails(String reference, String gatewayTransactionId) {
         this.reference = reference;
+        this.gatewayTransactionId = gatewayTransactionId;
     }
 
     public String getReference() {
         return reference;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -143,7 +143,7 @@ public class EventFactory {
                 return eventClass.getConstructor(String.class, String.class, RefundEventWithReferenceDetails.class, ZonedDateTime.class).newInstance(
                         refundHistory.getExternalId(),
                         refundHistory.getChargeExternalId(),
-                        new RefundEventWithReferenceDetails(refundHistory.getReference()),
+                        new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
                         refundHistory.getHistoryStartDate()
                 );
             }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -15,7 +15,7 @@ public class RefundError extends RefundEvent {
     public RefundError from(RefundHistory refundHistory) {
         return new RefundError(refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
-                new RefundEventWithReferenceDetails(refundHistory.getReference()),
+                new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
                 refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -15,7 +15,7 @@ public class RefundSubmitted extends RefundEvent {
     public static RefundSubmitted from(RefundHistory refundHistory) {
         return new RefundSubmitted(refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
-                new RefundEventWithReferenceDetails(refundHistory.getReference()),
+                new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
                 refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -15,7 +15,7 @@ public class RefundSucceeded extends RefundEvent {
     public static RefundSucceeded from(RefundHistory refundHistory) {
         return new RefundSucceeded(refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
-                new RefundEventWithReferenceDetails(refundHistory.getReference()),
+                new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
                 refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/ChargeRefundService.java
@@ -129,7 +129,11 @@ public class ChargeRefundService {
                 userNotificationService.sendRefundIssuedEmail(refundEntity, charge, gatewayAccountEntity);
             }
 
-            getRefundReference(refundEntity, gatewayRefundResponse).ifPresent(refundEntity::setReference);
+            getRefundReference(refundEntity, gatewayRefundResponse).ifPresent(gatewayTransactionId -> {
+                refundEntity.setReference(gatewayTransactionId);
+                refundEntity.setGatewayTransactionId(gatewayTransactionId);
+            });
+
             transitionRefundState(refundEntity, refundStatus);
         });
 

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
 import org.hamcrest.core.Is;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -192,6 +191,7 @@ public class EventFactoryTest {
                 .withUserExternalId("user_external_id")
                 .withChargeExternalId(charge.getExternalId())
                 .withAmount(charge.getAmount())
+                .withReference("reference")
                 .build();
         when(refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
                 refundErrorHistory.getExternalId(),
@@ -212,6 +212,7 @@ public class EventFactoryTest {
                 .findFirst().get();
         assertThat(refundError.getParentResourceExternalId(), is(charge.getExternalId()));
         assertThat(((RefundEventWithReferenceDetails) refundError.getEventDetails()).getReference(), is(refundErrorHistory.getReference()));
+        assertThat(((RefundEventWithReferenceDetails) refundError.getEventDetails()).getGatewayTransactionId(), is(refundErrorHistory.getReference()));
         assertThat(refundError.getResourceType(), is(ResourceType.REFUND));
         assertThat(refundError.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
 
@@ -240,13 +241,13 @@ public class EventFactoryTest {
 
         assertThat(events.size(), is(2));
         PaymentCreated event = (PaymentCreated) events.get(0); 
-        Assert.assertThat(event, instanceOf(PaymentCreated.class));
-        Assert.assertThat(event.getEventDetails(), instanceOf(PaymentCreatedEventDetails.class));
-        Assert.assertThat(event.getResourceExternalId(), Is.is(chargeEventEntity.getChargeEntity().getExternalId()));
+        assertThat(event, instanceOf(PaymentCreated.class));
+        assertThat(event.getEventDetails(), instanceOf(PaymentCreatedEventDetails.class));
+        assertThat(event.getResourceExternalId(), Is.is(chargeEventEntity.getChargeEntity().getExternalId()));
 
         RefundAvailabilityUpdated event2 = (RefundAvailabilityUpdated) events.get(1);
-        Assert.assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
-        Assert.assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
+        assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
+        assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
     }
 
     @Test
@@ -265,8 +266,8 @@ public class EventFactoryTest {
 
         assertThat(events.size(), is(1));
         CancelByExternalServiceSubmitted event = (CancelByExternalServiceSubmitted) events.get(0);
-        Assert.assertThat(event, instanceOf(CancelByExternalServiceSubmitted.class));
-        Assert.assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
+        assertThat(event, instanceOf(CancelByExternalServiceSubmitted.class));
+        assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
     }
 
     @Test
@@ -286,12 +287,12 @@ public class EventFactoryTest {
 
         assertThat(events.size(), is(2));
         CaptureConfirmed event1 = (CaptureConfirmed) events.get(0);
-        Assert.assertThat(event1, instanceOf(CaptureConfirmed.class));
-        Assert.assertThat(event1.getEventDetails(), instanceOf(CaptureConfirmedEventDetails.class));
+        assertThat(event1, instanceOf(CaptureConfirmed.class));
+        assertThat(event1.getEventDetails(), instanceOf(CaptureConfirmedEventDetails.class));
 
         RefundAvailabilityUpdated event2 = (RefundAvailabilityUpdated) events.get(1);
-        Assert.assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
-        Assert.assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
+        assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
+        assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
     }
 
     @Test
@@ -352,11 +353,11 @@ public class EventFactoryTest {
 
         assertThat(events.size(), is(2));
         CaptureSubmitted event1 = (CaptureSubmitted) events.get(0);
-        Assert.assertThat(event1, instanceOf(CaptureSubmitted.class));
+        assertThat(event1, instanceOf(CaptureSubmitted.class));
 
         RefundAvailabilityUpdated event2 = (RefundAvailabilityUpdated) events.get(1);
-        Assert.assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
-        Assert.assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
+        assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
+        assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
     }
 
     @Test
@@ -376,12 +377,12 @@ public class EventFactoryTest {
 
         assertThat(events.size(), is(2));
         CaptureAbandonedAfterTooManyRetries event = (CaptureAbandonedAfterTooManyRetries) events.get(0);
-        Assert.assertThat(event, instanceOf(CaptureAbandonedAfterTooManyRetries.class));
-        Assert.assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
+        assertThat(event, instanceOf(CaptureAbandonedAfterTooManyRetries.class));
+        assertThat(event.getEventDetails(), instanceOf(EmptyEventDetails.class));
 
         RefundAvailabilityUpdated event2 = (RefundAvailabilityUpdated) events.get(1);
-        Assert.assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
-        Assert.assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
+        assertThat(event2, instanceOf(RefundAvailabilityUpdated.class));
+        assertThat(event2.getEventDetails(), instanceOf(RefundAvailabilityUpdatedEventDetails.class));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundSucceededTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundSucceededTest.java
@@ -1,0 +1,45 @@
+package uk.gov.pay.connector.events.model.refund;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+
+import java.time.ZonedDateTime;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class RefundSucceededTest {
+
+    private final ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+            .withGatewayAccountEntity(ChargeEntityFixture.defaultGatewayAccountEntity()).build();
+    private ZonedDateTime createdDate = ZonedDateTime.parse("2018-03-12T16:25:01.123456Z");
+    private UTCDateTimeConverter timeConverter = new UTCDateTimeConverter();
+
+    private RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L,
+            RefundStatus.REFUNDED.getValue(), timeConverter.convertToDatabaseColumn(createdDate), 1L,
+            "reference", timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
+            timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
+            "user-external-id", "gateway_transaction_id", charge.getExternalId(),
+            "test@example.com");
+
+    @Test
+    public void serializesEventDetailsForAGivenRefundEvent() throws JsonProcessingException {
+        String actual = RefundSucceeded.from(refundHistory).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("REFUND_SUCCEEDED")));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo("2018-03-12T16:25:02.123456Z")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("refund")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(refundHistory.getExternalId())));
+        assertThat(actual, hasJsonPath("$.parent_resource_external_id", equalTo(charge.getExternalId())));
+
+        assertThat(actual, hasJsonPath("$.event_details.reference", equalTo("reference")));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo("reference")));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -195,7 +195,8 @@ public abstract class BaseEpdqPaymentProviderIT {
     }
 
     String successRefundResponse() {
-        return TestTemplateResourceLoader.load(EPDQ_REFUND_SUCCESS_RESPONSE);
+        return TestTemplateResourceLoader.load(EPDQ_REFUND_SUCCESS_RESPONSE)
+                .replace("{{payIdSub}}", "1");
     }
 
     String errorRefundResponse() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundIT.java
@@ -27,6 +27,7 @@ import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -87,7 +88,8 @@ public class EpdqRefundIT extends ChargingITestBase {
 
         Long refundAmount = defaultTestCharge.getAmount();
 
-        epdqMockClient.mockRefundSuccess();
+        String paySubId = randomNumeric(4);
+        epdqMockClient.mockRefundSuccess(paySubId);
         ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount());
         String refundId = assertRefundResponseWith(defaultTestCharge.getExternalChargeId(), refundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
@@ -95,6 +97,7 @@ public class EpdqRefundIT extends ChargingITestBase {
         assertThat(refundsFoundByChargeExternalId.size(), is(1));
         assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
         assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
+        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", format("3014644340/%s", paySubId)));
     }
 
     @Test
@@ -110,7 +113,7 @@ public class EpdqRefundIT extends ChargingITestBase {
 
         Long refundAmount = captureSubmittedCharge.getAmount();
 
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         ValidatableResponse validatableResponse = postRefundFor(captureSubmittedCharge.getExternalChargeId(), refundAmount, captureSubmittedCharge.getAmount());
         String refundId = assertRefundResponseWith(captureSubmittedCharge.getExternalChargeId(), refundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
@@ -126,11 +129,11 @@ public class EpdqRefundIT extends ChargingITestBase {
         Long secondRefundAmount = 20L;
         String externalChargeId = defaultTestCharge.getExternalChargeId();
 
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         ValidatableResponse firstValidatableResponse = postRefundFor(externalChargeId, firstRefundAmount, defaultTestCharge.getAmount());
         String firstRefundId = assertRefundResponseWith(externalChargeId, firstRefundAmount, firstValidatableResponse, ACCEPTED.getStatusCode());
 
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         ValidatableResponse secondValidatableResponse = postRefundFor(externalChargeId, secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount);
         String secondRefundId = assertRefundResponseWith(externalChargeId, secondRefundAmount, secondValidatableResponse, ACCEPTED.getStatusCode());
 
@@ -162,7 +165,7 @@ public class EpdqRefundIT extends ChargingITestBase {
 
         Long refundAmount = 20L;
 
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         postRefundFor(testCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("pending"))
@@ -179,7 +182,7 @@ public class EpdqRefundIT extends ChargingITestBase {
         Long refundAmount = defaultTestCharge.getAmount();
         String externalChargeId = defaultTestCharge.getExternalChargeId();
 
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         postRefundFor(externalChargeId, refundAmount, defaultTestCharge.getAmount())
                 .statusCode(ACCEPTED.getStatusCode());
 
@@ -196,7 +199,7 @@ public class EpdqRefundIT extends ChargingITestBase {
     @Test
     public void shouldFailRequestingARefund_whenAmountIsBiggerThanChargeAmount() {
         Long refundAmount = defaultTestCharge.getAmount() + 20;
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         postRefundFor(defaultTestCharge.getExternalChargeId(), refundAmount, defaultTestCharge.getAmount())
                 .statusCode(BAD_REQUEST.getStatusCode())
                 .body("reason", is("amount_not_available"))
@@ -242,7 +245,7 @@ public class EpdqRefundIT extends ChargingITestBase {
         Long firstRefundAmount = 80L;
         Long secondRefundAmount = 30L; // 10 more than available
 
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         ValidatableResponse validatableResponse = postRefundFor(defaultTestCharge.getExternalChargeId(), firstRefundAmount, defaultTestCharge.getAmount());
         String firstRefundId = assertRefundResponseWith(defaultTestCharge.getExternalChargeId(), firstRefundAmount, validatableResponse, ACCEPTED.getStatusCode());
 
@@ -250,7 +253,7 @@ public class EpdqRefundIT extends ChargingITestBase {
         assertThat(refundsFoundByChargeExternalId.size(), is(1));
         assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(firstRefundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), firstRefundAmount, "REFUND SUBMITTED")));
 
-        epdqMockClient.mockRefundSuccess();
+        epdqMockClient.mockRefundSuccess(randomNumeric(4));
         postRefundFor(defaultTestCharge.getExternalChargeId(), secondRefundAmount, defaultTestCharge.getAmount() - firstRefundAmount)
                 .statusCode(400)
                 .body("reason", is("amount_not_available"))

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
@@ -102,6 +102,8 @@ public class StripeRefundIT extends ChargingITestBase {
         assertThat(refundsFoundByChargeExternalId.size(), is(1));
         assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUNDED"));
         MatcherAssert.assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", testChargeCreatedWithStripeChargeAPI.getExternalChargeId()));
+        MatcherAssert.assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("reference", "re_1DRiccHj08j21DRiccHj08j2_test"));
+        MatcherAssert.assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", "re_1DRiccHj08j21DRiccHj08j2_test"));
         String refundId = response.extract().path("refund_id");
         
         verify(postRequestedFor(urlEqualTo("/v1/refunds"))

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundIT.java
@@ -99,6 +99,7 @@ public class WorldpayRefundIT extends ChargingITestBase {
         assertThat(refundsFoundByChargeExternalId.size(), is(1));
         assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(notNullValue()), defaultTestCharge.getExternalChargeId(), refundAmount, "REFUND SUBMITTED")));
         assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", defaultTestCharge.getExternalChargeId()));
+        assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", refundId));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -152,9 +152,11 @@ public class QueueMessageContractTest {
 
     @PactVerifyProvider("a refund succeeded message")
     public String verifyRefundedEvent() throws JsonProcessingException {
+        String gatewayTransactionId = RandomStringUtils.randomAlphanumeric(14);
         RefundHistory refundHistory = aValidRefundHistoryEntity()
                 .withStatus(RefundStatus.REFUNDED.getValue())
-                .withReference(RandomStringUtils.randomAlphanumeric(14))
+                .withReference(gatewayTransactionId)
+                .withGatewayTransactionId(gatewayTransactionId)
                 .build();
         RefundSucceeded refundSucceeded = RefundSucceeded.from(refundHistory);
 

--- a/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
@@ -70,4 +70,9 @@ public class RefundHistoryEntityFixture {
         this.userEmail = userEmail;
         return this;
     }
+
+    public RefundHistoryEntityFixture withGatewayTransactionId(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+        return this;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
@@ -79,8 +79,12 @@ public class EpdqMockClient {
         paymentServiceResponse(ROUTE_FOR_MAINTENANCE_ORDER, TestTemplateResourceLoader.load(EPDQ_CANCEL_SUCCESS_RESPONSE));
     }
 
-    public void mockRefundSuccess() {
-        paymentServiceResponse(ROUTE_FOR_MAINTENANCE_ORDER, TestTemplateResourceLoader.load(EPDQ_REFUND_SUCCESS_RESPONSE));
+    public void mockRefundSuccess(String... payIdSub) {
+        String payIdSubToUse = (payIdSub != null && payIdSub.length == 1) ? payIdSub[0] : "1";
+        paymentServiceResponse(ROUTE_FOR_MAINTENANCE_ORDER,
+                TestTemplateResourceLoader.load(EPDQ_REFUND_SUCCESS_RESPONSE)
+                        .replace("{{payIdSub}}", payIdSubToUse)
+        );
     }
 
     public void mockRefundError() {

--- a/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
@@ -86,8 +86,10 @@ public class SmartpayMockClient {
         );
     }
 
-    public void mockRefundSuccess() {
-        String refundResponse = TestTemplateResourceLoader.load(SMARTPAY_REFUND_SUCCESS_RESPONSE);
+    public void mockRefundSuccess(String... pspReference) {
+        String pspReferenceToUse = (pspReference != null && pspReference.length == 1) ? pspReference[0] : "8514774917520978";
+        String refundResponse = TestTemplateResourceLoader.load(SMARTPAY_REFUND_SUCCESS_RESPONSE)
+                .replace("{{pspReference}}", pspReferenceToUse);
         paymentServiceResponse(refundResponse);
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -293,7 +293,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefundsByChargeExternalId(String chargeExternalId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT external_id, reference, amount, status, created_date, user_external_id, user_email, charge_external_id " +
+                h.createQuery("SELECT external_id, reference, amount, status, created_date, user_external_id, user_email, charge_external_id, gateway_transaction_id " +
                         "FROM refunds r " +
                         "WHERE charge_external_id = :charge_external_id")
                         .bind("charge_external_id", chargeExternalId)

--- a/src/test/java/uk/gov/pay/connector/util/SmartpayXMLUnmarshallerTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/SmartpayXMLUnmarshallerTest.java
@@ -9,11 +9,20 @@ import uk.gov.pay.connector.gateway.smartpay.SmartpayCancelResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayCaptureResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayRefundResponse;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomNumeric;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.*;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CANCEL_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CANCEL_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_REFUND_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_REFUND_SUCCESS_RESPONSE;
 
 public class SmartpayXMLUnmarshallerTest {
 
@@ -98,11 +107,13 @@ public class SmartpayXMLUnmarshallerTest {
 
     @Test
     public void shouldUnmarshallARefundSuccessResponse() throws Exception {
-        String successPayload = TestTemplateResourceLoader.load(SMARTPAY_REFUND_SUCCESS_RESPONSE);
+        String pspReference = randomNumeric(16);
+        String successPayload = TestTemplateResourceLoader.load(SMARTPAY_REFUND_SUCCESS_RESPONSE)
+                .replace("{{pspReference}}", pspReference);
         SmartpayRefundResponse response = XMLUnmarshaller.unmarshall(successPayload, SmartpayRefundResponse.class);
 
         assertThat(response.getReference(), is(notNullValue()));
-        assertThat(response.getReference().get(), is("8514774917520978"));
+        assertThat(response.getReference().get(), is(pspReference));
         assertThat(response.getErrorCode(), is(nullValue()));
         assertThat(response.getErrorMessage(), is(nullValue()));
     }

--- a/src/test/resources/templates/epdq/refund-success-response.xml
+++ b/src/test/resources/templates/epdq/refund-success-response.xml
@@ -2,7 +2,7 @@
 <ncresponse
         orderID="ABREF1245"
         PAYID="3014644340"
-        PAYIDSUB="1"
+        PAYIDSUB="{{payIdSub}}"
         NCSTATUS="0"
         NCERROR="0"
         NCERRORPLUS="!"

--- a/src/test/resources/templates/smartpay/refund-success-response.xml
+++ b/src/test/resources/templates/smartpay/refund-success-response.xml
@@ -4,7 +4,7 @@
         <ns1:refundResponse xmlns:ns1="http://payment.services.adyen.com">
             <ns1:refundResult>
                 <additionalData xmlns="http://payment.services.adyen.com" xsi:nil="true"/>
-                <pspReference xmlns="http://payment.services.adyen.com">8514774917520978</pspReference>
+                <pspReference xmlns="http://payment.services.adyen.com">{{pspReference}}</pspReference>
                 <response xmlns="http://payment.services.adyen.com">[refund-received]</response>
             </ns1:refundResult>
         </ns1:refundResponse>


### PR DESCRIPTION
## WHAT
  - We store gateway reference for refunds in `reference` column. This contradicts with payments as   `gateway_transaction_id` (charges table) is used to store payment reference provided by PSPs.  Additionally `reference` on payment is the service provided value which further adds confusion to using the name reference on refunds.

**Changes**
   - Starts setting gateway_transaction_id on refunds table. `reference` is still set on refunds table but soon to be dropped.
   - Adding gateway_transaction_id (reference in refunds table) to refund events sent to Ledger. This will make the gateway_transaction_id naming consistent with payment event. `reference` will be removed from refund events payload once we fully switch over to using gateway_transaction_id column.

with @sandorarpa
