### PR TITLE
PP-6989 Refund expunger moves "charge exists" check from SQL

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -138,9 +138,8 @@ public class RefundDao extends JpaDao<RefundEntity> {
     }
 
     public Optional<RefundEntity> findRefundToExpunge(int minimumAgeOfRefundInDays, int excludeRefundsParityCheckedWithInDays) {
-        String query = "SELECT r FROM RefundEntity r left outer join ChargeEntity c on r.chargeExternalId = c.externalId " +
-                " WHERE c.externalId is null " +
-                " AND (r.parityCheckDate is null or r.parityCheckDate < :parityCheckedBeforeDate)" +
+        String query = "SELECT r FROM RefundEntity r" +
+                " WHERE (r.parityCheckDate is null or r.parityCheckDate < :parityCheckedBeforeDate)" +
                 " AND r.createdDate < :createdBeforeDate " +
                 " ORDER BY r.createdDate asc";
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/RefundDaoJpaIT.java
@@ -377,18 +377,6 @@ public class RefundDaoJpaIT extends DaoITestBase {
     }
 
     @Test
-    public void findRefundToExpunge_shouldNotReturnRefundIfChargeStillExists() {
-        RefundEntity refund = new RefundEntity(100L, userExternalId, userEmail, chargeTestRecord.getExternalChargeId());
-        refund.setStatus(REFUNDED);
-        refund.setCreatedDate(ZonedDateTime.now(UTC).minusDays(10));
-        refundDao.persist(refund);
-
-        Optional<RefundEntity> mayBeRefundToExpunge = refundDao.findRefundToExpunge(5, 7);
-
-        assertThat(mayBeRefundToExpunge.isPresent(), Matchers.is(false));
-    }
-
-    @Test
     public void expungeRefund_shouldExpungeRefundRelatedRecordsCorrectly() {
         RefundEntity refundToExpunge = new RefundEntity(100L, userExternalId, userEmail, chargeTestRecord.getExternalChargeId());
         refundToExpunge.setStatus(REFUNDED);


### PR DESCRIPTION
Move the check to see if a charge exists for a given refund that will be
expunged to refund expunge service. This moves it out of the DAO layer
which allows us to remove the join between refunds and charges.

The hypothesis is that this left outer join is complex as the buffer
gets recalculated every time a refund is removed from the bottom of the
table.

If this change has no impact on RDS CPU utilisation, it should be
reverted.