### PR TITLE
PP-6988 Add RefundParityChecker

### DIFF
--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -45,6 +45,9 @@ public class LedgerTransaction {
     private String walletType;
     @JsonProperty("metadata")
     private Map<String, Object> externalMetaData;
+    private String userEmail;
+    private String userExternalId;
+    private String parentTransactionId;
 
     public LedgerTransaction() {
 
@@ -252,5 +255,29 @@ public class LedgerTransaction {
 
     public void setExternalMetaData(Map<String, Object> externalMetaData) {
         this.externalMetaData = externalMetaData;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+
+    public String getUserExternalId() {
+        return userExternalId;
+    }
+
+    public void setUserExternalId(String userExternalId) {
+        this.userExternalId = userExternalId;
+    }
+
+    public String getParentTransactionId() {
+        return parentTransactionId;
+    }
+
+    public void setParentTransactionId(String parentTransactionId) {
+        this.parentTransactionId = parentTransactionId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/service/RefundParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/RefundParityChecker.java
@@ -1,0 +1,88 @@
+package uk.gov.pay.connector.tasks.service;
+
+import com.google.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+
+import java.time.ZonedDateTime;
+import java.util.Objects;
+import java.util.Optional;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.DATA_MISMATCH;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.EXISTS_IN_LEDGER;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.MISSING_IN_LEDGER;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
+import static uk.gov.pay.connector.tasks.service.ParityCheckService.FIELD_NAME;
+import static uk.gov.pay.logging.LoggingKeys.REFUND_EXTERNAL_ID;
+
+public class RefundParityChecker {
+
+    private static final Logger logger = LoggerFactory.getLogger(RefundParityChecker.class);
+    private final RefundDao refundDao;
+
+    @Inject
+    public RefundParityChecker(RefundDao refundDao) {
+        this.refundDao = refundDao;
+    }
+
+    public ParityCheckStatus checkParity(RefundEntity refundEntity, LedgerTransaction transaction) {
+        String externalId = refundEntity.getExternalId();
+        ParityCheckStatus parityCheckStatus;
+
+        MDC.put(REFUND_EXTERNAL_ID, externalId);
+
+        if (transaction == null) {
+            logger.info("Refund transaction missing in Ledger for Refund [external_id={}]", externalId);
+            parityCheckStatus = MISSING_IN_LEDGER;
+        } else {
+            boolean fieldsMatch;
+
+            fieldsMatch = isEquals(externalId, transaction.getTransactionId(), "external_id");
+            fieldsMatch = fieldsMatch && isEquals(refundEntity.getChargeExternalId(), transaction.getParentTransactionId(), "parent_transaction_id");
+            fieldsMatch = fieldsMatch && isEquals(refundEntity.getAmount(), transaction.getAmount(), "amount");
+            fieldsMatch = fieldsMatch && isEquals(refundEntity.getGatewayTransactionId(), transaction.getGatewayTransactionId(), "gateway_transaction_id");
+            fieldsMatch = fieldsMatch && isEquals(refundEntity.getUserExternalId(), transaction.getUserExternalId(), "user_external_id");
+            fieldsMatch = fieldsMatch && isEquals(refundEntity.getUserEmail(), transaction.getUserEmail(), "user_email");
+
+            String refundCreatedEventDate = getRefundCreatedDate(refundEntity.getExternalId())
+                    .map(ISO_INSTANT_MILLISECOND_PRECISION::format).orElse(null);
+            fieldsMatch = fieldsMatch && isEquals(refundCreatedEventDate, transaction.getCreatedDate(), "created_date");
+
+            String refundExternalStatus = refundEntity.getStatus().toExternal().getStatus();
+            fieldsMatch = fieldsMatch && isEquals(refundExternalStatus, transaction.getState().getStatus(), "status");
+
+            if (fieldsMatch) {
+                parityCheckStatus = EXISTS_IN_LEDGER;
+            } else {
+                parityCheckStatus = DATA_MISMATCH;
+            }
+        }
+        MDC.remove(REFUND_EXTERNAL_ID);
+        return parityCheckStatus;
+    }
+
+    private Optional<ZonedDateTime> getRefundCreatedDate(String refundExternalId) {
+        Optional<RefundHistory> refundHistoryForCreatedEvent =
+                refundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(refundExternalId, CREATED);
+
+        return refundHistoryForCreatedEvent.map(RefundHistory::getHistoryStartDate);
+    }
+
+    private boolean isEquals(Object value1, Object value2, String fieldName) {
+        if (Objects.equals(value1, value2)) {
+            return true;
+        } else {
+            logger.info("Field value does not match between ledger and connector [field_name={}]", fieldName,
+                    kv(FIELD_NAME, fieldName));
+            return false;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -76,7 +76,7 @@ public class StripeRefundHandlerTest {
         RefundEntity refundEntity = RefundEntityFixture
                 .aValidRefundEntity()
                 .withAmount(100L)
-                .withChargeTransactionId("pi_123")
+                .withGatewayTransactionId("pi_123")
                 .build();
         refundRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount);
         mockTransferSuccess();

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -60,6 +60,9 @@ public class LedgerTransactionFixture {
     private ZonedDateTime captureSubmittedDate;
     private ZonedDateTime capturedDate;
     private ChargeResponse.RefundSummary refundSummary;
+    private String parentTransactionId;
+    private String userEmail;
+    private String userExternalId;
 
     public static LedgerTransactionFixture aValidLedgerTransaction() {
         return new LedgerTransactionFixture();
@@ -135,6 +138,21 @@ public class LedgerTransactionFixture {
         return ledgerTransactionFixture;
     }
 
+    public static LedgerTransactionFixture from(RefundEntity refundEntity) {
+        LedgerTransactionFixture ledgerTransactionFixture =
+                aValidLedgerTransaction()
+                        .withAmount(refundEntity.getAmount())
+                        .withStatus(refundEntity.getStatus().toExternal().getStatus())
+                        .withCreatedDate(refundEntity.getCreatedDate())
+                        .withExternalId(refundEntity.getExternalId())
+                        .withGatewayTransactionId(refundEntity.getGatewayTransactionId())
+                        .withParentTransactionId(refundEntity.getChargeExternalId())
+                        .withUserEmail(refundEntity.getUserEmail())
+                        .withUserExternalId(refundEntity.getUserExternalId());
+
+        return ledgerTransactionFixture;
+    }
+
     private static ZonedDateTime getEventDate(List<ChargeEventEntity> chargeEventEntities, ChargeStatus status) {
         return ofNullable(chargeEventEntities).flatMap(entities -> entities.stream()
                 .filter(chargeEvent -> status.equals(chargeEvent.getStatus()))
@@ -183,10 +201,14 @@ public class LedgerTransactionFixture {
         ledgerTransaction.setSettlementSummary(settlementSummary);
         ledgerTransaction.setRefundSummary(refundSummary);
 
+        ledgerTransaction.setParentTransactionId(parentTransactionId);
+        ledgerTransaction.setUserEmail(userEmail);
+        ledgerTransaction.setUserExternalId(userExternalId);
+
         return ledgerTransaction;
     }
 
-    private LedgerTransactionFixture withCreatedDate(ZonedDateTime createdDate) {
+    public LedgerTransactionFixture withCreatedDate(ZonedDateTime createdDate) {
         this.createdDate = createdDate;
         return this;
     }
@@ -311,4 +333,18 @@ public class LedgerTransactionFixture {
         return this;
     }
 
+    public LedgerTransactionFixture withParentTransactionId(String chargeExternalId) {
+        this.parentTransactionId = chargeExternalId;
+        return this;
+    }
+
+    public LedgerTransactionFixture withUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+        return this;
+    }
+
+    public LedgerTransactionFixture withUserExternalId(String userExternalId) {
+        this.userExternalId = userExternalId;
+        return this;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundEntityFixture.java
@@ -75,7 +75,7 @@ public class RefundEntityFixture {
         return this;
     }
     
-    public RefundEntityFixture withChargeTransactionId(String transactionId) {
+    public RefundEntityFixture withGatewayTransactionId(String transactionId) {
         this.transactionId = transactionId;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/pact/RefundHistoryEntityFixture.java
@@ -7,13 +7,15 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 
+import static java.time.ZoneOffset.UTC;
+
 public class RefundHistoryEntityFixture {
 
     private Long id = 1L;
     private String externalId = RandomStringUtils.randomAlphanumeric(10);
     private Long amount = 50L;
     private String status = RefundStatus.CREATED.getValue();
-    private ZonedDateTime createdDate = ZonedDateTime.now().minusSeconds(5L);
+    private ZonedDateTime createdDate = ZonedDateTime.now(UTC).minusSeconds(5L);
     private Long version = 1L;
     private ZonedDateTime historyStartDate = createdDate.plusSeconds(2L);
     private ZonedDateTime historyEndDate = createdDate.plusSeconds(3L);
@@ -31,7 +33,9 @@ public class RefundHistoryEntityFixture {
 
     public RefundHistory build() {
         return new RefundHistory(id, externalId, amount, status, Timestamp.valueOf(createdDate.toLocalDateTime()),
-                version, Timestamp.valueOf(historyStartDate.toLocalDateTime()), Timestamp.valueOf(historyEndDate.toLocalDateTime()),
+                version,
+                Timestamp.from(historyStartDate.toInstant()),
+                Timestamp.from(historyEndDate.toInstant()),
                 userExternalId, gatewayTransactionId, chargeExternalId, userEmail);
     }
 
@@ -52,6 +56,11 @@ public class RefundHistoryEntityFixture {
 
     public RefundHistoryEntityFixture withChargeExternalId(String chargeExternalId) {
         this.chargeExternalId = chargeExternalId;
+        return this;
+    }
+
+    public RefundHistoryEntityFixture withHistoryStartDate(ZonedDateTime historyStartDate) {
+        this.historyStartDate = historyStartDate;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/tasks/service/RefundParityCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/service/RefundParityCheckerTest.java
@@ -1,0 +1,109 @@
+package uk.gov.pay.connector.tasks.service;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.pact.RefundHistoryEntityFixture;
+import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundHistory;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static java.time.ZoneOffset.UTC;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.DATA_MISMATCH;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.EXISTS_IN_LEDGER;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.MISSING_IN_LEDGER;
+import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.from;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
+import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RefundParityCheckerTest {
+
+    @Mock
+    private RefundDao mockRefundDao;
+    @InjectMocks
+    RefundParityChecker refundParityChecker;
+
+    private RefundEntity refundEntity;
+
+    @Before
+    public void setUp() {
+        refundEntity = RefundEntityFixture.aValidRefundEntity().build();
+
+        RefundHistory refundHistory = RefundHistoryEntityFixture.aValidRefundHistoryEntity().
+                withHistoryStartDate(refundEntity.getCreatedDate()).build();
+
+        when(mockRefundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(refundEntity.getExternalId(), CREATED))
+                .thenReturn(Optional.of(refundHistory));
+    }
+
+    @Test
+    public void parityCheck_shouldMatchIfRefundMatchesWithLedgerTransaction() {
+        LedgerTransaction transaction = from(refundEntity).build();
+        assertParityCheckStatus(transaction, EXISTS_IN_LEDGER);
+    }
+
+    @Test
+    public void parityCheck_shouldReturnMissingInLedgerIfTransactionIsNull() {
+        assertParityCheckStatus(null, MISSING_IN_LEDGER);
+    }
+
+    @Test
+    public void parityCheck_shouldReturnDataMismatchIfRefundDoesNotMatchWithLedger() {
+        LedgerTransaction transaction = from(refundEntity).withAmount(null).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+    }
+
+    @Test
+    public void parityCheck_shouldReturnDataMismatchIfUserEmailDoesNotMatchWithLedger() {
+        LedgerTransaction transaction = from(refundEntity).withUserEmail(null).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+    }
+
+    @Test
+    public void parityCheck_shouldReturnDataMismatchIfUserExternalIdDoesNotMatchWithLedger() {
+        LedgerTransaction transaction = from(refundEntity).withUserExternalId(null).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+    }
+
+    @Test
+    public void parityCheck_shouldReturnDataMismatchIfGatewayTransactionIdDoesNotMatchWithLedger() {
+        LedgerTransaction transaction = from(refundEntity).withGatewayTransactionId(null).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+    }
+
+    @Test
+    public void parityCheck_shouldReturnDataMismatchIfStatusDoesNotMatchWithLedger() {
+        LedgerTransaction transaction = from(refundEntity).withStatus(REFUNDED.toExternal().getStatus()).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+
+        transaction = from(refundEntity).withStatus(null).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+    }
+
+    @Test
+    public void parityCheck_shouldReturnDataMismatchIfCreatedDateDoesNotMatchWithLedger() {
+        LedgerTransaction transaction = from(refundEntity).withCreatedDate(ZonedDateTime.now(UTC).minusDays(1)).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+
+        transaction = from(refundEntity).withCreatedDate(null).build();
+        assertParityCheckStatus(transaction, DATA_MISMATCH);
+    }
+
+    private void assertParityCheckStatus(LedgerTransaction transaction, ParityCheckStatus parityCheckStatus) {
+        ParityCheckStatus status = refundParityChecker.checkParity(refundEntity, transaction);
+        assertThat(status, is(parityCheckStatus));
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Added RefundParityChecker which will be used by ExpungeService to parity check on refunds (between connector and ledger)  before removing from connector database.
