### PR TITLE
PP-7229 Remove Joda-Time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,11 +266,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-base</artifactId>
             <version>${jackson.version}</version>

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -1,11 +1,15 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import uk.gov.pay.connector.gateway.*;
+import uk.gov.pay.connector.gateway.CaptureHandler;
+import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 
 import java.net.URI;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.Map;
 
 import static uk.gov.pay.connector.gateway.CaptureResponse.ChargeState.PENDING;
@@ -40,10 +44,11 @@ public class WorldpayCaptureHandler implements CaptureHandler {
 
     private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
         return aWorldpayCaptureOrderRequestBuilder()
-                .withDate(DateTime.now(DateTimeZone.UTC))
+                .withDate(LocalDate.now(ZoneOffset.UTC))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withAmount(request.getAmountAsString())
                 .withTransactionId(request.getTransactionId())
                 .build();
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.OrderRequestBuilder;
@@ -8,15 +7,13 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.templates.PayloadBuilder;
 import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
-import uk.gov.pay.connector.northamericaregion.CanadaPostalcodeToProvinceOrTerritoryMapper;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
-import uk.gov.pay.connector.northamericaregion.UsZipCodeToStateMapper;
 import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
 
 import javax.ws.rs.core.MediaType;
-import java.util.Locale;
+import java.time.LocalDate;
 import java.util.Optional;
 
 public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
@@ -26,7 +23,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     static public class WorldpayTemplateData extends TemplateData {
         private String reference;
         private String amount;
-        private DateTime captureDate;
+        private LocalDate captureDate;
         private String sessionId;
         private String acceptHeader;
         private String userAgentHeader;
@@ -53,11 +50,11 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
             this.amount = amount;
         }
 
-        public DateTime getCaptureDate() {
+        public LocalDate getCaptureDate() {
             return captureDate;
         }
 
-        public void setCaptureDate(DateTime captureDate) {
+        public void setCaptureDate(LocalDate captureDate) {
             this.captureDate = captureDate;
         }
 
@@ -174,7 +171,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         return this;
     }
 
-    public WorldpayOrderRequestBuilder withDate(DateTime date) {
+    public WorldpayOrderRequestBuilder withDate(LocalDate date) {
         worldpayTemplateData.setCaptureDate(date);
         return this;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -1,8 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import io.dropwizard.setup.Environment;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
@@ -219,8 +217,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
         var builder = aWorldpayAuthoriseOrderRequestBuilder()
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
-                .with3dsRequired(is3dsRequired)
-                .withDate(DateTime.now(DateTimeZone.UTC));
+                .with3dsRequired(is3dsRequired);
 
         if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
             request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);

--- a/src/main/resources/templates/worldpay/WorldpayCaptureOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayCaptureOrderTemplate.xml
@@ -5,7 +5,7 @@
     <modify>
         <orderModification orderCode="${transactionId?xml}">
             <capture>
-                <date dayOfMonth="${captureDate.dayOfMonth().get()?string('00')}" month="${captureDate.monthOfYear().get()?string('00')}" year="${captureDate.year().get()?string('0000')}"/>
+                <date dayOfMonth="${captureDate.getDayOfMonth()?string('00')}" month="${captureDate.getMonthValue()?string('00')}" year="${captureDate.getYear()?string('0000')}"/>
                 <amount currencyCode="GBP" exponent="2" value="${amount}"/>
             </capture>
         </orderModification>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import org.joda.time.DateTime;
 import org.junit.Test;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -10,6 +9,8 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
+
+import java.time.LocalDate;
 
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.junit.Assert.assertEquals;
@@ -254,8 +255,7 @@ public class WorldpayOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidCaptureOrderRequest() throws Exception {
-
-        DateTime date = new DateTime(2013, 2, 23, 0, 0);
+        var date = LocalDate.of(2013, 2, 23);
 
         GatewayOrder actualRequest = aWorldpayCaptureOrderRequestBuilder()
                 .withDate(date)
@@ -270,8 +270,7 @@ public class WorldpayOrderRequestBuilderTest {
 
     @Test
     public void shouldGenerateValidCaptureOrderRequestWithSpecialCharactersInStrings() throws Exception {
-
-        DateTime date = new DateTime(2013, 2, 23, 0, 0);
+        var date = LocalDate.of(2013, 2, 23);
 
         GatewayOrder actualRequest = aWorldpayCaptureOrderRequestBuilder()
                 .withDate(date)


### PR DESCRIPTION
Stop using Joda-Time’s `DateTime` to represent the requested date to capture a payment when a capture request is created to send to Worldpay.

While the direct `java.time` equivalent of Joda-Time’s `DateTime` is `ZonedDateTime`, use `LocalDate` instead because only the date component is actually used. Retain the behaviour of determining the current date based what the day is right now in the UTC time zone.

Stop setting a capture date altogether for authorisation requests to Worldpay because it’s never used and doesn’t end up in the final payload sent to Worldpay.

In addition to the usual automated test suite, also ran the contract test that connects to Worldpay and inspected the generated capture request XML to make sure it looks good.

Also remove `jackson-datatype-joda` dependency from the POM because it’s not used.