### PR TITLE
PP-6614 - Add empty string for last four digits to Sandbox for Wallet Payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -745,8 +745,11 @@ public class ChargeService {
         if (hasFullCardNumber(authCardDetails)) { // Apple Pay etc. don’t give us a full card number, just the last four digits here
             detailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of(StringUtils.left(authCardDetails.getCardNo(), 6)));
         }
-        detailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of(StringUtils.right(authCardDetails.getCardNo(), 4)));
-
+        
+        if (hasLastFourCharactersCardNumber(authCardDetails)) {
+            detailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of(StringUtils.right(authCardDetails.getCardNo(), 4)));
+        }
+        
         if (authCardDetails.getAddress().isPresent())
             detailsEntity.setBillingAddress(new AddressEntity(authCardDetails.getAddress().get()));
 
@@ -757,6 +760,10 @@ public class ChargeService {
 
     private boolean hasFullCardNumber(AuthCardDetails authCardDetails) {
         return authCardDetails.getCardNo().length() > 6;
+    }
+    
+    private boolean hasLastFourCharactersCardNumber(AuthCardDetails authCardDetails) {
+        return authCardDetails.getCardNo().length() >= 4;
     }
 
     private TokenEntity createNewChargeEntityToken(ChargeEntity chargeEntity) {

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbers.java
@@ -1,34 +1,24 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
-import com.google.common.collect.ImmutableSet;
-
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toMap;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 
 public class SandboxCardNumbers {
-
+    
     private static final String GOOD_CARD_PREPAID_NON_CORPORATE = "4000160000000004";
-    private static final String GOOD_WALLET_LAST_DIGITS_CARD_NUMBER = "4242";
     private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD = "5101180000000007";
     private static final String GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD = "5200828282828210";
     private static final String GOOD_NON_CORPORATE_NON_PREPAID = "4000020000000000";
     private static final String GOOD_MASTERCARD_CREDIT_CARD = "5101110000000004";
     private static final String GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD = "4000000000000010";
-    private static final String DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER = "0002";
     private static final String DECLINED_CARD_NUMBER = "4000000000000002";
-    private static final String CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0127";
     private static final String CVC_ERROR_CARD_NUMBER = "4000000000000127";
-    private static final String EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER = "0069";
     private static final String EXPIRED_CARD_NUMBER = "4000000000000069";
-    private static final String PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0119";
     private static final String PROCESSING_ERROR_CARD_NUMBER = "4000000000000119";
 
-    private static final Set<String> GOOD_CARDS = ImmutableSet.of(
+    private static final Set<String> GOOD_CARDS = Set.of(
             "4444333322221111",
             "4242424242424242",
             "4917610000000000003",
@@ -40,35 +30,27 @@ public class SandboxCardNumbers {
             "36148900647913",
             GOOD_MASTERCARD_CREDIT_CARD,
             GOOD_VISA_PREPAID_UNKNOWN_CREDIT_OR_DEBIT_UNKNOWN_CARD,
-            GOOD_WALLET_LAST_DIGITS_CARD_NUMBER,
             GOOD_CARD_PREPAID_NON_CORPORATE,
             GOOD_NON_CORPORATE_NON_PREPAID);
 
-    private static final Set<String> GOOD_CORPORATE_CARDS = ImmutableSet.of(
+    private static final Set<String> GOOD_CORPORATE_CARDS = Set.of(
             "4988080000000000",
             "4000620000000007",
             "4293189100000008",
             GOOD_CORPORATE_PREPAID_UNKNOWN_CREDIT_CARD);
 
-    private static final Set<String> GOOD_CORPORATE_PREPAID_DEBIT_CARD = ImmutableSet.of(
+    private static final Set<String> GOOD_CORPORATE_PREPAID_DEBIT_CARD = Set.of(
             "4131840000000003",
             "4000180000000002",
             GOOD_CORPORATE_PREPAID_UNKNOWN_DEBIT_CARD);
 
-    private static final Set<String> REJECTED_CARDS = ImmutableSet.of(
+    private static final Set<String> REJECTED_CARDS = Set.of(
             DECLINED_CARD_NUMBER,
-            DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER,
             EXPIRED_CARD_NUMBER,
-            EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER,
-            CVC_ERROR_CARD_NUMBER,
-            CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER);
+            CVC_ERROR_CARD_NUMBER);
 
-    private static Map<String, CardError> ERROR_CARDS = Stream.of(
-            PROCESSING_ERROR_CARD_NUMBER,
-            PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER)
-            .collect(toMap(
-                    Function.identity(),
-                    cardNumber -> new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed.")));
+    private static Map<String, CardError> ERROR_CARDS = Map.of(
+            PROCESSING_ERROR_CARD_NUMBER, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
 
     public static boolean isValidCard(String cardNumber) {
         return GOOD_CARDS.contains(cardNumber) ||

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxWalletCardNumbers.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxWalletCardNumbers.java
@@ -1,0 +1,52 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+
+public class SandboxWalletCardNumbers extends SandboxCardNumbers {
+    
+    /*
+    The last four digits field for Apple and Google Pay aren't used for authorisation.
+    However for testing purposes Sandbox determines the authorisation status based on the last four digits field.
+     */
+
+    private static final String GOOD_WALLET_LAST_DIGITS_CARD_NUMBER = "4242";
+    private static final String GOOD_WALLET_EMPTY_STRING_CARD_NUMBER = "";
+    private static final String DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER = "0002";
+    private static final String CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0127";
+    private static final String EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER = "0069";
+    private static final String PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER = "0119";
+
+    private static final Set<String> GOOD_CARDS = Set.of(
+            GOOD_WALLET_EMPTY_STRING_CARD_NUMBER,
+            GOOD_WALLET_LAST_DIGITS_CARD_NUMBER);
+    
+    private static final Set<String> REJECTED_CARDS = Set.of(
+            DECLINED_WALLET_LAST_DIGITS_CARD_NUMBER,
+            EXPIRED_WALLET_LAST_DIGITS_CARD_NUMBER,
+            CVC_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER);
+
+    private static Map<String, CardError> ERROR_CARDS = Map.of(
+            PROCESSING_ERROR_WALLET_LAST_DIGITS_CARD_NUMBER, new CardError(AUTHORISATION_ERROR, "This transaction could be not be processed."));
+
+    public static boolean isValidCard(String cardNumber) {
+        return GOOD_CARDS.contains(cardNumber);
+    }
+
+    public static boolean isRejectedCard(String cardNumber) {
+        return REJECTED_CARDS.contains(cardNumber);
+    }
+
+    public static boolean isErrorCard(String cardNumber) {
+        return ERROR_CARDS.containsKey(cardNumber);
+    }
+
+    public static CardError cardErrorFor(String cardNumber) {
+        return ERROR_CARDS.get(cardNumber);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/applepay/SandboxWalletAuthorisationHandler.java
@@ -1,10 +1,16 @@
 package uk.gov.pay.connector.gateway.sandbox.applepay;
 
+import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.sandbox.CardError;
 import uk.gov.pay.connector.gateway.sandbox.SandboxGatewayResponseGenerator;
+import uk.gov.pay.connector.gateway.sandbox.SandboxWalletCardNumbers;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.WalletAuthorisationHandler;
+
+import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 
 public class SandboxWalletAuthorisationHandler implements WalletAuthorisationHandler, SandboxGatewayResponseGenerator {
     @Override
@@ -13,4 +19,23 @@ public class SandboxWalletAuthorisationHandler implements WalletAuthorisationHan
         return getSandboxGatewayResponse(lastDigitsCardNumber);
     }
 
+    @Override
+    public GatewayResponse getSandboxGatewayResponse(String lastDigitsCardNumber) {
+        GatewayResponse.GatewayResponseBuilder<BaseAuthoriseResponse> gatewayResponseBuilder = responseBuilder();
+
+        if (SandboxWalletCardNumbers.isErrorCard(lastDigitsCardNumber)) {
+            CardError errorInfo = SandboxWalletCardNumbers.cardErrorFor(lastDigitsCardNumber);
+            return gatewayResponseBuilder
+                    .withGatewayError(new GatewayError(errorInfo.getErrorMessage(), GENERIC_GATEWAY_ERROR))
+                    .build();
+        } else if (SandboxWalletCardNumbers.isRejectedCard(lastDigitsCardNumber)) {
+            return SandboxGatewayResponseGenerator.getSandboxGatewayResponse(false);
+        } else if (SandboxWalletCardNumbers.isValidCard(lastDigitsCardNumber)) {
+            return SandboxGatewayResponseGenerator.getSandboxGatewayResponse(true);
+        }
+
+        return gatewayResponseBuilder
+                .withGatewayError(new GatewayError("Unsupported card details.", GENERIC_GATEWAY_ERROR))
+                .build();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbersTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxCardNumbersTest.java
@@ -2,8 +2,8 @@ package uk.gov.pay.connector.gateway.sandbox;
 
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.gateway.sandbox.SandboxCardNumbers.cardErrorFor;
 import static uk.gov.pay.connector.gateway.sandbox.SandboxCardNumbers.isErrorCard;
@@ -14,31 +14,24 @@ public class SandboxCardNumbersTest {
 
     @Test
     public void shouldDetectValidCards() {
-        assertThat(isValidCard("4444333322221111"), is (true));
-        assertThat(isValidCard("4000180000000002"), is (true));
-        assertThat(isValidCard("4242"), is (true));
+        assertTrue(isValidCard("4444333322221111"));
+        assertTrue(isValidCard("4000180000000002"));
     }
 
     @Test
     public void shouldDetectErrorCards() {
-        assertThat(isErrorCard("4000000000000119"), is (true));
-        assertThat(isErrorCard("0119"), is (true));
+        assertTrue(isErrorCard("4000000000000119"));
     }
 
     @Test
     public void shouldDetectRejectedCards() {
-        assertThat(isRejectedCard("4000000000000002"), is (true));
-        assertThat(isRejectedCard("0002"), is (true));
-        assertThat(isRejectedCard("4000000000000069"), is (true));
-        assertThat(isRejectedCard("0069"), is (true));
-        assertThat(isRejectedCard("4000000000000127"), is (true));
-        assertThat(isRejectedCard("0127"), is (true));
+        assertTrue(isRejectedCard("4000000000000002"));
+        assertTrue(isRejectedCard("4000000000000069"));
+        assertTrue(isRejectedCard("4000000000000127"));
     }
 
     @Test
     public void shouldRetrieveStatusForErrorCards() {
-        assertThat(cardErrorFor("4000000000000119").getNewErrorStatus(), is(AUTHORISATION_ERROR));
-        assertThat(cardErrorFor("0119").getNewErrorStatus(), is(AUTHORISATION_ERROR));
+        assertEquals(cardErrorFor("4000000000000119").getNewErrorStatus(), AUTHORISATION_ERROR);
     }
-
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxWalletCardNumbersTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxWalletCardNumbersTest.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxWalletCardNumbers.cardErrorFor;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxWalletCardNumbers.isErrorCard;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxWalletCardNumbers.isRejectedCard;
+import static uk.gov.pay.connector.gateway.sandbox.SandboxWalletCardNumbers.isValidCard;
+
+public class SandboxWalletCardNumbersTest {
+
+    @Test
+    public void shouldDetectValidCards() {
+        assertTrue(isValidCard("4242"));
+        assertTrue(isValidCard(""));
+    }
+
+    @Test
+    public void shouldDetectErrorCards() {
+        assertTrue(isErrorCard("0119"));
+    }
+
+    @Test
+    public void shouldDetectRejectedCards() {
+        assertTrue(isRejectedCard("0002"));
+        assertTrue(isRejectedCard("0069"));
+        assertTrue(isRejectedCard("0127"));
+    }
+
+    @Test
+    public void shouldRetrieveStatusForErrorCards() {
+        assertEquals(cardErrorFor("0119").getNewErrorStatus(), AUTHORISATION_ERROR);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -20,7 +20,6 @@ import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import java.time.ZonedDateTime;
 import java.util.Collections;
-import java.util.Map;
 
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static uk.gov.pay.connector.pact.util.GatewayAccountUtil.setUpGatewayAccount;

--- a/src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json
+++ b/src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json
@@ -1,0 +1,13 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "",
+    "brand": "visa",
+    "cardholder_name": "Example Name",
+    "email": "example@test.example"
+  },
+  "encrypted_payment_data": {
+    "signature": "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl",
+    "protocol_version": "ECv1",
+    "signed_message": "aSignedMessage"
+  }
+}


### PR DESCRIPTION
Description:
- The lastFourDigitsCardNumber is not used for authorisation purposes by Apple and Google Pay it is purely cosmetic. However in our tests
Sandbox determines the authorisation status based on the lastFourDigitsCardNumber field which is not ideal. To ensure our pact test passes (see PP-6614 in frontend) we have added an empty string to
Sandbox allowed card numbers
- We add a check for whether lastFourDigitsCardNumber is of length 4 to handle the case of an empty string as otherwise an Exception will be thrown. This is to fix a bug as lastFourDigitsCardNumber isn't used for authorisation so upon successful authorisation the contents of lastFourDigitsCardNumber shouldn't matter.
- Apple/Google Pay don't use the last_four_digits as part of authorisation but we do for producing canned responses for authorisation. To better test Apple/Google Pay the test numbers have been moved to a separate class to ensure separation of concerns.