### PR TITLE
PP-6353: Get metric registry from the environment

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.queue.statetransition;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.persist.Transactional;
+import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,7 @@ import java.time.ZonedDateTime;
 
 import static java.lang.String.format;
 import static java.time.ZonedDateTime.now;
+import static net.logstash.logback.argument.StructuredArguments.e;
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
 public class StateTransitionService {
@@ -33,10 +35,11 @@ public class StateTransitionService {
 
     @Inject
     public StateTransitionService(StateTransitionQueue stateTransitionQueue,
-                                  EventService eventService, MetricRegistry metricRegistry) {
+                                  EventService eventService, 
+                                  Environment environment) {
         this.stateTransitionQueue = stateTransitionQueue;
         this.eventService = eventService;
-        this.metricRegistry = metricRegistry;
+        this.metricRegistry = environment.metrics();
     }
 
     @Transactional

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.queue;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.setup.Environment;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,14 +54,17 @@ public class StateTransitionServiceTest {
     @Mock
     EventService mockEventService;
     @Mock
+    Environment environment;
+    @Mock
     MetricRegistry metricRegistry;
     @Mock
     Counter counter;
 
     @Before
     public void setUp() {
+        when(environment.metrics()).thenReturn(metricRegistry);
         when(metricRegistry.counter(anyString())).thenReturn(counter);
-        stateTransitionService = new StateTransitionService(mockStateTransitionQueue, mockEventService, metricRegistry);
+        stateTransitionService = new StateTransitionService(mockStateTransitionQueue, mockEventService, environment);
     }
 
     @Test


### PR DESCRIPTION
This is the proper way to get a reference to the metric registry. Data won't be
sent to hosted graphite otherwise.

## WHAT YOU DID
_A brief description of the pull request:_

## How to test

- How should it be reviewed? 
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
