### PR TITLE
PP-7189 Make telephone payment requests idempotent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -88,8 +88,7 @@ public class ChargesApiResource {
     ) {
         return chargeService.findCharge(telephoneChargeCreateRequest)
                 .map(response -> Response.status(200).entity(response).build())
-                .orElse(Response.status(201).entity(chargeService.create(telephoneChargeCreateRequest, accountId).get())
-                .build());
+                .orElseGet(() -> Response.status(201).entity(chargeService.create(telephoneChargeCreateRequest, accountId).get()).build());
     }
 
     @POST

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -125,7 +125,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .body("state.finished", is(true));
 
         DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
-        Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId);
+        Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId).get(0);
         Long chargeId = Long.parseLong(chargeDetails.get("id").toString());
         assertThat(chargeDetails.get("language"), is("en"));
 
@@ -311,7 +311,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .contentType(JSON);
 
         DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
-        Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId);
+        Map<String, Object> chargeDetails = testHelper.getChargeByGatewayTransactionId(providerId).get(0);
 
         assertThat(chargeDetails.get("source"), is(CARD_EXTERNAL_TELEPHONE.toString()));
     }
@@ -344,6 +344,11 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .body("charge_id.length()", is(26))
                 .body("state.status", is("success"))
                 .body("state.finished", is(true));
+
+        DatabaseTestHelper testHelper = testContext.getDatabaseTestHelper();
+        List<Map<String, Object>> chargesByGatewayTransactionId = testHelper.getChargeByGatewayTransactionId(providerId);
+
+        assertThat(chargesByGatewayTransactionId.size(), is(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -388,12 +388,12 @@ public class DatabaseTestHelper {
         return result > 0;
     }
 
-    public Map<String, Object> getChargeByGatewayTransactionId(String gatewayTransactionId) {
+    public List<Map<String, Object>> getChargeByGatewayTransactionId(String gatewayTransactionId) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT * FROM charges WHERE gateway_transaction_id = :gatewayTransactionId")
                         .bind("gatewayTransactionId", gatewayTransactionId)
                         .mapToMap()
-                        .first());
+                        .list());
     }
 
     public Map<String, Object> getEmailForAccountAndType(Long accountId, EmailNotificationType type) {


### PR DESCRIPTION
## WHAT YOU DID
- Avoid creating additional charge (for telephone payment) when another already exists in charges table for a given `provider_id`
  Using `orElse` invokes the supplier function even when the optional value exists which is causing additional records to be created in database.
  With `orElseGet`, supplying function will only be invoked if value is not present
- Added an assertion to ensure only one record is created for multiple requests with same provider_id

