### PR TITLE
PP-6756 Remove reference column on refund tables

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1478,4 +1478,12 @@
         <dropTable tableName="emitted_events_swp" />
     </changeSet>
 
+    <changeSet id="drop reference from refunds table" runInTransaction="false" author="">
+        <dropColumn tableName="refunds" columnName="reference"/>
+    </changeSet>
+
+    <changeSet id="drop reference from refunds_history table" runInTransaction="false" author="">
+        <dropColumn tableName="refunds_history" columnName="reference"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT
- Removes `reference` column on refund & refund_history tables as we started using `gateway_transaction_id` through out code base and reference is no longer needed

Depends on https://github.com/alphagov/pay-connector/pull/2449