### PR TITLE
PP-6883 Add Notify Base URL

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -17,6 +17,7 @@ applications:
       - card-connector-db
     env:
       ENV_MAP_BP_USE_APP_PROFILE_DIR: true
+      NOTIFY_BASE_URL: ((notify_base_url))
 
       # Provided by the app-catalog service - see src/main/resources/env-map.yml
       FRONTEND_URL: ""
@@ -27,7 +28,6 @@ applications:
       SENTRY_DSN: ""
       CAPTURE_USING_SQS_FEATURE_FLAG: ""
       EVENT_QUEUE_ENABLED: ""
-      NOTIFY_BASE_URL: ""
       NOTIFY_PAYMENT_RECEIPT_EMAIL_TEMPLATE_ID: ""
       NOTIFY_REFUND_ISSUED_EMAIL_TEMPLATE_ID: ""
       STRIPE_TRANSACTION_FEE_PERCENTAGE: ""

--- a/src/main/resources/env-map.yml
+++ b/src/main/resources/env-map.yml
@@ -14,7 +14,6 @@ env_vars:
 
   CAPTURE_USING_SQS_FEATURE_FLAG:           '.[][] | select(.name == "card-connector-secret-service")       | .credentials.sqs_enabled'
   EVENT_QUEUE_ENABLED:                      '.[][] | select(.name == "card-connector-secret-service")       | .credentials.sqs_enabled'
-  NOTIFY_BASE_URL:                          '.[][] | select(.name == "card-connector-secret-service")       | .credentials.notify_base_url'
   NOTIFY_PAYMENT_RECEIPT_EMAIL_TEMPLATE_ID: '.[][] | select(.name == "card-connector-secret-service")       | .credentials.notify_payment_receipt_email_template_id'
   NOTIFY_REFUND_ISSUED_EMAIL_TEMPLATE_ID:   '.[][] | select(.name == "card-connector-secret-service")       | .credentials.notify_refund_email_template_id'
   STRIPE_TRANSACTION_FEE_PERCENTAGE:        '.[][] | select(.name == "card-connector-secret-service")       | .credentials.stripe_transaction_fee_percentage'


### PR DESCRIPTION
- To follow the convention set by adminnusers, we want to configure the
notify base url parameter in the manifest.yml instead of the env-map,
this means that we only have to configure a shared variable like this in
one place per environment.
