### PR TITLE
PP-7242 Use new CardExpiryDate type instead of strings

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-08-27T11:52:59Z",
+  "generated_at": "2020-10-01T14:37:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -184,7 +184,7 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 496,
+        "line_number": 497,
         "type": "Base64 High Entropy String"
       }
     ],
@@ -193,28 +193,28 @@
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 147,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 148,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "c272ed583c5dfbb2013e22812d200068997d5969",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 155,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "9c98d4fa9b3055dede39101f223aa53c2b830d95",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 156,
+        "line_number": 157,
         "type": "Base64 High Entropy String"
       }
     ],
@@ -241,14 +241,14 @@
         "hashed_secret": "7e0a1242bd8ef9044f27dca45f5f72ad5a1125bf",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 149,
+        "line_number": 137,
         "type": "Hex High Entropy String"
       },
       {
         "hashed_secret": "61407b57b06661de9d8f2858e0e5917fb6b55e48",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 160,
+        "line_number": 148,
         "type": "Hex High Entropy String"
       }
     ],

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.7</eclipselink.version>
         <guice.version>4.2.3</guice.version>
         <jackson.version>2.11.2</jackson.version>
-        <pay-java-commons.version>1.0.20200930144312</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20201001124822</pay-java-commons.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <javax.persistence.version>2.2.1</javax.persistence.version>
         <jooq.version>3.13.4</jooq.version>

