### PR TITLE
PP-6988 Expunge refunds configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 ### Expunger
 | Variable | Default | Purpose |
 |---------|---------|---------|
-| `EXPUNGE_NO_OF_CHARGES_OR_REFUNDS_PER_TASK_RUN`            | 25000 | Number of charges or refunds to expunge each time expunge resource endpoint is invoked |
 | `EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS` | 7 | Exclude charges or refunds from expunging if parity checked within the configured days  |
-| `EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS`  | 90 | Number of days after which charges in a certain state (ex: CAPTURE_SUBMITTED for charge) can be expunged, even when not in expungeable state  |
 | `EXPUNGE_CHARGES_ENABLED`   | false | Set to true to enable expunging charges (in expungeable state) |
+| `EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN`            | 15000 | Number of charges to expunge each time expunge resource endpoint is invoked |
 | `EXPUNGE_CHARGES_OLDER_THAN_DAYS` | 7 | Expunge charges older than 7 days (or as configured) based on created date | 
+| `EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS`  | 90 | Number of days after which charges in a certain state (ex: CAPTURE_SUBMITTED for charge) can be expunged, even when not in expungeable state  |
 | `EXPUNGE_REFUNDS_ENABLED`          | false |  Set to true to enable expunging refunds in terminal state |
+| `EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN`            | 1000 | Number of refunds to expunge each time expunge resource endpoint is invoked |
 | `EXPUNGE_REFUNDS_OLDER_THAN_DAYS`            | 7 | Expunge refunds older than 7 days (or as configured) based on created date |
 | `EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS`  | 90 | Number of days after which refunds in a certain state (ex: REFUND_SUBMITTED) can be expunged, even when not in terminal state  |
 

