### PR TITLE
PP-7253 Publish consumer pacts for Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,18 +19,25 @@ pipeline {
   environment {
     DOCKER_HOST = "unix:///var/run/docker.sock"
     RUN_END_TO_END_ON_PR = "${params.runEndToEndTestsOnPR}"
-    JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
-    PAY_SCRIPTS_BRANCH="${params.payScriptsBranch}"
+    JAVA_HOME = "/usr/lib/jvm/java-1.11.0-openjdk-amd64"
+    PAY_SCRIPTS_BRANCH = "${params.payScriptsBranch}"
   }
   stages {
     stage('Maven Build') {
       steps {
         script {
-          long stepBuildTime = System.currentTimeMillis()
+          def stepBuildTime = System.currentTimeMillis()
+          def commit = gitCommit()
+          def branchName = gitBranchName()
 
-          sh 'mvn -version'
-          sh 'mvn clean verify'
-          runProviderContractTests()
+          withCredentials([
+              string(credentialsId: 'pact_broker_username', variable: 'PACT_BROKER_USERNAME'),
+              string(credentialsId: 'pact_broker_password', variable: 'PACT_BROKER_PASSWORD')]
+          ) {
+            sh 'mvn -version'
+            sh "mvn clean verify pact:publish -DPACT_BROKER_URL=https://pact-broker-test.cloudapps.digital -DPACT_CONSUMER_VERSION=${commit}" +
+                " -DPACT_BROKER_USERNAME=${PACT_BROKER_USERNAME} -DPACT_BROKER_PASSWORD=${PACT_BROKER_PASSWORD} -DPACT_CONSUMER_TAG=${branchName}"
+          }
           postSuccessfulMetrics("connector.maven-build", stepBuildTime)
         }
       }
@@ -54,19 +61,50 @@ pipeline {
         }
       }
     }
+    stage('Contract Tests: Connector as Provider') {
+      steps {
+        script {
+          def stepBuildTime = System.currentTimeMillis()
+          runProviderContractTests()
+          postSuccessfulMetrics("connector.provider-contract-tests", stepBuildTime)
+        }
+      }
+      post {
+        failure {
+          postMetric("connector.provider-contract-tests.failure", 1)
+        }
+      }
+    }
+    stage('Contract Tests: Providers to Connector') {
+      steps {
+        script {
+          env.PACT_TAG = gitBranchName()
+        }
+        ws('contract-tests-wp') {
+          runPactProviderTests("pay-ledger", "${env.PACT_TAG}", "connector")
+        }
+      }
+      post {
+        always {
+          ws('contract-tests-wp') {
+            deleteDir()
+          }
+        }
+      }
+    }
     stage('Tests') {
       failFast true
       stages {
         stage('End-to-End Tests') {
-            when {
-                anyOf {
-                  branch 'master'
-                  environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
-                }
+          when {
+            anyOf {
+              branch 'master'
+              environment name: 'RUN_END_TO_END_ON_PR', value: 'true'
             }
-            steps {
-                runAppE2E("connector", "card")
-            }
+          }
+          steps {
+            runAppE2E("connector", "card")
+          }
         }
       }
     }


### PR DESCRIPTION
- As part of the "Maven build" step, publish consumer pact tests to the pact broker.
- Move running the contract tests with connector as the provider out of "Maven build" to a separate step.
- Add a step for running provider contract tests on ledger with connector as the consumer.