### PR TITLE
PP-7077 Get refunds from Ledger

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paritycheck/GetRefundsForPaymentException.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/GetRefundsForPaymentException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.paritycheck;
+
+import javax.ws.rs.core.Response;
+
+public class GetRefundsForPaymentException extends LedgerException {
+    public GetRefundsForPaymentException(Response response) {
+        super(response);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paritycheck/LedgerException.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/LedgerException.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.paritycheck;
+
+import javax.ws.rs.core.Response;
+
+public class LedgerException extends RuntimeException {
+    private Integer status;
+
+    public LedgerException(Response response) {
+        super(response.toString());
+        status = response.getStatus();
+    }
+
+    public LedgerException(Exception exception) {
+        super(exception);
+    }
+
+    @Override
+    public String toString() {
+        return "LedgerException{" +
+                "status=" + status +
+                ", message=" + getMessage() +
+                '}';
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paritycheck/RefundTransactionsForPayment.java
+++ b/src/main/java/uk/gov/pay/connector/paritycheck/RefundTransactionsForPayment.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.paritycheck;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.List;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RefundTransactionsForPayment {
+
+    String parentTransactionId;
+    List<LedgerTransaction> transactions;
+
+    public String getParentTransactionId() {
+        return parentTransactionId;
+    }
+
+    public List<LedgerTransaction> getTransactions() {
+        return transactions;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/paritycheck/LedgerServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paritycheck/LedgerServiceTest.java
@@ -8,14 +8,17 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 
+import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
+import java.util.List;
 import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.apache.http.HttpStatus.SC_NOT_FOUND;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -23,22 +26,24 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.LEDGER_GET_REFUNDS_FOR_PAYMENT;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.LEDGER_GET_TRANSACTION;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LedgerServiceTest {
 
-    ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper = new ObjectMapper();
     private LedgerService ledgerService;
+    private Response mockResponse;
 
     @Before
-    public void setUp() throws JsonProcessingException {
+    public void setUp() {
         Client mockClient = mock(Client.class);
         ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
         WebTarget mockWebTarget = mock(WebTarget.class);
         Invocation.Builder mockBuilder = mock(Invocation.Builder.class);
-        Response mockResponse = mock(Response.class);
+        mockResponse = mock(Response.class);
 
         when(mockConnectorConfiguration.getLedgerBaseUrl()).thenReturn("http://ledgerUrl");
         when(mockClient.target(any(UriBuilder.class))).thenReturn(mockWebTarget);
@@ -46,13 +51,14 @@ public class LedgerServiceTest {
         when(mockBuilder.accept(APPLICATION_JSON)).thenReturn(mockBuilder);
         when(mockBuilder.get()).thenReturn(mockResponse);
 
-        when(mockResponse.readEntity(LedgerTransaction.class)).thenReturn(objectMapper.readValue(load(LEDGER_GET_TRANSACTION), LedgerTransaction.class));
         when(mockResponse.getStatus()).thenReturn(SC_OK);
         ledgerService = new LedgerService(mockClient, mockConnectorConfiguration);
     }
 
     @Test
-    public void getTransaction_shouldSerialiseLedgerTransaction() {
+    public void getTransaction_shouldSerialiseLedgerTransaction() throws JsonProcessingException {
+        when(mockResponse.readEntity(LedgerTransaction.class)).thenReturn(objectMapper.readValue(load(LEDGER_GET_TRANSACTION), LedgerTransaction.class));
+
         String externalId = "external-id";
         Optional<LedgerTransaction> mayBeTransaction = ledgerService.getTransaction("external-id");
 
@@ -62,5 +68,44 @@ public class LedgerServiceTest {
         assertThat(transaction.getAmount(), is(12000L));
         assertThat(transaction.getGatewayAccountId(), is("3"));
         assertThat(transaction.getExternalMetaData(), is(notNullValue()));
+    }
+
+    @Test
+    public void getRefundsFromLedgerShouldSerialiseResponseCorrectly() throws JsonProcessingException {
+        when(mockResponse.readEntity(RefundTransactionsForPayment.class)).
+                thenReturn(objectMapper.readValue(load(LEDGER_GET_REFUNDS_FOR_PAYMENT), RefundTransactionsForPayment.class));
+
+        String externalId = "650516the13q5jpfo435f1m1fm";
+        RefundTransactionsForPayment refundTransactionsForPayment =
+                ledgerService.getRefundsForPayment(152L, externalId);
+
+        assertThat(refundTransactionsForPayment.getParentTransactionId(), is(externalId));
+
+        List<LedgerTransaction> transactions = refundTransactionsForPayment.getTransactions();
+
+        assertThat(transactions.get(0).getTransactionId(), is("nklfm1pk9flpu91j815kp2835o"));
+        assertThat(transactions.get(0).getGatewayAccountId(), is("152"));
+        assertThat(transactions.get(0).getAmount(), is(100L));
+        assertThat(transactions.get(0).getState().getStatus(), is("success"));
+
+        assertThat(transactions.get(1).getTransactionId(), is("migtkmlt6gvm16sim5h0p7oeje"));
+        assertThat(transactions.get(1).getAmount(), is(110L));
+        assertThat(transactions.get(1).getGatewayAccountId(), is("152"));
+        assertThat(transactions.get(1).getState().getStatus(), is("failed"));
+    }
+
+    @Test(expected = GetRefundsForPaymentException.class)
+    public void getRefundsFromLedgerShouldThrowExceptionForNon2xxResponse() {
+        when(mockResponse.getStatus()).thenReturn(SC_NOT_FOUND);
+
+        ledgerService.getRefundsForPayment(152L, "external-id");
+    }
+
+    @Test(expected = LedgerException.class)
+    public void getRefundsFromLedgerShouldThrowExceptionIfResponseCannotBeProcessed() {
+        when(mockResponse.readEntity(RefundTransactionsForPayment.class)).
+                thenThrow(ProcessingException.class);
+
+        ledgerService.getRefundsForPayment(152L, "external-id");
     }
 }

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -159,6 +159,7 @@ public class TestTemplateResourceLoader {
     public static final String SQS_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/error-response.xml";
     
     public static final String LEDGER_GET_TRANSACTION = TEMPLATE_BASE_NAME + "/ledger/transaction.json";
+    public static final String LEDGER_GET_REFUNDS_FOR_PAYMENT = TEMPLATE_BASE_NAME + "/ledger/refunds_for_payment.json";
 
     public static String load(String location) {
         return fixture(location);

--- a/src/test/resources/templates/ledger/refunds_for_payment.json
+++ b/src/test/resources/templates/ledger/refunds_for_payment.json
@@ -1,0 +1,62 @@
+{
+  "parent_transaction_id": "650516the13q5jpfo435f1m1fm",
+  "transactions": [
+    {
+      "gateway_account_id": "152",
+      "amount": 100,
+      "state": {
+        "finished": true,
+        "status": "success"
+      },
+      "created_date": "2019-12-23T15:24:07.061Z",
+      "gateway_transaction_id": "ff3f12da-fa4e-4f2c-8460-fa80d20b3e97",
+      "refunded_by": "refunded_by_user1",
+      "transaction_type": "REFUND",
+      "payment_details": {
+        "description": "An example payment description",
+        "reference": "V58CDG66T2",
+        "email": "test@example.org",
+        "card_details": {
+          "cardholder_name": "test",
+          "card_brand": "Visa",
+          "last_digits_card_number": "4242",
+          "first_digits_card_number": "424242",
+          "expiry_date": "11/21",
+          "card_type": "credit"
+        },
+        "transaction_type": "PAYMENT"
+      },
+      "transaction_id": "nklfm1pk9flpu91j815kp2835o",
+      "parent_transaction_id": "650516the13q5jpfo435f1m1fm"
+    },
+    {
+      "gateway_account_id": "152",
+      "amount": 110,
+      "state": {
+        "finished": true,
+        "status": "failed"
+      },
+      "created_date": "2019-12-23T16:20:12.343Z",
+      "gateway_transaction_id": "0ecb93b8-2db6-41b1-a63d-5438ab7cf0ba",
+      "refunded_by": "refunded_by_user1",
+      "refunded_by_user_email": "test@example.org",
+      "transaction_type": "REFUND",
+      "payment_details": {
+        "description": "An example payment description",
+        "reference": "V58CDG66T2",
+        "email": "test@example.org",
+        "card_details": {
+          "cardholder_name": "test",
+          "card_brand": "Visa",
+          "last_digits_card_number": "4242",
+          "first_digits_card_number": "424242",
+          "expiry_date": "11/21",
+          "card_type": "credit"
+        },
+        "transaction_type": "PAYMENT"
+      },
+      "transaction_id": "migtkmlt6gvm16sim5h0p7oeje",
+      "parent_transaction_id": "650516the13q5jpfo435f1m1fm"
+    }
+  ]
+}


### PR DESCRIPTION
## WHAT YOU DID
- Added service method to get refund transactions for payment from Ledger.
  This is going to be used to calculate refundability when refunds have been expunged from connector
