### PR TITLE
PP-7277 include gateway transaction id in cancelled by user event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CancelledByUserEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/CancelledByUserEventDetails.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+public class CancelledByUserEventDetails extends EventDetails {
+
+    private String gatewayTransactionId;
+
+    public CancelledByUserEventDetails(String gatewayTransactionId) {
+        this.gatewayTransactionId = gatewayTransactionId;
+    }
+
+    public static CancelledByUserEventDetails from(ChargeEntity charge) {
+        return new CancelledByUserEventDetails(charge.getGatewayTransactionId());
+    }
+
+    public String getGatewayTransactionId() {
+        return gatewayTransactionId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.events.exception.EventCreationException;
+import uk.gov.pay.connector.events.model.charge.CancelledByUser;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
 import uk.gov.pay.connector.events.model.charge.GatewayErrorDuringAuthorisation;
@@ -131,7 +132,10 @@ public class EventFactory {
                 return CaptureConfirmed.from(chargeEvent);
             } else if (eventClass == PaymentNotificationCreated.class) {
                 return PaymentNotificationCreated.from(chargeEvent);
-            } else {
+            } else if (eventClass == CancelledByUser.class) {
+                return CancelledByUser.from(chargeEvent);
+            }
+            else {
                 return eventClass.getConstructor(String.class, ZonedDateTime.class).newInstance(
                         chargeEvent.getChargeEntity().getExternalId(),
                         chargeEvent.getUpdated()

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CancelledByUser.java
@@ -1,9 +1,18 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetails;
+
 import java.time.ZonedDateTime;
 
-public class CancelledByUser extends PaymentEventWithoutDetails {
-    public CancelledByUser(String resourceExternalId, ZonedDateTime timestamp) {
-        super(resourceExternalId, timestamp);
+public class CancelledByUser extends PaymentEvent {
+    public CancelledByUser(String resourceExternalId, CancelledByUserEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static CancelledByUser from(ChargeEventEntity chargeEvent) {
+        ChargeEntity charge = chargeEvent.getChargeEntity();
+        return new CancelledByUser(charge.getExternalId(), CancelledByUserEventDetails.from(charge), chargeEvent.getUpdated());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetails;
+
+import java.time.ZonedDateTime;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+public class CancelledByUserTest {
+
+    private final String paymentId = "jweojfewjoifewj";
+    private final String time = "2020-10-13T16:25:01.123456Z";
+    private final String transactionId = "validTransactionId";
+    private final String gatewayTransactionId = "validGatewayTransactionId";
+
+    private ChargeEntityFixture chargeEntityFixture;
+
+    @Before
+    public void setUp() {
+        chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.parse(time))
+                .withStatus(ChargeStatus.USER_CANCELLED)
+                .withExternalId(paymentId)
+                .withTransactionId(transactionId)
+                .withGatewayTransactionId(gatewayTransactionId);
+    }
+
+    @Test
+    public void whenAllTheDataIsAvailable() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+
+        String actual = new CancelledByUser(transactionId, CancelledByUserEventDetails.from(chargeEntity), ZonedDateTime.parse(time)).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_USER")));
+        assertThat(actual, hasJsonPath("event_details.gateway_transaction_id", equalTo(gatewayTransactionId)));
+    }
+
+    @Test
+    public void whenNoGatewayTransactionIdIsAvailable() throws JsonProcessingException {
+        ChargeEntity charge = new ChargeEntity();
+        charge.setExternalId(transactionId);
+        charge.setGatewayTransactionId(null);
+        String actual = new CancelledByUser(transactionId, CancelledByUserEventDetails.from(charge), ZonedDateTime.parse(time)).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("CANCELLED_BY_USER")));
+        assertThat(actual, hasNoJsonPath("event_details.gateway_transaction_id"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
+import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureSubmittedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
@@ -310,7 +311,7 @@ public class EventFactoryTest {
                 new Object[]{CancelByUserFailed.class, EmptyEventDetails.class},
                 new Object[]{CancelledByExpiration.class, EmptyEventDetails.class},
                 new Object[]{CancelledByExternalService.class, EmptyEventDetails.class},
-                new Object[]{CancelledByUser.class, EmptyEventDetails.class},
+                new Object[]{CancelledByUser.class, CancelledByUserEventDetails.class},
                 new Object[]{CancelledWithGatewayAfterAuthorisationError.class, EmptyEventDetails.class},
                 new Object[]{CaptureAbandonedAfterTooManyRetries.class, EmptyEventDetails.class},
                 new Object[]{CaptureConfirmed.class, CaptureConfirmedEventDetails.class},

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDeta
 import uk.gov.pay.connector.events.eventdetails.charge.CaptureSubmittedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentDetailsEnteredEventDetails;
+import uk.gov.pay.connector.events.model.charge.CancelledByUser;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
@@ -235,6 +236,21 @@ public class QueueMessageContractTest {
     @PactVerifyProvider("a refund included in payout message")
     public String verifyRefundIncludedInPayoutEvent() throws JsonProcessingException {
         RefundIncludedInPayout event = new RefundIncludedInPayout(resourceId, "po_1234567890", ZonedDateTime.now());
+
+        return event.toJsonString();
+    }
+
+    @PactVerifyProvider("a cancelled by user message")
+    public String verifyCancelledByUserEvent() throws JsonProcessingException {
+        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+                .withTransactionId("gateway_transaction_id")
+                .withGatewayTransactionId("gateway_transaction_id")
+                .build();
+        ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture
+                .aValidChargeEventEntity()
+                .withCharge(charge)
+                .build();
+        CancelledByUser event = CancelledByUser.from(chargeEventEntity);
 
         return event.toJsonString();
     }


### PR DESCRIPTION
## WHAT YOU DID
- due to the nature of how gateway transaction id is emitted to Ledger, when user cancels a payment the aforementioned id is stored in Connector but not sent to Ledger. Thus causing a disparity between the two systems. This change ensures that the id is in Ledger and we can expunge those charges from Connector.
- also includes the producer part of a queue pact test
