### PR TITLE
PP-6756 Remove reference on Refunds

### DIFF
--- a/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/model/TransactionEvent.java
@@ -85,7 +85,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
 
     private final Type type;
     private String extChargeId;
-    private String extRefundReference;
+    private String refundGatewayTransactionId;
     private String userExternalId;
     private State state;
     private Long amount;
@@ -99,9 +99,9 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
         this.updated = updated;
     }
 
-    public TransactionEvent(Type type, String extChargeId, String extRefundReference, State state, Long amount, ZonedDateTime updated, String userExternalId) {
+    public TransactionEvent(Type type, String extChargeId, String refundGatewayTransactionId, State state, Long amount, ZonedDateTime updated, String userExternalId) {
         this.type = type;
-        this.extRefundReference = extRefundReference;
+        this.refundGatewayTransactionId = refundGatewayTransactionId;
         this.extChargeId = extChargeId;
         this.state = state;
         this.amount = amount;
@@ -116,7 +116,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
 
     @JsonProperty("refund_reference")
     public String getRefundId() {
-        return extRefundReference;
+        return refundGatewayTransactionId;
     }
 
     @JsonProperty("submitted_by")
@@ -169,7 +169,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
         TransactionEvent that = (TransactionEvent) o;
 
         if (type != that.type) return false;
-        if (extRefundReference != null ? !extRefundReference.equals(that.extRefundReference) : that.extRefundReference != null) return false;
+        if (refundGatewayTransactionId != null ? !refundGatewayTransactionId.equals(that.refundGatewayTransactionId) : that.refundGatewayTransactionId != null) return false;
         if (extChargeId != null ? !extChargeId.equals(that.extChargeId) : that.extChargeId != null) return false;
         if (state != null ? !state.equals(that.state) : that.state != null) return false;
         if (userExternalId != null ? !userExternalId.equals(that.userExternalId) : that.userExternalId != null) return false;
@@ -180,7 +180,7 @@ public class TransactionEvent implements Comparable<TransactionEvent> {
     @Override
     public int hashCode() {
         int result = type != null ? type.hashCode() : 0;
-        result = 31 * result + (extRefundReference != null ? extRefundReference.hashCode() : 0);
+        result = 31 * result + (refundGatewayTransactionId != null ? refundGatewayTransactionId.hashCode() : 0);
         result = 31 * result + (extChargeId != null ? extChargeId.hashCode() : 0);
         result = 31 * result + (state != null ? state.hashCode() : 0);
         result = 31 * result + (amount != null ? amount.hashCode() : 0);

--- a/src/main/java/uk/gov/pay/connector/chargeevent/resource/ChargeEventsResource.java
+++ b/src/main/java/uk/gov/pay/connector/chargeevent/resource/ChargeEventsResource.java
@@ -4,9 +4,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.chargeevent.model.TransactionEvent;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
 import javax.ws.rs.GET;
@@ -79,7 +79,7 @@ public class ChargeEventsResource {
                 .map(event -> new TransactionEvent(
                         REFUND,
                         event.getChargeExternalId(),
-                        event.getReference(),
+                        event.getGatewayTransactionId(),
                         extractState(event.getStatus().toExternal()),
                         event.getAmount(),
                         event.getHistoryStartDate(),

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -29,18 +29,18 @@ public class RefundNotificationProcessor {
     }
 
     public void invoke(PaymentGatewayName gatewayName, RefundStatus newStatus, GatewayAccountEntity gatewayAccountEntity,
-                       String reference, String transactionId, Charge charge) {
-        if (isBlank(reference)) {
+                       String gatewayTransactionId, String transactionId, Charge charge) {
+        if (isBlank(gatewayTransactionId)) {
             logger.warn("{} refund notification could not be used to update charge [{}] (missing reference)",
                     gatewayName, charge.getExternalId());
             return;
         }
 
         Optional<RefundEntity> optionalRefundEntity 
-                = refundService.findByChargeExternalIdAndReference(charge.getExternalId(), reference);
+                = refundService.findByChargeExternalIdAndGatewayTransactionId(charge.getExternalId(), gatewayTransactionId);
         if (optionalRefundEntity.isEmpty()) {
             logger.warn("{} notification '{}' could not be used to update refund (associated refund entity not found) for charge [{}]",
-                    gatewayName, reference, charge.getExternalId());
+                    gatewayName, gatewayTransactionId, charge.getExternalId());
             return;
         }
 
@@ -56,7 +56,7 @@ public class RefundNotificationProcessor {
         logger.info("Notification received for refund. Updating refund - charge_external_id={}, refund_reference={}, transaction_id={}, status={}, "
                         + "status_to={}, account_id={}, provider={}, provider_type={}",
                 refundEntity.getChargeExternalId(),
-                reference,
+                gatewayTransactionId,
                 transactionId,
                 oldStatus,
                 newStatus,

--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -15,7 +15,6 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
-
 @Transactional
 public class RefundDao extends JpaDao<RefundEntity> {
 
@@ -28,21 +27,21 @@ public class RefundDao extends JpaDao<RefundEntity> {
         return super.findById(RefundEntity.class, refundId);
     }
 
-    public Optional<RefundEntity> findByChargeExternalIdAndReference(String chargeExternalId, String reference) {
+    public Optional<RefundEntity> findByChargeExternalIdAndGatewayTransactionId(String chargeExternalId, String gatewayTransactionId) {
 
         String query = "SELECT refund FROM RefundEntity refund " +
-                "WHERE refund.reference = :reference AND refund.chargeExternalId = :chargeExternalId";
+                "WHERE refund.gatewayTransactionId = :gatewayTransactionId AND refund.chargeExternalId = :chargeExternalId";
 
         return entityManager.get()
                 .createQuery(query, RefundEntity.class)
-                .setParameter("reference", reference)
+                .setParameter("gatewayTransactionId", gatewayTransactionId)
                 .setParameter("chargeExternalId", chargeExternalId)
                 .getResultList().stream().findFirst();
     }
 
     public Optional<RefundHistory> getRefundHistoryByRefundExternalIdAndRefundStatus(String refundExternalId, RefundStatus refundStatus) {
         String query = "SELECT rh.id, rh.external_id, rh.amount, rh.status, rh.created_date, " +
-                "rh.version, rh.reference, rh.history_start_date, rh.history_end_date, rh.user_external_id, " +
+                "rh.version, rh.history_start_date, rh.history_end_date, rh.user_external_id, " +
                 "rh.gateway_transaction_id, rh.charge_external_id, rh.user_email " +
                 "FROM refunds_history rh " +
                 "WHERE rh.external_id = ?1 AND rh.status = ?2";
@@ -59,7 +58,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
 
     public List<RefundHistory> searchHistoryByChargeExternalId(String chargeExternalId) {
 
-        String query = "SELECT id, external_id, amount, status, created_date, version, reference, " +
+        String query = "SELECT id, external_id, amount, status, created_date, version, " +
                 "history_start_date, history_end_date, user_external_id, gateway_transaction_id, user_email, charge_external_id " +
                 "FROM refunds_history r " +
                 "WHERE charge_external_id = ?1 AND status != ?2";
@@ -73,7 +72,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
 
     public List<RefundHistory> searchAllHistoryByChargeExternalId(String chargeExternalId) {
         String query = "SELECT r.id, r.external_id, r.amount, r.status, r.created_date, r.version, " +
-                "r.reference, history_start_date, history_end_date, user_external_id, r.gateway_transaction_id, " +
+                "history_start_date, history_end_date, user_external_id, r.gateway_transaction_id, " +
                 "r.charge_external_id AS charge_external_id, r.user_email " +
                 " FROM refunds_history r " +
                 " WHERE charge_external_id = ?1";
@@ -96,7 +95,7 @@ public class RefundDao extends JpaDao<RefundEntity> {
 
     public List<RefundHistory> getRefundHistoryByDateRange(ZonedDateTime startDate, ZonedDateTime endDate, int page, int size) {
 
-        String query = "SELECT id, external_id, amount, status, created_date, version, reference, " +
+        String query = "SELECT id, external_id, amount, status, created_date, version, " +
                 "       history_start_date, history_end_date, user_external_id, gateway_transaction_id, user_email " +
                 " FROM refunds_history rh " +
                 " WHERE rh.history_start_date >= ?1 AND rh.history_start_date <= ?2" +

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.refund.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.persistence.annotations.Customizer;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import uk.gov.pay.connector.util.RandomIdGenerator;
@@ -17,8 +16,6 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.SqlResultSetMapping;
 import javax.persistence.Table;
@@ -40,7 +37,6 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
                         @ColumnResult(name = "status", type = String.class),
                         @ColumnResult(name = "created_date", type = Timestamp.class),
                         @ColumnResult(name = "version", type=Long.class),
-                        @ColumnResult(name = "reference", type = String.class),
                         @ColumnResult(name = "history_start_date", type = Timestamp.class),
                         @ColumnResult(name = "history_end_date", type = Timestamp.class),
                         @ColumnResult(name = "user_external_id", type = String.class),
@@ -63,9 +59,6 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     @Column(name = "external_id")
     private String externalId;
-
-    @Column(name = "reference")
-    private String reference;
 
     private Long amount;
 
@@ -108,10 +101,6 @@ public class RefundEntity extends AbstractVersionedEntity {
         return gatewayTransactionId;
     }
 
-    public String getReference() {
-        return reference;
-    }
-
     public Long getAmount() {
         return amount;
     }
@@ -122,10 +111,6 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     public ZonedDateTime getCreatedDate() {
         return createdDate;
-    }
-
-    public void setReference(String reference) {
-        this.reference = reference;
     }
 
     public void setAmount(Long amount) {
@@ -184,7 +169,6 @@ public class RefundEntity extends AbstractVersionedEntity {
     public String toString() {
         return "RefundEntity{" +
                 "externalId='" + externalId + '\'' +
-                ", reference='" + reference + '\'' +
                 ", amount=" + amount +
                 ", status='" + status + '\'' +
                 ", userExternalId='" + userExternalId + '\'' +

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundHistory.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.refund.model.domain;
 
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
@@ -17,7 +16,7 @@ public class RefundHistory extends RefundEntity {
     private ZonedDateTime historyEndDate;
 
     public RefundHistory(Long id, String externalId, Long amount, String status, Timestamp createdDate,
-                         Long version, String reference, Timestamp historyStartDate, Timestamp historyEndDate, 
+                         Long version, Timestamp historyStartDate, Timestamp historyEndDate, 
                          String userExternalId, String gatewayTransactionId, String chargeExternalId,
                          String userEmail) {
         super();
@@ -29,7 +28,6 @@ public class RefundHistory extends RefundEntity {
         setUserEmail(userEmail);
         setCreatedDate(new UTCDateTimeConverter().convertToEntityAttribute(createdDate));
         setVersion(version);
-        setReference(reference);
         setGatewayTransactionId(gatewayTransactionId);
 
         setHistoryStartDate(new UTCDateTimeConverter().convertToEntityAttribute(historyStartDate));

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -49,6 +49,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -190,8 +191,8 @@ public class EventFactoryTest {
                 .withStatus(RefundStatus.REFUND_ERROR.getValue())
                 .withUserExternalId("user_external_id")
                 .withChargeExternalId(charge.getExternalId())
+                .withGatewayTransactionId(randomAlphanumeric(30))
                 .withAmount(charge.getAmount())
-                .withReference("reference")
                 .build();
         when(refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(
                 refundErrorHistory.getExternalId(),

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByServiceTest.java
@@ -2,9 +2,9 @@ package uk.gov.pay.connector.events.model.refund;
 
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByServiceEventDetails;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
@@ -22,7 +22,7 @@ public class RefundCreatedByServiceTest {
 
     private RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L, RefundStatus.CREATED.getValue(),
             timeConverter.convertToDatabaseColumn(createdDate), 1L,
-            "reference", timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
+            timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
             timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
             null, "gateway_transaction_id", charge.getExternalId(),
             null);

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUserTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUserTest.java
@@ -2,9 +2,9 @@ package uk.gov.pay.connector.events.model.refund;
 
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByUserEventDetails;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
@@ -22,7 +22,7 @@ public class RefundCreatedByUserTest {
 
     private RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L, RefundStatus.CREATED.getValue(),
             timeConverter.convertToDatabaseColumn(createdDate), 1L,
-            "reference", timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
+            timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
             timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
             "user-external-id", "gateway_transaction_id", charge.getExternalId(),
             "test@example.com"

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundSucceededTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundSucceededTest.java
@@ -23,7 +23,7 @@ public class RefundSucceededTest {
 
     private RefundHistory refundHistory = new RefundHistory(1L, "external_id", 50L,
             RefundStatus.REFUNDED.getValue(), timeConverter.convertToDatabaseColumn(createdDate), 1L,
-            "reference", timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
+            timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
             timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
             "user-external-id", "gateway_transaction_id", charge.getExternalId(),
             "test@example.com");

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
-import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -84,8 +83,8 @@ public class SendRefundEmailIT {
         String refundExternalId = "999999";
 
         ChargeUtils.ExternalChargeId chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
-        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub,
-                100,  REFUND_SUBMITTED, randomAlphanumeric(10),
+        databaseTestHelper.addRefund(refundExternalId,
+                100,  REFUND_SUBMITTED, transactionId + "/" + payIdSub,
                 ZonedDateTime.now(), chargeId.toString());
 
         given().port(testContext.getPort())

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -126,8 +126,8 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestRefundHistory insert(RefundStatus status, String reference, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByExternalId, String userEmail) {
-            databaseTestHelper.addRefundHistory(id, externalId, reference, amount, status.toString(), createdDate, historyStartDate, historyEndDate, submittedByExternalId, userEmail, chargeExternalId);
+        public TestRefundHistory insert(RefundStatus status, String gatewayTransactionId, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByExternalId, String userEmail) {
+            databaseTestHelper.addRefundHistory(id, externalId, gatewayTransactionId, amount, status.toString(), createdDate, historyStartDate, historyEndDate, submittedByExternalId, userEmail, chargeExternalId);
             return this;
         }
 
@@ -706,7 +706,6 @@ public class DatabaseFixtures {
     public class TestRefund {
         int id;
         String externalRefundId = RandomIdGenerator.newId();
-        String reference;
         long amount = 101L;
         RefundStatus status = CREATED;
         ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
@@ -728,11 +727,6 @@ public class DatabaseFixtures {
 
         public TestRefund withType(RefundStatus status) {
             this.status = status;
-            return this;
-        }
-
-        public TestRefund withReference(String reference) {
-            this.reference = reference;
             return this;
         }
 
@@ -774,7 +768,7 @@ public class DatabaseFixtures {
         public TestRefund insert() {
             if (testCharge == null)
                 throw new IllegalStateException("Test charge must be provided.");
-            id = databaseTestHelper.addRefund(externalRefundId, reference, amount, status, gatewayTransactionId,
+            id = databaseTestHelper.addRefund(externalRefundId, amount, status, gatewayTransactionId,
                     createdDate, submittedByUserExternalId, userEmail,
                     chargeExternalId == null ? testCharge.getExternalChargeId() : chargeExternalId);
             return this;
@@ -786,10 +780,6 @@ public class DatabaseFixtures {
 
         public String getExternalRefundId() {
             return externalRefundId;
-        }
-
-        public String getReference() {
-            return reference;
         }
 
         public long getAmount() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
@@ -170,8 +170,8 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         int refundAmount = 1000;
 
         ChargeUtils.ExternalChargeId externalChargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
-        databaseTestHelper.addRefund(refundExternalId, transactionId + "/" + payIdSub, 1000,
-                REFUND_SUBMITTED, randomAlphanumeric(10), ZonedDateTime.now(),
+        databaseTestHelper.addRefund(refundExternalId, 1000,
+                REFUND_SUBMITTED, transactionId + "/" + payIdSub, ZonedDateTime.now(),
                 externalChargeId.toString());
 
         String response = notifyConnector(transactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
@@ -202,8 +202,8 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         
         ledgerStub.returnLedgerTransactionForProviderAndGatewayTransactionId(testCharge, getPaymentProvider());
 
-        databaseTestHelper.addRefund(refundExternalId, refundReference, refundAmount,
-                REFUND_SUBMITTED, randomAlphanumeric(10), ZonedDateTime.now(),
+        databaseTestHelper.addRefund(refundExternalId, refundAmount,
+                REFUND_SUBMITTED, refundReference, ZonedDateTime.now(),
                 chargeExternalId);
 
         String response = notifyConnector(gatewayTransactionId, payIdSub, "8", getCredentials().get(CREDENTIALS_SHA_OUT_PASSPHRASE))
@@ -219,7 +219,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         List<Map<String, Object>> refundsByChargeExternalId = databaseTestHelper.getRefundsByChargeExternalId(chargeExternalId);
         assertThat(refundsByChargeExternalId.size(), is(1));
         assertThat(refundsByChargeExternalId.get(0).get("charge_external_id"), is(chargeExternalId));
-        assertThat(refundsByChargeExternalId.get(0).get("reference"), is(refundReference));
+        assertThat(refundsByChargeExternalId.get(0).get("gateway_transaction_id"), is(refundReference));
         assertThat(refundsByChargeExternalId.get(0).get("status"), is("REFUNDED"));
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundIT.java
@@ -296,7 +296,7 @@ public class EpdqRefundIT extends ChargingITestBase {
                 .aTestRefund()
                 .withTestCharge(defaultTestCharge)
                 .withType(RefundStatus.REFUND_SUBMITTED)
-                .withReference(randomAlphanumeric(10))
+                .withGatewayTransactionId(randomAlphanumeric(10))
                 .withChargeExternalId(defaultTestCharge.getExternalChargeId())
                 .insert();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayNotificationResourceWithAccountSpecificAuthIT.java
@@ -131,15 +131,15 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthIT extends Charg
                 .then()
                 .statusCode(OK.getStatusCode());
 
-        String reference = randomId();
+        String gatewayTransactionId = randomId();
         String transactionId = randomId();
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         String externalRefundId = "refund-" + RandomUtils.nextInt();
-        int refundId = databaseTestHelper.addRefund(externalRefundId, reference, 10L,
-                REFUND_SUBMITTED, randomAlphanumeric(10), ZonedDateTime.now(),
+        int refundId = databaseTestHelper.addRefund(externalRefundId, 10L,
+                REFUND_SUBMITTED, gatewayTransactionId, ZonedDateTime.now(),
                 externalChargeId);
 
-        String response = notifyConnector(notificationPayloadForTransaction(externalRefundId, transactionId, reference, "notification-refund"))
+        String response = notifyConnector(notificationPayloadForTransaction(externalRefundId, transactionId, gatewayTransactionId, "notification-refund"))
                 .then()
                 .statusCode(200)
                 .extract().body().asString();
@@ -151,7 +151,7 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthIT extends Charg
 
     @Test
     public void shouldHandleARefundNotification_forAnExpungedCharge() throws JsonProcessingException {
-        String reference = randomId();
+        String refundTransactionId = randomId();
         String transactionId = randomId();
         String externalChargeId = randomAlphanumeric(26);
         String externalRefundId = "refund-" + RandomUtils.nextInt();
@@ -169,11 +169,11 @@ public class SmartpayNotificationResourceWithAccountSpecificAuthIT extends Charg
                 .withTransactionId(transactionId);
         ledgerStub.returnLedgerTransactionForProviderAndGatewayTransactionId(testCharge, getPaymentProvider());
 
-        int refundId = databaseTestHelper.addRefund(externalRefundId, reference, 10L,
-                REFUND_SUBMITTED, randomAlphanumeric(10), ZonedDateTime.now(),
+        int refundId = databaseTestHelper.addRefund(externalRefundId, 10L,
+                REFUND_SUBMITTED, refundTransactionId, ZonedDateTime.now(),
                 externalChargeId);
 
-        String response = notifyConnector(notificationPayloadForTransaction(externalRefundId, transactionId, reference, "notification-refund"))
+        String response = notifyConnector(notificationPayloadForTransaction(externalRefundId, transactionId, refundTransactionId, "notification-refund"))
                 .then()
                 .statusCode(200)
                 .extract().body().asString();

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundIT.java
@@ -285,7 +285,7 @@ public class SmartpayRefundIT extends ChargingITestBase {
 
         List<Map<String, Object>> refundsFoundByChargeExternalId = databaseTestHelper.getRefundsByChargeExternalId(defaultTestCharge.getExternalChargeId());
         assertThat(refundsFoundByChargeExternalId.size(), is(1));
-        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(testRefund.getReference()), defaultTestCharge.getExternalChargeId(), testRefund.getAmount(), "REFUND SUBMITTED")));
+        assertThat(refundsFoundByChargeExternalId, hasItems(aRefundMatching(refundId, is(testRefund.getGatewayTransactionId()), defaultTestCharge.getExternalChargeId(), testRefund.getAmount(), "REFUND SUBMITTED")));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundIT.java
@@ -102,7 +102,6 @@ public class StripeRefundIT extends ChargingITestBase {
         assertThat(refundsFoundByChargeExternalId.size(), is(1));
         assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUNDED"));
         MatcherAssert.assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("charge_external_id", testChargeCreatedWithStripeChargeAPI.getExternalChargeId()));
-        MatcherAssert.assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("reference", "re_1DRiccHj08j21DRiccHj08j2_test"));
         MatcherAssert.assertThat(refundsFoundByChargeExternalId.get(0), hasEntry("gateway_transaction_id", "re_1DRiccHj08j21DRiccHj08j2_test"));
         String refundId = response.extract().path("refund_id");
         

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -88,8 +88,8 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
 
         ledgerStub.returnLedgerTransactionForProviderAndGatewayTransactionId(testCharge, getPaymentProvider());
 
-        databaseTestHelper.addRefund(refundExternalId, refundExternalId, 1000,
-                REFUND_SUBMITTED, randomAlphanumeric(10), ZonedDateTime.now(),
+        databaseTestHelper.addRefund(refundExternalId, 1000,
+                REFUND_SUBMITTED, refundExternalId, ZonedDateTime.now(),
                 chargeExternalId);
 
         String response = notifyConnector(gatewayTransactionId, "REFUNDED", refundExternalId)
@@ -105,7 +105,7 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
         List<Map<String, Object>> refundsByChargeExternalId = databaseTestHelper.getRefundsByChargeExternalId(chargeExternalId);
         assertThat(refundsByChargeExternalId.size(), is(1));
         assertThat(refundsByChargeExternalId.get(0).get("charge_external_id"), is(chargeExternalId));
-        assertThat(refundsByChargeExternalId.get(0).get("reference"), is(refundExternalId));
+        assertThat(refundsByChargeExternalId.get(0).get("gateway_transaction_id"), is(refundExternalId));
         assertThat(refundsByChargeExternalId.get(0).get("status"), is("REFUNDED"));
     }
 
@@ -142,7 +142,7 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReturnNon2xxStatusIfChargeIsNotFoundForTransaction() throws Exception {
-        ledgerStub.returnNotFoundForFindByProviderAndGatewayTransactionId("worldpay", 
+        ledgerStub.returnNotFoundForFindByProviderAndGatewayTransactionId("worldpay",
                 "unknown-transaction-id");
         notifyConnector("unknown-transaction-id", "GARBAGE")
                 .statusCode(403)
@@ -228,8 +228,8 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
     private String createNewChargeWithRefund(String transactionId, String refundExternalId, long refundAmount) {
         String externalChargeId = createNewChargeWith(CAPTURED, transactionId);
         String chargeId = externalChargeId.substring(externalChargeId.indexOf("-") + 1);
-        databaseTestHelper.addRefund(refundExternalId, refundExternalId, refundAmount, REFUND_SUBMITTED,
-                randomAlphanumeric(10), ZonedDateTime.now(),
+        databaseTestHelper.addRefund(refundExternalId, refundAmount, REFUND_SUBMITTED,
+                refundExternalId, ZonedDateTime.now(),
                 externalChargeId);
         return externalChargeId;
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundIT.java
@@ -275,7 +275,7 @@ public class WorldpayRefundIT extends ChargingITestBase {
                 .aTestRefund()
                 .withTestCharge(defaultTestCharge)
                 .withType(RefundStatus.REFUND_SUBMITTED)
-                .withReference(randomAlphanumeric(10))
+                .withGatewayTransactionId(randomAlphanumeric(10))
                 .withChargeExternalId(defaultTestCharge.getExternalChargeId())
                 .insert();
 

--- a/src/test/java/uk/gov/pay/connector/matcher/RefundsMatcher.java
+++ b/src/test/java/uk/gov/pay/connector/matcher/RefundsMatcher.java
@@ -8,18 +8,18 @@ import java.util.Map;
 
 public class RefundsMatcher extends TypeSafeMatcher<Map<String, Object>> {
     private final String externalId;
-    private final Matcher reference;
+    private final Matcher gatewayTransactionId;
     private final String chargeExternalId;
     private final long amount;
     private final String status;
 
-    public static RefundsMatcher aRefundMatching(String externalId, Matcher reference, String chargeExternalId, long amount, String status) {
-        return new RefundsMatcher(externalId, reference, chargeExternalId, amount, status);
+    public static RefundsMatcher aRefundMatching(String externalId, Matcher gatewayTransactionId, String chargeExternalId, long amount, String status) {
+        return new RefundsMatcher(externalId, gatewayTransactionId, chargeExternalId, amount, status);
     }
 
-    private <T> RefundsMatcher(String externalId, Matcher<T> reference, String chargeExternalId, long amount, String status) {
+    private <T> RefundsMatcher(String externalId, Matcher<T> gatewayTransactionId, String chargeExternalId, long amount, String status) {
         this.externalId = externalId;
-        this.reference = reference;
+        this.gatewayTransactionId = gatewayTransactionId;
         this.chargeExternalId = chargeExternalId;
         this.amount = amount;
         this.status = status;
@@ -29,7 +29,7 @@ public class RefundsMatcher extends TypeSafeMatcher<Map<String, Object>> {
     public void describeTo(Description description) {
         description.appendText("{amount=").appendValue(amount).appendText(", ");
         description.appendText("charge_external_id=").appendValue(chargeExternalId).appendText(", ");
-        description.appendText("reference=").appendValue(reference).appendText(", ");
+        description.appendText("gateway_transaction_id=").appendValue(gatewayTransactionId).appendText(", ");
         description.appendText("external_id=").appendValue(externalId).appendText(", ");
         description.appendText("status=").appendValue(status).appendText("}");
     }
@@ -38,7 +38,7 @@ public class RefundsMatcher extends TypeSafeMatcher<Map<String, Object>> {
     protected boolean matchesSafely(Map<String, Object> record) {
         String external_id = record.get("external_id").toString().trim();
         return external_id.equals(externalId) &&
-                reference.matches(record.get("reference")) &&
+                gatewayTransactionId.matches(record.get("gateway_transaction_id")) &&
                 record.get("amount").equals(amount) &&
                 record.get("status").equals(status) &&
                 record.get("charge_external_id").equals(chargeExternalId);

--- a/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/TransactionEventTest.java
@@ -35,7 +35,7 @@ public class TransactionEventTest {
     }
 
     @Test
-    public void equals_shouldReturnFalse_whenFieldsRefundReferenceIsDifferent() {
+    public void equals_shouldReturnFalse_whenFieldsRefundTransactionIdIsDifferent() {
 
         TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(), USER_EXTERNAL_ID);
         TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
@@ -44,7 +44,7 @@ public class TransactionEventTest {
     }
 
     @Test
-    public void equals_shouldReturnFalse_whenFirstObjectRefundReferenceIsNull() {
+    public void equals_shouldReturnFalse_whenFirstObjectRefundTransactionIdIsNull() {
 
         TransactionEvent event1 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
         TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", "submitted", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
@@ -53,7 +53,7 @@ public class TransactionEventTest {
     }
 
     @Test
-    public void equals_shouldReturnFalse_whenSecondObjectRefundReferenceIsNull() {
+    public void equals_shouldReturnFalse_whenSecondObjectRefundTransactionIdIsNull() {
 
         TransactionEvent event1 = new TransactionEvent(Type.REFUND, null, "success", extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);
         TransactionEvent event2 = new TransactionEvent(Type.REFUND, "charge", null, extractState(EXTERNAL_SUBMITTED), 100L, ZonedDateTime.now(),USER_EXTERNAL_ID);

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -29,7 +29,6 @@ public class RefundEntityFixture {
         RefundEntity refundEntity = new RefundEntity(amount, userExternalId, userEmail, chargeExternalId);
         refundEntity.setId(id);
         refundEntity.setStatus(status);
-        refundEntity.setReference(reference);
         refundEntity.setExternalId(externalId);
         refundEntity.setUserExternalId(userExternalId);
         refundEntity.setCreatedDate(createdDate);

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityTest.java
@@ -28,7 +28,7 @@ public class RefundEntityTest {
         RefundEntity refundEntity = new RefundEntity(amount, userExternalId, userEmail, chargeEntity.getExternalId());
 
         assertNotNull(refundEntity.getExternalId());
-        assertThat(refundEntity.getReference(), is(nullValue()));
+        assertThat(refundEntity.getGatewayTransactionId(), is(nullValue()));
         assertThat(refundEntity.getAmount(), is(amount));
         assertThat(refundEntity.getUserExternalId(), is(userExternalId));
         assertThat(refundEntity.getChargeExternalId(), is(chargeEntity.getExternalId()));

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -149,7 +149,7 @@ public class ContractTest {
     private void setUpRefunds(int numberOfRefunds, Long chargeId,
                               ZonedDateTime createdDate, RefundStatus refundStatus, String chargeExternalId) {
         for (int i = 0; i < numberOfRefunds; i++) {
-            dbHelper.addRefund("external" + RandomUtils.nextInt(), "reference", 1L, refundStatus,
+            dbHelper.addRefund("external" + RandomUtils.nextInt(), 1L, refundStatus,
                     randomAlphanumeric(10), createdDate, "user_external_id1234", null, chargeExternalId);
         }
     }
@@ -363,7 +363,7 @@ public class ContractTest {
                 .withTransactionId("aTransactionId")
                 .withEmail("test@test.com")
                 .build());
-        dbHelper.addRefund(refundId, "reference", 100L, REFUNDED,
+        dbHelper.addRefund(refundId, 100L, REFUNDED,
                 randomAlphanumeric(10), createdDate,
                 Long.toString(paymentId));
     }

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -155,7 +155,6 @@ public class QueueMessageContractTest {
         String gatewayTransactionId = RandomStringUtils.randomAlphanumeric(14);
         RefundHistory refundHistory = aValidRefundHistoryEntity()
                 .withStatus(RefundStatus.REFUNDED.getValue())
-                .withReference(gatewayTransactionId)
                 .withGatewayTransactionId(gatewayTransactionId)
                 .build();
         RefundSucceeded refundSucceeded = RefundSucceeded.from(refundHistory);

--- a/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
@@ -15,7 +15,6 @@ public class RefundHistoryEntityFixture {
     private String status = RefundStatus.CREATED.getValue();
     private ZonedDateTime createdDate = ZonedDateTime.now().minusSeconds(5L);
     private Long version = 1L;
-    private String reference;
     private ZonedDateTime historyStartDate = createdDate.plusSeconds(2L);
     private ZonedDateTime historyEndDate = createdDate.plusSeconds(3L);
     private String userExternalId;
@@ -32,7 +31,7 @@ public class RefundHistoryEntityFixture {
 
     public RefundHistory build() {
         return new RefundHistory(id, externalId, amount, status, Timestamp.valueOf(createdDate.toLocalDateTime()),
-                version, reference, Timestamp.valueOf(historyStartDate.toLocalDateTime()), Timestamp.valueOf(historyEndDate.toLocalDateTime()),
+                version, Timestamp.valueOf(historyStartDate.toLocalDateTime()), Timestamp.valueOf(historyEndDate.toLocalDateTime()),
                 userExternalId, gatewayTransactionId, chargeExternalId, userEmail);
     }
 
@@ -48,11 +47,6 @@ public class RefundHistoryEntityFixture {
 
     public RefundHistoryEntityFixture withUserExternalId(String userExternalId) {
         this.userExternalId = userExternalId;
-        return this;
-    }
-
-    public RefundHistoryEntityFixture withReference(String reference) {
-        this.reference = reference;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/ChargeRefundServiceTest.java
@@ -44,8 +44,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.argThat;
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
@@ -64,7 +65,6 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
-import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
@@ -150,7 +150,7 @@ public class ChargeRefundServiceTest {
         verify(mockProvider).refund(argThat(aRefundRequestWith(chargeEntity, refundAmount)));
         verify(mockRefundDao, times(1)).findById(refundId);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_SUBMITTED);
-        verify(spiedRefundEntity).setReference(refundEntity.getExternalId());
+        verify(spiedRefundEntity).setGatewayTransactionId(refundEntity.getExternalId());
 
         verifyNoMoreInteractions(mockChargeDao);
     }
@@ -206,7 +206,7 @@ public class ChargeRefundServiceTest {
         verify(mockProvider).refund(any(RefundGatewayRequest.class));
         verify(mockRefundDao, times(1)).findById(refundId);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_SUBMITTED);
-        verify(spiedRefundEntity).setReference(refundEntity.getExternalId());
+        verify(spiedRefundEntity).setGatewayTransactionId(refundEntity.getExternalId());
 
         verifyNoMoreInteractions(mockChargeService);
     }
@@ -285,7 +285,7 @@ public class ChargeRefundServiceTest {
         verify(mockRefundDao, times(1)).findById(refundId);
         verify(spiedRefundEntity).setStatus(RefundStatus.REFUND_SUBMITTED);
         verify(spiedRefundEntity, never()).setStatus(RefundStatus.REFUNDED);
-        verify(spiedRefundEntity).setReference(reference);
+        verify(spiedRefundEntity).setGatewayTransactionId(reference);
 
         verifyNoMoreInteractions(mockChargeDao);
     }
@@ -329,7 +329,7 @@ public class ChargeRefundServiceTest {
 
         assertThat(gatewayResponse.getGatewayRefundResponse().isSuccessful(), is(true));
         assertThat(gatewayResponse.getRefundEntity(), is(spiedRefundEntity));
-        verify(spiedRefundEntity).setReference(providerReference);
+        verify(spiedRefundEntity).setGatewayTransactionId(providerReference);
 
     }
 
@@ -369,8 +369,7 @@ public class ChargeRefundServiceTest {
         ChargeRefundResponse gatewayResponse = chargeRefundService.doRefund(accountId, externalChargeId, new RefundRequest(amount, chargeEntity.getAmount(), userExternalId));
         assertThat(gatewayResponse.getGatewayRefundResponse().isSuccessful(), is(false));
         assertThat(gatewayResponse.getRefundEntity(), is(spiedRefundEntity));
-        verify(spiedRefundEntity, never()).setReference(anyString());
-
+        verify(spiedRefundEntity, never()).setGatewayTransactionId(anyString());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -132,23 +132,22 @@ public class DatabaseTestHelper {
                         .execute());
     }
 
-    public int addRefund(String externalId, String reference, long amount, RefundStatus status, String gatewayTransactionId, ZonedDateTime createdDate, String chargeExternalId) {
-        return addRefund(externalId, reference, amount, status, gatewayTransactionId, createdDate, null, null, chargeExternalId);
+    public int addRefund(String externalId, long amount, RefundStatus status, String gatewayTransactionId, ZonedDateTime createdDate, String chargeExternalId) {
+        return addRefund(externalId, amount, status, gatewayTransactionId, createdDate, null, null, chargeExternalId);
     }
 
-    public int addRefund(String externalId, String reference, long amount, RefundStatus status,
+    public int addRefund(String externalId, long amount, RefundStatus status,
                          String gatewayTransactionId, ZonedDateTime createdDate, String submittedByUserExternalId,
                          String userEmail, String chargeExternalId) {
         int refundId = RandomUtils.nextInt();
         jdbi.withHandle(handle ->
                 handle
-                        .createUpdate("INSERT INTO refunds(id, external_id, reference, amount, status, " +
+                        .createUpdate("INSERT INTO refunds(id, external_id, amount, status, " +
                                 " gateway_transaction_id, created_date, user_external_id, user_email, charge_external_id) " +
-                                "VALUES (:id, :external_id, :reference, :amount, :status, " +
+                                "VALUES (:id, :external_id, :amount, :status, " +
                                 ":gateway_transaction_id, :created_date, :user_external_id, :user_email, :charge_external_id)")
                         .bind("id", refundId)
                         .bind("external_id", externalId)
-                        .bind("reference", reference)
                         .bind("amount", amount)
                         .bind("status", status.getValue())
                         .bind("gateway_transaction_id", gatewayTransactionId)
@@ -162,13 +161,13 @@ public class DatabaseTestHelper {
         return refundId;
     }
 
-    public void addRefundHistory(long id, String externalId, String reference, long amount, String status, ZonedDateTime createdDate, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByUserExternalId, String userEmail, String chargeExternalId) {
+    public void addRefundHistory(long id, String externalId, String gatewayTransactionId, long amount, String status, ZonedDateTime createdDate, ZonedDateTime historyStartDate, ZonedDateTime historyEndDate, String submittedByUserExternalId, String userEmail, String chargeExternalId) {
         jdbi.withHandle(handle ->
                 handle
-                        .createUpdate("INSERT INTO refunds_history(id, external_id, reference, amount, status, created_date, history_start_date, history_end_date, user_external_id, user_email, charge_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :created_date, :history_start_date, :history_end_date, :user_external_id, :user_email, :charge_external_id)")
+                        .createUpdate("INSERT INTO refunds_history(id, external_id, gateway_transaction_id, amount, status, created_date, history_start_date, history_end_date, user_external_id, user_email, charge_external_id) VALUES (:id, :external_id, :gateway_transaction_id, :amount, :status, :created_date, :history_start_date, :history_end_date, :user_external_id, :user_email, :charge_external_id)")
                         .bind("id", id)
                         .bind("external_id", externalId)
-                        .bind("reference", reference)
+                        .bind("gateway_transaction_id", gatewayTransactionId)
                         .bind("amount", amount)
                         .bind("status", status)
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
@@ -182,13 +181,13 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void addRefundHistory(long id, String externalId, String reference, long amount, String status, ZonedDateTime createdDate, ZonedDateTime historyStartDate, String submittedByUserExternalId, String chargeExternalId) {
+    public void addRefundHistory(long id, String externalId, String gatewayTransactionId, long amount, String status, ZonedDateTime createdDate, ZonedDateTime historyStartDate, String submittedByUserExternalId, String chargeExternalId) {
         jdbi.withHandle(handle ->
                 handle
-                        .createUpdate("INSERT INTO refunds_history(id, external_id, reference, amount, status, created_date, history_start_date, user_external_id, charge_external_id) VALUES (:id, :external_id, :reference, :amount, :status, :created_date, :history_start_date, :user_external_id, :charge_external_id)")
+                        .createUpdate("INSERT INTO refunds_history(id, external_id, gateway_transaction_id, amount, status, created_date, history_start_date, user_external_id, charge_external_id) VALUES (:id, :external_id, :gateway_transaction_id, :amount, :status, :created_date, :history_start_date, :user_external_id, :charge_external_id)")
                         .bind("id", id)
                         .bind("external_id", externalId)
-                        .bind("reference", reference)
+                        .bind("gateway_transaction_id", gatewayTransactionId)
                         .bind("amount", amount)
                         .bind("status", status)
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
@@ -282,7 +281,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefund(long refundId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT external_id, reference, amount, status, created_date, user_external_id, user_email, charge_external_id " +
+                h.createQuery("SELECT external_id, gateway_transaction_id, amount, status, created_date, user_external_id, user_email, charge_external_id " +
                         "FROM refunds " +
                         "WHERE id = :refund_id")
                         .bind("refund_id", refundId)
@@ -293,7 +292,7 @@ public class DatabaseTestHelper {
 
     public List<Map<String, Object>> getRefundsByChargeExternalId(String chargeExternalId) {
         List<Map<String, Object>> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT external_id, reference, amount, status, created_date, user_external_id, user_email, charge_external_id, gateway_transaction_id " +
+                h.createQuery("SELECT external_id, amount, status, created_date, user_external_id, user_email, charge_external_id, gateway_transaction_id " +
                         "FROM refunds r " +
                         "WHERE charge_external_id = :charge_external_id")
                         .bind("charge_external_id", chargeExternalId)


### PR DESCRIPTION
## WHAT YOU DID
- Removed `reference` field on Refunds/RefundHistory tables and its usages. Uses gatewayTransactionId instead which is now being set on refunds.
