### PR TITLE
PP-6994 Don't use RefundDao to get refunds outside of RefundService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -36,7 +36,7 @@ import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_SUBMI
 public class RefundService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    
+
     private final RefundDao refundDao;
     private final GatewayAccountDao gatewayAccountDao;
     private final PaymentProviders providers;
@@ -246,10 +246,14 @@ public class RefundService {
         long availableToBeRefunded = getTotalAmountAvailableToBeRefunded(charge, postRefundList);
         checkIfRefundRequestIsInConflictOrTerminate(refundRequest, charge, availableToBeRefunded);
 
-        checkIfRefundAmountWithinLimitOrTerminate(refundRequest, charge, refundAvailability, 
+        checkIfRefundAmountWithinLimitOrTerminate(refundRequest, charge, refundAvailability,
                 gatewayAccountEntity, availableToBeRefunded);
 
         return availableToBeRefunded;
+    }
+
+    public List<RefundEntity> findNotExpungedRefunds(String chargeExternalId) {
+        return refundDao.findRefundsByChargeExternalId(chargeExternalId);
     }
 
     public List<Refund> findRefunds(Charge charge) {

--- a/src/main/java/uk/gov/pay/connector/tasks/service/ParityCheckService.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ParityCheckService.java
@@ -9,8 +9,8 @@ import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
-import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
 
 import java.util.List;
@@ -26,18 +26,19 @@ public class ParityCheckService {
     private static final Logger logger = LoggerFactory.getLogger(ParityCheckService.class);
     private LedgerService ledgerService;
     private ChargeService chargeService;
-    private RefundDao refundDao;
+    private RefundService refundService;
     private HistoricalEventEmitter historicalEventEmitter;
     private final ChargeParityChecker chargeParityChecker;
 
     @Inject
-    public ParityCheckService(LedgerService ledgerService, ChargeService chargeService,
-                              RefundDao refundDao,
+    public ParityCheckService(LedgerService ledgerService,
+                              ChargeService chargeService,
+                              RefundService refundService,
                               HistoricalEventEmitter historicalEventEmitter,
                               ChargeParityChecker chargeParityChecker) {
         this.ledgerService = ledgerService;
         this.chargeService = chargeService;
-        this.refundDao = refundDao;
+        this.refundService = refundService;
         this.historicalEventEmitter = historicalEventEmitter;
         this.chargeParityChecker = chargeParityChecker;
     }
@@ -45,7 +46,7 @@ public class ParityCheckService {
     public ParityCheckStatus getChargeAndRefundsParityCheckStatus(ChargeEntity charge) {
         ParityCheckStatus parityCheckStatus = getChargeParityCheckStatus(charge);
         if (parityCheckStatus.equals(EXISTS_IN_LEDGER)) {
-            return getRefundsParityCheckStatus(refundDao.findRefundsByChargeExternalId(charge.getExternalId()));
+            return getRefundsParityCheckStatus(refundService.findNotExpungedRefunds(charge.getExternalId()));
         }
 
         return parityCheckStatus;

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
@@ -15,7 +15,7 @@ import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.client.ledger.service.LedgerService;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.sandbox.SandboxPaymentProvider;
-import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.tasks.service.ChargeParityChecker;
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.tasks.service.ParityCheckService;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.time.ZonedDateTime.parse;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,8 +56,6 @@ public class ParityCheckServiceTest {
     @Mock
     private RefundService mockRefundService;
     @Mock
-    private RefundDao mockRefundDao;
-    @Mock
     private HistoricalEventEmitter mockHistoricalEventEmitter;
     @Mock
     private PaymentProviders mockProviders;
@@ -85,9 +84,9 @@ public class ParityCheckServiceTest {
                 .withEvents(List.of(chargeEventCreated, chargeEventCaptured, chargeEventCaptureSubmitted))
                 .build();
 
-        when(mockRefundDao.findRefundsByChargeExternalId(any())).thenReturn(refundEntities);
+        when(mockRefundService.findRefunds(any())).thenReturn(refundEntities.stream().map(Refund::from).collect(Collectors.toList()));
         when(mockProviders.byName(any())).thenReturn(new SandboxPaymentProvider());
-        parityCheckService = new ParityCheckService(mockLedgerService, mockChargeService, mockRefundDao,
+        parityCheckService = new ParityCheckService(mockLedgerService, mockChargeService, mockRefundService,
                 mockHistoricalEventEmitter, chargeParityChecker);
     }
 


### PR DESCRIPTION
As we will now be retrieving refunds from both the connector database and from ledger when calculating refundability, make it more explicit in other places where we only retrieve non-expunged refunds from the database by using a method in RefundService rather than directly calling the RefundDao.

It is better practice that only the service uses the DAO, so removing use of it from the resource is also a good thing to do.
