### PR TITLE
PP-6703 Set cookie header directly for gateway request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -66,7 +66,7 @@ public class GatewayClient {
 
             Builder requestBuilder = client.target(url).request();
             headers.keySet().forEach(headerKey -> requestBuilder.header(headerKey, headers.get(headerKey)));
-            cookies.forEach(cookie -> requestBuilder.cookie(cookie.getName(), cookie.getValue()));
+            cookies.forEach(cookie -> requestBuilder.header("Cookie", cookie.getName() + "=" + cookie.getValue()));
             response = requestBuilder.post(Entity.entity(request.getPayload(), request.getMediaType()));
             int statusCode = response.getStatus();
             Response gatewayResponse = new Response(response);

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -108,7 +108,7 @@ public class GatewayClientTest {
                 ImmutableList.of(new HttpCookie("machine", "value")), emptyMap());
 
         InOrder inOrder = Mockito.inOrder(mockBuilder);
-        inOrder.verify(mockBuilder).cookie("machine", "value");
+        inOrder.verify(mockBuilder).header("Cookie", "machine=value");
         inOrder.verify(mockBuilder).post(Entity.entity(orderPayload, mediaType));
     }
 }


### PR DESCRIPTION
Worldpay 3DS authorisation requests are currently failing for test accounts because we are setting the machine cookie header twice on requests. We've possibly always been doing this but Worldpay recently started returning an error in this case.

It looks like  we are adding the $Version=1 attribute to the cookie which is part of obsolete  specification rfc2965 for HTTP State Management Mechanism and has been removed in the latest rfc6265. On top of it RequestAddCookies adds the same cookie without $Version making it 2 different cookies.

This solution attempts to set the cookie on the request without a version so that it is only included once.