### PR TITLE
PP-7242 Add test to check invalid card expiry date still rejected

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -24,22 +24,22 @@ public class JsonRequestHelper {
     private static final PayersCardPrepaidStatus PREPAID_STATUS = PayersCardPrepaidStatus.NOT_PREPAID;
 
     public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cardBrand) {
-        return buildJsonAuthorisationDetailsFor(cardNumber, CVC, EXPIRY_DATE, cardBrand);
+        return buildJsonAuthorisationDetailsFor(cardNumber, CVC, EXPIRY_DATE.toString(), cardBrand);
     }
 
     public static String buildJsonAuthorisationDetailsFor(String cardHolderName, String cardNumber, String cardBrand) {
-        return buildJsonAuthorisationDetailsFor(cardHolderName, cardNumber, CVC, EXPIRY_DATE, cardBrand, CARD_TYPE, ADDRESS_LINE_1,
+        return buildJsonAuthorisationDetailsFor(cardHolderName, cardNumber, CVC, EXPIRY_DATE.toString(), cardBrand, CARD_TYPE, ADDRESS_LINE_1,
                 null, ADDRESS_CITY, null, ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     }
 
-    public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cvc, CardExpiryDate expiryDate, String cardBrand) {
+    public static String buildJsonAuthorisationDetailsFor(String cardNumber, String cvc, String expiryDate, String cardBrand) {
         return buildJsonAuthorisationDetailsFor(CARD_HOLDER_NAME, cardNumber, cvc, expiryDate, cardBrand, CARD_TYPE, ADDRESS_LINE_1,
                 null, ADDRESS_CITY, null, ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     }
 
     public static String buildDetailedJsonAuthorisationDetailsFor(String cardNumber,
                                                                   String cvc,
-                                                                  CardExpiryDate expiryDate,
+                                                                  String expiryDate,
                                                                   String cardBrand,
                                                                   String cardType,
                                                                   String cardHolderName,
@@ -55,7 +55,7 @@ public class JsonRequestHelper {
     public static String buildJsonAuthorisationDetailsFor(String cardHolderName,
                                                           String cardNumber,
                                                           String cvc,
-                                                          CardExpiryDate expiryDate,
+                                                          String expiryDate,
                                                           String cardBrand,
                                                           String cardType,
                                                           String line1,
@@ -73,7 +73,7 @@ public class JsonRequestHelper {
                 CARD_HOLDER_NAME,
                 CARD_NUMBER,
                 CVC,
-                EXPIRY_DATE,
+                EXPIRY_DATE.toString(),
                 CARD_BRAND,
                 ADDRESS_LINE_1,
                 null,
@@ -91,7 +91,7 @@ public class JsonRequestHelper {
                 CARD_HOLDER_NAME,
                 CARD_NUMBER,
                 CVC,
-                EXPIRY_DATE,
+                EXPIRY_DATE.toString(),
                 CARD_BRAND,
                 CARD_TYPE,
                 ADDRESS_LINE_1,
@@ -108,7 +108,7 @@ public class JsonRequestHelper {
                 CARD_HOLDER_NAME,
                 CARD_NUMBER,
                 CVC,
-                EXPIRY_DATE,
+                EXPIRY_DATE.toString(),
                 CARD_BRAND,
                 Boolean.TRUE,
                 PayersCardType.CREDIT.toString(),
@@ -120,7 +120,7 @@ public class JsonRequestHelper {
     private static String buildCorporateJsonAuthorisationDetailsFor(String cardHolderName,
                                                                     String cardNumber,
                                                                     String cvc,
-                                                                    CardExpiryDate expiryDate,
+                                                                    String expiryDate,
                                                                     String cardBrand,
                                                                     String line1,
                                                                     String line2,
@@ -171,7 +171,7 @@ public class JsonRequestHelper {
     private static JsonObject buildJsonAuthorisationDetailsWithoutAddress(String cardHolderName,
                                                                           String cardNumber,
                                                                           String cvc,
-                                                                          CardExpiryDate expiryDate,
+                                                                          String expiryDate,
                                                                           String cardBrand,
                                                                           Boolean isCorporateCard,
                                                                           String payersCardType,

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
@@ -357,7 +359,8 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
         connectorRestApiClient
                 .postCreateTelephoneCharge(toJson(postBody))
-                .statusCode(400);
+                .statusCode(400)
+                .body("message", hasItem(containsString("CardExpiryDate")));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
@@ -10,7 +10,6 @@ import io.restassured.response.ValidatableResponse;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -232,7 +231,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
                 "Mr.Payment",
                 "5555444433331111",
                 cvc,
-                CardExpiryDate.valueOf("08/18"),
+                "08/18",
                 "visa",
                 "CREDIT",
                 "The Money Pool", "line 2",

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
@@ -82,7 +82,7 @@ public class StripeResourceAuthorizeIT {
 
     private String stripeAccountId;
     private final String validAuthorisationDetails = buildJsonAuthorisationDetailsFor(CARD_HOLDER_NAME, CARD_NUMBER, CVC,
-            EXPIRY, CARD_BRAND, CARD_TYPE, ADDRESS_LINE_1, ADDRESS_LINE_2, ADDRESS_CITY,
+            EXPIRY.toString(), CARD_BRAND, CARD_TYPE, ADDRESS_LINE_1, ADDRESS_LINE_2, ADDRESS_CITY,
             "London", ADDRESS_POSTCODE, ADDRESS_COUNTRY_GB);
     private final String validAuthorisationDetailsWithoutBillingAddress = buildJsonAuthorisationDetailsWithoutAddress();
     private final String validApplePayAuthorisationDetails = buildJsonApplePayAuthorisationDetails("mr payment", "mr@payment.test");


### PR DESCRIPTION
We no longer validate the card expiry date when processing card details from a regular card payment, instead relying on the instantiation of `CardExpiryDate` to fail if it’s not legit.

Add a test for this behaviour at the integration level to make up for the fact we don’t have validation tests that cover this any more.

Adding this test required changing some variables back from `CardExpiryDates` to strings so that we can test with invalid values (since `CardExpiryDate` can’t represent invalid values). However, this is limited only to integration tests that construct JSON payloads.