### PR TITLE
PP-6756 Remove reference from refund events payload

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundEventWithGatewayTransactionIdDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/refund/RefundEventWithGatewayTransactionIdDetails.java
@@ -2,18 +2,12 @@ package uk.gov.pay.connector.events.eventdetails.refund;
 
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
-public class RefundEventWithReferenceDetails extends EventDetails {
+public class RefundEventWithGatewayTransactionIdDetails extends EventDetails {
 
-    private String reference;
     private String gatewayTransactionId;
 
-    public RefundEventWithReferenceDetails(String reference, String gatewayTransactionId) {
-        this.reference = reference;
+    public RefundEventWithGatewayTransactionIdDetails(String gatewayTransactionId) {
         this.gatewayTransactionId = gatewayTransactionId;
-    }
-
-    public String getReference() {
-        return reference;
     }
 
     public String getGatewayTransactionId() {

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -7,7 +7,7 @@ import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
-import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.events.exception.EventCreationException;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
@@ -140,10 +140,10 @@ public class EventFactory {
             } else if (eventClass == RefundCreatedByUser.class) {
                 return RefundCreatedByUser.from(refundHistory, gatewayAccountId);
             } else {
-                return eventClass.getConstructor(String.class, String.class, RefundEventWithReferenceDetails.class, ZonedDateTime.class).newInstance(
+                return eventClass.getConstructor(String.class, String.class, RefundEventWithGatewayTransactionIdDetails.class, ZonedDateTime.class).newInstance(
                         refundHistory.getExternalId(),
                         refundHistory.getChargeExternalId(),
-                        new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
+                        new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
                         refundHistory.getHistoryStartDate()
                 );
             }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
-import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
@@ -8,14 +8,14 @@ import java.time.ZonedDateTime;
 public class RefundError extends RefundEvent {
 
     public RefundError(String resourceExternalId, String parentResourceExternalId,
-                       RefundEventWithReferenceDetails referenceDetails, ZonedDateTime timestamp) {
+                       RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public RefundError from(RefundHistory refundHistory) {
         return new RefundError(refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
-                new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
+                new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
                 refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
-import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
@@ -8,14 +8,14 @@ import java.time.ZonedDateTime;
 public class RefundSubmitted extends RefundEvent {
 
     public RefundSubmitted(String resourceExternalId, String parentResourceExternalId,
-                           RefundEventWithReferenceDetails referenceDetails, ZonedDateTime timestamp) {
+                           RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSubmitted from(RefundHistory refundHistory) {
         return new RefundSubmitted(refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
-                new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
+                new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
                 refundHistory.getHistoryStartDate());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
-import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import java.time.ZonedDateTime;
@@ -8,14 +8,14 @@ import java.time.ZonedDateTime;
 public class RefundSucceeded extends RefundEvent {
 
     public RefundSucceeded(String resourceExternalId, String parentResourceExternalId,
-                           RefundEventWithReferenceDetails referenceDetails, ZonedDateTime timestamp) {
+                           RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSucceeded from(RefundHistory refundHistory) {
         return new RefundSucceeded(refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
-                new RefundEventWithReferenceDetails(refundHistory.getReference(), refundHistory.getReference()),
+                new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
                 refundHistory.getHistoryStartDate());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -20,7 +20,7 @@ import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetail
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentNotificationCreatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByUserEventDetails;
-import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithReferenceDetails;
+import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.EventFactory;
 import uk.gov.pay.connector.events.model.ResourceType;
@@ -149,7 +149,7 @@ public class EventFactoryTest {
         assertThat(refundSubmitted.getParentResourceExternalId(), is(charge.getExternalId()));
         assertThat(refundSubmitted.getResourceExternalId(), is(refundSubmittedHistory.getExternalId()));
         assertThat(refundSubmitted.getResourceType(), is(ResourceType.REFUND));
-        assertThat(refundSubmitted.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
+        assertThat(refundSubmitted.getEventDetails(), is(instanceOf(RefundEventWithGatewayTransactionIdDetails.class)));
     }
 
     @Test
@@ -180,7 +180,7 @@ public class EventFactoryTest {
         assertThat(refundSucceeded.getParentResourceExternalId(), is(charge.getExternalId()));
         assertThat(refundSucceeded.getResourceExternalId(), is(refundSucceededHistory.getExternalId()));
         assertThat(refundSucceeded.getResourceType(), is(ResourceType.REFUND));
-        assertThat(refundSucceeded.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
+        assertThat(refundSucceeded.getEventDetails(), is(instanceOf(RefundEventWithGatewayTransactionIdDetails.class)));
     }
 
     @Test
@@ -211,10 +211,9 @@ public class EventFactoryTest {
                 .filter(e -> ResourceType.REFUND.equals(e.getResourceType()))
                 .findFirst().get();
         assertThat(refundError.getParentResourceExternalId(), is(charge.getExternalId()));
-        assertThat(((RefundEventWithReferenceDetails) refundError.getEventDetails()).getReference(), is(refundErrorHistory.getReference()));
-        assertThat(((RefundEventWithReferenceDetails) refundError.getEventDetails()).getGatewayTransactionId(), is(refundErrorHistory.getReference()));
+        assertThat(((RefundEventWithGatewayTransactionIdDetails) refundError.getEventDetails()).getGatewayTransactionId(), is(refundErrorHistory.getGatewayTransactionId()));
         assertThat(refundError.getResourceType(), is(ResourceType.REFUND));
-        assertThat(refundError.getEventDetails(), is(instanceOf(RefundEventWithReferenceDetails.class)));
+        assertThat(refundError.getEventDetails(), is(instanceOf(RefundEventWithGatewayTransactionIdDetails.class)));
 
         RefundAvailabilityUpdated refundAvailabilityUpdated = (RefundAvailabilityUpdated) refundEvents.stream()
                 .filter(e -> ResourceType.PAYMENT.equals(e.getResourceType()))

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundSucceededTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundSucceededTest.java
@@ -38,8 +38,7 @@ public class RefundSucceededTest {
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(refundHistory.getExternalId())));
         assertThat(actual, hasJsonPath("$.parent_resource_external_id", equalTo(charge.getExternalId())));
 
-        assertThat(actual, hasJsonPath("$.event_details.reference", equalTo("reference")));
-        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo("reference")));
+        assertThat(actual, hasJsonPath("$.event_details.gateway_transaction_id", equalTo("gateway_transaction_id")));
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
@@ -140,7 +140,7 @@ public class StateTransitionsIT extends ChargingITestBase {
 
         assertThat(message4.get("event_type").getAsString(), is("REFUND_SUCCEEDED"));
         assertThat(message4.get("resource_external_id").getAsString(), is(refundId));
-        assertThat(message4.get("event_details").getAsJsonObject().get("reference").getAsString(), is(notNullValue()));
+        assertThat(message4.get("event_details").getAsJsonObject().get("gateway_transaction_id").getAsString(), is(notNullValue()));
     }
 
     private ZonedDateTime getTimestampFromMessage(Message message) {


### PR DESCRIPTION
## WHAT YOU DID
- We are now setting gateway_transaction_id on refunds with transaction id provided by PSP.
  Uses `gateway_transaction_id` for refund payloads to ledger and removed `reference` from these events

depends on https://github.com/alphagov/pay-ledger/pull/838