### PR TITLE
PP-6756 Drop gateway_processing_details column on refunds

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1486,4 +1486,8 @@
         <dropColumn tableName="refunds_history" columnName="reference"/>
     </changeSet>
 
+    <changeSet id="drop gateway_processing_details from refunds table" runInTransaction="false" author="">
+        <dropColumn tableName="refunds" columnName="gateway_processing_details"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
 - Drops `gateway_processing_details` column from `refunds` table as it is never used and not required at this time.

with @sandorarpa
