### PR TITLE
PP-7226 CodeQL Changes

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -159,6 +159,13 @@ public class Charge {
                 Objects.equals(email, charge.email);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(externalId, amount, status, externalStatus, gatewayTransactionId, corporateSurcharge,
+                refundAvailabilityStatus, reference, description, createdDate, email, gatewayAccountId,
+                paymentGatewayName, historic);
+    }
+
     public String getExternalStatus() {
         return externalStatus;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatus.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayoutStatus.java
@@ -36,7 +36,7 @@ public enum StripePayoutStatus {
                 return stat;
             }
         }
-        throw new IllegalArgumentException(format("Stripe payout status not recognized: [{}]", status));
+        throw new IllegalArgumentException(format("Stripe payout status not recognized: [%s]", status));
     }
 
     public Optional<Class<? extends PayoutEvent>> getEventClass() {

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/Refund.java
@@ -107,4 +107,10 @@ public class Refund {
                 Objects.equals(chargeExternalId, refund.chargeExternalId) &&
                 Objects.equals(gatewayTransactionId, refund.gatewayTransactionId);
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(externalId, amount, userExternalId, userEmail, gatewayTransactionId, chargeExternalId,
+                externalStatus, historic);
+    }
 }


### PR DESCRIPTION
- CodeQL detected that the equals method was implemented without a
corresponding hashcode override for two classes `Charge` and `Refund`,
this adds them.

- CodeQL detected that the format() function was being called
incorrectly in `StripePayoutStatus`, this fixes the string interpolation
