### PR TITLE
PP-6994 Rename refund files

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -57,7 +57,7 @@ import uk.gov.pay.connector.paymentprocessor.resource.DiscrepancyResource;
 import uk.gov.pay.connector.queue.managed.CaptureMessageReceiver;
 import uk.gov.pay.connector.queue.managed.PayoutReconcileMessageReceiver;
 import uk.gov.pay.connector.queue.managed.StateTransitionMessageReceiver;
-import uk.gov.pay.connector.refund.resource.ChargeRefundsResource;
+import uk.gov.pay.connector.refund.resource.RefundsResource;
 import uk.gov.pay.connector.report.resource.PerformanceReportResource;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitterByDateRangeTask;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitterTask;
@@ -133,7 +133,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(ChargesApiResource.class));
         environment.jersey().register(injector.getInstance(ExpungeResource.class));
         environment.jersey().register(injector.getInstance(ChargesFrontendResource.class));
-        environment.jersey().register(injector.getInstance(ChargeRefundsResource.class));
+        environment.jersey().register(injector.getInstance(RefundsResource.class));
         environment.jersey().register(injector.getInstance(NotificationResource.class));
         environment.jersey().register(injector.getInstance(CardResource.class));
         environment.jersey().register(injector.getInstance(CardTypesResource.class));

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -8,7 +8,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
-import uk.gov.pay.connector.refund.service.ChargeRefundService;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import java.util.Optional;
@@ -18,11 +18,11 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 public class RefundNotificationProcessor {
 
     private Logger logger = LoggerFactory.getLogger(getClass());
-    private ChargeRefundService refundService;
+    private RefundService refundService;
     private UserNotificationService userNotificationService;
 
     @Inject
-    RefundNotificationProcessor(ChargeRefundService refundService,
+    RefundNotificationProcessor(RefundService refundService,
                                 UserNotificationService userNotificationService) {
         this.refundService = refundService;
         this.userNotificationService = userNotificationService;

--- a/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/ChargeRefundsResource.java
@@ -13,7 +13,7 @@ import uk.gov.pay.connector.refund.model.RefundResponse;
 import uk.gov.pay.connector.refund.model.RefundsResponse;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.service.ChargeRefundResponse;
-import uk.gov.pay.connector.refund.service.ChargeRefundService;
+import uk.gov.pay.connector.refund.service.RefundService;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -38,13 +38,13 @@ import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 @Path("/")
 public class ChargeRefundsResource {
 
-    private final ChargeRefundService refundService;
+    private final RefundService refundService;
     private final ChargeService chargeService;
     private final ChargeDao chargeDao;
     private final RefundDao refundDao;
 
     @Inject
-    public ChargeRefundsResource(ChargeRefundService refundService, ChargeService chargeService, ChargeDao chargeDao, RefundDao refundDao) {
+    public ChargeRefundsResource(RefundService refundService, ChargeService chargeService, ChargeDao chargeDao, RefundDao refundDao) {
         this.refundService = refundService;
         this.chargeService = chargeService;
         this.chargeDao = chargeDao;

--- a/src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java
+++ b/src/main/java/uk/gov/pay/connector/refund/resource/RefundsResource.java
@@ -36,7 +36,7 @@ import static uk.gov.pay.connector.util.ResponseUtil.responseWithRefundNotFound;
 import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
 @Path("/")
-public class ChargeRefundsResource {
+public class RefundsResource {
 
     private final RefundService refundService;
     private final ChargeService chargeService;
@@ -44,7 +44,7 @@ public class ChargeRefundsResource {
     private final RefundDao refundDao;
 
     @Inject
-    public ChargeRefundsResource(RefundService refundService, ChargeService chargeService, ChargeDao chargeDao, RefundDao refundDao) {
+    public RefundsResource(RefundService refundService, ChargeService chargeService, ChargeDao chargeDao, RefundDao refundDao) {
         this.refundService = refundService;
         this.chargeService = chargeService;
         this.chargeDao = chargeDao;

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -31,7 +31,7 @@ import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_ERROR;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMITTED;
 
-public class ChargeRefundService {
+public class RefundService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     
@@ -42,8 +42,8 @@ public class ChargeRefundService {
     private StateTransitionService stateTransitionService;
 
     @Inject
-    public ChargeRefundService(RefundDao refundDao, GatewayAccountDao gatewayAccountDao, PaymentProviders providers,
-                               UserNotificationService userNotificationService, StateTransitionService stateTransitionService
+    public RefundService(RefundDao refundDao, GatewayAccountDao gatewayAccountDao, PaymentProviders providers,
+                         UserNotificationService userNotificationService, StateTransitionService stateTransitionService
     ) {
         this.refundDao = refundDao;
         this.gatewayAccountDao = gatewayAccountDao;

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessorTest.java
@@ -22,7 +22,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
-import uk.gov.pay.connector.refund.service.ChargeRefundService;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import java.util.List;
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 public class RefundNotificationProcessorTest {
 
     @Mock
-    private ChargeRefundService refundService;
+    private RefundService refundService;
     @Mock
     private UserNotificationService userNotificationService;
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
@@ -43,12 +43,12 @@ import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class EpdqRefundIT extends ChargingITestBase {
+public class EpdqRefundsResourceIT extends ChargingITestBase {
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCharge defaultTestCharge;
 
-    public EpdqRefundIT() {
+    public EpdqRefundsResourceIT() {
         super("epdq");
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
@@ -39,12 +39,12 @@ import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternal
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class SandboxRefundIT extends ChargingITestBase {
+public class SandboxRefundsResourceIT extends ChargingITestBase {
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCharge defaultTestCharge;
 
-    public SandboxRefundIT() {
+    public SandboxRefundsResourceIT() {
         super("sandbox");
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundsResourceIT.java
@@ -43,13 +43,13 @@ import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class SmartpayRefundIT extends ChargingITestBase {
+public class SmartpayRefundsResourceIT extends ChargingITestBase {
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCharge defaultTestCharge;
     private String pspReference;
 
-    public SmartpayRefundIT() {
+    public SmartpayRefundsResourceIT() {
         super("smartpay");
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
@@ -35,7 +35,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class StripeRefundIT extends ChargingITestBase {
+public class StripeRefundsResourceIT extends ChargingITestBase {
     private String stripeAccountId = "stripe_account_id";
     private String accountId = "555";
 
@@ -43,7 +43,7 @@ public class StripeRefundIT extends ChargingITestBase {
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCharge defaultTestCharge;
 
-    public StripeRefundIT() {
+    public StripeRefundsResourceIT() {
         super("stripe");
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -43,12 +43,12 @@ import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
-public class WorldpayRefundIT extends ChargingITestBase {
+public class WorldpayRefundsResourceIT extends ChargingITestBase {
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
     private DatabaseFixtures.TestCharge defaultTestCharge;
 
-    public WorldpayRefundIT() {
+    public WorldpayRefundsResourceIT() {
         super("worldpay");
     }
 


### PR DESCRIPTION
Just some casual renaming

ChargeRefund -> Refund because the "Charge" part doesn't seem useful.

Rename the integration tests to make them more discoverable in the IDE.
