### PR TITLE
PP-6960 Support setting MOTO mask properties on gateway accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
@@ -40,8 +39,11 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_INTEGRATION_VERSION_3DS = "integration_version_3ds";
     public static final String FIELD_BLOCK_PREPAID_CARDS = "block_prepaid_cards";
     public static final String FIELD_ALLOW_MOTO = "allow_moto";
+    public static final String FIELD_MOTO_MASK_CARD_NUMBER_INPUT = "moto_mask_card_number_input";
+    public static final String FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT = "moto_mask_card_security_code_input";
 
-    private static final List<String> VALID_PATHS = asList(
+
+    private static final List<String> VALID_PATHS = List.of(
             CREDENTIALS_GATEWAY_MERCHANT_ID,
             FIELD_NOTIFY_SETTINGS,
             FIELD_EMAIL_COLLECTION_MODE,
@@ -54,7 +56,9 @@ public class GatewayAccountRequestValidator {
             FIELD_ALLOW_ZERO_AMOUNT,
             FIELD_INTEGRATION_VERSION_3DS,
             FIELD_BLOCK_PREPAID_CARDS,
-            FIELD_ALLOW_MOTO);
+            FIELD_ALLOW_MOTO,
+            FIELD_MOTO_MASK_CARD_NUMBER_INPUT,
+            FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT);
 
     private final RequestValidator requestValidator;
 
@@ -87,6 +91,8 @@ public class GatewayAccountRequestValidator {
             case FIELD_ALLOW_ZERO_AMOUNT:
             case FIELD_ALLOW_APPLE_PAY:
             case FIELD_ALLOW_MOTO:
+            case FIELD_MOTO_MASK_CARD_NUMBER_INPUT:
+            case FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT:
                 validateReplaceBooleanValue(payload);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT:

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -65,7 +65,13 @@ public class GatewayAccountRequestValidatorTest {
             "replace, block_prepaid_cards, unfalse, Value [unfalse] must be of type boolean for path [block_prepaid_cards]",
             "bad, allow_moto, true, Operation [bad] is not valid for path [allow_moto]",
             "replace, allow_moto, null, Field [value] is required",
-            "replace, allow_moto, unfalse, Value [unfalse] must be of type boolean for path [allow_moto]"
+            "replace, allow_moto, unfalse, Value [unfalse] must be of type boolean for path [allow_moto]",
+            "bad, moto_mask_card_number_input, true, Operation [bad] is not valid for path [moto_mask_card_number_input]",
+            "replace, moto_mask_card_number_input, null, Field [value] is required",
+            "replace, moto_mask_card_number_input, unfalse, Value [unfalse] must be of type boolean for path [moto_mask_card_number_input]",
+            "bad, moto_mask_card_security_code_input, true, Operation [bad] is not valid for path [moto_mask_card_security_code_input]",
+            "replace, moto_mask_card_security_code_input, null, Field [value] is required",
+            "replace, moto_mask_card_security_code_input, unfalse, Value [unfalse] must be of type boolean for path [moto_mask_card_security_code_input]"
     })
     public void shouldThrowWhenRequestsAreInvalid(String op, String path, @Nullable String value, String expectedErrorMessage) {
         Map<String, String> patch = new HashMap<String, String>() {{

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -86,9 +85,11 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateNotifySettingsWhenUpdate() {
-        Map<String, String> settings = Map.of("api_token", "anapitoken",
+        Map<String, String> settings = Map.of(
+                "api_token", "anapitoken",
                 "template_id", "atemplateid");
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "notify_settings",
                 "value", settings)));
 
@@ -117,7 +118,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateEmailCollectionMode() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "email_collection_mode",
                 "value", "off")));
 
@@ -133,7 +135,8 @@ public class GatewayAccountServiceTest {
     
     @Test
     public void shouldUpdateCorporateCreditCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "corporate_credit_card_surcharge_amount",
                 "value", 100)));
 
@@ -146,7 +149,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateCorporateDebitCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "corporate_debit_card_surcharge_amount",
                 "value", 100)));
 
@@ -159,7 +163,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateCorporatePrepaidDebitCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "corporate_prepaid_debit_card_surcharge_amount",
                 "value", 100)));
 
@@ -172,7 +177,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateCorporatePrepaidCreditCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "corporate_prepaid_credit_card_surcharge_amount",
                 "value", 100)));
 
@@ -185,7 +191,8 @@ public class GatewayAccountServiceTest {
 
     @Test(expected = DigitalWalletNotSupportedGatewayException.class)
     public void shouldNotAllowDigitalWalletForUnsupportedGateways() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "add",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "add",
                 "path", "allow_apple_pay",
                 "value", "true")));
 
@@ -197,7 +204,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowZeroAmountTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "allow_zero_amount",
                 "value", true)));
 
@@ -211,7 +219,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowZeroAmountFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "allow_zero_amount",
                 "value", false)));
 
@@ -224,7 +233,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateBlockPrepaidCardsTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "block_prepaid_cards",
                 "value", true)));
 
@@ -237,7 +247,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateBlockPrepaidCardsFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "block_prepaid_cards",
                 "value", false)));
 
@@ -250,7 +261,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowMotoTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "allow_moto",
                 "value", true)));
 
@@ -264,7 +276,8 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowMotoFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
                 "path", "allow_moto",
                 "value", false)));
 
@@ -274,7 +287,63 @@ public class GatewayAccountServiceTest {
         verify(mockGatewayAccountEntity).setAllowMoto(false);
         verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
     }
-    
+
+    @Test
+    public void shouldUpdateMotoMaskCardNumberInputTrue() {
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
+                "path", "moto_mask_card_number_input",
+                "value", true)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setMotoMaskCardNumberInput(true);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
+    public void shouldUpdateMotoMaskCardNumberInputFalse() {
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
+                "path", "moto_mask_card_number_input",
+                "value", false)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setMotoMaskCardNumberInput(false);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
+    public void shouldUpdateMotoMaskCardSecurityCodeInputTrue() {
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
+                "path", "moto_mask_card_security_code_input",
+                "value", true)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setMotoMaskCardSecurityCodeInput(true);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
+    public void shouldUpdateMotoMaskCardSecurityCodeInputFalse() {
+        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+                "op", "replace",
+                "path", "moto_mask_card_security_code_input",
+                "value", false)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setMotoMaskCardSecurityCodeInput(false);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
     @Test
     public void shouldUpdateIntegrationVersion3ds() {
         JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(


### PR DESCRIPTION
Support sending PATCH requests to `/v1/api/accounts/{accountId}` with JSON bodies like this:

```json
{
  "op": "replace",
  "path": "moto_mask_card_number_input",
  "value": true
}
```

… or this:

```json
{
  "op": "replace",
  "path": "moto_mask_card_security_code_input",
  "value": false
}
```