### PR TITLE
PP-6256 - Add address_state_province column to charges database

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1490,4 +1490,11 @@
         <dropColumn tableName="refunds" columnName="gateway_processing_details"/>
     </changeSet>
 
+    <changeSet id="add address_state_province column to charges table" author="">
+        <addColumn tableName="charges">
+            <column name="address_state_province" type="varchar(2)">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Description:
- As part of PP-6256 to determine the US state or Canadian province from the postal code we need to add a new column to the database