### PR TITLE
PP-6994 Use RefundService when calculating refundability

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.charge.util;
 
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
@@ -16,18 +17,18 @@ public class RefundCalculator {
         // prevent Java for adding a public constructor
     }
 
-    public static long getTotalAmountAvailableToBeRefunded(Charge charge, List<RefundEntity> refundEntities) {
-        return CorporateCardSurchargeCalculator.getTotalAmountFor(charge) - getRefundedAmount(refundEntities);
+    public static long getTotalAmountAvailableToBeRefunded(Charge charge, List<Refund> refundList) {
+        return CorporateCardSurchargeCalculator.getTotalAmountFor(charge) - getRefundedAmount(refundList);
     }
 
-    public static long getTotalAmountAvailableToBeRefunded(ChargeEntity chargeEntity, List<RefundEntity> refundEntities) {
-        return CorporateCardSurchargeCalculator.getTotalAmountFor(chargeEntity) - getRefundedAmount(refundEntities);
+    public static long getTotalAmountAvailableToBeRefunded(ChargeEntity chargeEntity, List<Refund> refundList) {
+        return CorporateCardSurchargeCalculator.getTotalAmountFor(chargeEntity) - getRefundedAmount(refundList);
     }
 
-    public static long getRefundedAmount(List<RefundEntity> refundEntities) {
-        return refundEntities.stream()
-                .filter(p -> p.hasStatus(RefundStatus.CREATED, RefundStatus.REFUND_SUBMITTED, RefundStatus.REFUNDED))
-                .mapToLong(RefundEntity::getAmount)
+    public static long getRefundedAmount(List<Refund> refundList) {
+        return refundList.stream()
+                .filter(p -> List.of(RefundStatus.CREATED, RefundStatus.REFUND_SUBMITTED, RefundStatus.REFUNDED).contains(p.getStatus()))
+                .mapToLong(Refund::getAmount)
                 .sum();
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
@@ -21,10 +22,10 @@ public class RefundAvailabilityUpdatedEventDetails extends EventDetails {
     }
     
 
-    public static RefundAvailabilityUpdatedEventDetails from(Charge charge, List<RefundEntity> refundEntityList, ExternalChargeRefundAvailability availability) {
+    public static RefundAvailabilityUpdatedEventDetails from(Charge charge, List<Refund> refundList, ExternalChargeRefundAvailability availability) {
         return new RefundAvailabilityUpdatedEventDetails(
-                RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntityList),
-                RefundCalculator.getRefundedAmount(refundEntityList),
+                RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundList),
+                RefundCalculator.getRefundedAmount(refundList),
                 availability.getStatus()
         );
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -41,5 +42,5 @@ public interface PaymentProvider {
 
     GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayException;
 
-    ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList);
+    ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundEntityList);
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -41,7 +41,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
@@ -236,8 +236,8 @@ public class EpdqPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
     /**

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxWalletAuthorisationHandler;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -99,8 +100,8 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
     private GatewayResponse<BaseCancelResponse> createGatewayBaseCancelResponse() {

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -30,7 +30,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
@@ -156,8 +156,8 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
     private GatewayOrder buildAuthoriseOrderFor(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -36,7 +36,7 @@ import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeAuthoriseRequest;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -188,7 +188,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/DefaultExternalRefundAvailabilityCalculator.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
@@ -47,18 +48,18 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
     private static final List<ExternalChargeRefundAvailability> MUTABLE_REFUND_STATES = ImmutableList.of(EXTERNAL_AVAILABLE, EXTERNAL_FULL);
 
     @Override
-    public ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList) {
-        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+    public ExternalChargeRefundAvailability calculate(Charge charge, List<Refund> refundList) {
+        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundList);
     }
 
     protected ExternalChargeRefundAvailability calculate(Charge charge, List<ChargeStatus> statusesThatMapToExternalPending,
                                                          List<ChargeStatus> statusesThatMapToExternalAvailableOrExternalFull,
-                                                         List<RefundEntity> refundEntityList) {
+                                                         List<Refund> refundList) {
         if (charge.isHistoric()) {
             ExternalChargeRefundAvailability currentChargeRefundAvailability = ExternalChargeRefundAvailability.from(charge.getRefundAvailabilityStatus());
 
             if (MUTABLE_REFUND_STATES.contains(currentChargeRefundAvailability)) {
-                return calculateRefundAvailability(charge, refundEntityList);
+                return calculateRefundAvailability(charge, refundList);
             } else {
                 return currentChargeRefundAvailability;
             }
@@ -66,14 +67,14 @@ public class DefaultExternalRefundAvailabilityCalculator implements ExternalRefu
             if (chargeIsPending(charge, statusesThatMapToExternalPending)) {
                 return EXTERNAL_PENDING;
             } else if (chargeIsAvailableOrFull(charge, statusesThatMapToExternalAvailableOrExternalFull)) {
-                return calculateRefundAvailability(charge, refundEntityList);
+                return calculateRefundAvailability(charge, refundList);
             }
             return EXTERNAL_UNAVAILABLE;
         }
     }
 
-    private ExternalChargeRefundAvailability calculateRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
-        long amountAvailableToBeRefunded = RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundEntityList);
+    private ExternalChargeRefundAvailability calculateRefundAvailability(Charge charge, List<Refund> refundList) {
+        long amountAvailableToBeRefunded = RefundCalculator.getTotalAmountAvailableToBeRefunded(charge, refundList);
         if (amountAvailableToBeRefunded > 0) {
             return EXTERNAL_AVAILABLE;
         } else {

--- a/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/EpdqExternalRefundAvailabilityCalculator.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
@@ -42,8 +43,8 @@ public class EpdqExternalRefundAvailabilityCalculator extends DefaultExternalRef
             CAPTURED);
 
     @Override
-    public ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList) {
-        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundEntityList);
+    public ExternalChargeRefundAvailability calculate(Charge charge, List<Refund> refundList) {
+        return calculate(charge, STATUSES_THAT_MAP_TO_EXTERNAL_PENDING, STATUSES_THAT_MAP_TO_EXTERNAL_AVAILABLE_OR_EXTERNAL_FULL, refundList);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/ExternalRefundAvailabilityCalculator.java
@@ -2,11 +2,12 @@ package uk.gov.pay.connector.gateway.util;
 
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 
 public interface ExternalRefundAvailabilityCalculator {
 
-    ExternalChargeRefundAvailability calculate(Charge charge, List<RefundEntity> refundEntityList);
+    ExternalChargeRefundAvailability calculate(Charge charge, List<Refund> refundEntityList);
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -32,7 +32,7 @@ import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalcul
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.applepay.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import javax.inject.Inject;
@@ -207,8 +207,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<RefundEntity> refundEntityList) {
-        return externalRefundAvailabilityCalculator.calculate(charge, refundEntityList);
+    public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
+        return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
     private GatewayOrder buildAuthoriseOrder(CardAuthorisationGatewayRequest request) {

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
@@ -5,14 +5,14 @@ import java.util.Objects;
 public class Refund {
     private String externalId;
     private Long amount;
-    private String status;
     private String userExternalId;
     private String userEmail;
     private String gatewayTransactionId;
     private String chargeExternalId;
+    private RefundStatus status;
     private boolean historic;
 
-    public Refund(String externalId, Long amount, String status, String userExternalId, String userEmail, String gatewayTransactionId, String chargeExternalId, boolean historic) {
+    public Refund(String externalId, Long amount, RefundStatus status, String userExternalId, String userEmail, String gatewayTransactionId, String chargeExternalId, boolean historic) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
@@ -21,6 +21,19 @@ public class Refund {
         this.gatewayTransactionId = gatewayTransactionId;
         this.chargeExternalId = chargeExternalId;
         this.historic = historic;
+    }
+
+    public static Refund from(RefundEntity refundEntity) {
+        return new Refund(
+                refundEntity.getExternalId(),
+                refundEntity.getAmount(),
+                refundEntity.getStatus(),
+                refundEntity.getUserExternalId(),
+                refundEntity.getUserEmail(),
+                refundEntity.getGatewayTransactionId(),
+                refundEntity.getChargeExternalId(),
+                false
+        );
     }
 
     public boolean isHistoric() {
@@ -43,7 +56,7 @@ public class Refund {
         return userExternalId;
     }
 
-    public String getStatus() {
+    public RefundStatus getStatus() {
         return status;
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
@@ -1,0 +1,76 @@
+package uk.gov.pay.connector.refund.model.domain;
+
+import java.util.Objects;
+
+public class Refund {
+    private String externalId;
+    private Long amount;
+    private String status;
+    private String userExternalId;
+    private String userEmail;
+    private String gatewayTransactionId;
+    private String chargeExternalId;
+    private boolean historic;
+
+    public Refund(String externalId, Long amount, String status, String userExternalId, String userEmail, String gatewayTransactionId, String chargeExternalId, boolean historic) {
+        this.externalId = externalId;
+        this.amount = amount;
+        this.status = status;
+        this.userExternalId = userExternalId;
+        this.userEmail = userEmail;
+        this.gatewayTransactionId = gatewayTransactionId;
+        this.chargeExternalId = chargeExternalId;
+        this.historic = historic;
+    }
+
+    public boolean isHistoric() {
+        return historic;
+    }
+
+    public String getChargeExternalId() {
+        return chargeExternalId;
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public String getUserExternalId() {
+        return userExternalId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Refund refund = (Refund) obj;
+        return Objects.equals(externalId, refund.externalId) &&
+                Objects.equals(amount, refund.amount) &&
+                Objects.equals(status, refund.status) &&
+                Objects.equals(gatewayTransactionId, refund.gatewayTransactionId) &&
+                Objects.equals(historic, refund.historic) &&
+                Objects.equals(chargeExternalId, refund.chargeExternalId) &&
+                Objects.equals(gatewayTransactionId, refund.gatewayTransactionId);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.exception.RefundException;
 import uk.gov.pay.connector.refund.model.RefundRequest;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
@@ -23,6 +24,7 @@ import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static uk.gov.pay.connector.charge.util.RefundCalculator.getTotalAmountAvailableToBeRefunded;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
@@ -245,5 +247,13 @@ public class RefundService {
                 gatewayAccountEntity, availableToBeRefunded);
 
         return availableToBeRefunded;
+    }
+
+    public List<Refund> findRefunds(Charge charge) {
+        return refundDao
+                .findRefundsByChargeExternalId(charge.getExternalId())
+                .stream()
+                .map(Refund::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -55,6 +55,7 @@ import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.northamericaregion.UsState;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 
@@ -160,7 +161,7 @@ public class ChargeServiceTest {
     protected StateTransitionService mockStateTransitionService;
 
     @Mock
-    protected RefundDao mockRefundDao;
+    protected RefundService mockedRefundService;
 
     @Mock
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
@@ -213,7 +214,7 @@ public class ChargeServiceTest {
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
-                mockStateTransitionService, ledgerService, mockEventService, mockRefundDao, mockNorthAmericanRegionMapper);
+                mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockNorthAmericanRegionMapper);
     }
 
     @After

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -44,6 +44,7 @@ import uk.gov.pay.connector.queue.statetransition.StateTransition;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
+import uk.gov.pay.connector.refund.service.RefundService;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -66,6 +67,8 @@ public class EventFactoryTest {
     @Mock
     private RefundDao refundDao;
     @Mock
+    private RefundService refundService;
+    @Mock
     private ChargeEventDao chargeEventDao;
     @Mock
     private PaymentProviders paymentProviders;
@@ -77,7 +80,7 @@ public class EventFactoryTest {
         PaymentProvider paymentProvider = new SandboxPaymentProvider();
         when(paymentProviders.byName(any(PaymentGatewayName.class))).thenReturn(paymentProvider);
         
-        eventFactory = new EventFactory(chargeService, refundDao, chargeEventDao, paymentProviders);
+        eventFactory = new EventFactory(chargeService, refundDao, refundService, chargeEventDao, paymentProviders);
     }
     
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -19,12 +19,14 @@ import uk.gov.pay.connector.client.ledger.model.TransactionState;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
 import static java.util.Optional.ofNullable;
@@ -127,7 +129,7 @@ public class LedgerTransactionFixture {
         ExternalChargeRefundAvailability refundAvailability;
         if (refundsList != null) {
             refundAvailability = new DefaultExternalRefundAvailabilityCalculator()
-                    .calculate(Charge.from(chargeEntity), refundsList);
+                    .calculate(Charge.from(chargeEntity), refundsList.stream().map(Refund::from).collect(Collectors.toList()));
         } else {
             refundAvailability = new DefaultExternalRefundAvailabilityCalculator()
                     .calculate(Charge.from(chargeEntity), List.of());

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.util.AuthUtils;
 
 import java.util.Optional;
@@ -69,6 +70,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private Authorisation3dsConfig mockAuthorisation3dsConfig;
     @Mock
     private NorthAmericanRegionMapper northAmericanRegionMapper;
+    @Mock
+    private RefundService mockedRefundService;
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
@@ -95,7 +98,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockConfiguration.getAuthorisation3dsConfig()).thenReturn(mockAuthorisation3dsConfig);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockEventService, mockedRefundDao, northAmericanRegionMapper);
+                null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, northAmericanRegionMapper);
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService, mockConfiguration);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -45,6 +45,7 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
+import uk.gov.pay.connector.refund.service.RefundService;
 
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -112,6 +113,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private EventService mockEventService;
+    
+    @Mock
+    private RefundService mockRefundService;
 
     @Mock
     private NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
@@ -126,7 +130,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                stateTransitionService, ledgerService, mockEventService, mockedRefundDao, mockNorthAmericanRegionMapper);
+                stateTransitionService, ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper);
 
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -41,6 +41,7 @@ import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import javax.persistence.OptimisticLockException;
@@ -110,8 +111,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private LedgerService ledgerService;
     @Mock
     private EventService mockEventService;
-    @Mock
-    private RefundDao mockRefundDao;
+    @Mock 
+    private RefundService mockedRefundService;
     @Mock
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
 
@@ -123,7 +124,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                mockStateTransitionService, ledgerService, mockEventService, mockRefundDao, mockNorthAmericanRegionMapper);
+                mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockNorthAmericanRegionMapper);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
@@ -7,11 +7,14 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static org.hamcrest.core.Is.is;
@@ -83,24 +86,24 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
 
     @Test
     public void testGetChargeRefundAvailabilityReturnsAvailableIfChargeIsCaptured() {
-        List<RefundEntity> refunds = Arrays.asList(
+        List<Refund> refunds = Stream.of(
                 aValidRefundEntity().withStatus(RefundStatus.CREATED).withAmount(100L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUND_SUBMITTED).withAmount(200L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUND_ERROR).withAmount(100L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(199L).build()
-        );
+        ).map(Refund::from).collect(Collectors.toList());
 
         assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L), refunds), is(EXTERNAL_AVAILABLE));
     }
 
     @Test
     public void testGetChargeRefundAvailabilityReturnsAvailableIfChargeIsCapturedSubmitted() {
-        List<RefundEntity> refunds = Arrays.asList(
+        List<Refund> refunds = Stream.of(
                 aValidRefundEntity().withStatus(RefundStatus.CREATED).withAmount(100L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUND_SUBMITTED).withAmount(200L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUND_ERROR).withAmount(100L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(199L).build()
-        );
+        ).map(Refund::from).collect(Collectors.toList());
 
         assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L), refunds), is(EXTERNAL_AVAILABLE));
     }
@@ -112,22 +115,22 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
 
     @Test
     public void testGetChargeRefundAvailabilityReturnsFullIfChargeIsCaptured() {
-        List<RefundEntity> refunds = Arrays.asList(
+        List<Refund> refunds = Stream.of(
                 aValidRefundEntity().withStatus(RefundStatus.CREATED).withAmount(100L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUND_SUBMITTED).withAmount(200L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(200L).build()
-        );
+        ).map(Refund::from).collect(Collectors.toList());
 
         assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURED, 500L), refunds), is(EXTERNAL_FULL));
     }
 
     @Test
     public void testGetChargeRefundAvailabilityReturnsFullIfChargeIsCapturedSubmitted() {
-        List<RefundEntity> refunds = Arrays.asList(
+        List<Refund> refunds = Stream.of(
                 aValidRefundEntity().withStatus(RefundStatus.CREATED).withAmount(100L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUND_SUBMITTED).withAmount(200L).build(),
                 aValidRefundEntity().withStatus(RefundStatus.REFUNDED).withAmount(200L).build()
-        );
+        ).map(Refund::from).collect(Collectors.toList());
 
         assertThat(epdqExternalRefundAvailabilityCalculator.calculate(chargeEntity(CAPTURE_SUBMITTED, 500L), refunds), is(EXTERNAL_FULL));
     }

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -606,7 +606,7 @@ public class RefundServiceTest {
         when(mockRefundDao.findRefundsByChargeExternalId(charge.getExternalId()))
                 .thenReturn(List.of(refundOne, refundTwo));
 
-        List<Refund> refunds = chargeRefundService.findRefunds(charge);
+        List<Refund> refunds = refundService.findRefunds(charge);
 
         assertThat(refunds.size(), is(2));
         assertThat(refunds.get(0).getChargeExternalId(), is(charge.getExternalId()));

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.exception.RefundException;
 import uk.gov.pay.connector.refund.model.RefundRequest;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.refund.service.ChargeRefundResponse;
@@ -585,6 +586,34 @@ public class RefundServiceTest {
 
         refundService.transitionRefundState(refundEntity, CREATED);
         verify(mockStateTransitionService).offerRefundStateTransition(refundEntity, CREATED);
+    }
+
+    @Test
+    public void shouldFindRefundsGivenValidCharge() {
+        Charge charge = Charge.from(aValidChargeEntity().build());
+
+        RefundEntity refundOne = aValidRefundEntity()
+                .withChargeExternalId(charge.getExternalId())
+                .withAmount(100L)
+                .withStatus(CREATED)
+                .build();
+        RefundEntity refundTwo = aValidRefundEntity()
+                .withChargeExternalId(charge.getExternalId())
+                .withAmount(400L)
+                .withStatus(RefundStatus.REFUND_SUBMITTED)
+                .build();
+
+        when(mockRefundDao.findRefundsByChargeExternalId(charge.getExternalId()))
+                .thenReturn(List.of(refundOne, refundTwo));
+
+        List<Refund> refunds = chargeRefundService.findRefunds(charge);
+
+        assertThat(refunds.size(), is(2));
+        assertThat(refunds.get(0).getChargeExternalId(), is(charge.getExternalId()));
+        assertThat(refunds.get(0).getAmount(), is(refundOne.getAmount()));
+        assertThat(refunds.get(0).getStatus(), is(RefundStatus.CREATED));
+        assertThat(refunds.get(1).getStatus(), is(RefundStatus.REFUND_SUBMITTED));
+        assertThat(refunds.get(1).getAmount(), is(refundTwo.getAmount()));
     }
 
     private ArgumentMatcher<RefundEntity> aRefundEntity(long amount, ChargeEntity chargeEntity) {

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.tasks.service.ChargeParityChecker;
 import uk.gov.pay.connector.tasks.service.ParityCheckService;
 
@@ -51,6 +52,8 @@ public class ParityCheckServiceTest {
     private LedgerService mockLedgerService;
     @Mock
     private ChargeService mockChargeService;
+    @Mock
+    private RefundService mockRefundService;
     @Mock
     private RefundDao mockRefundDao;
     @Mock

--- a/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
@@ -14,8 +14,8 @@ import uk.gov.pay.connector.client.ledger.model.CardDetails;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
-import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.service.RefundService;
 
 import java.util.List;
 
@@ -45,7 +45,7 @@ import static uk.gov.pay.connector.wallets.WalletType.GOOGLE_PAY;
 public class ChargeParityCheckerTest {
 
     @Mock
-    private RefundDao mockRefundDao;
+    private RefundService mockRefundService;
     @Mock
     private PaymentProviders mockProviders;
     @InjectMocks
@@ -73,7 +73,7 @@ public class ChargeParityCheckerTest {
                 .withEvents(List.of(chargeEventCreated, chargeEventCaptured, chargeEventCaptureSubmitted))
                 .build();
 
-        when(mockRefundDao.findRefundsByChargeExternalId(any())).thenReturn(refundEntities);
+        when(mockRefundService.findRefunds(any())).thenReturn(List.of());
         when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider());
     }
 

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -44,6 +44,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
@@ -114,6 +115,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     private EmittedEventDao emittedEventDao;
     @Mock
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
+    @Mock
+    private RefundService mockRefundService;
 
     private WalletAuthoriseService walletAuthoriseService;
 
@@ -143,7 +146,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null, mockStateTransitionService,
-                ledgerService, mockEventService, mockedRefundDao, mockNorthAmericanRegionMapper));
+                ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
Following the same `ChargeEntity` -> `Charge` POJO pattern, add a POJO to represent refunds. These will be buildable from Connector database entities and historic transactions if the database entities have been expunged.

When calculating refundability, instead of directly getting refunds from the database using the RefundDao, use a new method in RefundService, which returns a list of these new Refund objects.

This method will later be updated to retrieve refunds from ledger and combine this set of refunds with the set retrieved from the connector database so that we can handle calculating refundability when refunds are expunged.
