### PR TITLE
PP-6256 - Send US states and Canadian provinces or territories to gateway, ledger and database

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-08-26T11:15:45Z",
+  "generated_at": "2020-08-27T11:52:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -28,6 +28,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private final String addressPostcode;
     private final String addressCity;
     private final String addressCounty;
+    private final String addressStateProvince;
     private final String addressCountry;
     private final String wallet;
     private final Long totalAmount;
@@ -49,6 +50,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         this.addressPostcode = builder.addressPostcode;
         this.addressCity = builder.addressCity;
         this.addressCounty = builder.addressCounty;
+        this.addressStateProvince = builder.addressStateProvince;
         this.addressCountry = builder.addressCountry;
         this.wallet = builder.wallet;
         this.totalAmount = builder.totalAmount;
@@ -82,6 +84,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
                             .withAddressCity(cardDetails.getBillingAddress().map(AddressEntity::getCity).orElse(null))
                             .withAddressCountry(cardDetails.getBillingAddress().map(AddressEntity::getCountry).orElse(null))
                             .withAddressCounty(cardDetails.getBillingAddress().map(AddressEntity::getCounty).orElse(null))
+                            .withAddressStateProvince(cardDetails.getBillingAddress().map(AddressEntity::getStateOrProvince).orElse(null))
                             .withAddressPostcode(cardDetails.getBillingAddress().map(AddressEntity::getPostcode).orElse(null)));
                 
         return builder.build();
@@ -151,6 +154,10 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         return addressCountry;
     }
 
+    public String getAddressStateProvince() {
+        return addressStateProvince;
+    }
+
     public String getWallet() {
         return wallet;
     }
@@ -178,6 +185,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
                 Objects.equals(addressPostcode, that.addressPostcode) &&
                 Objects.equals(addressCity, that.addressCity) &&
                 Objects.equals(addressCounty, that.addressCounty) &&
+                Objects.equals(addressStateProvince, that.addressStateProvince) &&
                 Objects.equals(addressCountry, that.addressCountry) &&
                 Objects.equals(wallet, that.wallet) &&
                 Objects.equals(totalAmount, that.totalAmount);
