### PR TITLE
PP-6977 Mask Moto credit card number and security code pact tests

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -330,6 +330,9 @@ public class DatabaseFixtures {
         private long corporatePrepaidCreditCardSurchargeAmount;
         private long corporatePrepaidDebitCardSurchargeAmount;
         private int integrationVersion3ds = 2;
+        private boolean allowMoto;
+        private boolean motoMaskCardNumberInput;
+        private boolean motoMaskCardSecurityCodeInput;
 
         public long getAccountId() {
             return accountId;
@@ -455,6 +458,21 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestAccount withAllowMoto(boolean allowMoto) {
+            this.allowMoto = allowMoto;
+            return this;
+        }
+
+        public TestAccount withMotoMaskCardNumberInput(boolean motoMaskCardNumberInput) {
+            this.motoMaskCardNumberInput = motoMaskCardNumberInput;
+            return this;
+        }
+
+        public TestAccount withMotoMaskCardSecurityCodeInput(boolean motoMaskCardSecurityCodeInput) {
+            this.motoMaskCardSecurityCodeInput = motoMaskCardSecurityCodeInput;
+            return this;
+        }
+
         public TestAccount insert() {
             databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(accountId))
@@ -470,6 +488,9 @@ public class DatabaseFixtures {
                     .withCorporatePrepaidCreditCardSurchargeAmount(corporatePrepaidCreditCardSurchargeAmount)
                     .withCorporatePrepaidDebitCardSurchargeAmount(corporatePrepaidDebitCardSurchargeAmount)
                     .withIntegrationVersion3ds(integrationVersion3ds)
+                    .withAllowMoto(allowMoto)
+                    .withMotoMaskCardNumberInput(motoMaskCardNumberInput)
+                    .withMotoMaskCardSecurityCodeInput(motoMaskCardSecurityCodeInput)
                     .build());
             for (TestCardType cardType : cardTypes) {
                 databaseTestHelper.addAcceptedCardType(this.getAccountId(), cardType.getId());
@@ -533,7 +554,7 @@ public class DatabaseFixtures {
             this.returnUrl = returnUrl;
             return this;
         }
-        
+
         public TestCharge withChargeStatus(ChargeStatus chargeStatus) {
             this.chargeStatus = chargeStatus;
             return this;

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -195,6 +195,18 @@ public class ContractTest {
                 .withPaymentProvider(aDigitalWalletSupportedPaymentProvider)
                 .insert();
     }
+    
+    @State("a gateway account with MOTO enabled and an external id 667 exists in the database")
+    public void anAccountExistsWithMotoEnableAndMaskCardNumberAndSecurityCode() {
+        DatabaseFixtures
+                .withDatabaseTestHelper(dbHelper)
+                .aTestAccount()
+                .withAccountId(667L)
+                .withAllowMoto(true)
+                .withMotoMaskCardNumberInput(true)
+                .withMotoMaskCardSecurityCodeInput(true)
+                .insert();
+    }
 
     @State("gateway accounts with ids 111, 222 exist in the database")
     public void multipleGatewayAccountsExist() {

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -23,6 +23,8 @@ public class AddGatewayAccountParams {
     private long corporatePrepaidDebitCardSurchargeAmount;
     private int integrationVersion3ds;
     private boolean allowMoto;
+    private boolean motoMaskCardNumberInput;
+    private boolean motoMaskCardSecurityCodeInput;
     private boolean allowApplePay;
     private boolean allowGooglePay;
     private boolean requires3ds;
@@ -83,6 +85,14 @@ public class AddGatewayAccountParams {
         return allowMoto;
     }
 
+    public boolean isMotoMaskCardNumberInput() {
+        return motoMaskCardNumberInput;
+    }
+
+    public boolean isMotoMaskCardSecurityCodeInput() {
+        return motoMaskCardSecurityCodeInput;
+    }
+
     public boolean isAllowApplePay() {
         return allowApplePay;
     }
@@ -110,6 +120,8 @@ public class AddGatewayAccountParams {
         private long corporatePrepaidDebitCardSurchargeAmount;
         private int integrationVersion3ds = 2;
         private boolean allowMoto;
+        private boolean motoMaskCardNumberInput;
+        private boolean motoMaskCardSecurityCodeInput;
         private boolean allowApplePay;
         private boolean allowGooglePay;
         private boolean requires3ds;
@@ -185,6 +197,16 @@ public class AddGatewayAccountParams {
             this.allowMoto = allowMoto;
             return this;
         }
+
+        public AddGatewayAccountParamsBuilder withMotoMaskCardNumberInput(boolean motoMaskCardNumberInput) {
+            this.motoMaskCardNumberInput = motoMaskCardNumberInput;
+            return this;
+        }
+
+        public AddGatewayAccountParamsBuilder withMotoMaskCardSecurityCodeInput(boolean motoMaskCardSecurityCodeInput) {
+            this.motoMaskCardSecurityCodeInput = motoMaskCardSecurityCodeInput;
+            return this;
+        }
         
         public AddGatewayAccountParamsBuilder withAllowApplePay(boolean allowApplePay) {
             this.allowApplePay = allowApplePay;
@@ -217,6 +239,8 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.corporateDebitCardSurchargeAmount = this.corporateDebitCardSurchargeAmount;
             addGatewayAccountParams.integrationVersion3ds = this.integrationVersion3ds;
             addGatewayAccountParams.allowMoto = this.allowMoto;
+            addGatewayAccountParams.motoMaskCardNumberInput = this.motoMaskCardNumberInput;
+            addGatewayAccountParams.motoMaskCardSecurityCodeInput = this.motoMaskCardSecurityCodeInput;
             addGatewayAccountParams.allowApplePay = this.allowApplePay;
             addGatewayAccountParams.allowGooglePay = this.allowGooglePay;
             addGatewayAccountParams.requires3ds = this.requires3ds;

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -50,14 +50,15 @@ public class DatabaseTestHelper {
                             "service_name, type, description, analytics_id, email_collection_mode, " +
                             "integration_version_3ds, corporate_credit_card_surcharge_amount, " +
                             "corporate_debit_card_surcharge_amount, corporate_prepaid_credit_card_surcharge_amount, " +
-                            "corporate_prepaid_debit_card_surcharge_amount, allow_moto, allow_apple_pay, " +
-                            "allow_google_pay, requires_3ds) " +
+                            "corporate_prepaid_debit_card_surcharge_amount, allow_moto, moto_mask_card_number_input, " +
+                            "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds) " +
                             "VALUES (:id, :payment_provider, :credentials, :service_name, :type, " +
                             ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                             ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
                             ":corporate_prepaid_credit_card_surcharge_amount, " +
-                            ":corporate_prepaid_debit_card_surcharge_amount, :allow_moto, :allow_apple_pay, " +
-                            ":allow_google_pay, :requires_3ds)")
+                            ":corporate_prepaid_debit_card_surcharge_amount, "+
+                            ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, "+
+                            ":allow_apple_pay, :allow_google_pay, :requires_3ds)")
                             .bind("id", Long.valueOf(params.getAccountId()))
                             .bind("payment_provider", params.getPaymentGateway())
                             .bindBySqlType("credentials", jsonObject, OTHER)
@@ -72,6 +73,8 @@ public class DatabaseTestHelper {
                             .bind("corporate_prepaid_credit_card_surcharge_amount", params.getCorporatePrepaidCreditCardSurchargeAmount())
                             .bind("corporate_prepaid_debit_card_surcharge_amount", params.getCorporatePrepaidDebitCardSurchargeAmount())
                             .bind("allow_moto", params.isAllowMoto())
+                            .bind("moto_mask_card_number_input", params.isMotoMaskCardNumberInput())
+                            .bind("moto_mask_card_security_code_input", params.isMotoMaskCardSecurityCodeInput())
                             .bind("allow_apple_pay", params.isAllowApplePay())
                             .bind("allow_google_pay", params.isAllowGooglePay())
                             .bind("requires_3ds", params.isRequires3ds())


### PR DESCRIPTION
Description:
- Adding missing MOTO pact test database fixtures for card number and card security code mask 