### PR TITLE
PP-6852 Categorise Stripe authorisation client error as REJECTED/ERROR

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -2,16 +2,20 @@ package uk.gov.pay.connector.gateway.stripe.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
 
-/** Example response from Stripe:
-{
-  "error": {
-    "message": "Invalid API Key provided: sk_test_************S8wL",
-    "type": "invalid_request_error"
-  }
-}
- 
- For more detail see https://stripe.com/docs/api/errors?lang=java
+import java.util.StringJoiner;
+
+/**
+ * Example response from Stripe:
+ * {
+ * "error": {
+ * "message": "Invalid API Key provided: sk_test_************S8wL",
+ * "type": "invalid_request_error"
+ * }
+ * }
+ * <p>
+ * For more detail see https://stripe.com/docs/api/errors?lang=java
  **/
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StripeErrorResponse {
@@ -28,10 +32,16 @@ public class StripeErrorResponse {
 
         @JsonProperty("charge")
         private String charge;
+        @JsonProperty("type")
+        private String type;
         @JsonProperty("code")
         private String code;
         @JsonProperty("message")
         private String message;
+
+        public String getType() {
+            return type;
+        }
 
         public String getCode() {
             return code;
@@ -44,5 +54,29 @@ public class StripeErrorResponse {
         public String getCharge() {
             return charge;
         }
+
+        @Override
+        public String toString() {
+            StringJoiner joiner = new StringJoiner(", ");
+            if (StringUtils.isNotBlank(type)) {
+                joiner.add("stripe charge: " + getCharge());
+            }
+            if (StringUtils.isNotBlank(type)) {
+                joiner.add("type: " + getType());
+            }
+            if (StringUtils.isNotBlank(code)) {
+                joiner.add("code: " + getCode());
+            }
+            if (StringUtils.isNotBlank(message)) {
+                joiner.add("message: " + getMessage());
+            }
+
+            return joiner.toString();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return error.toString();
     }
 }

--- a/src/test/resources/templates/stripe/error_response.json
+++ b/src/test/resources/templates/stripe/error_response.json
@@ -1,7 +1,8 @@
 {
   "error": {
+    "charge": "ch_1DX3j5C6H5MjhE5YhPcLhENF",
     "code": "resource_missing",
     "message": "No such charge: ch_123456 or something similar",
-    "type": "invalid_request_error"
+    "type": "{{type}}"
   }
 }

--- a/src/test/resources/templates/stripe/error_response_general.json
+++ b/src/test/resources/templates/stripe/error_response_general.json
@@ -1,9 +1,0 @@
-{
-  "error": {
-    "charge": "ch_1DX3j5C6H5MjhE5YhPcLhENF",
-    "code": "processing_error",
-    "doc_url": "https://stripe.com/docs/error-codes/processing-error",
-    "message": "An error occurred while processing your card. Try again in a little bit.",
-    "type": "card_error"
-  }
-}


### PR DESCRIPTION
## WHAT YOU DID
- Currently we treat all 4xx error types as REJECTED, but it is only `card_error` type that is expected for payments rejected by card issuer.
  Rest of the 4xx error types (like api_error, rate_limit_error) are unexpected and should be treated as ERROR.

**Changes** 
- Only `card_error` type is now treated as AUTHORISATION_REJECTED for 4xx status and rest of error types will be marked as AUTHORISATION_ERROR

- Also improved toString() representation for `StripeAuthorisationFailedResponse`. It is current logged with default toString() method (which appears like `StripeAuthorisationFailedResponse@36e182ac`) in the upstream which is not helpful.
