### PR TITLE
PP-6988 Fix parity checker for card expiry date

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
@@ -133,7 +133,7 @@ public class ChargeParityChecker {
                     isEmpty(ledgerCardDetails.getCardBrand()) ? null : ledgerCardDetails.getCardBrand(),
                     "card_brand");
             fieldsMatch = fieldsMatch && isEquals(
-                    Optional.of(cardDetailsEntity.getExpiryDate()).map(CardExpiryDate::toString).orElse(null),
+                    Optional.ofNullable(cardDetailsEntity.getExpiryDate()).map(CardExpiryDate::toString).orElse(null),
                     ledgerCardDetails.getExpiryDate(), "expiry_date");
 
             String cardType = null;

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.model.domain;
 
+import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.cardtype.model.domain.CardBrandLabelEntity;
@@ -115,7 +116,7 @@ public class LedgerTransactionFixture {
                     chargeEntityCardDetails.getCardTypeDetails().map(CardBrandLabelEntity::getLabel).orElse(null),
                     ofNullable(chargeEntityCardDetails.getLastDigitsCardNumber()).map(LastDigitsCardNumber::toString).orElse(null),
                     ofNullable(chargeEntityCardDetails.getFirstDigitsCardNumber()).map(FirstDigitsCardNumber::toString).orElse(null),
-                    chargeEntityCardDetails.getExpiryDate().toString(),
+                    ofNullable(chargeEntityCardDetails.getExpiryDate()).map(CardExpiryDate::toString).orElse(null),
                     ofNullable(chargeEntityCardDetails.getCardType()).map(cardType -> cardType.toString().toLowerCase()).orElse(null)
             );
 

--- a/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/service/ChargeParityCheckerTest.java
@@ -95,6 +95,7 @@ public class ChargeParityCheckerTest {
     @Test
     public void parityCheck_shouldReturnDataMismatchIfCardDetailsDoesNotMatchWithLedger() {
         chargeEntity.getCardDetails().setBillingAddress(null);
+        chargeEntity.getCardDetails().setExpiryDate(null);
         LedgerTransaction transaction = from(chargeEntity, refundEntities)
                 .withCardDetails(new CardDetails("test-name", null, "test-brand",
                         "6666", "123656", "11/88", null))


### PR DESCRIPTION
## WHAT YOU DID
- Use Optional.ofNullable to map and parity check expiry date as date may not be available for wallet payments
