### PR TITLE
PP-6959 Add MOTO mask columns to gateway_accounts table in database

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1497,4 +1497,20 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add moto_mask_card_number_input column to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="moto_mask_card_number_input" type="boolean" defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add moto_mask_card_security_code_input column to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="moto_mask_card_security_code_input" type="boolean" defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Add two new columns to the `gateway_accounts` table in the connector database:

- `moto_mask_card_number_input`
- `moto_mask_card_security_code_input`

Both columns are of type `BOOLEAN`, are `NOT NULL` and have a default of `FALSE` (meaning all existing rows will be set to `FALSE` and all new rows will have the value `FALSE` by default).

Since we’re using PostgreSQL 11 now, we don’t have to worry about adding a new column with a default locking the table while it updates all the existing rows because PostgreSQL 11 stores the default in the catalog instead.