### PR TITLE
PP-6994 Add test for ledger failure

### DIFF
--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -97,6 +97,14 @@ public class LedgerStub {
         stubFor(WireMock.get(urlPathEqualTo(url))
                 .willReturn(response));
     }
+    
+    public void returnErrorForFindRefundsForPayment(String chargeExternalId) {
+        ResponseDefinitionBuilder repsonse = aResponse().withStatus(500);
+        String url = format("/v1/transaction/%s/transaction", chargeExternalId);
+        stubFor(WireMock.get(urlPathEqualTo(url))
+                .willReturn(repsonse));
+
+    }
 
     private void stubResponseForProviderAndGatewayTransactionId(String gatewayTransactionId, String paymentProvider,
                                                                 Map<String, Object> ledgerTransactionFields, int status) throws JsonProcessingException {


### PR DESCRIPTION
Add a test that an error is returned and a refund is not created when there is an error retrieving refunds for a payment from ledger.