### PR TITLE
PP-6988 Refactor expunge service

### DIFF
--- a/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
@@ -66,8 +66,11 @@ public class ChargeExpungeServiceTest {
 
     @Test
     public void expunge_shouldExpungeNoOfChargesAsPerConfiguration() {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
         when(mockExpungeConfig.getMinimumAgeOfChargeInDays()).thenReturn(minimumAgeOfChargeInDays);
         when(mockExpungeConfig.getExcludeChargesOrRefundsParityCheckedWithInDays()).thenReturn(defaultExcludeChargesParityCheckedWithInDays);
+        when(mockChargeDao.findChargeToExpunge(minimumAgeOfChargeInDays,defaultExcludeChargesParityCheckedWithInDays))
+                .thenReturn(Optional.of(chargeEntity));
 
         chargeExpungeService.expunge(defaultNumberOfChargesToExpunge);
         verify(mockChargeDao, times(defaultNumberOfChargesToExpunge)).findChargeToExpunge(minimumAgeOfChargeInDays,


### PR DESCRIPTION
## WHAT YOU DID

- We are using stream to loop through to find and expunge n (no of charges/refunds) records from connector.
  This is causing *ExpungeService to query for expungeable charges/refunds n times even when there are
  no records to expunge or the records available to expunge are less than n.

- Replaced IntStream with loop to stop trying to find & expunge when there are no records returned.

