### PR TITLE
PP-6353: Log payment transition to hosted graphite

### DIFF
--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.queue;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,9 +29,11 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.events.model.ResourceType.PAYMENT;
@@ -48,10 +52,15 @@ public class StateTransitionServiceTest {
     StateTransitionQueue mockStateTransitionQueue;
     @Mock
     EventService mockEventService;
+    @Mock
+    MetricRegistry metricRegistry;
+    @Mock
+    Counter counter;
 
     @Before
     public void setUp() {
-        stateTransitionService = new StateTransitionService(mockStateTransitionQueue, mockEventService);
+        when(metricRegistry.counter(anyString())).thenReturn(counter);
+        stateTransitionService = new StateTransitionService(mockStateTransitionQueue, mockEventService, metricRegistry);
     }
 
     @Test


### PR DESCRIPTION
We want to be able to detect anomalous drops in successful live authorisations.
It is envisaged that we can do this by noticing trends in authorisation errors
and successes. However it is currently hard to see this in the way we send data
to hosted graphite (HG). For example, currently we have to drill into
`aggregates.production.connector.gateway-operations.worldpay.live.gatewa-account-id`
(which is fine) then into `authorise/authorise3ds`,
`without-billing-address/with-billing-address` which makes it difficult to
graph the data we want. This PR sends the states a payment goes into which will
help us graph the trends more easily. This is similar to what we send to splunk.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
