### PR TITLE
PP-6994 Use external refund status to calculate refundability

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/RefundCalculator.java
@@ -3,10 +3,11 @@ package uk.gov.pay.connector.charge.util;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.util.List;
+
+import static uk.gov.pay.connector.common.model.api.ExternalRefundStatus.EXTERNAL_SUBMITTED;
+import static uk.gov.pay.connector.common.model.api.ExternalRefundStatus.EXTERNAL_SUCCESS;
 
 /**
  * Holder for utility methods used to calculate refund amounts
@@ -27,7 +28,7 @@ public class RefundCalculator {
 
     public static long getRefundedAmount(List<Refund> refundList) {
         return refundList.stream()
-                .filter(p -> List.of(RefundStatus.CREATED, RefundStatus.REFUND_SUBMITTED, RefundStatus.REFUNDED).contains(p.getStatus()))
+                .filter(p -> List.of(EXTERNAL_SUBMITTED, EXTERNAL_SUCCESS).contains(p.getExternalStatus()))
                 .mapToLong(Refund::getAmount)
                 .sum();
     }

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.refund.model.domain;
 
+import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
+
 import java.util.Objects;
 
 public class Refund {
@@ -9,13 +11,18 @@ public class Refund {
     private String userEmail;
     private String gatewayTransactionId;
     private String chargeExternalId;
-    private RefundStatus status;
+    private ExternalRefundStatus externalStatus;
     private boolean historic;
 
-    public Refund(String externalId, Long amount, RefundStatus status, String userExternalId, String userEmail, String gatewayTransactionId, String chargeExternalId, boolean historic) {
+    public Refund(String externalId, Long amount,
+                  ExternalRefundStatus externalStatus,
+                  String userExternalId, String userEmail,
+                  String gatewayTransactionId,
+                  String chargeExternalId,
+                  boolean historic) {
         this.externalId = externalId;
         this.amount = amount;
-        this.status = status;
+        this.externalStatus = externalStatus;
         this.userExternalId = userExternalId;
         this.userEmail = userEmail;
         this.gatewayTransactionId = gatewayTransactionId;
@@ -27,7 +34,7 @@ public class Refund {
         return new Refund(
                 refundEntity.getExternalId(),
                 refundEntity.getAmount(),
-                refundEntity.getStatus(),
+                refundEntity.getStatus().toExternal(),
                 refundEntity.getUserExternalId(),
                 refundEntity.getUserEmail(),
                 refundEntity.getGatewayTransactionId(),
@@ -56,8 +63,8 @@ public class Refund {
         return userExternalId;
     }
 
-    public RefundStatus getStatus() {
-        return status;
+    public ExternalRefundStatus getExternalStatus() {
+        return externalStatus;
     }
 
     public Long getAmount() {
@@ -80,7 +87,7 @@ public class Refund {
         Refund refund = (Refund) obj;
         return Objects.equals(externalId, refund.externalId) &&
                 Objects.equals(amount, refund.amount) &&
-                Objects.equals(status, refund.status) &&
+                Objects.equals(externalStatus, refund.externalStatus) &&
                 Objects.equals(gatewayTransactionId, refund.gatewayTransactionId) &&
                 Objects.equals(historic, refund.historic) &&
                 Objects.equals(chargeExternalId, refund.chargeExternalId) &&

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -611,8 +611,8 @@ public class RefundServiceTest {
         assertThat(refunds.size(), is(2));
         assertThat(refunds.get(0).getChargeExternalId(), is(charge.getExternalId()));
         assertThat(refunds.get(0).getAmount(), is(refundOne.getAmount()));
-        assertThat(refunds.get(0).getStatus(), is(RefundStatus.CREATED));
-        assertThat(refunds.get(1).getStatus(), is(RefundStatus.REFUND_SUBMITTED));
+        assertThat(refunds.get(0).getExternalStatus(), is(RefundStatus.CREATED.toExternal()));
+        assertThat(refunds.get(1).getExternalStatus(), is(RefundStatus.REFUND_SUBMITTED.toExternal()));
         assertThat(refunds.get(1).getAmount(), is(refundTwo.getAmount()));
     }
 


### PR DESCRIPTION
Refunds that we get from ledger have a status corresponding to an external status in connector.

Use the external status for charges from the connector database when determining which refunds should be included in the refundability calculation so that it will work for refunds retrieved from ledger.
