### PR TITLE
PP-6353 Add per gateway meter

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
@@ -102,7 +102,7 @@ public class StateTransitionService {
     
     private void incrementPerGatewayStateTransitionMeter(ChargeStatus targetChargeState, ChargeEventEntity chargeEventEntity) {
         metricRegistry.meter(String.format(
-                "state-transition.%s.%s.to.%s",
+                "state-transition.%s.%s.to.%s.rate",
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getType(),
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getGatewayName(),
                 targetChargeState)).mark();

--- a/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
@@ -75,6 +75,7 @@ public class StateTransitionService {
                 fromChargeState, targetChargeState, chargeEventEntity.getId(), externalId);
 
         incrementPerGatewayStateTransitionCounter(targetChargeState, chargeEventEntity);
+        incrementPerGatewayStateTransitionMeter(targetChargeState, chargeEventEntity);
         incrementPerGatewayAccountStateTransitionCounter(targetChargeState, chargeEventEntity);
 
         Object[] structuredArgs = ArrayUtils.addAll(
@@ -97,6 +98,14 @@ public class StateTransitionService {
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getGatewayName(),
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getId(),
                 targetChargeState)).inc();
+    }
+    
+    private void incrementPerGatewayStateTransitionMeter(ChargeStatus targetChargeState, ChargeEventEntity chargeEventEntity) {
+        metricRegistry.meter(String.format(
+                "state-transition.%s.%s.to.%s",
+                chargeEventEntity.getChargeEntity().getGatewayAccount().getType(),
+                chargeEventEntity.getChargeEntity().getGatewayAccount().getGatewayName(),
+                targetChargeState)).mark();
     }
 
     private void incrementPerGatewayStateTransitionCounter(ChargeStatus targetChargeState, ChargeEventEntity chargeEventEntity) {

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.queue;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
@@ -59,11 +60,14 @@ public class StateTransitionServiceTest {
     MetricRegistry metricRegistry;
     @Mock
     Counter counter;
+    @Mock
+    Meter meter;
 
     @Before
     public void setUp() {
         when(environment.metrics()).thenReturn(metricRegistry);
         when(metricRegistry.counter(anyString())).thenReturn(counter);
+        when(metricRegistry.meter(anyString())).thenReturn(meter);
         stateTransitionService = new StateTransitionService(mockStateTransitionQueue, mockEventService, environment);
     }
 


### PR DESCRIPTION
We think that a meter will play better with hosted graphite's aggregation API.

It doesn't seem possible to compute aggregates for counters in a way that makes sense.
