### PR TITLE
PP-6988 Use native query to update refund parity check status

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -2,7 +2,9 @@ package uk.gov.pay.connector.refund.dao;
 
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.common.dao.JpaDao;
+import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import uk.gov.pay.connector.events.model.ResourceType;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
@@ -10,6 +12,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import javax.persistence.Query;
 import javax.persistence.TemporalType;
 import java.sql.Date;
 import java.time.ZonedDateTime;
@@ -182,5 +185,18 @@ public class RefundDao extends JpaDao<RefundEntity> {
                 .createNativeQuery(query, "RefundEntityHistoryMapping")
                 .setParameter(1, refundExternalId)
                 .getResultList();
+    }
+
+    public void updateParityCheckStatus(String externalId, ZonedDateTime parityCheckDate, ParityCheckStatus parityCheckStatus) {
+        Query query = entityManager.get().createNativeQuery("update refunds " +
+                " set parity_check_status = ?1, parity_check_date = ?2" +
+                " where external_id = ?3");
+
+        UTCDateTimeConverter utcDateTimeConverter = new UTCDateTimeConverter();
+
+        query.setParameter(1, parityCheckStatus.toString())
+                .setParameter(2, utcDateTimeConverter.convertToDatabaseColumn(parityCheckDate))
+                .setParameter(3, externalId)
+                .executeUpdate();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -273,7 +273,7 @@ public class RefundService {
                 .stream()
                 .map(Refund::from)
                 .collect(Collectors.toList());
-        
+
         if (charge.isHistoric()) {
             // Combine refunds that have been expunged and so only exist in ledger with refunds that still exist in
             // the database, preferring records that still exist in the database as they might be in-flight.
@@ -288,15 +288,11 @@ public class RefundService {
         } else {
             return refundsFromDatabase;
         }
-        
+
     }
-    
+
     @Transactional
     public void updateRefundParityStatus(String externalId, ParityCheckStatus parityCheckStatus) {
-        refundDao.findByExternalId(externalId)
-                .ifPresent(refundEntity -> {
-                    refundEntity.setParityCheckDate(ZonedDateTime.now(ZoneId.of("UTC")));
-                    refundEntity.setParityCheckStatus(parityCheckStatus);
-                });
+        refundDao.updateParityCheckStatus(externalId, ZonedDateTime.now(ZoneId.of("UTC")), parityCheckStatus);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/service/RefundParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/RefundParityChecker.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static uk.gov.pay.commons.model.ApiResponseDateTimeFormatter.ISO_INSTANT_MILLISECOND_PRECISION;
 import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.DATA_MISMATCH;
 import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.EXISTS_IN_LEDGER;
@@ -46,6 +47,13 @@ public class RefundParityChecker {
             boolean fieldsMatch;
 
             fieldsMatch = isEquals(externalId, transaction.getTransactionId(), "external_id");
+
+            if (isBlank(transaction.getGatewayAccountId())) {
+                logger.info("Field value does not match between ledger and connector [field_name={}]", "gateway_account_id",
+                        kv(FIELD_NAME, "gateway_account_id"));
+                fieldsMatch = false;
+            }
+
             fieldsMatch = fieldsMatch && isEquals(refundEntity.getChargeExternalId(), transaction.getParentTransactionId(), "parent_transaction_id");
             fieldsMatch = fieldsMatch && isEquals(refundEntity.getAmount(), transaction.getAmount(), "amount");
             fieldsMatch = fieldsMatch && isEquals(refundEntity.getGatewayTransactionId(), transaction.getGatewayTransactionId(), "gateway_transaction_id");

--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -54,13 +54,15 @@ public class LedgerStub {
     }
 
     public void returnLedgerTransactionWithMismatch(RefundEntity refund, ZonedDateTime refundCreatedEventDate) throws JsonProcessingException {
-        Map<String, Object> ledgerTransactionFields = refundEntityToLedgerTransaction(refund, null);
+        Map<String, Object> ledgerTransactionFields = refundEntityToLedgerTransaction(refund, null, refundCreatedEventDate);
         ledgerTransactionFields.put("external_id", "This is a mismatch");
         stubResponse(refund.getExternalId(), ledgerTransactionFields);
     }
 
-    public void returnLedgerTransaction(RefundEntity refund, ZonedDateTime refundCreatedEventDate) throws JsonProcessingException {
-        Map<String, Object> ledgerTransactionFields = refundEntityToLedgerTransaction(refund, refundCreatedEventDate);
+    public void returnLedgerTransaction(RefundEntity refund, Long gatewayAccountId,
+                                        ZonedDateTime refundCreatedEventDate) throws JsonProcessingException {
+        Map<String, Object> ledgerTransactionFields = refundEntityToLedgerTransaction(refund,
+                gatewayAccountId, refundCreatedEventDate);
         stubResponse(refund.getExternalId(), ledgerTransactionFields);
     }
 
@@ -97,7 +99,7 @@ public class LedgerStub {
         stubFor(WireMock.get(urlPathEqualTo(url))
                 .willReturn(response));
     }
-    
+
     public void returnErrorForFindRefundsForPayment(String chargeExternalId) {
         ResponseDefinitionBuilder repsonse = aResponse().withStatus(500);
         String url = format("/v1/transaction/%s/transaction", chargeExternalId);
@@ -184,10 +186,12 @@ public class LedgerStub {
         return map;
     }
 
-    private Map<String, Object> refundEntityToLedgerTransaction(RefundEntity refund, ZonedDateTime refundCreatedEventDate) {
+    private Map<String, Object> refundEntityToLedgerTransaction(RefundEntity refund, Long gatewayAccountId,
+                                                                ZonedDateTime refundCreatedEventDate) {
         var map = new HashMap<String, Object>();
 
         Optional.ofNullable(refund.getExternalId()).ifPresent(value -> map.put("transaction_id", value));
+        Optional.ofNullable(gatewayAccountId).ifPresent(value -> map.put("gateway_account_id", gatewayAccountId));
         Optional.ofNullable(refund.getChargeExternalId()).ifPresent(value -> map.put("parent_transaction_id", value));
         Optional.of(refund.getAmount()).ifPresent(value -> map.put("amount", String.valueOf(value)));
         Optional.ofNullable(refund.getGatewayTransactionId()).ifPresent(value -> map.put("gateway_transaction_id", value));

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -140,9 +140,10 @@ public class LedgerTransactionFixture {
         return ledgerTransactionFixture;
     }
 
-    public static LedgerTransactionFixture from(RefundEntity refundEntity) {
+    public static LedgerTransactionFixture from(Long gatewayAccountId, RefundEntity refundEntity) {
         LedgerTransactionFixture ledgerTransactionFixture =
                 aValidLedgerTransaction()
+                        .withGatewayAccountId(gatewayAccountId)
                         .withAmount(refundEntity.getAmount())
                         .withStatus(refundEntity.getStatus().toExternal().getStatus())
                         .withCreatedDate(refundEntity.getCreatedDate())

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckServiceTest.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.time.ZonedDateTime.parse;
+import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -148,7 +149,7 @@ public class ParityCheckServiceTest {
 
     @Test
     public void parityCheckRefundForExpunger_shouldBackfillRefundIfParityCheckFails() {
-        LedgerTransaction transaction = from(refundEntity)
+        LedgerTransaction transaction = from(nextLong(), refundEntity)
                 .withStatus(REFUND_ERROR.toExternal().getStatus()).build();
         when(mockLedgerService.getTransaction(refundEntity.getExternalId())).thenReturn(Optional.of(transaction));
 
@@ -166,7 +167,7 @@ public class ParityCheckServiceTest {
         when(mockRefundDao.getRefundHistoryByRefundExternalIdAndRefundStatus(refundEntity.getExternalId(), RefundStatus.CREATED))
                 .thenReturn(Optional.of(refundHistory));
 
-        LedgerTransaction transaction = from(refundEntity).build();
+        LedgerTransaction transaction = from(nextLong(), refundEntity).build();
         when(mockLedgerService.getTransaction(refundEntity.getExternalId())).thenReturn(Optional.of(transaction));
 
         boolean matchesWithLedger = parityCheckService.parityCheckRefundForExpunger(refundEntity);

--- a/src/test/java/uk/gov/pay/connector/tasks/service/RefundParityCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/service/RefundParityCheckerTest.java
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static java.time.ZoneOffset.UTC;
+import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
@@ -35,7 +36,7 @@ public class RefundParityCheckerTest {
     private RefundDao mockRefundDao;
     @InjectMocks
     RefundParityChecker refundParityChecker;
-
+    private Long gatewayAccountId = nextLong();
     private RefundEntity refundEntity;
 
     @Before
@@ -51,7 +52,7 @@ public class RefundParityCheckerTest {
 
     @Test
     public void parityCheck_shouldMatchIfRefundMatchesWithLedgerTransaction() {
-        LedgerTransaction transaction = from(refundEntity).build();
+        LedgerTransaction transaction = from(gatewayAccountId, refundEntity).build();
         assertParityCheckStatus(transaction, EXISTS_IN_LEDGER);
     }
 
@@ -62,43 +63,43 @@ public class RefundParityCheckerTest {
 
     @Test
     public void parityCheck_shouldReturnDataMismatchIfRefundDoesNotMatchWithLedger() {
-        LedgerTransaction transaction = from(refundEntity).withAmount(null).build();
+        LedgerTransaction transaction = from(gatewayAccountId, refundEntity).withAmount(null).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
     }
 
     @Test
     public void parityCheck_shouldReturnDataMismatchIfUserEmailDoesNotMatchWithLedger() {
-        LedgerTransaction transaction = from(refundEntity).withRefundedByUserEmail(null).build();
+        LedgerTransaction transaction = from(gatewayAccountId, refundEntity).withRefundedByUserEmail(null).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
     }
 
     @Test
     public void parityCheck_shouldReturnDataMismatchIfUserExternalIdDoesNotMatchWithLedger() {
-        LedgerTransaction transaction = from(refundEntity).withRefundedBy(null).build();
+        LedgerTransaction transaction = from(gatewayAccountId, refundEntity).withRefundedBy(null).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
     }
 
     @Test
     public void parityCheck_shouldReturnDataMismatchIfGatewayTransactionIdDoesNotMatchWithLedger() {
-        LedgerTransaction transaction = from(refundEntity).withGatewayTransactionId(null).build();
+        LedgerTransaction transaction = from(gatewayAccountId, refundEntity).withGatewayTransactionId(null).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
     }
 
     @Test
     public void parityCheck_shouldReturnDataMismatchIfStatusDoesNotMatchWithLedger() {
-        LedgerTransaction transaction = from(refundEntity).withStatus(REFUNDED.toExternal().getStatus()).build();
+        LedgerTransaction transaction = from(gatewayAccountId, refundEntity).withStatus(REFUNDED.toExternal().getStatus()).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
 
-        transaction = from(refundEntity).withStatus(null).build();
+        transaction = from(gatewayAccountId, refundEntity).withStatus(null).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
     }
 
     @Test
     public void parityCheck_shouldReturnDataMismatchIfCreatedDateDoesNotMatchWithLedger() {
-        LedgerTransaction transaction = from(refundEntity).withCreatedDate(ZonedDateTime.now(UTC).minusDays(1)).build();
+        LedgerTransaction transaction = from(gatewayAccountId, refundEntity).withCreatedDate(ZonedDateTime.now(UTC).minusDays(1)).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
 
-        transaction = from(refundEntity).withCreatedDate(null).build();
+        transaction = from(gatewayAccountId, refundEntity).withCreatedDate(null).build();
         assertParityCheckStatus(transaction, DATA_MISMATCH);
     }
 


### PR DESCRIPTION
## WHAT YOU DID
- Uses native sql query to update refund parity check status as using JPA to update refund also adds additional refunds_history record. As we generate events to Ledger based on refunds_history and history timestamp, additional records in refund_history causes duplicate events to be emitted to ledger but with different timestamps.
- Also added check to fail parity check on refund when gateway account is not available