@@ -187,7 +195,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     public int hashCode() {
         return Objects.hash(corporateSurcharge, email, cardType, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
                 gatewayTransactionId, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode,
-                addressCounty, addressCountry, wallet, totalAmount);
+                addressCounty, addressStateProvince, addressCountry, wallet, totalAmount);
     }
 
     private static class Builder {
@@ -207,6 +215,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         private String addressCity;
         private String addressCounty;
         private String addressCountry;
+        private String addressStateProvince;
         private String wallet;
         private Long totalAmount;
 
@@ -282,6 +291,11 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
         Builder withAddressCounty(String addressCounty) {
             this.addressCounty = addressCounty;
+            return this;
+        }
+
+        Builder withAddressStateProvince(String addressStateProvince) {
+            this.addressStateProvince = addressStateProvince;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -83,8 +83,10 @@ public class SmartpayPaymentProvider implements PaymentProvider {
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) throws GatewayException {
-        GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
-                request.getGatewayAccount(), buildAuthoriseOrderFor(request), 
+        GatewayClient.Response response = client.postRequestFor(
+                gatewayUrlMap.get(request.getGatewayAccount().getType()), 
+                request.getGatewayAccount(), 
+                buildAuthoriseOrderFor(request), 
                 getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
         return getSmartpayGatewayResponse(response, SmartpayAuthorisationResponse.class);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -2,16 +2,24 @@ package uk.gov.pay.connector.gateway.stripe.request;
 
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.AddressEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.northamericaregion.CanadaPostalcodeToProvinceOrTerritoryMapper;
+import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
+import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
+import uk.gov.pay.connector.northamericaregion.UsZipCodeToStateMapper;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class StripePaymentMethodRequest extends StripeRequest {
     private final AuthCardDetails authCardDetails;
+    private final NorthAmericanRegionMapper northAmericanRegionMapper;
     
     public StripePaymentMethodRequest(
             GatewayAccountEntity gatewayAccount,
@@ -21,6 +29,7 @@ public class StripePaymentMethodRequest extends StripeRequest {
     {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig);
         this.authCardDetails = authCardDetails;
+        this.northAmericanRegionMapper = new NorthAmericanRegionMapper();
     }
     
     public static StripePaymentMethodRequest of(CardAuthorisationGatewayRequest request, StripeGatewayConfig config) {
@@ -47,6 +56,9 @@ public class StripePaymentMethodRequest extends StripeRequest {
             if (StringUtils.isNotBlank(address.getLine2())) {
                 localParams.put("billing_details[address[line2]]", address.getLine2());
             }
+            northAmericanRegionMapper.getNorthAmericanRegionForCountry(address)
+                    .map(NorthAmericaRegion::getFullName)
+                    .ifPresent(stateOrProvince -> localParams.put("billing_details[address[state]]", stateOrProvince));
             localParams.put("billing_details[address[city]]", address.getCity());
             localParams.put("billing_details[address[country]]", address.getCountry());
             localParams.put("billing_details[address[postal_code]]", address.getPostcode());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -141,11 +141,10 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
     @Override
     public GatewayResponse<BaseAuthoriseResponse> authorise(CardAuthorisationGatewayRequest request) throws GatewayException {
-        GatewayOrder gatewayOrder = buildAuthoriseOrder(request);
         GatewayClient.Response response = authoriseClient.postRequestFor(
                 gatewayUrlMap.get(request.getGatewayAccount().getType()),
                 request.getGatewayAccount(),
-                gatewayOrder,
+                buildAuthoriseOrder(request),
                 getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
 
         if (response.getEntity().contains("request3DSecure")) {

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapper.java
@@ -21,11 +21,11 @@ import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.
 
 public class CanadaPostalcodeToProvinceOrTerritoryMapper {
 
-    private static final Pattern WELL_FORMED_POSTAL_CODE = Pattern.compile("([A-Z])[0-9][A-Z][0-9][A-Z][0-9]");
-    private static final Pattern WELL_FORMED_X_POSTAL_CODE = Pattern.compile("(X[0-9][A-Z])[0-9][A-Z][0-9]");
-    private static final String SANTA_CLAUS_POSTAL_CODE = "H0H0H0";
+    private final Pattern WELL_FORMED_POSTAL_CODE = Pattern.compile("([A-Z])[0-9][A-Z][0-9][A-Z][0-9]");
+    private final Pattern WELL_FORMED_X_POSTAL_CODE = Pattern.compile("(X[0-9][A-Z])[0-9][A-Z][0-9]");
+    private final String SANTA_CLAUS_POSTAL_CODE = "H0H0H0";
 
-    public static final Map<String, CanadaProvinceOrTerritory> NON_X_POSTAL_CODE_TERRITORY_PROVINCE_MAP = Map.ofEntries(
+    public final Map<String, CanadaProvinceOrTerritory> NON_X_POSTAL_CODE_TERRITORY_PROVINCE_MAP = Map.ofEntries(
             entry("A", NEWFOUNDLAND_AND_LABRADOR),
             entry("B", NOVA_SCOTIA),
             entry("C", PRINCE_EDWARD_ISLAND),
@@ -45,15 +45,15 @@ public class CanadaPostalcodeToProvinceOrTerritoryMapper {
             entry("Y", YUKON)
     );
 
-    public static final Map<String, CanadaProvinceOrTerritory> X_POSTAL_CODE_TERRITORY_MAP = Map.ofEntries(
+    public final Map<String, CanadaProvinceOrTerritory> X_POSTAL_CODE_TERRITORY_MAP = Map.ofEntries(
             entry("X0A", NUNAVUT),
             entry("X0B", NUNAVUT),
             entry("X0C", NUNAVUT),
             entry("X0E", NORTHWEST_TERRITORIES),
             entry("X0G", NORTHWEST_TERRITORIES)
     );
-    
-    public static Optional<CanadaProvinceOrTerritory> getProvinceOrTerritory(String normalisedPostalCode) {
+
+    public Optional<CanadaProvinceOrTerritory> getProvinceOrTerritory(String normalisedPostalCode) {
         var xPostalCodeMatcher = WELL_FORMED_X_POSTAL_CODE.matcher(normalisedPostalCode);
         var postalCodeMatcher = WELL_FORMED_POSTAL_CODE.matcher(normalisedPostalCode);
 

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapper.java
@@ -20,7 +20,7 @@ import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.
 import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NORTHWEST_TERRITORIES;
 
 public class CanadaPostalcodeToProvinceOrTerritoryMapper {
-    
+
     private static final Pattern WELL_FORMED_POSTAL_CODE = Pattern.compile("([A-Z])[0-9][A-Z][0-9][A-Z][0-9]");
     private static final Pattern WELL_FORMED_X_POSTAL_CODE = Pattern.compile("(X[0-9][A-Z])[0-9][A-Z][0-9]");
     private static final String SANTA_CLAUS_POSTAL_CODE = "H0H0H0";

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaProvinceOrTerritory.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaProvinceOrTerritory.java
@@ -19,7 +19,7 @@ public enum CanadaProvinceOrTerritory implements NorthAmericaRegion {
 
     private final String abbreviation;
     private final String fullName;
-
+    
     CanadaProvinceOrTerritory(String abbreviation, String provinceOrTerritory) {
         this.abbreviation = Objects.requireNonNull(abbreviation);
         this.fullName = Objects.requireNonNull(provinceOrTerritory);

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaProvinceOrTerritory.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaProvinceOrTerritory.java
@@ -19,7 +19,7 @@ public enum CanadaProvinceOrTerritory implements NorthAmericaRegion {
 
     private final String abbreviation;
     private final String fullName;
-    
+
     CanadaProvinceOrTerritory(String abbreviation, String provinceOrTerritory) {
         this.abbreviation = Objects.requireNonNull(abbreviation);
         this.fullName = Objects.requireNonNull(provinceOrTerritory);

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapper.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.northamericaregion;
+
+import uk.gov.pay.connector.common.model.domain.Address;
+
+import javax.inject.Inject;
+import java.util.Locale;
+import java.util.Optional;
+
+public class NorthAmericanRegionMapper {
+    
+    private final UsZipCodeToStateMapper usZipCodeToStateMapper;
+    private final CanadaPostalcodeToProvinceOrTerritoryMapper canadaPostalcodeToProvinceOrTerritoryMapper;
+
+    public NorthAmericanRegionMapper() {
+        this.usZipCodeToStateMapper = new UsZipCodeToStateMapper();
+        this.canadaPostalcodeToProvinceOrTerritoryMapper = new CanadaPostalcodeToProvinceOrTerritoryMapper();
+    }
+
+    @Inject
+    public NorthAmericanRegionMapper(UsZipCodeToStateMapper usZipCodeToStateMapper, CanadaPostalcodeToProvinceOrTerritoryMapper canadaPostalcodeToProvinceOrTerritoryMapper) {
+        this.usZipCodeToStateMapper = usZipCodeToStateMapper;
+        this.canadaPostalcodeToProvinceOrTerritoryMapper = canadaPostalcodeToProvinceOrTerritoryMapper;
+    }
+    
+    public Optional<? extends NorthAmericaRegion> getNorthAmericanRegionForCountry(Address address) {
+        switch (address.getCountry()) {
+            case "US":
+                return usZipCodeToStateMapper.getState(getNormalisedPostalCode(address));
+            case "CA":
+                return canadaPostalcodeToProvinceOrTerritoryMapper.getProvinceOrTerritory(getNormalisedPostalCode(address));
+            default:
+                return Optional.empty();
+        }
+    }
+
+    private String getNormalisedPostalCode(Address address) {
+        return address.getPostcode().replaceAll("\\s", "").toUpperCase(Locale.ENGLISH);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/UsState.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/UsState.java
@@ -60,7 +60,6 @@ public enum UsState implements NorthAmericaRegion {
     WEST_VIRGINIA("WV", "West Virginia"),
     WISCONSIN("WI", "Wisconsin"),
     WYOMING("WY", "Wyoming");
-    
 
     private final String abbreviation;
     private final String fullName;

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMap.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMap.java
@@ -71,7 +71,7 @@ public class UsZipCodeToStateMap {
         put("005", NEW_YORK);
         put("006", PUERTO_RICO);
         put("007", PUERTO_RICO);
-        put("008", VIRGIN_ISLANDS);
+        put("008", VIRGINIA);
         put("009", PUERTO_RICO);
         put("010", MASSACHUSETTS);
         put("011", MASSACHUSETTS);

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMap.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMap.java
@@ -71,7 +71,7 @@ public class UsZipCodeToStateMap {
         put("005", NEW_YORK);
         put("006", PUERTO_RICO);
         put("007", PUERTO_RICO);
-        put("008", VIRGINIA);
+        put("008", VIRGIN_ISLANDS);
         put("009", PUERTO_RICO);
         put("010", MASSACHUSETTS);
         put("011", MASSACHUSETTS);

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMapper.java
@@ -10,12 +10,12 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public class UsZipCodeToStateMapper {
 
-    private static final Pattern WELL_FORMED_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([0-9]{3})[0-9]{2}(?:-[0-9]{4})?");
-    private static final Pattern WELL_FORMED_STATE_WITH_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([A-Z]{2})[0-9]{5}(?:-[0-9]{4})?");
-    private static final Map<String, UsState> US_STATE_ABBREVIATIONS_MAPPING = Arrays.stream(UsState.values()).collect(
-            toUnmodifiableMap(UsState::getAbbreviation, identity())); 
+    private final Pattern WELL_FORMED_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([0-9]{3})[0-9]{2}(?:-[0-9]{4})?");
+    private final Pattern WELL_FORMED_STATE_WITH_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([A-Z]{2})[0-9]{5}(?:-[0-9]{4})?");
+    private final Map<String, UsState> US_STATE_ABBREVIATIONS_MAPPING = Arrays.stream(UsState.values()).collect(
+            toUnmodifiableMap(NorthAmericaRegion::getAbbreviation, identity())); 
 
-    public static Optional<UsState> getState(String normalisedZipCode) {
+    public Optional<UsState> getState(String normalisedZipCode) {
         var wellFormedZipCodeAndOptionalPlusFourMatcher = WELL_FORMED_STATE_WITH_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR.matcher(normalisedZipCode);
         var wellFormedStateWithZipAndOptionalPlusFourMatcher = WELL_FORMED_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR.matcher(normalisedZipCode);
 

--- a/src/main/resources/templates/smartpay/Smartpay3dsRequiredOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/Smartpay3dsRequiredOrderTemplate.xml
@@ -32,7 +32,7 @@
                         <ns2:houseNumberOrName>${authCardDetails.address.get().line1?xml}</ns2:houseNumberOrName>
                         <ns2:street><#if authCardDetails.address.get().line2?has_content>${authCardDetails.address.get().line2?xml}<#else>N/A</#if></ns2:street>
                         <ns2:postalCode>${authCardDetails.address.get().postcode?xml}</ns2:postalCode>
-                        <ns2:stateOrProvince><#if authCardDetails.address.get().county??>${authCardDetails.address.get().county?xml}</#if></ns2:stateOrProvince>
+                        <ns2:stateOrProvince><#if stateOrProvince?has_content>${stateOrProvince?xml}</#if></ns2:stateOrProvince>
                         <ns2:city>${authCardDetails.address.get().city?xml}</ns2:city>
                         <ns2:country>${authCardDetails.address.get().country?xml}</ns2:country>
                     </ns1:billingAddress>

--- a/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
@@ -21,7 +21,7 @@
                         <ns2:houseNumberOrName>${authCardDetails.address.get().line1?xml}</ns2:houseNumberOrName>
                         <ns2:street><#if authCardDetails.address.get().line2?has_content>${authCardDetails.address.get().line2?xml}<#else>N/A</#if></ns2:street>
                         <ns2:postalCode>${authCardDetails.address.get().postcode?xml}</ns2:postalCode>
-                        <ns2:stateOrProvince><#if authCardDetails.address.get().county??>${authCardDetails.address.get().county?xml}</#if></ns2:stateOrProvince>
+                        <ns2:stateOrProvince><#if stateOrProvince?has_content>${stateOrProvince?xml}</#if></ns2:stateOrProvince>
                         <ns2:city>${authCardDetails.address.get().city?xml}</ns2:city>
                         <ns2:country>${authCardDetails.address.get().country?xml}</ns2:country>
                     </ns1:billingAddress>

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -23,8 +23,8 @@
                             </#if>
                             <postalCode>${authCardDetails.address.get().postcode?xml}</postalCode>
                             <city>${authCardDetails.address.get().city?xml}</city>
-                            <#if authCardDetails.address.get().county??>
-                            <state>${authCardDetails.address.get().county?xml}</state>
+                            <#if state??>
+                            <state>${state?xml}</state>
                             </#if>
                             <countryCode>${authCardDetails.address.get().country?xml}</countryCode>
                         </address>

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.northamericaregion.UsState;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.time.ZonedDateTime;
@@ -81,6 +82,21 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasJsonPath("$.event_details.address_country", equalTo("GB")));
         assertThat(actual, hasJsonPath("$.event_details.wallet", equalTo("APPLE_PAY")));
     }
+    
+    @Test
+    public void whenAllTheDataIsAvailableForUsCountry() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        chargeEntity.getCardDetails().getBillingAddress().ifPresent(address -> address.setStateOrProvince(UsState.VERMONT.getAbbreviation()));
+        String actual = PaymentDetailsEntered.from(chargeEntity).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("PAYMENT_DETAILS_ENTERED")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.title", equalTo("Payment details entered event")));
+        assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are entered")));
+        assertThat(actual, hasJsonPath("$.event_details.address_state_province", equalTo(UsState.VERMONT.getAbbreviation())));
+    }
 
     @Test
     public void whenNotAllTheDataIsAvailable() throws JsonProcessingException {
@@ -115,6 +131,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasNoJsonPath("$.event_details.address_city"));
         assertThat(actual, hasNoJsonPath("$.event_details.address_county"));
         assertThat(actual, hasNoJsonPath("$.event_details.address_country"));
+        assertThat(actual, hasNoJsonPath("$.event_details.address_state_province"));
         assertThat(actual, hasNoJsonPath("$.event_details.wallet"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
@@ -22,9 +22,11 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_SPEC
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_SPECIAL_CHAR_VALID_CAPTURE_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_INCLUDING_STATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_MINIMAL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_INCLUDING_STATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_CANCEL_SMARTPAY_REQUEST;
@@ -48,7 +50,7 @@ public class SmartpayOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidAuthoriseOrderRequestForAddressWithAllFields() throws Exception {
-        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", "London", "GB");
+        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(address);
 
@@ -82,7 +84,7 @@ public class SmartpayOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidAuthoriseOrderRequestWithSpecialCharactersInUserInput() throws Exception {
-        Address address = new Address("41", "Scala & Haskell Rocks", "EC2A 1AE", "London <!-- ", "London -->", "GB");
+        Address address = new Address("41", "Scala & Haskell Rocks", "EC2A 1AE", "London <!-- ", null, "GB -->");
 
         AuthCardDetails authCardDetails = getValidTestCard(address);
 
@@ -118,8 +120,27 @@ public class SmartpayOrderRequestBuilderTest {
     }
 
     @Test
+    public void shouldGenerateValidAuthoriseOrderRequestForUsAddress() throws Exception {
+
+        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
+
+        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
+
+        GatewayOrder actualRequest = aSmartpayAuthoriseOrderRequestBuilder()
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription")
+                .withPaymentPlatformReference("MyPlatformReference")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
     public void shouldGenerateValidAuthorise3dsRequiredOrderRequestForAddressWithAllFields() throws Exception {
-        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", "London", "GB");
+        Address address = new Address("41", "Scala Street", "EC2A 1AE", "London", null, "GB");
 
         AuthCardDetails authCardDetails = getValidTestCard(address);
 
@@ -153,7 +174,7 @@ public class SmartpayOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidAuthorise3dsRequiredOrderRequestWithSpecialCharactersInUserInput() throws Exception {
-        Address address = new Address("41", "Scala & Haskell Rocks", "EC2A 1AE", "London <!-- ", "London -->", "GB");
+        Address address = new Address("41", "Scala & Haskell Rocks", "EC2A 1AE", "London <!-- ", null, "GB -->");
 
         AuthCardDetails authCardDetails = getValidTestCard(address);
 
@@ -185,6 +206,25 @@ public class SmartpayOrderRequestBuilderTest {
                 .build();
 
         assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_MINIMAL), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthorise3dsRequiredOrderRequestForUsAddress() throws Exception {
+
+        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
+
+        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
+
+        GatewayOrder actualRequest = aSmartpay3dsRequiredOrderRequestBuilder()
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription")
+                .withPaymentPlatformReference("MyPlatformReference")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE_3DS, actualRequest.getOrderRequestType());
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -95,6 +95,46 @@ public class StripePaymentMethodRequestTest {
         assertThat(payload, containsString("billing_details%5Baddress%5Bcountry%5D%5D=" + country));
         assertThat(payload, containsString("billing_details%5Baddress%5Bpostal_code%5D%5D=" + postcode));
     }
+    
+    @Test
+    public void shouldHaveCanadianProvinceOrTerritoryInBillingDetailsWhenProvided() {
+        Address address = new Address();
+        address.setLine1(line1);
+        address.setLine2(line2);
+        address.setCity(city);
+        address.setCountry("CA");
+        address.setPostcode("X0A0A0");
+        authCardDetails.setAddress(address);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+
+        stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
+
+        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+
+        assertThat(payload, containsString("billing_details%5Baddress%5Bstate%5D%5D=Nunavut"));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bcountry%5D%5D=CA"));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bpostal_code%5D%5D=X0A0A0"));
+    }
+
+    @Test
+    public void shouldHaveUsStateInBillingDetailsWhenProvided() {
+        Address address = new Address();
+        address.setLine1(line1);
+        address.setLine2(line2);
+        address.setCity(city);
+        address.setCountry("US");
+        address.setPostcode("90210");
+        authCardDetails.setAddress(address);
+        CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
+
+        stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
+
+        String payload = stripePaymentMethodRequest.getGatewayOrder().getPayload();
+
+        assertThat(payload, containsString("billing_details%5Baddress%5Bstate%5D%5D=California"));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bcountry%5D%5D=US"));
+        assertThat(payload, containsString("billing_details%5Baddress%5Bpostal_code%5D%5D=90210"));
+    }
 
     @Test
     public void shouldHaveCorrectParametersWithoutAddress() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -24,10 +24,12 @@ import static uk.gov.pay.connector.model.domain.applepay.ApplePayPaymentInfoFixt
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_SPECIAL_CHAR_VALID_CAPTURE_WORLDPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_3DS_RESPONSE_AUTH_WORLDPAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CANCEL_WORLDPAY_REQUEST;
@@ -84,6 +86,51 @@ public class WorldpayOrderRequestBuilderTest {
                 .build();
 
         assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthoriseOrderRequestForAddressWithState() throws Exception {
+
+        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
+
+        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
+
+        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
+                .withAcceptHeader("text/html")
+                .withUserAgentHeader("Mozilla/5.0")
+                .withTransactionId("MyUniqueTransactionId!")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthoriseOrderRequestForAddressWithStateWhen3dsEnabled() throws Exception {
+
+        Address usAddress = new Address("10 WCB", null, "20500", "Washington D.C.", null, "US");
+
+        AuthCardDetails authCardDetails = getValidTestCard(usAddress);
+
+        GatewayOrder actualRequest = aWorldpayAuthoriseOrderRequestBuilder()
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
+                .with3dsRequired(true)
+                .withAcceptHeader("text/html")
+                .withUserAgentHeader("Mozilla/5.0")
+                .withTransactionId("MyUniqueTransactionId!")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.app.GatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
@@ -119,6 +120,48 @@ public class SmartpayPaymentProviderTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCardNo(VALID_SMARTPAY_CARD_NUMBER)
                 .withAddress(null)
+                .build();
+
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
+
+        GatewayResponse response = paymentProvider.authorise(request);
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    public void shouldSendSuccessfullyAnOrderForMerchantWithUsAddressInRequest() throws Exception {
+        PaymentProvider paymentProvider = getSmartpayPaymentProvider();
+        Address usAddress = new Address();
+        usAddress.setLine1("125 Kingsway");
+        usAddress.setLine2("Aviation House");
+        usAddress.setPostcode("90210");
+        usAddress.setCity("Washington D.C.");
+        usAddress.setCountry("US");
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo(VALID_SMARTPAY_CARD_NUMBER)
+                .withAddress(usAddress)
+                .build();
+
+        CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);
+
+        GatewayResponse response = paymentProvider.authorise(request);
+        assertTrue(response.isSuccessful());
+    }
+
+    @Test
+    public void shouldSendSuccessfullyAnOrderForMerchantWithCanadaAddressInRequest() throws Exception {
+        PaymentProvider paymentProvider = getSmartpayPaymentProvider();
+        Address canadaAddress = new Address();
+        canadaAddress.setLine1("125 Kingsway");
+        canadaAddress.setLine2("Aviation House");
+        canadaAddress.setPostcode("X0A0A0");
+        canadaAddress.setCity("Arctic Bay");
+        canadaAddress.setCountry("CA");
+
+        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
+                .withCardNo(VALID_SMARTPAY_CARD_NUMBER)
+                .withAddress(canadaAddress)
                 .build();
 
         CardAuthorisationGatewayRequest request = new CardAuthorisationGatewayRequest(chargeEntity, authCardDetails);

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.WorldpayConfig;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
@@ -158,6 +159,36 @@ public class WorldpayPaymentProviderTest {
     public void shouldBeAbleToSendAuthorisationRequestForMerchantWithoutAddress() throws Exception {
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         AuthCardDetails authCardDetails = anAuthCardDetails().withAddress(null).build();
+        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        assertTrue(response.getBaseResponse().isPresent());
+    }
+
+    @Test
+    public void shouldBeAbleToSendAuthorisationRequestForMerchantWithUsAddress() throws Exception {
+        WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
+        Address usAddress = new Address();
+        usAddress.setLine1("125 Kingsway");
+        usAddress.setLine2("Aviation House");
+        usAddress.setPostcode("90210");
+        usAddress.setCity("Washington D.C.");
+        usAddress.setCountry("US");
+        AuthCardDetails authCardDetails = anAuthCardDetails().withAddress(usAddress).build();
+        CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
+        GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
+        assertTrue(response.getBaseResponse().isPresent());
+    }
+
+    @Test
+    public void shouldBeAbleToSendAuthorisationRequestForMerchantWithCanadaAddress() throws Exception {
+        WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
+        Address canadaAddress = new Address();
+        canadaAddress.setLine1("125 Kingsway");
+        canadaAddress.setLine2("Aviation House");
+        canadaAddress.setPostcode("X0A0A0");
+        canadaAddress.setCity("Arctic Bay");
+        canadaAddress.setCountry("CA");
+        AuthCardDetails authCardDetails = anAuthCardDetails().withAddress(canadaAddress).build();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertTrue(response.getBaseResponse().isPresent());

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -91,6 +91,30 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
     }
 
     @Test
+    public void shouldStoreAddressStateProvinceForAuthorisedChargeFromUnitedStates() {
+        String cardBrand = "visa";
+        String validUsCardDetails = buildJsonAuthorisationDetailsFor(
+                "Mr. Name",
+                "4444333322221111",
+                "123",
+                "10/99",
+                "visa",
+                "CREDIT",
+                "Line1",
+                "Line2",
+                "Washington D.C.",
+                null,
+                "20500",
+                "US"
+        );
+        String externalChargeId = shouldAuthoriseChargeFor(validUsCardDetails);
+        Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge-"));
+        Map<String, Object> chargeCardDetails = databaseTestHelper.getChargeCardDetailsByChargeId(chargeId);
+        assertThat(chargeCardDetails, hasEntry("address_state_province", "DC"));
+        assertThat(databaseTestHelper.getChargeCardBrand(chargeId), is(cardBrand));
+    }
+
+    @Test
     public void sanitizeCardDetails_shouldStoreSanitizedCardDetailsForAuthorisedCharge_forFieldsWithValuesContainingMoreThan10Numbers() {
         String sanitizedValue = "r-**-**-*  Ju&^****-**";
         String valueWithMoreThan10CharactersAsNumbers = "r-12-34-5  Ju&^6501-76";

--- a/src/test/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapperTest.java
@@ -32,9 +32,9 @@ public class CanadaPostalcodeToProvinceOrTerritoryMapperTest {
         assertThat(canadaProvinceTerritory.isPresent(), is (true));
         assertThat(canadaProvinceTerritory.get(), is (CanadaProvinceOrTerritory.NORTHWEST_TERRITORIES));
     }
-    
+
     @Test
-    public void shouldNotReturnAStateForSantaPostalCode() {
+    public void shouldNotReturnAStateForSantaPostCode() {
         Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = CanadaPostalcodeToProvinceOrTerritoryMapper.getProvinceOrTerritory("H0H0H0");
 
         assertThat(canadaProvinceTerritory.isEmpty(), is (true));

--- a/src/test/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapperTest.java
@@ -9,9 +9,11 @@ import static org.hamcrest.Matchers.is;
 
 public class CanadaPostalcodeToProvinceOrTerritoryMapperTest {
 
+    public final CanadaPostalcodeToProvinceOrTerritoryMapper mapper = new CanadaPostalcodeToProvinceOrTerritoryMapper();
+
     @Test
     public void shouldReturnTheCorrectStateForNonXPostalCode() {
-        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = CanadaPostalcodeToProvinceOrTerritoryMapper.getProvinceOrTerritory("A1A1A1");
+        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = mapper.getProvinceOrTerritory("A1A1A1");
 
         assertThat(canadaProvinceTerritory.isPresent(), is (true));
         assertThat(canadaProvinceTerritory.get(), is (CanadaProvinceOrTerritory.NEWFOUNDLAND_AND_LABRADOR));
@@ -19,7 +21,7 @@ public class CanadaPostalcodeToProvinceOrTerritoryMapperTest {
 
     @Test
     public void shouldReturnTheCorrectStateForNunavutPostalCode() {
-        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = CanadaPostalcodeToProvinceOrTerritoryMapper.getProvinceOrTerritory("X0A0A0");
+        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = mapper.getProvinceOrTerritory("X0A0A0");
 
         assertThat(canadaProvinceTerritory.isPresent(), is (true));
         assertThat(canadaProvinceTerritory.get(), is (CanadaProvinceOrTerritory.NUNAVUT));
@@ -27,15 +29,15 @@ public class CanadaPostalcodeToProvinceOrTerritoryMapperTest {
 
     @Test
     public void shouldReturnTheCorrectStateForNorthwestTerritoriesPostalCode() {
-        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = CanadaPostalcodeToProvinceOrTerritoryMapper.getProvinceOrTerritory("X0E1Z0");
+        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = mapper.getProvinceOrTerritory("X0E1Z0");
 
         assertThat(canadaProvinceTerritory.isPresent(), is (true));
         assertThat(canadaProvinceTerritory.get(), is (CanadaProvinceOrTerritory.NORTHWEST_TERRITORIES));
     }
-
+    
     @Test
-    public void shouldNotReturnAStateForSantaPostCode() {
-        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = CanadaPostalcodeToProvinceOrTerritoryMapper.getProvinceOrTerritory("H0H0H0");
+    public void shouldNotReturnAStateForSantaPostalCode() {
+        Optional<CanadaProvinceOrTerritory> canadaProvinceTerritory = mapper.getProvinceOrTerritory("H0H0H0");
 
         assertThat(canadaProvinceTerritory.isEmpty(), is (true));
     }

--- a/src/test/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/northamericaregion/NorthAmericanRegionMapperTest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.northamericaregion;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.AddressEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class NorthAmericanRegionMapperTest {
+    
+    private final NorthAmericanRegionMapper mapper = new NorthAmericanRegionMapper(
+            new UsZipCodeToStateMapper(),
+            new CanadaPostalcodeToProvinceOrTerritoryMapper()
+    );
+    
+    private Address address;
+    
+    @Before
+    public void setUp() {
+        address = new Address();
+        address.setLine1("Line 1");
+        address.setLine2("Line 2");
+    }
+    
+    @Test
+    public void shouldNotReturnRegionForCountryOutsideNorthAmerica() {
+        address.setCountry("GB");
+        address.setCity("London");
+        address.setPostcode("CR91AT");
+        
+        Optional<? extends NorthAmericaRegion> northAmericaRegion = mapper.getNorthAmericanRegionForCountry(address);
+
+        assertThat(northAmericaRegion.isEmpty(), is (true));
+    }
+
+    @Test
+    public void shouldReturnTheCorrectStateForValidAddressInUnitedStates() {
+        address.setCountry("US");
+        address.setCity("Washington D.C.");
+        address.setPostcode("20500");
+
+        Optional<? extends NorthAmericaRegion> northAmericaRegion = mapper.getNorthAmericanRegionForCountry(address);
+
+        assertThat(northAmericaRegion.isPresent(), is (true));
+        assertThat(northAmericaRegion.get(), is (UsState.WASHINGTON_DC));
+    }
+
+    @Test
+    public void shouldReturnTheCorrectProvinceOrTerritoryForValidAddressInCanada() {
+        address.setCountry("CA");
+        address.setCity("Arctic Region");
+        address.setPostcode("X0A0A0");
+
+        Optional<? extends NorthAmericaRegion> northAmericaRegion = mapper.getNorthAmericanRegionForCountry(address);
+
+        assertThat(northAmericaRegion.isPresent(), is (true));
+        assertThat(northAmericaRegion.get(), is (CanadaProvinceOrTerritory.NUNAVUT));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMapperTest.java
@@ -10,9 +10,11 @@ import static org.hamcrest.Matchers.is;
 
 public class UsZipCodeToStateMapperTest {
 
+    public final UsZipCodeToStateMapper mapper = new UsZipCodeToStateMapper();
+
     @Test
     public void shouldReturnTheCorrectStateForValidZipCode() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("05910");
+        Optional<UsState> usState = mapper.getState("05910");
 
         assertThat(usState.isPresent(), is (true));
         assertThat(usState.get(), is (UsState.VERMONT));
@@ -20,7 +22,7 @@ public class UsZipCodeToStateMapperTest {
 
     @Test
     public void shouldReturnTheCorrectStateForValidZipCodePlusFour() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("05910-1234");
+        Optional<UsState> usState = mapper.getState("05910-1234");
 
         assertThat(usState.isPresent(), is (true));
         assertThat(usState.get(), is (UsState.VERMONT));
@@ -28,7 +30,7 @@ public class UsZipCodeToStateMapperTest {
 
     @Test
     public void shouldReturnTheCorrectStateForValidStateAndZipCode() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("VT05910");
+        Optional<UsState> usState = mapper.getState("VT05910");
 
         assertThat(usState.isPresent(), is (true));
         assertThat(usState.get(), is (UsState.VERMONT));
@@ -36,7 +38,7 @@ public class UsZipCodeToStateMapperTest {
 
     @Test
     public void shouldReturnTheCorrectStateForValidStateAndZipCodeFourPlus() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("VT05910-1234");
+        Optional<UsState> usState = mapper.getState("VT05910-1234");
 
         assertThat(usState.isPresent(), is (true));
         assertThat(usState.get(), is (UsState.VERMONT));
@@ -44,25 +46,25 @@ public class UsZipCodeToStateMapperTest {
 
     @Test
     public void shouldNotReturnStateForInvalidStateAndZipCodeFormat() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("XX05910");
+        Optional<UsState> usState = mapper.getState("XX05910");
         assertThat(usState.isEmpty(), is (true));
     }
 
     @Test
     public void shouldNotReturnStateForInvalidStateAndZipCodePlusFourFormat() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("XX05910-1234");
+        Optional<UsState> usState = mapper.getState("XX05910-1234");
         assertThat(usState.isEmpty(), is (true));
     }
 
     @Test
     public void shouldNotReturnStateForZipCodeNotInUse() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("00000");
+        Optional<UsState> usState = mapper.getState("00000");
         assertThat(usState.isEmpty(), is (true));
     }
 
     @Test
     public void shouldNotReturnStateForInvalidZipCodeFormat() {
-        Optional<UsState> usState = UsZipCodeToStateMapper.getState("xxxxx");
+        Optional<UsState> usState = mapper.getState("xxxxx");
         assertThat(usState.isEmpty(), is (true));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -27,6 +27,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
+import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.util.AuthUtils;
@@ -66,6 +67,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private StateTransitionService mockStateTransitionService;
     @Mock
     private Authorisation3dsConfig mockAuthorisation3dsConfig;
+    @Mock
+    private NorthAmericanRegionMapper northAmericanRegionMapper;
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
@@ -92,7 +95,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockConfiguration.getAuthorisation3dsConfig()).thenReturn(mockAuthorisation3dsConfig);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockEventService, mockedRefundDao);
+                null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockEventService, mockedRefundDao, northAmericanRegionMapper);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService, mockConfiguration);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -41,6 +41,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
+import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
@@ -108,8 +109,12 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private EventQueue eventQueue;
+
     @Mock
     private EventService mockEventService;
+
+    @Mock
+    private NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
 
     private CardAuthoriseService cardAuthorisationService;
 
@@ -121,7 +126,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                stateTransitionService, ledgerService, mockEventService, mockedRefundDao);
+                stateTransitionService, ledgerService, mockEventService, mockedRefundDao, mockNorthAmericanRegionMapper);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -35,6 +35,7 @@ import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
+import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
 import uk.gov.pay.connector.queue.QueueException;
@@ -111,6 +112,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private EventService mockEventService;
     @Mock
     private RefundDao mockRefundDao;
+    @Mock
+    protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
 
     @Before
     public void beforeTest() {
@@ -120,7 +123,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                mockStateTransitionService, ledgerService, mockEventService, mockRefundDao);
+                mockStateTransitionService, ledgerService, mockEventService, mockRefundDao, mockNorthAmericanRegionMapper);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -303,7 +303,7 @@ public class DatabaseTestHelper {
 
     public Map<String, Object> getChargeCardDetailsByChargeId(Long chargeId) {
         Map<String, Object> ret = jdbi.withHandle(h ->
-                h.createQuery("SELECT id, card_brand, last_digits_card_number, first_digits_card_number, cardholder_name, expiry_date, address_line1, address_line2, address_postcode, address_city, address_county, address_country " +
+                h.createQuery("SELECT id, card_brand, last_digits_card_number, first_digits_card_number, cardholder_name, expiry_date, address_line1, address_line2, address_postcode, address_city, address_county, address_state_province, address_country " +
                         "FROM charges " +
                         "WHERE id = :charge_id")
                         .bind("charge_id", chargeId)

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -16,10 +16,12 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-pares-parse-error-response.xml";
     public static final String WORLDPAY_SPECIAL_CHAR_VALID_AUTHORISE_WORLDPAY_REQUEST_ADDRESS = WORLDPAY_BASE_NAME + "/special-char-valid-authorise-worldpay-request-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-min-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-including-state.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-excluding-3ds.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-full-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds-with-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds-without-ip-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-state.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-min-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-min-data.xml";
@@ -65,10 +67,12 @@ public class TestTemplateResourceLoader {
     public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-minimal.xml";
+    public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_INCLUDING_STATE = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-including-state.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITHOUT_ADDRESS = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-without-address.xml";
     public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-3ds-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_MINIMAL = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request-minimal.xml";
+    public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_INCLUDING_STATE = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request-including-state.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_WITHOUT_ADDRESS = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request-without-address.xml";
 
     static final String SMARTPAY_CANCEL_ERROR_RESPONSE = SMARTPAY_BASE_NAME + "/cancel-error-response.xml";

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -38,6 +38,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.paritycheck.LedgerService;
 import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
@@ -111,6 +112,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     private EventQueue eventQueue;
     @Mock
     private EmittedEventDao emittedEventDao;
+    @Mock
+    protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
 
     private WalletAuthoriseService walletAuthoriseService;
 
@@ -140,7 +143,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null, mockStateTransitionService,
-                ledgerService, mockEventService, mockedRefundDao));
+                ledgerService, mockEventService, mockedRefundDao, mockNorthAmericanRegionMapper));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,

--- a/src/test/resources/templates/smartpay/special-char-valid-authorise-smartpay-3ds-request.xml
+++ b/src/test/resources/templates/smartpay/special-char-valid-authorise-smartpay-3ds-request.xml
@@ -31,9 +31,9 @@
                         <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
                         <ns2:street>Scala &amp; Haskell Rocks</ns2:street>
                         <ns2:postalCode>EC2A 1AE</ns2:postalCode>
-                        <ns2:stateOrProvince>London --&gt;</ns2:stateOrProvince>
+                        <ns2:stateOrProvince></ns2:stateOrProvince>
                         <ns2:city>London &lt;!-- </ns2:city>
-                        <ns2:country>GB</ns2:country>
+                        <ns2:country>GB --&gt;</ns2:country>
                     </ns1:billingAddress>
                 </ns1:card>
                 <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>

--- a/src/test/resources/templates/smartpay/special-char-valid-authorise-smartpay-request.xml
+++ b/src/test/resources/templates/smartpay/special-char-valid-authorise-smartpay-request.xml
@@ -20,9 +20,9 @@
                         <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
                         <ns2:street>Scala &amp; Haskell Rocks</ns2:street>
                         <ns2:postalCode>EC2A 1AE</ns2:postalCode>
-                        <ns2:stateOrProvince>London --&gt;</ns2:stateOrProvince>
+                        <ns2:stateOrProvince></ns2:stateOrProvince>
                         <ns2:city>London &lt;!-- </ns2:city>
-                        <ns2:country>GB</ns2:country>
+                        <ns2:country>GB --&gt;</ns2:country>
                     </ns1:billingAddress>
                 </ns1:card>
                 <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request-including-state.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-3ds-request-including-state.xml
@@ -28,12 +28,12 @@
                     <ns1:holderName>Mr. Payment</ns1:holderName>
                     <ns1:number>5555444433331111</ns1:number>
                     <ns1:billingAddress>
-                        <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
-                        <ns2:street>Scala Street</ns2:street>
-                        <ns2:postalCode>EC2A 1AE</ns2:postalCode>
-                        <ns2:stateOrProvince></ns2:stateOrProvince>
-                        <ns2:city>London</ns2:city>
-                        <ns2:country>GB</ns2:country>
+                        <ns2:houseNumberOrName>10 WCB</ns2:houseNumberOrName>
+                        <ns2:street>N/A</ns2:street>
+                        <ns2:postalCode>20500</ns2:postalCode>
+                        <ns2:stateOrProvince>DC</ns2:stateOrProvince>
+                        <ns2:city>Washington D.C.</ns2:city>
+                        <ns2:country>US</ns2:country>
                     </ns1:billingAddress>
                 </ns1:card>
                 <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-including-state.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-including-state.xml
@@ -2,21 +2,10 @@
 <soap:Envelope
         xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
         xmlns:ns1="http://payment.services.adyen.com"
-        xmlns:ns2="http://common.services.adyen.com"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        xmlns:ns2="http://common.services.adyen.com">
     <soap:Body>
         <ns1:authorise>
             <ns1:paymentRequest>
-                <ns1:additionalData>
-                    <ns2:entry>
-                        <ns2:key xsi:type="xsd:string">executeThreeD</ns2:key>
-                        <ns2:value xsi:type="xsd:string">true</ns2:value>
-                    </ns2:entry>
-                </ns1:additionalData>
-                <ns1:browserInfo>
-                    <ns2:acceptHeader>text/html</ns2:acceptHeader>
-                    <ns2:userAgent>Mozilla/5.0</ns2:userAgent>
-                </ns1:browserInfo>
                 <ns1:amount>
                     <ns2:currency>GBP</ns2:currency>
                     <ns2:value>2000</ns2:value>
@@ -28,12 +17,12 @@
                     <ns1:holderName>Mr. Payment</ns1:holderName>
                     <ns1:number>5555444433331111</ns1:number>
                     <ns1:billingAddress>
-                        <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
-                        <ns2:street>Scala Street</ns2:street>
-                        <ns2:postalCode>EC2A 1AE</ns2:postalCode>
-                        <ns2:stateOrProvince></ns2:stateOrProvince>
-                        <ns2:city>London</ns2:city>
-                        <ns2:country>GB</ns2:country>
+                        <ns2:houseNumberOrName>10 WCB</ns2:houseNumberOrName>
+                        <ns2:street>N/A</ns2:street>
+                        <ns2:postalCode>20500</ns2:postalCode>
+                        <ns2:stateOrProvince>DC</ns2:stateOrProvince>
+                        <ns2:city>Washington D.C.</ns2:city>
+                        <ns2:country>US</ns2:country>
                     </ns1:billingAddress>
                 </ns1:card>
                 <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-request.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-request.xml
@@ -20,7 +20,7 @@
                         <ns2:houseNumberOrName>41</ns2:houseNumberOrName>
                         <ns2:street>Scala Street</ns2:street>
                         <ns2:postalCode>EC2A 1AE</ns2:postalCode>
-                        <ns2:stateOrProvince>London</ns2:stateOrProvince>
+                        <ns2:stateOrProvince></ns2:stateOrProvince>
                         <ns2:city>London</ns2:city>
                         <ns2:country>GB</ns2:country>
                     </ns1:billingAddress>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-including-state.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-3ds-request-including-state.xml
@@ -3,8 +3,8 @@
         "http://dtd.worldpay.com/paymentService_v1.dtd">
 <paymentService version="1.4" merchantCode="MERCHANTCODE">
     <submit>
-        <order orderCode="transaction-id">
-            <description>This is a description</description>
+        <order orderCode="MyUniqueTransactionId!">
+            <description>This is the description</description>
             <amount currencyCode="GBP" exponent="2" value="500"/>
             <paymentDetails>
                 <VISA-SSL>
@@ -16,15 +16,15 @@
                     <cvc>123</cvc>
                     <cardAddress>
                         <address>
-                            <address1>123 My Street</address1>
-                            <address2>This road</address2>
-                            <postalCode>SW8URR</postalCode>
-                            <city>London</city>
-                            <countryCode>GB</countryCode>
+                            <address1>10 WCB</address1>
+                            <postalCode>20500</postalCode>
+                            <city>Washington D.C.</city>
+                            <state>DC</state>
+                            <countryCode>US</countryCode>
                         </address>
                     </cardAddress>
                 </VISA-SSL>
-                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
+                <session id="uniqueSessionId"/>
             </paymentDetails>
             <shopper>
                 <browser>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds.xml
@@ -20,7 +20,6 @@
                             <address2>This road</address2>
                             <postalCode>SW8URR</postalCode>
                             <city>London</city>
-                            <state>London state</state>
                             <countryCode>GB</countryCode>
                         </address>
                     </cardAddress>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-full-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-full-address.xml
@@ -20,7 +20,6 @@
                             <address2>This road</address2>
                             <postalCode>SW8URR</postalCode>
                             <city>London</city>
-                            <state>London county</state>
                             <countryCode>GB</countryCode>
                         </address>
                     </cardAddress>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds-without-ip-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds-without-ip-address.xml
@@ -20,7 +20,6 @@
                             <address2>This road</address2>
                             <postalCode>SW8URR</postalCode>
                             <city>London</city>
-                            <state>London state</state>
                             <countryCode>GB</countryCode>
                         </address>
                     </cardAddress>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-state.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-state.xml
@@ -3,8 +3,8 @@
         "http://dtd.worldpay.com/paymentService_v1.dtd">
 <paymentService version="1.4" merchantCode="MERCHANTCODE">
     <submit>
-        <order orderCode="transaction-id">
-            <description>This is a description</description>
+        <order orderCode="MyUniqueTransactionId!">
+            <description>This is the description</description>
             <amount currencyCode="GBP" exponent="2" value="500"/>
             <paymentDetails>
                 <VISA-SSL>
@@ -16,22 +16,15 @@
                     <cvc>123</cvc>
                     <cardAddress>
                         <address>
-                            <address1>123 My Street</address1>
-                            <address2>This road</address2>
-                            <postalCode>SW8URR</postalCode>
-                            <city>London</city>
-                            <countryCode>GB</countryCode>
+                            <address1>10 WCB</address1>
+                            <postalCode>20500</postalCode>
+                            <city>Washington D.C.</city>
+                            <state>DC</state>
+                            <countryCode>US</countryCode>
                         </address>
                     </cardAddress>
                 </VISA-SSL>
-                <session id="uniqueSessionId" shopperIPAddress="127.0.0.1"/>
             </paymentDetails>
-            <shopper>
-                <browser>
-                    <acceptHeader>text/html</acceptHeader>
-                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
-                </browser>
-            </shopper>
         </order>
     </submit>
 </paymentService>


### PR DESCRIPTION
Description:
- Since the mappings are now in place we can store the US states and Canadian provinces in the charge database, a PaymentDetailsEnteredEvent which contains the address_state_province and sent to Ledger as well as being sent to the payment gateways
- The StripePaymentProvider contract test previously had an incorrect configuration. This is because the previous configuration uses the DropwizardAppRule to spin up the Guice container which contains the StripePaymentProvider class as well as recreating it manually which causes an exception as the metric already exists. The new configuration merely retrieves the existing class.
- Since some of the code is reused across the payment provider builders it has been extracted into NorthAmericanRegionMapper
