### PR TITLE
PP-6988 Add parity check fields on refunds

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1513,4 +1513,30 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add parity-check columns to refunds" author="">
+        <addColumn tableName="refunds">
+            <column name="parity_check_status" type="varchar(100)">
+            </column>
+        </addColumn>
+        <addColumn tableName="refunds">
+            <column name="parity_check_date" type="timestamp without timezone">
+            </column>
+        </addColumn>
+        <createIndex indexName="idx_refunds_parity_check_date"
+                     tableName="refunds"
+                     unique="false">
+            <column name="parity_check_date"/>
+        </createIndex>
+    </changeSet>
+    <changeSet id="add parity-check columns to refunds history" author="">
+        <addColumn tableName="refunds_history">
+            <column name="parity_check_status" type="varchar(100)">
+            </column>
+        </addColumn>
+        <addColumn tableName="refunds_history">
+            <column name="parity_check_date" type="timestamp without timezone">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- Added new fields on refunds and refunds_history tables to be used to record parity check status