--- a/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/ExpungeConfig.java
@@ -23,7 +23,12 @@ public class ExpungeConfig extends Configuration {
     @Valid
     @NotNull
     @Min(1)
-    private int numberOfChargesOrRefundsToExpunge;
+    private int numberOfChargesToExpunge;
+
+    @Valid
+    @NotNull
+    @Min(1)
+    private int numberOfRefundsToExpunge;
 
     @Valid
     @NotNull
@@ -42,8 +47,12 @@ public class ExpungeConfig extends Configuration {
         return minimumAgeOfChargeInDays;
     }
 
-    public int getNumberOfChargesOrRefundsToExpunge() {
-        return numberOfChargesOrRefundsToExpunge;
+    public int getNumberOfChargesToExpunge() {
+        return numberOfChargesToExpunge;
+    }
+
+    public int getNumberOfRefundsToExpunge() {
+        return numberOfRefundsToExpunge;
     }
 
     public int getExcludeChargesOrRefundsParityCheckedWithInDays() {

--- a/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/resource/ExpungeResource.java
@@ -29,10 +29,11 @@ public class ExpungeResource {
     @POST
     @Path("/v1/tasks/expunge")
     @Produces(APPLICATION_JSON)
-    public Response expunge(@QueryParam("number_of_charges_or_refunds_to_expunge") Integer noOfChargesOrRefundsToExpunge) {
+    public Response expunge(@QueryParam("number_of_charges_to_expunge") Integer noOfChargesToExpunge,
+                            @QueryParam("number_of_refunds_to_expunge") Integer noOfRefundsToExpunge) {
         String correlationId = MDC.get(HEADER_REQUEST_ID) == null ? "ExpungeResource-" + UUID.randomUUID().toString() : MDC.get(HEADER_REQUEST_ID);
         MDC.put(HEADER_REQUEST_ID, correlationId);
-        expungeService.expunge(noOfChargesOrRefundsToExpunge);
+        expungeService.expunge(noOfChargesToExpunge, noOfRefundsToExpunge);
         MDC.remove(HEADER_REQUEST_ID);
         return status(OK).build();
     }

--- a/src/main/java/uk/gov/pay/connector/expunge/service/ExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ExpungeService.java
@@ -19,16 +19,25 @@ public class ExpungeService {
         expungeConfig = connectorConfiguration.getExpungeConfig();
     }
 
-    public void expunge(Integer noOfChargesOrRefundsToExpungeQueryParam) {
-        int noOfRecordsToExpunge = getNumberOfRecordsToExpunge(noOfChargesOrRefundsToExpungeQueryParam);
-        chargeExpungeService.expunge(noOfRecordsToExpunge);
-        refundExpungeService.expunge(noOfRecordsToExpunge);
+    public void expunge(Integer noOfChargesToExpungeQueryParam, Integer noOfRefundsToExpungeQueryParam) {
+        int noOfChargesToExpunge = getNumberOfChargesToExpunge(noOfChargesToExpungeQueryParam);
+        chargeExpungeService.expunge(noOfChargesToExpunge);
+
+        int noOfRefundsToExpunge = getNumberOfRefundsToExpunge(noOfRefundsToExpungeQueryParam);
+        refundExpungeService.expunge(noOfRefundsToExpunge);
     }
 
-    private int getNumberOfRecordsToExpunge(Integer noOfChargesToExpungeQueryParam) {
+    private int getNumberOfChargesToExpunge(Integer noOfChargesToExpungeQueryParam) {
         if (noOfChargesToExpungeQueryParam != null && noOfChargesToExpungeQueryParam > 0) {
             return noOfChargesToExpungeQueryParam;
         }
-        return expungeConfig.getNumberOfChargesOrRefundsToExpunge();
+        return expungeConfig.getNumberOfChargesToExpunge();
+    }
+
+    private int getNumberOfRefundsToExpunge(Integer noOfRefundsToExpungeQueryParam) {
+        if (noOfRefundsToExpungeQueryParam != null && noOfRefundsToExpungeQueryParam > 0) {
+            return noOfRefundsToExpungeQueryParam;
+        }
+        return expungeConfig.getNumberOfRefundsToExpunge();
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -242,12 +242,13 @@ restClientConfig:
 ledgerBaseURL: ${LEDGER_URL}
 
 expungeConfig:
-  numberOfChargesOrRefundsToExpunge: ${EXPUNGE_NO_OF_CHARGES_OR_REFUNDS_PER_TASK_RUN:-25000}
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN:-15000}
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
   expungeRefundsEnabled: ${EXPUNGE_REFUNDS_ENABLED:-false}
+  numberOfRefundsToExpunge: ${EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN:-1000}
   minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricRefundExceptions: ${EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 

--- a/src/test/java/uk/gov/pay/connector/expunge/service/ExpungeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/ExpungeServiceTest.java
@@ -22,31 +22,33 @@ public class ExpungeServiceTest {
     @Mock
     ConnectorConfiguration mockConnectorConfiguration;
 
-    int defaultNumberOfChargesOrRefundsToExpunge = 999;
+    int defaultNumberOfChargesToExpunge = 999;
+    int defaultNumberOfRefundsToExpunge = 100;
     ExpungeService expungeService;
 
     @Before
     public void setUp() {
         ExpungeConfig expungeConfig = mock(ExpungeConfig.class);
         when(mockConnectorConfiguration.getExpungeConfig()).thenReturn(expungeConfig);
-        when(expungeConfig.getNumberOfChargesOrRefundsToExpunge()).thenReturn(defaultNumberOfChargesOrRefundsToExpunge);
+        when(expungeConfig.getNumberOfChargesToExpunge()).thenReturn(defaultNumberOfChargesToExpunge);
+        when(expungeConfig.getNumberOfRefundsToExpunge()).thenReturn(defaultNumberOfRefundsToExpunge);
 
         expungeService = new ExpungeService(mockChargeExpungeService, mockRefundExpungeService, mockConnectorConfiguration);
     }
 
     @Test
     public void shouldInvokeChargeAndRefundExpungerWithNoOfRecordsToExpungeBasedOnConfigurationWhenQueryParamIsNotPassed() {
-        expungeService.expunge(null);
+        expungeService.expunge(null, null);
 
-        verify(mockChargeExpungeService).expunge(defaultNumberOfChargesOrRefundsToExpunge);
-        verify(mockRefundExpungeService).expunge(defaultNumberOfChargesOrRefundsToExpunge);
+        verify(mockChargeExpungeService).expunge(defaultNumberOfChargesToExpunge);
+        verify(mockRefundExpungeService).expunge(defaultNumberOfRefundsToExpunge);
     }
 
     @Test
     public void shouldInvokeChargeAndRefundExpungerWithQueryParameterPassedForNoOfRecordsToExpunge() {
-        expungeService.expunge(5);
+        expungeService.expunge(5, 10);
 
         verify(mockChargeExpungeService).expunge(5);
-        verify(mockRefundExpungeService).expunge(5);
+        verify(mockRefundExpungeService).expunge(10);
     }
 }

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -187,12 +187,13 @@ restClientConfig:
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
-  numberOfChargesOrRefundsToExpunge: ${EXPUNGE_NO_OF_CHARGES_OR_REFUNDS_PER_TASK_RUN:-25000}
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN:-1000}
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
   expungeRefundsEnabled: ${EXPUNGE_REFUNDS_ENABLED:-false}
+  numberOfRefundsToExpunge: ${EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN:-1000}
   minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricRefundExceptions: ${EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -186,12 +186,13 @@ restClientConfig:
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
-  numberOfChargesOrRefundsToExpunge: ${EXPUNGE_NO_OF_CHARGES_OR_REFUNDS_PER_TASK_RUN:-25000}
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN:-1000}
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
   expungeRefundsEnabled: ${EXPUNGE_REFUNDS_ENABLED:-false}
+  numberOfRefundsToExpunge: ${EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN:-1000}
   minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricRefundExceptions: ${EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -176,12 +176,13 @@ restClientConfig:
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
-  numberOfChargesOrRefundsToExpunge: ${EXPUNGE_NO_OF_CHARGES_OR_REFUNDS_PER_TASK_RUN:-25000}
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN:-1000}
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
   expungeRefundsEnabled: ${EXPUNGE_REFUNDS_ENABLED:-false}
+  numberOfRefundsToExpunge: ${EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN:-1000}
   minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricRefundExceptions: ${EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -182,12 +182,13 @@ restClientConfig:
 ledgerBaseURL: ${LEDGER_URL:-localhost:10700}
 
 expungeConfig:
-  numberOfChargesOrRefundsToExpunge: ${EXPUNGE_NO_OF_CHARGES_OR_REFUNDS_PER_TASK_RUN:-25000}
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN:-1000}
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
   expungeRefundsEnabled: ${EXPUNGE_REFUNDS_ENABLED:-false}
+  numberOfRefundsToExpunge: ${EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN:-1000}
   minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-7}
   minimumAgeForHistoricRefundExceptions: ${EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -181,12 +181,13 @@ restClientConfig:
 ledgerBaseURL: ${LEDGER_URL:-http://localhost:10700}
 
 expungeConfig:
-  numberOfChargesOrRefundsToExpunge: ${EXPUNGE_NO_OF_CHARGES_OR_REFUNDS_PER_TASK_RUN:-10}
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-true}
+  numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN:-1000}
   minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-90}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
   expungeRefundsEnabled: ${EXPUNGE_REFUNDS_ENABLED:-true}
+  numberOfRefundsToExpunge: ${EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN:-1000}
   minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-90}
   minimumAgeForHistoricRefundExceptions: ${EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 


### PR DESCRIPTION
## WHAT YOU DID
- Splits single config variable for number of charge and refunds to expunge to charges and refunds specific variables.
  This is so we can set the number proportional to the volumes for charges & refunds.
