### PR TITLE
PP-6959 MOTO masking properties in gateway account responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -100,6 +100,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Column(name = "allow_moto")
     private boolean allowMoto;
 
+    @Column(name = "moto_mask_card_number_input")
+    private boolean motoMaskCardNumberInput;
+
+    @Column(name = "moto_mask_card_security_code_input")
+    private boolean motoMaskCardSecurityCodeInput;
+
     @Column(name = "integration_version_3ds")
     private int integrationVersion3ds;
 
@@ -253,6 +259,18 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return allowMoto;
     }
 
+    @JsonProperty("moto_mask_card_number_input")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isMotoMaskCardNumberInput() {
+        return motoMaskCardNumberInput;
+    }
+
+    @JsonProperty("moto_mask_card_security_code_input")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isMotoMaskCardSecurityCodeInput() {
+        return motoMaskCardSecurityCodeInput;
+    }
+
     @JsonProperty("corporate_credit_card_surcharge_amount")
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public long getCorporateNonPrepaidCreditCardSurchargeAmount() {
@@ -386,6 +404,14 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setAllowMoto(boolean allowMoto) {
         this.allowMoto = allowMoto;
+    }
+
+    public void setMotoMaskCardNumberInput(boolean motoMaskCardNumberInput) {
+        this.motoMaskCardNumberInput = motoMaskCardNumberInput;
+    }
+
+    public void setMotoMaskCardSecurityCodeInput(boolean motoMaskCardSecurityCodeInput) {
+        this.motoMaskCardSecurityCodeInput = motoMaskCardSecurityCodeInput;
     }
 
     public void setIntegrationVersion3ds(int integrationVersion3ds) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -72,7 +72,13 @@ public class GatewayAccountResourceDTO {
     
     @JsonProperty("allow_moto")
     private boolean allowMoto;
-    
+
+    @JsonProperty("moto_mask_card_number_input")
+    private boolean motoMaskCardNumberInput;
+
+    @JsonProperty("moto_mask_card_security_code_input")
+    private boolean motoMaskCardSecurityCodeInput;
+
     public GatewayAccountResourceDTO() {
     }
 
@@ -94,7 +100,9 @@ public class GatewayAccountResourceDTO {
                                      boolean requires3ds,
                                      boolean allowZeroAmount,
                                      int integrationVersion3ds,
-                                     boolean allowMoto) {
+                                     boolean allowMoto,
+                                     boolean motoMaskCardNumberInput,
+                                     boolean motoMaskCardSecurityCodeInput) {
         this.accountId = accountId;
         this.paymentProvider = paymentProvider;
         this.type = type;
@@ -114,6 +122,8 @@ public class GatewayAccountResourceDTO {
         this.allowZeroAmount = allowZeroAmount;
         this.integrationVersion3ds = integrationVersion3ds;
         this.allowMoto = allowMoto;
+        this.motoMaskCardNumberInput = motoMaskCardNumberInput;
+        this.motoMaskCardSecurityCodeInput = motoMaskCardSecurityCodeInput;
     }
 
     public static GatewayAccountResourceDTO fromEntity(GatewayAccountEntity gatewayAccountEntity) {
@@ -136,7 +146,9 @@ public class GatewayAccountResourceDTO {
                 gatewayAccountEntity.isRequires3ds(),
                 gatewayAccountEntity.isAllowZeroAmount(),
                 gatewayAccountEntity.getIntegrationVersion3ds(),
-                gatewayAccountEntity.isAllowMoto()
+                gatewayAccountEntity.isAllowMoto(),
+                gatewayAccountEntity.isMotoMaskCardNumberInput(),
+                gatewayAccountEntity.isMotoMaskCardSecurityCodeInput()
         );
     }
 
@@ -223,4 +235,13 @@ public class GatewayAccountResourceDTO {
     public boolean isAllowMoto() {
         return allowMoto;
     }
+
+    public boolean isMotoMaskCardNumberInput() {
+        return motoMaskCardNumberInput;
+    }
+
+    public boolean isMotoMaskCardSecurityCodeInput() {
+        return motoMaskCardSecurityCodeInput;
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -36,6 +36,8 @@ public class GatewayAccountResourceDTOTest {
         entity.setIntegrationVersion3ds(2);
         entity.setBlockPrepaidCards(true);
         entity.setAllowMoto(true);
+        entity.setMotoMaskCardNumberInput(true);
+        entity.setMotoMaskCardSecurityCodeInput(true);
 
         Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
@@ -62,5 +64,7 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.getIntegrationVersion3ds(), is(entity.getIntegrationVersion3ds()));
         assertThat(dto.isBlockPrepaidCards(), is(entity.isBlockPrepaidCards()));
         assertThat(dto.isAllowMoto(), is(entity.isAllowMoto()));
+        assertThat(dto.isMotoMaskCardNumberInput(), is(entity.isMotoMaskCardNumberInput()));
+        assertThat(dto.isMotoMaskCardSecurityCodeInput(), is(entity.isMotoMaskCardSecurityCodeInput()));
     }
 }


### PR DESCRIPTION
Include `moto_mask_card_number_input` and `moto_mask_card_security_code_input` JSON responses in gateway account responses.

Manual testing confirms that the properties are included in responses from:

- `/v1/api/accounts/1`
- `/v1/api/accounts`
- `/v1/frontend/accounts/1`
- `/v1/frontend/accounts?accountIds=1`
- `/v1/frontend/charges/abcdefghijklmnopqrstuvwxyz`