### PR TITLE
PP-6353 specify metric units

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -205,6 +205,8 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         GraphiteSender graphiteUDP = new GraphiteUDP(configuration.getGraphiteHost(), Integer.parseInt(configuration.getGraphitePort()));
         GraphiteReporter.forRegistry(environment.metrics())
                 .prefixedWith(SERVICE_METRICS_NODE)
+                .convertRatesTo(TimeUnit.MINUTES)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .build(graphiteUDP)
                 .start(GRAPHITE_SENDING_PERIOD_SECONDS, TimeUnit.SECONDS);
 


### PR DESCRIPTION
According to https://github.com/dropwizard/metrics/issues/946 the default precision for
rate metrics is milliseconds which means that the accuracy of the metrics can be lost due
to the precision of the numbers reporter. Rates measured in minutes is a more management granularity.

Also specify the duration unit as milliseconds (for latencies etc) which is the default
but this makes it explicit.