### PR TITLE
PP-6501 Log more about 3DS data sent to gateways when authorising

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <commons-lang3.version>3.11</commons-lang3.version>
         <jjwt.version>0.11.2</jjwt.version>
         <pact.version>3.6.15</pact.version>
+        <mockito.version>3.5.13</mockito.version>
         <PACT_BROKER_URL/>
         <PACT_BROKER_USERNAME/>
         <PACT_BROKER_PASSWORD/>
@@ -367,7 +368,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.5.13</version>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gateway;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -14,7 +16,6 @@ import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationRespon
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import java.util.List;
@@ -43,4 +44,7 @@ public interface PaymentProvider {
     GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayException;
 
     ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundEntityList);
+    
+    AuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails);
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummary.java
@@ -1,0 +1,38 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+public class EpdqAuthorisationRequestSummary implements AuthorisationRequestSummary {
+
+    private final Presence billingAddress;
+    private final Presence dataFor3ds;
+    private final Presence dataFor3ds2;
+
+    public EpdqAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
+        dataFor3ds = chargeEntity.getGatewayAccount().isRequires3ds() ? PRESENT : NOT_PRESENT;
+        dataFor3ds2 = (chargeEntity.getGatewayAccount().isRequires3ds()
+                && chargeEntity.getGatewayAccount().getIntegrationVersion3ds() == 2) ? PRESENT : NOT_PRESENT;
+    }
+
+    @Override
+    public Presence billingAddress() {
+        return billingAddress;
+    }
+
+    @Override
+    public Presence dataFor3ds() {
+        return dataFor3ds;
+    }
+
+    @Override
+    public Presence dataFor3ds2() {
+        return dataFor3ds2;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -28,6 +28,7 @@ import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNew3dsO
 import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForNewOrder;
 import uk.gov.pay.connector.gateway.epdq.payload.EpdqPayloadDefinitionForQueryOrder;
 import uk.gov.pay.connector.gateway.model.Auth3dsResult.Auth3dsResultOutcome;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -238,6 +239,11 @@ public class EpdqPaymentProvider implements PaymentProvider {
     @Override
     public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
         return externalRefundAvailabilityCalculator.calculate(charge, refundList);
+    }
+
+    @Override
+    public EpdqAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        return new EpdqAuthorisationRequestSummary(chargeEntity, authCardDetails);
     }
 
     /**

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.gateway.model;
+
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+
+public interface AuthorisationRequestSummary {
+
+    enum Presence {
+        PRESENT, NOT_PRESENT, NOT_APPLICABLE
+    }
+
+    default Presence billingAddress() {
+        return NOT_APPLICABLE;
+    }
+
+    default Presence dataFor3ds() {
+        return NOT_APPLICABLE;
+    }
+
+    default Presence dataFor3ds2() {
+        return NOT_APPLICABLE;
+    }
+
+    default Presence deviceDataCollectionResult() {
+        return NOT_APPLICABLE;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummary.java
@@ -1,0 +1,7 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+public class SandboxAuthorisationRequestSummary implements AuthorisationRequestSummary {
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -4,9 +4,10 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
-import uk.gov.pay.connector.gateway.ChargeQueryResponse;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -24,7 +25,6 @@ import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxWalletAuthorisationH
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
 import java.util.List;
@@ -102,6 +102,11 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     @Override
     public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
         return externalRefundAvailabilityCalculator.calculate(charge, refundList);
+    }
+
+    @Override
+    public SandboxAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        return new SandboxAuthorisationRequestSummary();
     }
 
     private GatewayResponse<BaseCancelResponse> createGatewayBaseCancelResponse() {

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummary.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+public class SmartpayAuthorisationRequestSummary implements AuthorisationRequestSummary {
+
+    private final Presence billingAddress;
+    private final Presence dataFor3ds;
+
+    public SmartpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
+        dataFor3ds = chargeEntity.getGatewayAccount().isRequires3ds() ? PRESENT : NOT_PRESENT;
+    }
+
+    @Override
+    public Presence billingAddress() {
+        return billingAddress;
+    }
+
+    @Override
+    public Presence dataFor3ds() {
+        return dataFor3ds;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -160,6 +161,11 @@ public class SmartpayPaymentProvider implements PaymentProvider {
         return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
+    @Override
+    public SmartpayAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        return new SmartpayAuthorisationRequestSummary(chargeEntity, authCardDetails);
+    }
+
     private GatewayOrder buildAuthoriseOrderFor(CardAuthorisationGatewayRequest request) {
         SmartpayOrderRequestBuilder smartpayOrderRequestBuilder = request.getGatewayAccount().isRequires3ds() ?
                 SmartpayOrderRequestBuilder.aSmartpay3dsRequiredOrderRequestBuilder() : SmartpayOrderRequestBuilder.aSmartpayAuthoriseOrderRequestBuilder();
@@ -191,4 +197,5 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     private String getMerchantCode(GatewayRequest request) {
         return request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID);
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
@@ -1,0 +1,22 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+public class StripeAuthorisationRequestSummary implements AuthorisationRequestSummary {
+
+    private final Presence billingAddress;
+
+    public StripeAuthorisationRequestSummary(AuthCardDetails authCardDetails) {
+        billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
+    }
+
+    @Override
+    public Presence billingAddress() {
+        return billingAddress;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -191,4 +192,10 @@ public class StripePaymentProvider implements PaymentProvider {
     public ExternalChargeRefundAvailability getExternalChargeRefundAvailability(Charge charge, List<Refund> refundList) {
         return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
+
+    @Override
+    public StripeAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        return new StripeAuthorisationRequestSummary(authCardDetails);
+    }
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -1,0 +1,59 @@
+package uk.gov.pay.connector.gateway.util;
+
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import java.util.StringJoiner;
+
+public class AuthorisationRequestSummaryStringifier {
+
+    public String stringify(AuthorisationRequestSummary authorisationRequestSummary) {
+        var stringJoiner = new StringJoiner(" and ", " ", "");
+
+        switch (authorisationRequestSummary.billingAddress()) {
+            case PRESENT:
+                stringJoiner.add("with billing address");
+                break;
+            case NOT_PRESENT:
+                stringJoiner.add("without billing address");
+                break;
+            default:
+                break;
+        }
+
+        switch (authorisationRequestSummary.dataFor3ds()) {
+            case PRESENT:
+                stringJoiner.add("with 3DS data");
+                break;
+            case NOT_PRESENT:
+                stringJoiner.add("without 3DS data");
+                break;
+            default:
+                break;
+        }
+
+        switch (authorisationRequestSummary.dataFor3ds2()) {
+            case PRESENT:
+                stringJoiner.add("with 3DS2 data");
+                break;
+            case NOT_PRESENT:
+                stringJoiner.add("without 3DS2 data");
+                break;
+            default:
+                break;
+        }
+
+        switch (authorisationRequestSummary.deviceDataCollectionResult()) {
+            case PRESENT:
+                stringJoiner.add("with device data collection result");
+                break;
+            case NOT_PRESENT:
+                stringJoiner.add("without device data collection result");
+                break;
+            default:
+                break;
+        }
+
+        return stringJoiner.toString();
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+public class WorldpayAuthorisationRequestSummary implements AuthorisationRequestSummary {
+
+    private final Presence billingAddress;
+    private final Presence dataFor3ds;
+    private final Presence deviceDataCollectionResult;
+
+    public WorldpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
+        deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
+        dataFor3ds = (deviceDataCollectionResult == PRESENT || chargeEntity.getGatewayAccount().isRequires3ds()) ? PRESENT : NOT_PRESENT;
+    }
+
+    @Override
+    public Presence billingAddress() {
+        return billingAddress;
+    }
+
+    @Override
+    public Presence dataFor3ds() {
+        return dataFor3ds;
+    }
+
+    @Override
+    public Presence deviceDataCollectionResult() {
+        return deviceDataCollectionResult;
+    }
+
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -209,6 +210,11 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         return externalRefundAvailabilityCalculator.calculate(charge, refundList);
     }
 
+    @Override
+    public WorldpayAuthorisationRequestSummary generateAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
+        return new WorldpayAuthorisationRequestSummary(chargeEntity, authCardDetails);
+    }
+
     private GatewayOrder buildAuthoriseOrder(CardAuthorisationGatewayRequest request) {
         logMissingDdcResultFor3dsFlexIntegration(request);
 
@@ -259,4 +265,5 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     private String sanitiseMessage(String message) {
         return message.replaceAll("<cardHolderName>.*</cardHolderName>", "<cardHolderName>REDACTED</cardHolderName>");
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummaryTest.java
@@ -1,0 +1,92 @@
+package uk.gov.pay.connector.gateway.epdq;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+@ExtendWith(MockitoExtension.class)
+class EpdqAuthorisationRequestSummaryTest {
+
+    @Mock private ChargeEntity mockChargeEntity;
+    @Mock private GatewayAccountEntity mockGatewayAccountEntity;
+    @Mock private AuthCardDetails mockAuthCardDetails;
+
+    @BeforeEach
+    void setUp() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+    }
+
+    @Test
+    void billingAddressPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.billingAddress(), is(PRESENT));
+    }
+
+    @Test
+    void billingAddressNotPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void requires3dsTrueMeansDataFor3dsPresent() {
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
+    }
+
+    @Test
+    void requires3dsFalseMeansDataFor3dsNotPresent() {
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void requires3dsFalseMeansDataFor3ds2NotPresent() {
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.dataFor3ds2(), is(NOT_PRESENT));
+    }
+    
+    @Test
+    void requires3dsTrueAnd3dsVersion1MeansDataFor3ds2NotPresent() {
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        given(mockGatewayAccountEntity.getIntegrationVersion3ds()).willReturn(1);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.dataFor3ds2(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void requires3dsTrueAnd3dsVersion2MeansDataFor3ds2Present() {
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        given(mockGatewayAccountEntity.getIntegrationVersion3ds()).willReturn(2);
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.dataFor3ds2(), is(PRESENT));
+    }
+
+    @Test
+    void deviceDataCollectionResultAlwaysNotApplicable() {
+        var epdqAuthorisationRequestSummary = new EpdqAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(epdqAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxAuthorisationRequestSummaryTest.java
@@ -1,0 +1,35 @@
+package uk.gov.pay.connector.gateway.sandbox;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+
+class SandboxAuthorisationRequestSummaryTest {
+
+    @Test
+    void billingAddressAlwaysNotApplicable() {
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        assertThat(sandboxAuthorisationRequestSummary.billingAddress(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void dataFor3dsAlwaysNotApplicable() {
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        assertThat(sandboxAuthorisationRequestSummary.dataFor3ds(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void dataFor3ds2AlwaysNotApplicable() {
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        assertThat(sandboxAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void deviceDataCollectionResultAlwaysNotApplicable() {
+        var sandboxAuthorisationRequestSummary = new SandboxAuthorisationRequestSummary();
+        assertThat(sandboxAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummaryTest.java
@@ -1,0 +1,75 @@
+package uk.gov.pay.connector.gateway.smartpay;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+@ExtendWith(MockitoExtension.class)
+class SmartpayAuthorisationRequestSummaryTest {
+
+    @Mock private ChargeEntity mockChargeEntity;
+    @Mock private GatewayAccountEntity mockGatewayAccountEntity;
+    @Mock private AuthCardDetails mockAuthCardDetails;
+
+    @BeforeEach
+    void setUp() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+    }
+
+    @Test
+    void billingAddressPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(smartpayAuthorisationRequestSummary.billingAddress(), is(PRESENT));
+    }
+
+    @Test
+    void billingAddressNotPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(smartpayAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void requires3dsTrueMeansDataFor3dsPresent() {
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(smartpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
+    }
+
+    @Test
+    void requires3dsFalseMeansDataFor3dsNotPresent() {
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(smartpayAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void dataFor3ds2AlwaysNotApplicable() {
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(smartpayAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void deviceDataCollectionResultAlwaysNotApplicable() {
+        var smartpayAuthorisationRequestSummary = new SmartpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(smartpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummaryTest.java
@@ -1,0 +1,57 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+@ExtendWith(MockitoExtension.class)
+class StripeAuthorisationRequestSummaryTest {
+
+    @Mock private AuthCardDetails mockAuthCardDetails;
+
+    @Test
+    void billingAddressPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        assertThat(stripeAuthorisationRequestSummary.billingAddress(), is(PRESENT));
+    }
+
+    @Test
+    void billingAddressNotPresent() {
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        assertThat(stripeAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void dataFor3dsAlwaysNotApplicable() {
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        assertThat(stripeAuthorisationRequestSummary.dataFor3ds(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void dataFor3ds2AlwaysNotApplicable() {
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        assertThat(stripeAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
+    }
+
+    @Test
+    void deviceDataCollectionResultAlwaysNotApplicable() {
+        var stripeAuthorisationRequestSummary = new StripeAuthorisationRequestSummary(mockAuthCardDetails);
+        assertThat(stripeAuthorisationRequestSummary.deviceDataCollectionResult(), is(NOT_APPLICABLE));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.gateway.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorisationRequestSummaryStringifierTest {
+
+    @Mock private AuthorisationRequestSummary mockAuthorisationRequestSummary;
+
+    private final AuthorisationRequestSummaryStringifier stringifier = new AuthorisationRequestSummaryStringifier();
+
+    @Test
+    void stringifySummarises() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
+
+        String result = stringifier.stringify(mockAuthorisationRequestSummary);
+        
+        assertThat(result, is(" with billing address and with 3DS data and without device data collection result"));
+    }
+
+    @Test
+    void stringifyWithEverythingNotApplicableReturnsSingleSpace() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
+
+        String result = stringifier.stringify(mockAuthorisationRequestSummary);
+
+        assertThat(result, is(" "));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
@@ -1,0 +1,83 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+
+@ExtendWith(MockitoExtension.class)
+class WorldpayAuthorisationRequestSummaryTest {
+
+    @Mock private ChargeEntity mockChargeEntity;
+    @Mock private GatewayAccountEntity mockGatewayAccountEntity;
+    @Mock private AuthCardDetails mockAuthCardDetails;
+
+    @Test
+    void billingAddressPresent() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.of(mock(Address.class)));
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(PRESENT));
+    }
+
+    @Test
+    void billingAddressNotPresent() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockAuthCardDetails.getAddress()).willReturn(Optional.empty());
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.billingAddress(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void requires3dsTrueMeansDataFor3dsPresent() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
+    }
+
+    @Test
+    void requires3dsFalseMeansDataFor3dsNotPresent() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void deviceDataCollectionResultPresentMeansDataFor3dsPresent() {
+        given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
+    }
+
+    @Test
+    void deviceDataCollectionResultPresent() {
+        given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(PRESENT));
+    }
+
+    @Test
+    void dataFor3ds2AlwaysNotApplicable() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.dataFor3ds2(), is(NOT_APPLICABLE));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.epdq.model.response.EpdqAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.PayersCardPrepaidStatus;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
@@ -37,6 +38,8 @@ import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
+import uk.gov.pay.connector.gateway.sandbox.SandboxAuthorisationRequestSummary;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
@@ -121,12 +124,18 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
     @Mock
     private NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
 
+    @Mock
+    private AuthorisationRequestSummaryStringifier mockAuthorisationRequestSummaryStringifier;
+    
     private CardAuthoriseService cardAuthorisationService;
 
     @Before
     public void setUpCardAuthorisationService() {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
         when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+        when(mockedPaymentProvider.generateAuthorisationRequestSummary(any(ChargeEntity.class), any(AuthCardDetails.class)))
+                .thenReturn(new SandboxAuthorisationRequestSummary());
+        when(mockAuthorisationRequestSummaryStringifier.stringify(any(AuthorisationRequestSummary.class))).thenReturn("");
 
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
@@ -139,6 +148,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 mockedProviders,
                 cardAuthoriseBaseService,
                 chargeService,
+                mockAuthorisationRequestSummaryStringifier,
                 mockEnvironment);
     }
 


### PR DESCRIPTION
When we send an authorisation request to a gateway, we currently log something like:

“Authorisation with billing address for abcdefghijklmnopqrstuvwxyz (worldpay xxx) for…”

The word “with” can be “without” if appropriate.

Enhance this to also include more information about what additional data used for 3D Secure we’re sending to the payment gateway, if any.

In all the below examples, each “with” will be “without” as appropriate.

Worldpay:

“Authorisation with billing address and with 3DS data and with device data collection result for abcdefghijklmnopqrstuvwxyz (worldpay xxx) for…”

Stripe:

“Authorisation with billing address for abcdefghijklmnopqrstuvwxyz (stripe xxx) for …”

Smartpay:

“Authorisation with billing address and with 3DS data for abcdefghijklmnopqrstuvwxyz (smartpay xxx) for…”

ePDQ:

“Authorisation with billing address and with 3DS data and with 3DS2 data for abcdefghijklmnopqrstuvwxyz (epdq xxx) for…”

Sandbox:

“Authorisation for abcdefghijklmnopqrstuvwxyz (sandbox xxx) for…”

If a gateway account’s 3DS configuaration is changed close to an authorisation request being sent to the gateway, it’s possible we might misreport whether more 3D Secure data was being sent or not. However, this will be exceptionally rare so isn’t worth the effort to fix.