### PR TITLE
BAU — Make some US/Canada postcode mapping constants static

### DIFF
--- a/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/CanadaPostalcodeToProvinceOrTerritoryMapper.java
@@ -5,27 +5,27 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static java.util.Map.entry;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NEWFOUNDLAND_AND_LABRADOR;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NOVA_SCOTIA;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.PRINCE_EDWARD_ISLAND;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NEW_BRUNSWICK;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.QUEBEC;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.ONTARIO;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.SASKATCHEWAN;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.MANITOBA;
 import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.ALBERTA;
 import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.BRITISH_COLUMBIA;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.YUKON;
-import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NUNAVUT;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.MANITOBA;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NEWFOUNDLAND_AND_LABRADOR;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NEW_BRUNSWICK;
 import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NORTHWEST_TERRITORIES;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NOVA_SCOTIA;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.NUNAVUT;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.ONTARIO;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.PRINCE_EDWARD_ISLAND;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.QUEBEC;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.SASKATCHEWAN;
+import static uk.gov.pay.connector.northamericaregion.CanadaProvinceOrTerritory.YUKON;
 
 public class CanadaPostalcodeToProvinceOrTerritoryMapper {
 
-    private final Pattern WELL_FORMED_POSTAL_CODE = Pattern.compile("([A-Z])[0-9][A-Z][0-9][A-Z][0-9]");
-    private final Pattern WELL_FORMED_X_POSTAL_CODE = Pattern.compile("(X[0-9][A-Z])[0-9][A-Z][0-9]");
-    private final String SANTA_CLAUS_POSTAL_CODE = "H0H0H0";
+    private static final Pattern WELL_FORMED_POSTAL_CODE = Pattern.compile("([A-Z])[0-9][A-Z][0-9][A-Z][0-9]");
+    private static final Pattern WELL_FORMED_X_POSTAL_CODE = Pattern.compile("(X[0-9][A-Z])[0-9][A-Z][0-9]");
+    private static final String SANTA_CLAUS_POSTAL_CODE = "H0H0H0";
 
-    public final Map<String, CanadaProvinceOrTerritory> NON_X_POSTAL_CODE_TERRITORY_PROVINCE_MAP = Map.ofEntries(
+    private static final Map<String, CanadaProvinceOrTerritory> NON_X_POSTAL_CODE_TERRITORY_PROVINCE_MAP = Map.ofEntries(
             entry("A", NEWFOUNDLAND_AND_LABRADOR),
             entry("B", NOVA_SCOTIA),
             entry("C", PRINCE_EDWARD_ISLAND),
@@ -45,7 +45,7 @@ public class CanadaPostalcodeToProvinceOrTerritoryMapper {
             entry("Y", YUKON)
     );
 
-    public final Map<String, CanadaProvinceOrTerritory> X_POSTAL_CODE_TERRITORY_MAP = Map.ofEntries(
+    private static final Map<String, CanadaProvinceOrTerritory> X_POSTAL_CODE_TERRITORY_MAP = Map.ofEntries(
             entry("X0A", NUNAVUT),
             entry("X0B", NUNAVUT),
             entry("X0C", NUNAVUT),

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMap.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMap.java
@@ -5,11 +5,11 @@ import java.util.Map;
 
 import static uk.gov.pay.connector.northamericaregion.UsState.ALABAMA;
 import static uk.gov.pay.connector.northamericaregion.UsState.ALASKA;
-import static uk.gov.pay.connector.northamericaregion.UsState.ARMED_FORCES_AMERICAS;
 import static uk.gov.pay.connector.northamericaregion.UsState.ARIZONA;
 import static uk.gov.pay.connector.northamericaregion.UsState.ARKANSAS;
-import static uk.gov.pay.connector.northamericaregion.UsState.ARMED_FORCES_PACIFIC;
+import static uk.gov.pay.connector.northamericaregion.UsState.ARMED_FORCES_AMERICAS;
 import static uk.gov.pay.connector.northamericaregion.UsState.ARMED_FORCES_EUROPE;
+import static uk.gov.pay.connector.northamericaregion.UsState.ARMED_FORCES_PACIFIC;
 import static uk.gov.pay.connector.northamericaregion.UsState.CALIFORNIA;
 import static uk.gov.pay.connector.northamericaregion.UsState.COLORADO;
 import static uk.gov.pay.connector.northamericaregion.UsState.CONNECTICUT;
@@ -64,10 +64,10 @@ import static uk.gov.pay.connector.northamericaregion.UsState.WYOMING;
 public class UsZipCodeToStateMap {
     
     /**
-    We have to use this initializiation method because using 'Map.ofEntries(...)' with hundreds of arguments is excessively slow to compile. See https://youtrack.jetbrains.com/issue/IDEA-245963
-     */
-
-    public final static Map<String, UsState> ZIP_CODE_TO_US_STATE_ABBREVIATIONS = Map.copyOf(new HashMap<>() {{
+     * We have to use this initializiation method because using 'Map.ofEntries(...)' with hundreds of arguments is excessively slow to compile.
+     * See https://youtrack.jetbrains.com/issue/IDEA-245963
+    **/
+    public static final Map<String, UsState> ZIP_CODE_TO_US_STATE_ABBREVIATIONS = Map.copyOf(new HashMap<>() {{
         put("005", NEW_YORK);
         put("006", PUERTO_RICO);
         put("007", PUERTO_RICO);

--- a/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMapper.java
+++ b/src/main/java/uk/gov/pay/connector/northamericaregion/UsZipCodeToStateMapper.java
@@ -10,9 +10,10 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public class UsZipCodeToStateMapper {
 
-    private final Pattern WELL_FORMED_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([0-9]{3})[0-9]{2}(?:-[0-9]{4})?");
-    private final Pattern WELL_FORMED_STATE_WITH_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([A-Z]{2})[0-9]{5}(?:-[0-9]{4})?");
-    private final Map<String, UsState> US_STATE_ABBREVIATIONS_MAPPING = Arrays.stream(UsState.values()).collect(
+    private static final Pattern WELL_FORMED_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([0-9]{3})[0-9]{2}(?:-[0-9]{4})?");
+    private static final Pattern WELL_FORMED_STATE_WITH_ZIP_CODE_AND_OPTIONAL_PLUS_FOUR = Pattern.compile("([A-Z]{2})[0-9]{5}(?:-[0-9]{4})?");
+
+    private static final Map<String, UsState> US_STATE_ABBREVIATIONS_MAPPING = Arrays.stream(UsState.values()).collect(
             toUnmodifiableMap(NorthAmericaRegion::getAbbreviation, identity())); 
 
     public Optional<UsState> getState(String normalisedZipCode) {


### PR DESCRIPTION
Make some constants in the code that maps US ZIP codes to states and Canadian postal codes to provinces or territories static, so they’re only created once in the lifetime of the application.

The affected constants are all either regex patterns, unmodifiable maps or strings, which are all immutable and thread-safe, so making them static is safe.

Otherwise, each constant is created each time the class it’s in is instantiated, which for some payment gateways can happen every time an authorisation request is sent, even if the payment does not have a US or Canadian address.