### PR TITLE
PP-6989 Add gateway error states to events affecting refundabiltiy

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitions.java
@@ -261,6 +261,7 @@ public class PaymentGatewayStateTransitions {
                 .flatMap(Optional::stream)
                 .map(me -> (ModelledTypedEvent) me)
                 .map(ModelledTypedEvent::getClazz)
+                .distinct()
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -11,11 +11,14 @@ import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTra
 import uk.gov.pay.connector.events.exception.EventCreationException;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
+import uk.gov.pay.connector.events.model.charge.GatewayErrorDuringAuthorisation;
+import uk.gov.pay.connector.events.model.charge.GatewayTimeoutDuringAuthorisation;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
+import uk.gov.pay.connector.events.model.charge.UnexpectedGatewayErrorDuringAuthorisation;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByService;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
 import uk.gov.pay.connector.events.model.refund.RefundError;
@@ -49,7 +52,10 @@ public class EventFactory {
             RefundCreatedByService.class,
             RefundError.class,
             PaymentCreated.class,
-            CaptureSubmitted.class
+            CaptureSubmitted.class,
+            GatewayErrorDuringAuthorisation.class,
+            GatewayTimeoutDuringAuthorisation.class,
+            UnexpectedGatewayErrorDuringAuthorisation.class
     );
     
     private static final List<Class> EVENTS_LEADING_TO_TERMINAL_STATE = 

--- a/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/model/domain/PaymentGatewayStateTransitionsTest.java
@@ -24,10 +24,10 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsIterableContaining.hasItem;
 import static org.hamcrest.core.IsIterableContaining.hasItems;
-import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ABORTED;


### PR DESCRIPTION
## WHAT YOU DID
- AUTHORISATION_ERROR, AUTHORISATION_TIMEOUT, AUTHORISATION_UNEXPECTED_ERROR states are terminal states which affects refundability. But these states are now appearing as non-terminal (as per payment gateway state transition graph) due to new states introduced for cleanup up job. As a result, refundability events are not generated for ERROR states and refund_summary status in ledger ended up as 'pending' instead of 'unavailable'.

  This has majorly impacted expunge process, as refund_summary.status doesn't match with ledger and connector, but little or no impact for services. Services using API are getting incorrect refund_summary.status in search results.

- Added error states to events affecting refundability. For existing charges failing parity check, new refundability events will be emitted by connector which also fixes ledger.

