### PR TITLE
PP-7253 Rename consumer contract test

### DIFF
--- a/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
+++ b/src/test/java/uk/gov/pay/connector/client/ledger/service/LedgerServiceConsumerTest.java
@@ -20,12 +20,11 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class LedgerServiceContractTest {
+public class LedgerServiceConsumerTest {
 
     @Rule
     public PactProviderRule ledgerRule = new PactProviderRule("ledger", this);


### PR DESCRIPTION
Rename test so that it is included when `mvn verify` is run. The maven build profiles exclude tests ending in "ContractTest" as these are the provider contract tests which are run separately.