### PR TITLE
PP-6994 Use expunged refunds from ledger when calculating refundability

### DIFF
--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/RefundTransactionsForPayment.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/RefundTransactionsForPayment.java
@@ -20,4 +20,12 @@ public class RefundTransactionsForPayment {
     public List<LedgerTransaction> getTransactions() {
         return transactions;
     }
+
+    public void setParentTransactionId(String parentTransactionId) {
+        this.parentTransactionId = parentTransactionId;
+    }
+
+    public void setTransactions(List<LedgerTransaction> transactions) {
+        this.transactions = transactions;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.refund.model.domain;
 
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
 
 import java.util.Objects;
@@ -40,6 +41,19 @@ public class Refund {
                 refundEntity.getGatewayTransactionId(),
                 refundEntity.getChargeExternalId(),
                 false
+        );
+    }
+
+    public static Refund from(LedgerTransaction ledgerTransaction) {
+        return new Refund(
+                ledgerTransaction.getTransactionId(),
+                ledgerTransaction.getAmount(),
+                ExternalRefundStatus.fromPublicStatusLabel(ledgerTransaction.getState().getStatus()),
+                ledgerTransaction.getUserExternalId(),
+                ledgerTransaction.getUserEmail(),
+                ledgerTransaction.getParentTransactionId(),
+                ledgerTransaction.getGatewayTransactionId(),
+                true
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundStatus.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundStatus.java
@@ -1,12 +1,14 @@
 package uk.gov.pay.connector.refund.model.domain;
 
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.connector.client.ledger.model.TransactionState;
 import uk.gov.pay.connector.common.model.Status;
 import uk.gov.pay.connector.common.model.api.ExternalRefundStatus;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static java.util.Arrays.stream;
 import static uk.gov.pay.connector.common.model.api.ExternalRefundStatus.EXTERNAL_ERROR;
 import static uk.gov.pay.connector.common.model.api.ExternalRefundStatus.EXTERNAL_SUBMITTED;

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -47,7 +47,7 @@ public class LedgerTransactionFixture {
     private String returnUrl;
     private SupportedLanguage language;
     private CardDetails cardDetails;
-    private ZonedDateTime createdDate;
+    private ZonedDateTime createdDate = ZonedDateTime.now();
     private boolean live;
     private Long gatewayAccountId;
     private String paymentProvider;

--- a/src/test/java/uk/gov/pay/connector/model/domain/RefundTransactionsForPaymentFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/RefundTransactionsForPaymentFixture.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.model.domain;
+
+import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
+import uk.gov.pay.connector.client.ledger.model.RefundTransactionsForPayment;
+
+import java.util.List;
+
+public class RefundTransactionsForPaymentFixture {
+    private List<LedgerTransaction> transactions = List.of();
+    private String parentTransactionId;
+    
+    public static RefundTransactionsForPaymentFixture aValidRefundTransactionsForPayment() {
+        return new RefundTransactionsForPaymentFixture();
+    }
+    
+    public RefundTransactionsForPaymentFixture withParentTransactionId(String parentTransactionId) {
+        this.parentTransactionId = parentTransactionId;
+        return this;
+    }
+    
+    public RefundTransactionsForPaymentFixture withTransactions(List<LedgerTransaction> transactions) {
+        this.transactions = transactions;
+        return this;
+    }
+    
+    public RefundTransactionsForPayment build() {
+        RefundTransactionsForPayment refundTransactionsForPayment = new RefundTransactionsForPayment();
+        refundTransactionsForPayment.setParentTransactionId(parentTransactionId);
+        refundTransactionsForPayment.setTransactions(transactions);
+        return refundTransactionsForPayment;
+    }
+}


### PR DESCRIPTION
If the charge is historic, make a request to ledger to get any refunds that exist there. If the refunds also exist in the connector database, prefer the record from the database as the refund may be in-flight.