--- a/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/CardDetailsEntity.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.charge.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.commons.jpa.CardExpiryDateConverter;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
@@ -40,8 +42,10 @@ public class CardDetailsEntity {
     private String cardHolderName;
 
     @Column(name = "expiry_date")
+    @Convert(converter = CardExpiryDateConverter.class)
     @JsonProperty("expiry_date")
-    private String expiryDate;
+    @JsonSerialize(using = ToStringSerializer.class)
+    private CardExpiryDate expiryDate;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "card_brand", referencedColumnName = "brand", updatable = false, insertable = false)
@@ -63,7 +67,8 @@ public class CardDetailsEntity {
     public CardDetailsEntity() {
     }
     
-    public CardDetailsEntity(LastDigitsCardNumber lastDigitsCardNumber, FirstDigitsCardNumber firstDigitsCardNumber, String cardHolderName, String expiryDate, String cardBrand, CardType cardType) {
+    public CardDetailsEntity(LastDigitsCardNumber lastDigitsCardNumber, FirstDigitsCardNumber firstDigitsCardNumber, String cardHolderName,
+                             CardExpiryDate expiryDate, String cardBrand, CardType cardType) {
         this.lastDigitsCardNumber = lastDigitsCardNumber;
         this.firstDigitsCardNumber = firstDigitsCardNumber;
         this.cardHolderName = cardHolderName;
@@ -72,7 +77,8 @@ public class CardDetailsEntity {
         this.cardType = cardType;
     }
 
-    public CardDetailsEntity(FirstDigitsCardNumber firstDigitsCardNumber, LastDigitsCardNumber lastDigitsCardNumber, String cardHolderName, String expiryDate, String cardBrand, CardType cardType, AddressEntity billingAddress) {
+    public CardDetailsEntity(FirstDigitsCardNumber firstDigitsCardNumber, LastDigitsCardNumber lastDigitsCardNumber, String cardHolderName,
+                             CardExpiryDate expiryDate, String cardBrand, CardType cardType, AddressEntity billingAddress) {
         this.lastDigitsCardNumber = lastDigitsCardNumber;
         this.firstDigitsCardNumber = firstDigitsCardNumber;
         this.cardHolderName = cardHolderName;
@@ -118,11 +124,11 @@ public class CardDetailsEntity {
         this.cardHolderName = cardHolder;
     }
 
-    public String getExpiryDate() {
+    public CardExpiryDate getExpiryDate() {
         return expiryDate;
     }
 
-    public void setExpiryDate(String expiryDate) {
+    public void setExpiryDate(CardExpiryDate expiryDate) {
         this.expiryDate = expiryDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/PersistedCard.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/PersistedCard.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
@@ -27,7 +28,8 @@ public class PersistedCard {
     private String cardHolderName;
 
     @JsonProperty("expiry_date")
-    private String expiryDate;
+    @JsonSerialize(using = ToStringSerializer.class)
+    private CardExpiryDate expiryDate;
 
     @JsonProperty("billing_address")
     private Address billingAddress;
@@ -72,11 +74,11 @@ public class PersistedCard {
         this.cardHolderName = cardHolderName;
     }
 
-    public String getExpiryDate() {
+    public CardExpiryDate getExpiryDate() {
         return expiryDate;
     }
 
-    public void setExpiryDate(String expiryDate) {
+    public void setExpiryDate(CardExpiryDate expiryDate) {
         this.expiryDate = expiryDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -4,6 +4,7 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
@@ -172,7 +173,7 @@ public class ChargeService {
                     LastDigitsCardNumber.ofNullable(telephoneChargeRequest.getLastFourDigits().orElse(null)),
                     FirstDigitsCardNumber.ofNullable(telephoneChargeRequest.getFirstSixDigits().orElse(null)),
                     telephoneChargeRequest.getNameOnCard().orElse(null),
-                    telephoneChargeRequest.getCardExpiry().orElse(null),
+                    telephoneChargeRequest.getCardExpiry().map(CardExpiryDate::valueOf).orElse(null),
                     telephoneChargeRequest.getCardType().orElse(null),
                     null
             );

--- a/src/main/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/validation/telephone/CardExpiryValidator.java
@@ -1,20 +1,15 @@
 package uk.gov.pay.connector.charge.validation.telephone;
 
+import uk.gov.pay.commons.model.CardExpiryDate;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import java.util.regex.Pattern;
 
 public class CardExpiryValidator implements ConstraintValidator<ValidCardExpiryDate, String> {
 
-    private Pattern pattern = Pattern.compile("(0[1-9]|1[0-2])\\/[0-9]{2}");
-
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
-
-        if(value == null) {
-            return true;
-        }
-        
-        return pattern.matcher(value).matches();
+        return value == null || CardExpiryDate.CARD_EXPIRY_DATE_PATTERN.matcher(value).matches();
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/AuthCardDetailsValidator.java
@@ -16,7 +16,6 @@ public class AuthCardDetailsValidator implements ConstraintValidator<ValidAuthCa
     private static final Pattern TWELVE_TO_NINETEEN_DIGITS = compile("[0-9]{12,19}");
     private static final Pattern THREE_TO_FOUR_DIGITS = compile("[0-9]{3,4}");
     private static final Pattern THREE_TO_FOUR_DIGITS_POSSIBLY_SURROUNDED_BY_WHITESPACE = compile("\\s*[0-9]{3,4}\\s*");
-    private static final Pattern EXPIRY_DATE = compile("[0-9]{2}/[0-9]{2}");
     private static final Pattern CONTAINS_MORE_THAN_11_NOT_NECESSARILY_CONTIGUOUS_DIGITS = compile(".*([0-9].*){12,}");
     private static final short MAX_LENGTH = 255;
 
@@ -35,7 +34,6 @@ public class AuthCardDetailsValidator implements ConstraintValidator<ValidAuthCa
     private static boolean isWellFormatted(AuthCardDetails authCardDetails) {
         return isValidCardNumberLength(authCardDetails.getCardNo()) &&
                 isBetween3To4Digits(authCardDetails.getCvc()) &&
-                hasExpiryDateFormat(authCardDetails.getEndDate()) &&
                 hasCardBrand(authCardDetails.getCardBrand()) &&
                 unlikelyToContainACardNumber(authCardDetails.getCardBrand()) &&
                 isAddressValid(authCardDetails) &&
@@ -75,10 +73,6 @@ public class AuthCardDetailsValidator implements ConstraintValidator<ValidAuthCa
 
     private static boolean isBetween3To4Digits(String number) {
         return notNullAndMatches(THREE_TO_FOUR_DIGITS, number);
-    }
-
-    private static boolean hasExpiryDateFormat(String date) {
-        return notNullAndMatches(EXPIRY_DATE, date);
     }
 
     private static boolean addressUnlikelyToContainACardNumber(Address address) {

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
@@ -78,7 +79,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
                                     .orElse(null)
                             )
                             .withCardholderName(cardDetails.getCardHolderName())
-                            .withExpiryDate(cardDetails.getExpiryDate())
+                            .withExpiryDate(Optional.ofNullable(cardDetails.getExpiryDate()).map(CardExpiryDate::toString).orElse(null))
                             .withAddressLine1(cardDetails.getBillingAddress().map(AddressEntity::getLine1).orElse(null))
                             .withAddressLine2(cardDetails.getBillingAddress().map(AddressEntity::getLine2).orElse(null))
                             .withAddressCity(cardDetails.getBillingAddress().map(AddressEntity::getCity).orElse(null))

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
@@ -1,12 +1,18 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
+import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
+import uk.gov.pay.connector.charge.model.CardDetailsEntity;
+import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
+import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 public class PaymentNotificationCreatedEventDetails extends EventDetails {
 
@@ -55,44 +61,24 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
     }
 
     public static PaymentNotificationCreatedEventDetails from(ChargeEntity charge) {
-            String firstDigitsCardNumber = null;
-            String lastDigitsCardNumber = null;
-            String cardHolderName = null;
-            String expiryDate = null;
-            String cardBrand = null;
-            String cardBrandLabel = null;
-
-            if (charge.getCardDetails() != null) {
-                if (charge.getCardDetails().getLastDigitsCardNumber() != null) {
-                    lastDigitsCardNumber = charge.getCardDetails().getLastDigitsCardNumber().toString();
-                }
-                if (charge.getCardDetails().getFirstDigitsCardNumber() != null) {
-                    firstDigitsCardNumber = charge.getCardDetails().getFirstDigitsCardNumber().toString();
-                }
-                cardHolderName = charge.getCardDetails().getCardHolderName();
-                expiryDate = charge.getCardDetails().getExpiryDate();
-                cardBrand = charge.getCardDetails().getCardBrand();
-                if (charge.getCardDetails().getCardTypeDetails().isPresent()) {
-                    cardBrandLabel = charge.getCardDetails().getCardTypeDetails().get().getLabel();
-                }
-            }
-            return new PaymentNotificationCreatedEventDetails(charge.getGatewayAccount().getId(),
-                    charge.getAmount(),
-                    charge.getReference().toString(),
-                    charge.getDescription(),
-                    charge.getGatewayTransactionId(),
-                    firstDigitsCardNumber,
-                    lastDigitsCardNumber,
-                    cardHolderName,
-                    charge.getEmail(),
-                    expiryDate,
-                    cardBrand,
-                    cardBrandLabel,
-                    charge.getGatewayAccount().isLive(),
-                    charge.getGatewayAccount().getGatewayName(),
-                    charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null),
-                    charge.getSource(),
-                    charge.getLanguage().toString());
+        Optional<CardDetailsEntity> cardDetails = Optional.ofNullable(charge.getCardDetails());
+        return new PaymentNotificationCreatedEventDetails(charge.getGatewayAccount().getId(),
+                charge.getAmount(),
+                charge.getReference().toString(),
+                charge.getDescription(),
+                charge.getGatewayTransactionId(),
+                cardDetails.map(CardDetailsEntity::getFirstDigitsCardNumber).map(FirstDigitsCardNumber::toString).orElse(null),
+                cardDetails.map(CardDetailsEntity::getLastDigitsCardNumber).map(LastDigitsCardNumber::toString).orElse(null),
+                cardDetails.map(CardDetailsEntity::getCardHolderName).orElse(null),
+                charge.getEmail(),
+                cardDetails.map(CardDetailsEntity::getExpiryDate).map(CardExpiryDate::toString).orElse(null),
+                cardDetails.map(CardDetailsEntity::getCardBrand).orElse(null),
+                cardDetails.flatMap(CardDetailsEntity::getCardTypeDetails).map(CardBrandLabelEntity::getLabel).orElse(null),
+                charge.getGatewayAccount().isLive(),
+                charge.getGatewayAccount().getGatewayName(),
+                charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null),
+                charge.getSource(),
+                charge.getLanguage().toString());
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3dsOrder.java
@@ -45,7 +45,7 @@ public class EpdqPayloadDefinitionForNew3dsOrder extends EpdqPayloadDefinitionFo
                 .add(CVC_KEY, getAuthCardDetails().getCvc())
                 .add(DECLINEURL_KEY, frontend3dsIncomingUrl + "?status=declined")
                 .add(EXCEPTIONURL_KEY, frontend3dsIncomingUrl + "?status=error")
-                .add(EXPIRY_DATE_KEY, getAuthCardDetails().getEndDate())
+                .add(EXPIRY_DATE_KEY, getAuthCardDetails().getEndDate().toString())
                 .add(FLAG3D_KEY, "Y")
                 .add(HTTPACCEPT_KEY, getBrowserAcceptHeader())
                 .add(HTTPUSER_AGENT_KEY, getBrowserUserAgent())

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNewOrder.java
@@ -90,7 +90,7 @@ public class EpdqPayloadDefinitionForNewOrder extends EpdqPayloadDefinition {
                 .add(CARDHOLDER_NAME_KEY, authCardDetails.getCardHolder())
                 .add(CURRENCY_KEY, "GBP")
                 .add(CVC_KEY, authCardDetails.getCvc())
-                .add(EXPIRY_DATE_KEY, authCardDetails.getEndDate())
+                .add(EXPIRY_DATE_KEY, authCardDetails.getEndDate().toString())
                 .add(OPERATION_KEY, "RES")
                 .add(ORDER_ID_KEY, orderId);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -1,10 +1,11 @@
 package uk.gov.pay.connector.gateway.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.common.model.domain.Address;
 
-import java.time.YearMonth;
-import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.model.PayersCardType.CREDIT_OR_DEBIT;
@@ -15,7 +16,7 @@ public class AuthCardDetails implements AuthorisationDetails {
     private String cardNo;
     private String cardHolder;
     private String cvc;
-    private String endDate;
+    private CardExpiryDate endDate;
     private Address address;
     private String cardBrand;
     private String userAgentHeader;
@@ -92,7 +93,8 @@ public class AuthCardDetails implements AuthorisationDetails {
     }
 
     @JsonProperty("expiry_date")
-    public void setEndDate(String endDate) {
+    @JsonSerialize(using = ToStringSerializer.class)
+    public void setEndDate(CardExpiryDate endDate) {
         this.endDate = endDate;
     }
 
@@ -148,18 +150,8 @@ public class AuthCardDetails implements AuthorisationDetails {
         return cvc;
     }
 
-    public String getEndDate() {
+    public CardExpiryDate getEndDate() {
         return endDate;
-    }
-
-    public String expiryMonth() {
-        YearMonth yearMonth = YearMonth.parse(endDate, DateTimeFormatter.ofPattern("MM/yy"));
-        return String.valueOf(yearMonth.getMonthValue());
-    }
-
-    public String expiryYear() {
-        YearMonth yearMonth = YearMonth.parse(endDate, DateTimeFormatter.ofPattern("MM/yy"));
-        return String.valueOf(yearMonth.getYear()).substring(2, 4);
     }
 
     public Optional<Address> getAddress() {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequest.java
@@ -2,19 +2,14 @@ package uk.gov.pay.connector.gateway.stripe.request;
 
 import org.apache.commons.lang3.StringUtils;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.charge.model.AddressEntity;
-import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.northamericaregion.CanadaPostalcodeToProvinceOrTerritoryMapper;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
-import uk.gov.pay.connector.northamericaregion.UsZipCodeToStateMapper;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 public class StripePaymentMethodRequest extends StripeRequest {
@@ -44,8 +39,8 @@ public class StripePaymentMethodRequest extends StripeRequest {
     @Override
     protected Map<String, String> params() {
         Map<String, String> localParams = new HashMap<>();
-        localParams.put("card[exp_month]", authCardDetails.expiryMonth());
-        localParams.put("card[exp_year]", authCardDetails.expiryYear());
+        localParams.put("card[exp_month]", Integer.valueOf(authCardDetails.getEndDate().getTwoDigitMonth()).toString());
+        localParams.put("card[exp_year]", authCardDetails.getEndDate().getTwoDigitYear());
         localParams.put("card[number]", authCardDetails.getCardNo());
         localParams.put("card[cvc]", authCardDetails.getCvc());
         localParams.put("billing_details[name]", authCardDetails.getCardHolder());

--- a/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.charge.model.AddressEntity;
@@ -131,7 +132,9 @@ public class ChargeParityChecker {
                     cardDetailsEntity.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null),
                     isEmpty(ledgerCardDetails.getCardBrand()) ? null : ledgerCardDetails.getCardBrand(),
                     "card_brand");
-            fieldsMatch = fieldsMatch && isEquals(cardDetailsEntity.getExpiryDate(), ledgerCardDetails.getExpiryDate(), "expiry_date");
+            fieldsMatch = fieldsMatch && isEquals(
+                    Optional.of(cardDetailsEntity.getExpiryDate()).map(CardExpiryDate::toString).orElse(null),
+                    ledgerCardDetails.getExpiryDate(), "expiry_date");
 
             String cardType = null;
             if (cardDetailsEntity.getCardType() != null) {

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -6,6 +6,7 @@ import com.google.inject.persist.Transactional;
 import io.dropwizard.setup.Environment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
@@ -177,8 +178,7 @@ public class WalletAuthoriseService {
         authCardDetails.setCardNo(walletAuthorisationData.getPaymentInfo().getLastDigitsCardNumber());
         authCardDetails.setPayersCardType(walletAuthorisationData.getPaymentInfo().getCardType());
         authCardDetails.setCardBrand(walletAuthorisationData.getPaymentInfo().getBrand());
-        walletAuthorisationData.getCardExpiryDate().ifPresent(
-                cardExpiry -> authCardDetails.setEndDate(cardExpiry.format(EXPIRY_DATE_FORMAT)));
+        walletAuthorisationData.getCardExpiryDate().map(EXPIRY_DATE_FORMAT::format).map(CardExpiryDate::valueOf).ifPresent(authCardDetails::setEndDate);
         authCardDetails.setCorporateCard(false);
         return authCardDetails;
     }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -3,6 +3,7 @@
     <persistence-unit name="ConnectorUnit" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>uk.gov.pay.commons.model.SupportedLanguageJpaConverter</class>
+        <class>uk.gov.pay.commons.jpa.CardExpiryDateConverter</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/templates/smartpay/Smartpay3dsRequiredOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/Smartpay3dsRequiredOrderTemplate.xml
@@ -23,8 +23,8 @@
                 </ns1:amount>
                 <ns1:card>
                     <ns1:cvc>${authCardDetails.cvc}</ns1:cvc>
-                    <ns1:expiryMonth>${authCardDetails.endDate?split('/')?first}</ns1:expiryMonth>
-                    <ns1:expiryYear>20${authCardDetails.endDate?split('/')?last}</ns1:expiryYear>
+                    <ns1:expiryMonth>${authCardDetails.endDate.twoDigitMonth?xml}</ns1:expiryMonth>
+                    <ns1:expiryYear>${authCardDetails.endDate.fourDigitYear?xml}</ns1:expiryYear>
                     <ns1:holderName>${authCardDetails.cardHolder?xml}</ns1:holderName>
                     <ns1:number>${authCardDetails.cardNo}</ns1:number>
                     <#if authCardDetails.address.isPresent()>

--- a/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
@@ -12,8 +12,8 @@
                 </ns1:amount>
                 <ns1:card>
                     <ns1:cvc>${authCardDetails.cvc}</ns1:cvc>
-                    <ns1:expiryMonth>${authCardDetails.endDate?split('/')?first}</ns1:expiryMonth>
-                    <ns1:expiryYear>20${authCardDetails.endDate?split('/')?last}</ns1:expiryYear>
+                    <ns1:expiryMonth>${authCardDetails.endDate.twoDigitMonth?xml}</ns1:expiryMonth>
+                    <ns1:expiryYear>${authCardDetails.endDate.fourDigitYear?xml}</ns1:expiryYear>
                     <ns1:holderName>${authCardDetails.cardHolder?xml}</ns1:holderName>
                     <ns1:number>${authCardDetails.cardNo}</ns1:number>
                     <#if authCardDetails.address.isPresent()>

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -10,7 +10,7 @@
                 <VISA-SSL>
                     <cardNumber>${authCardDetails.cardNo}</cardNumber>
                     <expiryDate>
-                        <date month="${authCardDetails.endDate?split('/')?first}" year="20${authCardDetails.endDate?split('/')?last}"/>
+                        <date month="${authCardDetails.endDate.twoDigitMonth?xml}" year="${authCardDetails.endDate.fourDigitYear?xml}"/>
                     </expiryDate>
                     <cardHolderName>${authCardDetails.cardHolder?xml}</cardHolderName>
                     <cvc>${authCardDetails.cvc}</cvc>

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
@@ -78,7 +79,7 @@ public class ChargeEntityFixture {
 
         cardDetailsEntity.setCardHolderName("Test");
         cardDetailsEntity.setCardBrand("visa");
-        cardDetailsEntity.setExpiryDate("11/99");
+        cardDetailsEntity.setExpiryDate(CardExpiryDate.valueOf("11/99"));
         cardDetailsEntity.setFirstDigitsCardNumber(FirstDigitsCardNumber.of("123456"));
         cardDetailsEntity.setLastDigitsCardNumber(LastDigitsCardNumber.of("1234"));
         cardDetailsEntity.setCardType(CardType.DEBIT);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.exparity.hamcrest.date.ZonedDateTimeMatchers;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
@@ -85,7 +86,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 LastDigitsCardNumber.of("1234"),
                 FirstDigitsCardNumber.of("123456"),
                 "Jane Doe",
-                "01/19",
+                CardExpiryDate.valueOf("01/19"),
                 "visa",
                 CardType.valueOf("DEBIT")
         );
@@ -126,7 +127,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(telephoneChargeResponse.get().getCardDetails().getCardBrand(), is("visa"));
         assertThat(telephoneChargeResponse.get().getCardDetails().getCardHolderName(), is("Jane Doe"));
         assertThat(telephoneChargeResponse.get().getEmail(), is("jane.doe@example.com"));
-        assertThat(telephoneChargeResponse.get().getCardDetails().getExpiryDate(), is("01/19"));
+        assertThat(telephoneChargeResponse.get().getCardDetails().getExpiryDate().toString(), is("01/19"));
         assertThat(telephoneChargeResponse.get().getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(telephoneChargeResponse.get().getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(telephoneChargeResponse.get().getTelephoneNumber(), is("+447700900796"));
@@ -514,7 +515,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
-        assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
+        assertThat(createdChargeEntity.getCardDetails().getExpiryDate().toString(), is("01/19"));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
         assertThat(createdChargeEntity.getCardDetails().getCardType(), is(nullValue()));
         assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
@@ -676,7 +677,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
-        assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
+        assertThat(createdChargeEntity.getCardDetails().getExpiryDate().toString(), is("01/19"));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
         assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
@@ -732,7 +733,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
-        assertThat(createdChargeEntity.getCardDetails().getExpiryDate(), is("01/19"));
+        assertThat(createdChargeEntity.getCardDetails().getExpiryDate().toString(), is("01/19"));
         assertThat(createdChargeEntity.getCardDetails().getCardBrand(), is("visa"));
         assertThat(createdChargeEntity.getGatewayTransactionId(), is("1PROV"));
         assertThat(createdChargeEntity.getExternalMetadata().get().getMetadata(), equalTo(metadata));
@@ -781,7 +782,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(chargeResponse.getCardDetails().getCardBrand(), is("visa"));
         assertThat(chargeResponse.getCardDetails().getCardHolderName(), is("Jane Doe"));
         assertThat(chargeResponse.getEmail(), is("jane.doe@example.com"));
-        assertThat(chargeResponse.getCardDetails().getExpiryDate(), is("01/19"));
+        assertThat(chargeResponse.getCardDetails().getExpiryDate().toString(), is("01/19"));
         assertThat(chargeResponse.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(chargeResponse.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(chargeResponse.getTelephoneNumber(), is("+447700900796"));

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
 import org.mockito.Mock;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.GatewayConfig;
 import uk.gov.pay.connector.app.LinksConfig;
@@ -368,7 +369,7 @@ public abstract class BaseEpdqPaymentProviderIT {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("5555444433331111")
                 .withCvc("737")
-                .withEndDate("08/18")
+                .withEndDate(CardExpiryDate.valueOf("08/18"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3dsOrder;
@@ -55,7 +56,7 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
 
     private static final String CARD_NO = "4242424242424242";
     private static final String CVC = "321";
-    private static final String END_DATE = "01/18";
+    private static final CardExpiryDate END_DATE = CardExpiryDate.valueOf("01/18");
 
     private static final String AMOUNT = "500";
     private static final String CURRENCY = "GBP";
@@ -127,7 +128,7 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("5555444433331111")
                 .withCvc("737")
-                .withEndDate("08/18")
+                .withEndDate(CardExpiryDate.valueOf("08/18"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();
@@ -149,7 +150,7 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
                 new BasicNameValuePair(CURRENCY_KEY, CURRENCY),
                 new BasicNameValuePair(CVC_KEY, CVC),
                 new BasicNameValuePair(DECLINEURL_KEY, expectedFrontend3dsIncomingUrl + "?status=declined"),
-                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE),
+                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE.toString()),
                 new BasicNameValuePair(EXCEPTIONURL_KEY, expectedFrontend3dsIncomingUrl + "?status=error"),
                 new BasicNameValuePair(FLAG3D_KEY, "Y"),
                 new BasicNameValuePair(HTTPACCEPT_KEY, ACCEPT_HEADER),
@@ -185,7 +186,7 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
                 new BasicNameValuePair(CURRENCY_KEY, CURRENCY),
                 new BasicNameValuePair(CVC_KEY, CVC),
                 new BasicNameValuePair(DECLINEURL_KEY, expectedFrontend3dsIncomingUrl + "?status=declined"),
-                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE),
+                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE.toString()),
                 new BasicNameValuePair(EXCEPTIONURL_KEY, expectedFrontend3dsIncomingUrl + "?status=error"),
                 new BasicNameValuePair(FLAG3D_KEY, "Y"),
                 new BasicNameValuePair(HTTPACCEPT_KEY, ACCEPT_HEADER),
@@ -220,7 +221,7 @@ public class EpdqPayloadDefinitionForNew3dsOrderTest {
                 new BasicNameValuePair(CURRENCY_KEY, CURRENCY),
                 new BasicNameValuePair(CVC_KEY, CVC),
                 new BasicNameValuePair(DECLINEURL_KEY, expectedFrontend3dsIncomingUrl + "?status=declined"),
-                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE),
+                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE.toString()),
                 new BasicNameValuePair(EXCEPTIONURL_KEY, expectedFrontend3dsIncomingUrl + "?status=error"),
                 new BasicNameValuePair(FLAG3D_KEY, "Y"),
                 new BasicNameValuePair(HTTPACCEPT_KEY, ACCEPT_HEADER),

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNewOrder;
@@ -47,7 +48,7 @@ public class EpdqPayloadDefinitionForNewOrderTest {
 
     private static final String CARD_NO = "4242424242424242";
     private static final String CVC = "321";
-    private static final String END_DATE = "01/18";
+    private static final CardExpiryDate END_DATE = CardExpiryDate.valueOf("01/18");
 
     private static final String AMOUNT = "500";
     private static final String CURRENCY = "GBP";
@@ -113,7 +114,7 @@ public class EpdqPayloadDefinitionForNewOrderTest {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("5555444433331111")
                 .withCvc("737")
-                .withEndDate("08/18")
+                .withEndDate(CardExpiryDate.valueOf("08/18"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();
@@ -131,7 +132,7 @@ public class EpdqPayloadDefinitionForNewOrderTest {
                 new BasicNameValuePair(CARDHOLDER_NAME_KEY, CARDHOLDER_NAME),
                 new BasicNameValuePair(CURRENCY_KEY, CURRENCY),
                 new BasicNameValuePair(CVC_KEY, CVC),
-                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE),
+                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE.toString()),
                 new BasicNameValuePair(OPERATION_KEY, OPERATION_TYPE),
                 new BasicNameValuePair(ORDER_ID_KEY, ORDER_ID),
                 new BasicNameValuePair(OWNER_ADDRESS_KEY, ADDRESS_LINE_1),
@@ -157,7 +158,7 @@ public class EpdqPayloadDefinitionForNewOrderTest {
                 new BasicNameValuePair(CARDHOLDER_NAME_KEY, CARDHOLDER_NAME),
                 new BasicNameValuePair(CURRENCY_KEY, CURRENCY),
                 new BasicNameValuePair(CVC_KEY, CVC),
-                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE),
+                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE.toString()),
                 new BasicNameValuePair(OPERATION_KEY, OPERATION_TYPE),
                 new BasicNameValuePair(ORDER_ID_KEY, ORDER_ID),
                 new BasicNameValuePair(OWNER_ADDRESS_KEY, ADDRESS_LINE_1 + ", " + ADDRESS_LINE_2),
@@ -182,7 +183,7 @@ public class EpdqPayloadDefinitionForNewOrderTest {
                 new BasicNameValuePair(CARDHOLDER_NAME_KEY, CARDHOLDER_NAME),
                 new BasicNameValuePair(CURRENCY_KEY, CURRENCY),
                 new BasicNameValuePair(CVC_KEY, CVC),
-                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE),
+                new BasicNameValuePair(EXPIRY_DATE_KEY, END_DATE.toString()),
                 new BasicNameValuePair(OPERATION_KEY, OPERATION_TYPE),
                 new BasicNameValuePair(ORDER_ID_KEY, ORDER_ID),
                 new BasicNameValuePair(PSPID_KEY, PSP_ID),

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java
@@ -9,6 +9,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -74,7 +75,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
     private static final String ORDER_ID = "OrderId";
     private static final String CARD_NO = "4242424242424242";
     private static final String CVC = "321";
-    private static final String END_DATE = "01/18";
+    private static final CardExpiryDate END_DATE = CardExpiryDate.valueOf("01/18");
     private static final String AMOUNT = "500";
     private static final String CURRENCY = "GBP";
     private static final String CARDHOLDER_NAME = "Ms Making A Payment";
@@ -510,7 +511,7 @@ public class EpdqPayloadDefinitionForNew3ds2OrderTest {
                     .add(CURRENCY_KEY, CURRENCY)
                     .add(CVC_KEY, CVC)
                     .add(DECLINEURL_KEY, expectedFrontend3dsIncomingUrl + "?status=declined")
-                    .add(EXPIRY_DATE_KEY, END_DATE)
+                    .add(EXPIRY_DATE_KEY, END_DATE.toString())
                     .add(EXCEPTIONURL_KEY, expectedFrontend3dsIncomingUrl + "?status=error")
                     .add(FLAG3D_KEY, "Y")
                     .add(HTTPACCEPT_KEY, browserAcceptHeader)

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
@@ -4,6 +4,7 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -281,7 +282,7 @@ public class SmartpayOrderRequestBuilderTest {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("5555444433331111")
                 .withCvc("737")
-                .withEndDate("08/18")
+                .withEndDate(CardExpiryDate.valueOf("08/18"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -7,6 +7,7 @@ import io.dropwizard.setup.Environment;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.LinksConfig;
 import uk.gov.pay.connector.app.StripeAuthTokens;
@@ -340,7 +341,7 @@ public class StripePaymentProviderTest {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("4242424242424242")
                 .withCvc("111")
-                .withEndDate("08/99")
+                .withEndDate(CardExpiryDate.valueOf("08/99"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();
@@ -352,7 +353,7 @@ public class StripePaymentProviderTest {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("4242424242424242")
                 .withCvc("111")
-                .withEndDate("08/99")
+                .withEndDate(CardExpiryDate.valueOf("08/99"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -18,7 +19,6 @@ import java.net.URI;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +62,7 @@ public class StripePaymentMethodRequestTest {
         authCardDetails.setCardNo(cardNo);
         authCardDetails.setCardHolder(cardHolder);
         authCardDetails.setCvc(cvc);
-        authCardDetails.setEndDate(endMonth + "/" + endYear);
+        authCardDetails.setEndDate(CardExpiryDate.valueOf(endMonth + "/" + endYear));
 
         CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
 import org.junit.Test;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -314,7 +315,7 @@ public class WorldpayOrderRequestBuilderTest {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("4111111111111111")
                 .withCvc("123")
-                .withEndDate("12/15")
+                .withEndDate(CardExpiryDate.valueOf("12/15"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -12,6 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.w3c.dom.Document;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.GatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.Charge;
@@ -557,7 +558,7 @@ public class WorldpayPaymentProviderTest {
                 .withCardHolder("Mr. Payment")
                 .withCardNo("4111111111111111")
                 .withCvc("123")
-                .withEndDate("12/15")
+                .withEndDate(CardExpiryDate.valueOf("12/15"))
                 .withCardBrand("visa")
                 .withAddress(address)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.it;
 
 import com.google.gson.JsonObject;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 
@@ -9,7 +10,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 public class JsonRequestHelper {
 
     private static final String CVC = "123";
-    private static final String EXPIRY_DATE = "11/99";
+    private static final CardExpiryDate EXPIRY_DATE = CardExpiryDate.valueOf("11/99");
     private static final String CARD_HOLDER_NAME = "Scrooge McDuck";
     private static final String ADDRESS_LINE_1 = "The Money Pool";
     private static final String ADDRESS_CITY = "London";
@@ -31,14 +32,14 @@ public class JsonRequestHelper {
                 null, ADDRESS_CITY, null, ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     }
 
-    public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cvc, String expiryDate, String cardBrand) {
+    public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cvc, CardExpiryDate expiryDate, String cardBrand) {
         return buildJsonAuthorisationDetailsFor(CARD_HOLDER_NAME, cardNumber, cvc, expiryDate, cardBrand, CARD_TYPE, ADDRESS_LINE_1,
                 null, ADDRESS_CITY, null, ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     }
 
     public static String buildDetailedJsonAuthorisationDetailsFor(String cardNumber,
                                                                   String cvc,
-                                                                  String expiryDate,
+                                                                  CardExpiryDate expiryDate,
                                                                   String cardBrand,
                                                                   String cardType,
                                                                   String cardHolderName,
@@ -54,7 +55,7 @@ public class JsonRequestHelper {
     public static String buildJsonAuthorisationDetailsFor(String cardHolderName,
                                                           String cardNumber,
                                                           String cvc,
-                                                          String expiryDate,
+                                                          CardExpiryDate expiryDate,
                                                           String cardBrand,
                                                           String cardType,
                                                           String line1,
@@ -119,7 +120,7 @@ public class JsonRequestHelper {
     private static String buildCorporateJsonAuthorisationDetailsFor(String cardHolderName,
                                                                     String cardNumber,
                                                                     String cvc,
-                                                                    String expiryDate,
+                                                                    CardExpiryDate expiryDate,
                                                                     String cardBrand,
                                                                     String line1,
                                                                     String line2,
@@ -170,7 +171,7 @@ public class JsonRequestHelper {
     private static JsonObject buildJsonAuthorisationDetailsWithoutAddress(String cardHolderName,
                                                                           String cardNumber,
                                                                           String cvc,
-                                                                          String expiryDate,
+                                                                          CardExpiryDate expiryDate,
                                                                           String cardBrand,
                                                                           Boolean isCorporateCard,
                                                                           String payersCardType,
@@ -179,7 +180,7 @@ public class JsonRequestHelper {
         JsonObject authorisationDetails = new JsonObject();
         authorisationDetails.addProperty("card_number", cardNumber);
         authorisationDetails.addProperty("cvc", cvc);
-        authorisationDetails.addProperty("expiry_date", expiryDate);
+        authorisationDetails.addProperty("expiry_date", expiryDate.toString());
         authorisationDetails.addProperty("card_brand", cardBrand);
         authorisationDetails.addProperty("cardholder_name", cardHolderName);
         authorisationDetails.addProperty("accept_header", "text/html");

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -11,6 +11,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
@@ -370,7 +371,8 @@ public class ChargingITestBase {
         addCharge(chargeId, externalChargeId, chargeStatus, reference, fromDate, null);
         databaseTestHelper.addToken(chargeId, "tokenId");
         databaseTestHelper.addEvent(chargeId, chargeStatus.getValue());
-        databaseTestHelper.updateChargeCardDetails(chargeId, cardBrand, "1234", "123456", "Mr. McPayment", "03/18", null, "line1", null, "postcode", "city", null, "country");
+        databaseTestHelper.updateChargeCardDetails(chargeId, cardBrand, "1234", "123456", "Mr. McPayment",
+                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
 
         return externalChargeId;
     }

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
@@ -71,7 +72,7 @@ public class StripePaymentProviderTest {
     public void shouldAuthoriseSuccessfully_WithNoBillingAddress() {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withAddress(null)
-                .withEndDate("01/30")
+                .withEndDate(CardExpiryDate.valueOf("01/30"))
                 .build();
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(), authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request);
@@ -89,7 +90,7 @@ public class StripePaymentProviderTest {
         usAddress.setCountry("US");
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withAddress(usAddress)
-                .withEndDate("01/30")
+                .withEndDate(CardExpiryDate.valueOf("01/30"))
                 .build();
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(), authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request);
@@ -107,7 +108,7 @@ public class StripePaymentProviderTest {
         canadaAddress.setCountry("CA");
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withAddress(canadaAddress)
-                .withEndDate("01/30")
+                .withEndDate(CardExpiryDate.valueOf("01/30"))
                 .build();
         CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(), authCardDetails);
         GatewayResponse gatewayResponse = stripePaymentProvider.authorise(request);
@@ -211,7 +212,8 @@ public class StripePaymentProviderTest {
     }
 
     private GatewayResponse<BaseAuthoriseResponse> authorise() {
-        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(), anAuthCardDetails().withEndDate("01/21").build());
+        CardAuthorisationGatewayRequest request = CardAuthorisationGatewayRequest.valueOf(getCharge(),
+                anAuthCardDetails().withEndDate(CardExpiryDate.valueOf("01/21")).build());
         return stripePaymentProvider.authorise(request);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.it.dao;
 
 import org.junit.Before;
 import org.junit.Test;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.AddressEntity;
@@ -9,12 +10,12 @@ import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AddressFixture;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -121,7 +122,8 @@ public class ChargeDaoCardDetailsIT extends DaoITestBase {
 
         Address billingAddress = AddressFixture.anAddress().build();
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
-        CardDetailsEntity cardDetailsEntity = new CardDetailsEntity(FirstDigitsCardNumber.of("123456"), LastDigitsCardNumber.of("1258"), "Mr. Pay Mc Payment", "03/09", "VISA", CardType.DEBIT, new AddressEntity(billingAddress));
+        CardDetailsEntity cardDetailsEntity = new CardDetailsEntity(FirstDigitsCardNumber.of("123456"), LastDigitsCardNumber.of("1258"),
+                "Mr. Pay Mc Payment", CardExpiryDate.valueOf("03/09"), "VISA", CardType.DEBIT, new AddressEntity(billingAddress));
         chargeEntity.setCardDetails(cardDetailsEntity);
         chargeDao.persist(chargeEntity);
 
@@ -136,7 +138,8 @@ public class ChargeDaoCardDetailsIT extends DaoITestBase {
 
         Address billingAddress = AddressFixture.anAddress().build();
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
-        CardDetailsEntity cardDetailsEntity = new CardDetailsEntity(FirstDigitsCardNumber.of("123456"), LastDigitsCardNumber.of("1258"), "Mr. Pay Mc Payment", "03/09", "VISA", null, new AddressEntity(billingAddress));
+        CardDetailsEntity cardDetailsEntity = new CardDetailsEntity(FirstDigitsCardNumber.of("123456"), LastDigitsCardNumber.of("1258"),
+                "Mr. Pay Mc Payment", CardExpiryDate.valueOf("03/09"), "VISA", null, new AddressEntity(billingAddress));
         chargeEntity.setCardDetails(cardDetailsEntity);
         chargeDao.persist(chargeEntity);
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.it.dao;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.RandomUtils;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
@@ -217,7 +218,7 @@ public class DatabaseFixtures {
         private LastDigitsCardNumber lastDigitsCardNumber = LastDigitsCardNumber.of("1234");
         private FirstDigitsCardNumber firstDigitsCardNumber = FirstDigitsCardNumber.of("123456");
         private String cardHolderName = "Mr. Pay McPayment";
-        private String expiryDate = "02/17";
+        private CardExpiryDate expiryDate = CardExpiryDate.valueOf("02/17");
         private TestAddress billingAddress = new TestAddress();
         private Long chargeId;
         private String cardBrand = "visa";
@@ -238,7 +239,7 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestCardDetails withExpiryDate(String expiryDate) {
+        public TestCardDetails withExpiryDate(CardExpiryDate expiryDate) {
             this.expiryDate = expiryDate;
             return this;
         }
@@ -275,7 +276,7 @@ public class DatabaseFixtures {
             return cardHolderName;
         }
 
-        public String getExpiryDate() {
+        public CardExpiryDate getExpiryDate() {
             return expiryDate;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang.math.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
@@ -76,7 +77,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
 
     @Test
     public void shouldAuthoriseCharge_ForAValidAmericanExpress() {
-        shouldAuthoriseChargeFor(buildJsonAuthorisationDetailsFor("371449635398431", "1234", "11/99", "american-express"));
+        shouldAuthoriseChargeFor(buildJsonAuthorisationDetailsFor("371449635398431", "1234", CardExpiryDate.valueOf("11/99"), "american-express"));
     }
 
     @Test
@@ -97,7 +98,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
                 "Mr. Name",
                 "4444333322221111",
                 "123",
-                "10/99",
+                CardExpiryDate.valueOf("10/99"),
                 "visa",
                 "CREDIT",
                 "Line1",
@@ -120,7 +121,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
         String valueWithMoreThan10CharactersAsNumbers = "r-12-34-5  Ju&^6501-76";
 
         String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor(
-                "4444333322221111", "123", "11/30",
+                "4444333322221111", "123", CardExpiryDate.valueOf("11/30"),
                 valueWithMoreThan10CharactersAsNumbers, "CREDIT", valueWithMoreThan10CharactersAsNumbers,
                 valueWithMoreThan10CharactersAsNumbers, valueWithMoreThan10CharactersAsNumbers,
                 valueWithMoreThan10CharactersAsNumbers, valueWithMoreThan10CharactersAsNumbers,
@@ -146,7 +147,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
         String valueWith10CharactersAsNumbers = "r-12-34-5  Ju&^6501-7m";
 
         String externalChargeId = shouldAuthoriseChargeFor(buildDetailedJsonAuthorisationDetailsFor(
-                "4444333322221111", "123", "11/30",
+                "4444333322221111", "123", CardExpiryDate.valueOf("11/30"),
                 valueWith10CharactersAsNumbers, "CREDIT", valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers,
                 valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers,
                 valueWith10CharactersAsNumbers, valueWith10CharactersAsNumbers));
@@ -216,7 +217,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
     @Test
     public void shouldReturnError_WhenCvcIsMoreThan4Digits() {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
-        String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "12345", "11/99", "visa");
+        String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "12345", CardExpiryDate.valueOf("11/99"), "visa");
 
         shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(chargeId, randomCardNumberDetails);
         assertFrontendChargeStatusIs(chargeId, ENTERING_CARD_DETAILS.getValue());
@@ -225,7 +226,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
     @Test
     public void shouldReturnError_WhenCvcIsLessThan3Digits() {
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
-        String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "12", "11/99", "visa");
+        String randomCardNumberDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "12", CardExpiryDate.valueOf("11/99"), "visa");
 
         shouldContain_valuesDoNotMatchExpectedFormat_errorMessageFor(chargeId, randomCardNumberDetails);
         assertFrontendChargeStatusIs(chargeId, ENTERING_CARD_DETAILS.getValue());
@@ -361,7 +362,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
                         "Charge1 Name",
                         "4242424242424242",
                         "123",
-                        "10/99",
+                        CardExpiryDate.valueOf("10/99"),
                         "visa",
                         "CREDIT",
                         "Charge1 Line1",
@@ -377,7 +378,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
                         "Charge2 Name",
                         "4444333322221111",
                         "456",
-                        "11/99",
+                        CardExpiryDate.valueOf("11/99"),
                         "visa",
                         null,
                         "Charge2 Line1",

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.it.resources;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -224,7 +225,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, mastercardCredit.getBrand(), "1234", "123456", "Mr. McPayment",
-                "03/18", null, "line1", null, "postcode", "city", null, "country");
+                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
         databaseTestHelper.addToken(chargeId, "tokenId");
 
         connectorRestApiClient
@@ -249,7 +250,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "unknown-brand", "1234", "123456", "Mr. McPayment",
-                "03/18", null, "line1", null, "postcode", "city", null, "country");
+                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
         databaseTestHelper.addToken(chargeId, "tokenId");
 
         connectorRestApiClient
@@ -274,7 +275,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "Visa", "1234", "123456", "Mr. McPayment",
-                "03/18", null, null, null, null, null, null, null);
+                CardExpiryDate.valueOf("03/18"), null, null, null, null, null, null, null);
         databaseTestHelper.addToken(chargeId, "tokenId");
 
         connectorRestApiClient
@@ -505,7 +506,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "Visa", "1234", "123456", "Mr. McPayment",
-                "03/18", DEBIT.toString(), null, null, null, null, null, null);
+                CardExpiryDate.valueOf("03/18"), DEBIT.toString(), null, null, null, null, null, null);
         databaseTestHelper.addToken(chargeId, "tokenId");
 
         connectorRestApiClient
@@ -531,7 +532,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "Visa", "1234", "123456", "Mr. McPayment",
-                "03/18", null, null, null, null, null, null, null);
+                CardExpiryDate.valueOf("03/18"), null, null, null, null, null, null, null);
         databaseTestHelper.addToken(chargeId, "tokenId");
 
         connectorRestApiClient
@@ -553,7 +554,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
                 .withReturnUrl(RETURN_URL)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "unknown-brand", "1234", "123456", "Mr. McPayment",
-                "03/18", null, "line1", null, "postcode", "city", null, "country");
+                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
         databaseTestHelper.updateCorporateSurcharge(chargeId, 150L);
         databaseTestHelper.addToken(chargeId, "tokenId");
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -5,12 +5,11 @@ import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
-import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
@@ -20,17 +19,14 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.RestAssuredClient;
 import uk.gov.pay.connector.wallets.WalletType;
 
-import javax.ws.rs.core.HttpHeaders;
 import java.time.ZonedDateTime;
 import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.SECONDS;
-import static java.util.Arrays.asList;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -52,11 +48,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
@@ -212,8 +204,9 @@ public class ChargesFrontendResourceIT {
                 .withDelayedCapture(false)
                 .withEmail(email)
                 .build());
-        databaseTestHelper.updateChargeCardDetails(chargeId, mastercardCredit.getBrand(), "1234", "123456", "Mr. McPayment",
-                "03/18", null, "line1", null, "postcode", "city", null, "country");
+        databaseTestHelper.updateChargeCardDetails(chargeId, mastercardCredit.getBrand(), "1234", "123456",
+                "Mr. McPayment", CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city",
+                null, "country");
         validateGetCharge(expectedAmount, externalChargeId, AUTHORISATION_SUCCESS, false);
     }
 
@@ -233,7 +226,7 @@ public class ChargesFrontendResourceIT {
                 .withEmail(email)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "unknown", "1234", "123456", "Mr. McPayment",
-                "03/18", null, "line1", null, "postcode", "city", null, "country");
+                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
         validateGetCharge(expectedAmount, externalChargeId, AUTHORISATION_SUCCESS, false);
     }
 
@@ -252,7 +245,7 @@ public class ChargesFrontendResourceIT {
                 .withStatus(AUTHORISATION_3DS_REQUIRED)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "unknown", "1234", "123456", "Mr. McPayment",
-                "03/18", null, "line1", null, "postcode", "city", null, "country");
+                CardExpiryDate.valueOf("03/18"), null, "line1", null, "postcode", "city", null, "country");
         databaseTestHelper.updateCharge3dsDetails(chargeId, issuerUrl, paRequest, null);
 
         connectorRestApi
@@ -277,7 +270,7 @@ public class ChargesFrontendResourceIT {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());
         databaseTestHelper.updateChargeCardDetails(chargeId, "unknown", "1234", "123456", "Mr. McPayment",
-                "03/18", null, null, null, null, null, null, null);
+                CardExpiryDate.valueOf("03/18"), null, null, null, null, null, null, null);
 
         connectorRestApi
                 .withChargeId(externalChargeId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
@@ -10,6 +10,7 @@ import io.restassured.response.ValidatableResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -231,7 +232,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
                 "Mr.Payment",
                 "5555444433331111",
                 cvc,
-                "08/18",
+                CardExpiryDate.valueOf("08/18"),
                 "visa",
                 "CREDIT",
                 "The Money Pool", "line 2",

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
@@ -12,6 +12,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -66,8 +67,7 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 public class StripeResourceAuthorizeIT {
     private static final String CARD_HOLDER_NAME = "Scrooge McDuck";
     private static final String CVC = "123";
-    private static final String EXP_MONTH = "11";
-    private static final String EXP_YEAR = "99";
+    private static final CardExpiryDate EXPIRY = CardExpiryDate.valueOf("11/99");
     private static final String CARD_NUMBER = "4242424242424242";
     private static final String AMOUNT = "6234";
     private static final String CARD_TYPE = "CREDIT"; 
@@ -82,7 +82,7 @@ public class StripeResourceAuthorizeIT {
 
     private String stripeAccountId;
     private final String validAuthorisationDetails = buildJsonAuthorisationDetailsFor(CARD_HOLDER_NAME, CARD_NUMBER, CVC,
-            EXP_MONTH + "/" + EXP_YEAR, CARD_BRAND, CARD_TYPE, ADDRESS_LINE_1, ADDRESS_LINE_2, ADDRESS_CITY,
+            EXPIRY, CARD_BRAND, CARD_TYPE, ADDRESS_LINE_1, ADDRESS_LINE_2, ADDRESS_CITY,
             "London", ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     private final String validAuthorisationDetailsWithoutBillingAddress = buildJsonAuthorisationDetailsWithoutAddress();
     private final String validApplePayAuthorisationDetails = buildJsonApplePayAuthorisationDetails("mr payment", "mr@payment.test");

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.model.domain;
 
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
 import uk.gov.pay.connector.charge.model.AddressEntity;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
@@ -15,7 +16,7 @@ public final class AuthCardDetailsFixture {
     private String cardNo = "4242424242424242";
     private String cardHolder = "Mr Test";
     private String cvc = "123";
-    private String endDate = "12/99";
+    private CardExpiryDate endDate = CardExpiryDate.valueOf("12/99");
     private Address address = AddressFixture.anAddress().build();
     private String cardBrand = "visa";
     private String userAgentHeader = "Mozilla/5.0";
@@ -53,7 +54,7 @@ public final class AuthCardDetailsFixture {
         return this;
     }
 
-    public AuthCardDetailsFixture withEndDate(String endDate) {
+    public AuthCardDetailsFixture withEndDate(CardExpiryDate endDate) {
         this.endDate = endDate;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -115,7 +115,7 @@ public class LedgerTransactionFixture {
                     chargeEntityCardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null),
                     ofNullable(chargeEntityCardDetails.getLastDigitsCardNumber()).map(LastDigitsCardNumber::toString).orElse(null),
                     ofNullable(chargeEntityCardDetails.getFirstDigitsCardNumber()).map(FirstDigitsCardNumber::toString).orElse(null),
-                    chargeEntityCardDetails.getExpiryDate(),
+                    chargeEntityCardDetails.getExpiryDate().toString(),
                     ofNullable(chargeEntityCardDetails.getCardType()).map(cardType -> cardType.toString().toLowerCase()).orElse(null)
             );
 

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -11,6 +11,7 @@ import org.apache.commons.lang.math.RandomUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -137,7 +138,8 @@ public class ContractTest {
                 .withEmail("test@test.com")
                 .withDelayedCapture(delayedCapture)
                 .build());
-        dbHelper.updateChargeCardDetails(chargeId, "visa", lastDigitsCardNumber, firstDigitsCardNumber, cardHolderName, "08/23", String.valueOf(DEBIT),
+        dbHelper.updateChargeCardDetails(chargeId, "visa", lastDigitsCardNumber, firstDigitsCardNumber, cardHolderName,
+                CardExpiryDate.valueOf("08/23"), String.valueOf(DEBIT),
                 "aFirstAddress", "aSecondLine", "aPostCode", "aCity", "aCounty", "aCountry");
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
@@ -530,7 +531,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         String cardholderName = "Mr Bright";
         String cardNumber = "4242424242424242";
         String cvc = "123";
-        String expiryDate = "12/23";
+        CardExpiryDate expiryDate = CardExpiryDate.valueOf("12/23");
         String cardBrand = "visa";
         String addressLine1 = "Line 1";
         String addressLine2 = "Line 1";

--- a/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java
@@ -77,17 +77,6 @@ public class AuthCardDetailsValidatorTest {
     }
 
     @Test
-    public void validationFailsForMissingExpiryDate() {
-        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
-                .withEndDate(null)
-                .build();
-
-        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
-        assertEquals(1, violations.size());
-        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
-    }
-
-    @Test
     public void validationFailsForMissingCardBrand() {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCardBrand(null)
@@ -103,7 +92,6 @@ public class AuthCardDetailsValidatorTest {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCardNo("")
                 .withCvc("")
-                .withEndDate("")
                 .withCardBrand("")
                 .build();
 
@@ -191,17 +179,6 @@ public class AuthCardDetailsValidatorTest {
     public void validationFailsForCVCwithLessThan3Digits() {
         AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
                 .withCvc("12")
-                .build();
-
-        Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);
-        assertEquals(1, violations.size());
-        assertEquals("Values do not match expected format/length.", violations.iterator().next().getMessage());
-    }
-
-    @Test
-    public void validationFailsForExpiryDateWithWrongFormat() {
-        AuthCardDetails authCardDetails = AuthCardDetailsFixture.anAuthCardDetails()
-                .withEndDate("1290")
                 .build();
 
         Set<ConstraintViolation<AuthCardDetails>> violations = validator.validate(authCardDetails);

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang.math.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.postgresql.util.PGobject;
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
@@ -212,8 +213,9 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void updateChargeCardDetails(Long chargeId, String cardBrand, String lastDigitsCardNumber, String firstDigitsCardNumber, String cardHolderName, String expiryDate, String cardType,
-                                        String line1, String line2, String postcode, String city, String county, String country) {
+    public void updateChargeCardDetails(Long chargeId, String cardBrand, String lastDigitsCardNumber, String firstDigitsCardNumber, String cardHolderName,
+                                        CardExpiryDate expiryDate, String cardType, String line1, String line2, String postcode, String city, String county,
+                                        String country) {
         jdbi.withHandle(handle ->
                 handle
                         .createUpdate("UPDATE charges SET card_brand=:card_brand, last_digits_card_number=:last_digits_card_number, first_digits_card_number=:first_digits_card_number, cardholder_name=:cardholder_name, expiry_date=:expiry_date, address_line1=:address_line1, address_line2=:address_line2, address_postcode=:address_postcode, address_city=:address_city, address_county=:address_county, address_country=:address_country, card_type=:card_type WHERE id=:id")
@@ -222,7 +224,7 @@ public class DatabaseTestHelper {
                         .bind("last_digits_card_number", lastDigitsCardNumber)
                         .bind("first_digits_card_number", firstDigitsCardNumber)
                         .bind("cardholder_name", cardHolderName)
-                        .bind("expiry_date", expiryDate)
+                        .bind("expiry_date", expiryDate.toString())
                         .bind("address_line1", line1)
                         .bind("address_line2", line2)
                         .bind("address_postcode", postcode)

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -356,7 +356,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
         assertThat(cardDetails.getCardHolderName(), is("Mr. Payment"));
         assertThat(cardDetails.getCardBrand(), is("visa"));
-        assertThat(cardDetails.getExpiryDate(), is("12/23"));
+        assertThat(cardDetails.getExpiryDate().toString(), is("12/23"));
         assertThat(cardDetails.getLastDigitsCardNumber().toString(), is("4242"));
         assertThat(cardDetails.getFirstDigitsCardNumber(), is(nullValue()));
         assertThat(cardDetails.getBillingAddress().isPresent(), is(false));


### PR DESCRIPTION
Use the new `CardExpiryDate` instead of strings in most places in connector to represent card expiry dates.

This does not change how card expiry dates are represented in the API (in either requests or responses), nor does it change how card expiry dates are formatted when sent to payment gateways, nor does it change how card expiry dates are stored in the database.

Due to the limitations of our current validation mechanism, there is a change what happens when an invalid expiry date is supplied to `/v1/frontend/charges/{chargeId}/cards`. Previously the validator would catch it and return a 400 response with a friendly error message. Now it will fail when Jersey tries to deserialise it into a `CardExpiryDate` object and a 400 response will be returned with an exception message. This should be OK because only frontend calls this endpoint and only for regular card payments (not Apple Pay or Google Pay) and it has its own validation (tightened in PP-7080) so should never send invalid expiry dates. The format required by `CardExpiryDate` is actually stricter than the previous validation that was in place for this endpoint but since frontend should only send valid expiry dates this make no difference.

`/v1/api/accounts/{accountId}/telephone-charges` continues to deserialise the expiry date to a string. It is only converted to a `CardExpiryDate` object later, after the endpoint has performed its own validation, which allows card expiry dates in the exact same format as required by `CardExpiryDate` (and now it actually uses `CardExpiryDate`’s code to check the format). Therefore the behaviour of this endpoint when supplied with an invalid expiry date should not have changed.

The mechanism by which 2-digit years are made into 4-digit years by prefixing them with “20” when sending them in authorisation requests to Worldpay and Smartpay remains but this logic is now encapsulated in `CardExpiryDate` rather than in the Freemarker XML templates.

Prior to this change, an expiry date associated with a payment was converted to a string when retrieved from the database. Now it is immediately converted to a `CardExpiryDate` object, which will fail if the expiry date in the database is not in the required format. A check of all the expiry dates stored in the production database a couple of days ago confirmed that all are in the correct format and we do not expect this to have changed since then due to the existing validation we have in place in connector and frontend.

Expiry dates in payments retrieved from ledger remain as strings, as is the convention in this area of code (in addition, we haven’t verified that every expiry date in the ledger database matches the required format). Expiry dates that are sent to ledger in events are converted to strings prior to the event object being serialised to JSON; again, this matches the existing conventions in this area of code.

In addition to the automated tests, I tested this by creating a payment, filling in the card details and checking the database and the API response to make sure the expiry date matched the existing format. I also threw a payload at `/v1/frontend/charges/{chargeId}/cards` to verify that it deserialised valid expiry dates and gave an error for invalid ones.