### PR TITLE
PP-7174 Lookup telephone payments by gateway account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -82,6 +82,19 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .findFirst();
     }
 
+    public Optional<ChargeEntity> findByGatewayTransactionIdAndAccount(Long accountId, String gatewayTransactionId) {
+        String query = "SELECT c from ChargeEntity c WHERE c.gatewayTransactionId=:gatewayTransactionId" +
+                " and c.gatewayAccount.id = :accountId";
+
+        return entityManager.get()
+                .createQuery(query, ChargeEntity.class)
+                .setParameter("gatewayTransactionId", gatewayTransactionId)
+                .setParameter("accountId", accountId)
+                .getResultList()
+                .stream()
+                .findFirst();
+    }
+
     public Optional<ChargeEntity> findByExternalIdAndGatewayAccount(String chargeExternalId, Long accountId) {
 
         String query = "SELECT c FROM ChargeEntity c " +

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -86,7 +86,7 @@ public class ChargesApiResource {
             @NotNull @Valid TelephoneChargeCreateRequest telephoneChargeCreateRequest,
             @Context UriInfo uriInfo
     ) {
-        return chargeService.findCharge(telephoneChargeCreateRequest)
+        return chargeService.findCharge(accountId, telephoneChargeCreateRequest)
                 .map(response -> Response.status(200).entity(response).build())
                 .orElseGet(() -> Response.status(201).entity(chargeService.create(telephoneChargeCreateRequest, accountId).get()).build());
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -144,13 +144,12 @@ public class ChargeService {
     }
 
     @Transactional
-    public Optional<ChargeResponse> findCharge(TelephoneChargeCreateRequest telephoneChargeRequest) {
-        return chargeDao.findByGatewayTransactionId(telephoneChargeRequest.getProviderId())
+    public Optional<ChargeResponse> findCharge(Long gatewayAccountId, TelephoneChargeCreateRequest telephoneChargeRequest) {
+        return chargeDao.findByGatewayTransactionIdAndAccount(gatewayAccountId, telephoneChargeRequest.getProviderId())
                 .map(charge -> populateResponseBuilderWith(aChargeResponseBuilder(), charge).build());
     }
 
     public Optional<ChargeResponse> create(TelephoneChargeCreateRequest telephoneChargeCreateRequest, Long accountId) {
-
         return createCharge(telephoneChargeCreateRequest, accountId)
                 .map(charge ->
                         populateResponseBuilderWith(aChargeResponseBuilder(), charge).build());

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
@@ -102,14 +103,15 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withCardDetails(cardDetails)
                 .build();
 
-        when(mockedChargeDao.findByGatewayTransactionId("1PROV")).thenReturn(Optional.of(returnedChargeEntity));
+        when(mockedChargeDao.findByGatewayTransactionIdAndAccount(gatewayAccount.getId(), "1PROV"))
+                .thenReturn(Optional.of(returnedChargeEntity));
 
         service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
 
-        Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(telephoneChargeCreateRequest);
+        Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(gatewayAccount.getId(), telephoneChargeCreateRequest);
 
         ArgumentCaptor<String> gatewayTransactionIdArgumentCaptor = forClass(String.class);
-        verify(mockedChargeDao).findByGatewayTransactionId(gatewayTransactionIdArgumentCaptor.capture());
+        verify(mockedChargeDao).findByGatewayTransactionIdAndAccount(anyLong(), gatewayTransactionIdArgumentCaptor.capture());
 
         String providerId = gatewayTransactionIdArgumentCaptor.getValue();
         assertThat(providerId, is("1PROV"));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -56,10 +57,10 @@ public class ChargeServiceFindTest extends ChargeServiceTest {
                 .withPaymentOutcome(paymentOutcome)
                 .build();
 
-        Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(telephoneChargeCreateRequest);
+        Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(1234L, telephoneChargeCreateRequest);
 
         ArgumentCaptor<String> gatewayTransactionIdArgumentCaptor = forClass(String.class);
-        verify(mockedChargeDao).findByGatewayTransactionId(gatewayTransactionIdArgumentCaptor.capture());
+        verify(mockedChargeDao).findByGatewayTransactionIdAndAccount(anyLong(), gatewayTransactionIdArgumentCaptor.capture());
 
         String providerId = gatewayTransactionIdArgumentCaptor.getValue();
         assertThat(providerId, is("new"));

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -672,6 +672,36 @@ public class ChargeDaoIT extends DaoITestBase {
     }
 
     @Test
+    public void findByGatewayTransactionIdAndAccount() {
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .withExternalChargeId("some-external-id")
+                .withTransactionId("gateway-transaction-id")
+                .insert();
+
+        DatabaseFixtures.TestAccount anotherGatewayAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .withAccountId(nextLong())
+                .insert();
+        DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(anotherGatewayAccount)
+                .withExternalChargeId("some-external-id2")
+                .withTransactionId("gateway-transaction-id")
+                .insert();
+
+        ChargeEntity chargeEntity = chargeDao.
+                findByGatewayTransactionIdAndAccount(defaultTestAccount.getAccountId(), "gateway-transaction-id")
+                .get();
+
+        assertThat(chargeEntity.getExternalId(), is("some-external-id"));
+    }
+
+    @Test
     public void getChargeWithAFee_shouldReturnFeeOnCharge() {
         insertTestCharge();
 


### PR DESCRIPTION
## WHAT YOU DID
For telephone payments, we expect provider_id to be unique for given gateway account. If a charge exists for a given provider_id, 200 response is returned and record is not saved to DB. If charge doesn't exists, 201 response is returned and the charge is added to DB.

At the moment, we look up for charges by only provider_id which could cause below issues:
  - if another service uses same provider_id, we send response from an existing charge which is incorrect
  - provider_id may not be unique as these are generated independently by external providers

 
Updated to lookup charges by both gateway_account and provider_id
