### PR TITLE
PP-7276 Emit email collected event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -4,7 +4,6 @@ import com.google.inject.persist.Transactional;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
@@ -51,6 +50,7 @@ import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.common.model.domain.PrefilledAddress;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -321,6 +321,7 @@ public class ChargeService {
                 .map(chargeEntity -> {
                     if (chargePatchRequest.getPath().equals(ChargesApiResource.EMAIL_KEY)) {
                         chargeEntity.setEmail(sanitize(chargePatchRequest.getValue()));
+                        eventService.emitAndRecordEvent(UserEmailCollected.from(chargeEntity));
                     }
                     return Optional.of(chargeEntity);
                 })

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/UserEmailCollectedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/UserEmailCollectedEventDetails.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class UserEmailCollectedEventDetails extends EventDetails {
+    private final String email;
+
+    public UserEmailCollectedEventDetails(String email) {
+        this.email = email;
+    }
+
+    public static UserEmailCollectedEventDetails from(ChargeEntity chargeEntity) {
+        return new UserEmailCollectedEventDetails(chargeEntity.getEmail());
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
@@ -1,0 +1,33 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.charge.exception.ChargeEventNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.UserEmailCollectedEventDetails;
+
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+
+public class UserEmailCollected extends PaymentEvent {
+
+    public UserEmailCollected(String resourceExternalId,
+                              UserEmailCollectedEventDetails eventDetails,
+                              ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static UserEmailCollected from(ChargeEntity charge) {
+        ZonedDateTime lastEventDate = charge.getEvents().stream()
+                .filter(e -> e.getStatus() == ENTERING_CARD_DETAILS ||  e.getStatus() == CREATED)
+                .map(ChargeEventEntity::getUpdated)
+                .max(ZonedDateTime::compareTo)
+                .orElseThrow(() -> new ChargeEventNotFoundRuntimeException(charge.getExternalId()));
+
+        return new UserEmailCollected(
+                charge.getExternalId(),
+                UserEmailCollectedEventDetails.from(charge),
+                lastEventDate);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -82,7 +82,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasJsonPath("$.event_details.address_country", equalTo("GB")));
         assertThat(actual, hasJsonPath("$.event_details.wallet", equalTo("APPLE_PAY")));
     }
-    
+
     @Test
     public void whenAllTheDataIsAvailableForUsCountry() throws JsonProcessingException {
         ChargeEntity chargeEntity = chargeEntityFixture.build();

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
@@ -1,0 +1,56 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity.ChargeEventEntityBuilder.aChargeEventEntity;
+
+public class UserEmailCollectedTest {
+
+    private final String paymentId = "jweojfewjoifewj";
+    private final String time = "2018-03-12T16:25:01.123456Z";
+    private final String validTransactionId = "validTransactionId";
+
+    private ChargeEntityFixture chargeEntityFixture;
+
+    @Before
+    public void setUp() {
+        ZonedDateTime latestDateTime = ZonedDateTime.parse(time);
+
+        List<ChargeEventEntity> list = List.of(
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.CREATED).withUpdated(latestDateTime.minusHours(3)).build(),
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.ENTERING_CARD_DETAILS).withUpdated(latestDateTime).build(),
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.USER_CANCELLED).withUpdated(latestDateTime.plusHours(1)).build()
+        );
+
+        chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.parse(time))
+                .withStatus(ChargeStatus.USER_CANCELLED)
+                .withExternalId(paymentId)
+                .withAmount(100L)
+                .withEvents(list);
+    }
+
+    @Test
+    public void serializesEventDetailsGivenChargeEvent() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        String actual = UserEmailCollected.from(chargeEntity).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("USER_EMAIL_COLLECTED")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.event_details.email", equalTo(chargeEntity.getEmail())));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -96,7 +96,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
                 .body("code", is(404))
                 .body("message", is("HTTP 404 Not Found"));
     }
-    
+
     @Test
     public void shouldReturn404WhenGettingNonExistentChargeId() {
         connectorRestApiClient

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -60,7 +60,7 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
 
 @RunWith(DropwizardJUnitRunner.class)
-@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
 public class ChargesFrontendResourceIT {
 
     @DropwizardTestContext


### PR DESCRIPTION
## WHAT YOU DID
- Emits separate event to ledger when email is patched by frontend. This is so email can be sent to ledger
  even when user cancels payment during authoration operation.
  When a charge is cancelled by user, authorisation operation in progress fails on invalid state transition and no further events related to authorisation are emitted to ledger.

