### PR TITLE
PP-6960 Add MOTO properties to PATCH gateway account API docs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-08-25T17:00:11Z",
+  "generated_at": "2020-08-26T11:15:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -93,7 +93,7 @@
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1196,
+        "line_number": 1197,
         "type": "Secret Keyword"
       }
     ],

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -925,9 +925,10 @@ Content-Type: application/json
 
 ## PATCH /v1/api/accounts/{accountId}
 
-A generic endpoint that allows the patching of `allow_apple_pay`, `allow_google_pay`, `block_prepaid_cards`, `credentials/gateway_merchant_id`, `notify_settings`, `email_collection_mode`,
-`corporate_credit_card_surcharge_amount`, `corporate_debit_card_surcharge_amount`, `corporate_prepaid_credit_card_surcharge_amount`, 
-`corporate_prepaid_debit_card_surcharge_amount` or `allow_zero_amount`
+A generic endpoint that allows the patching of `allow_apple_pay`, `allow_google_pay`, `block_prepaid_cards`, `credentials/gateway_merchant_id`,
+`notify_settings`, `email_collection_mode`, `corporate_credit_card_surcharge_amount`, `corporate_debit_card_surcharge_amount`,
+`corporate_prepaid_credit_card_surcharge_amount`, `corporate_prepaid_debit_card_surcharge_amount`, `allow_zero_amount`, `allow_moto`,
+`moto_mask_card_number_input` or `moto_mask_card_security_code_input` using a JSON Patch-esque message body.
 
 ### Request example
 


### PR DESCRIPTION
In the API specification for PATCHing a gateway account, add the MOTO properties: `allow_moto`, `moto_mask_card_number_input` and `moto_mask_card_security_code_input`.