### PR TITLE
PP-6501 Add structured logging for authorisation request data

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
@@ -1,0 +1,67 @@
+package uk.gov.pay.connector.gateway.util;
+
+import net.logstash.logback.argument.StructuredArgument;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import java.util.ArrayList;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+public class AuthorisationRequestSummaryStructuredLogging {
+    
+    public static final String BILLING_ADDRESS = "billing_address";
+    public static final String DATA_FOR_3DS = "data_for_3ds";
+    public static final String DATA_FOR_3DS2 = "data_for_3ds2";
+    public static final String WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT = "worldpay_3ds_flex_device_data_collection_result";
+
+    public StructuredArgument[] createArgs(AuthorisationRequestSummary authorisationRequestSummary) {
+        var structuredArguments = new ArrayList<StructuredArgument>();
+        
+        switch (authorisationRequestSummary.billingAddress()) {
+            case PRESENT:
+                structuredArguments.add(kv(BILLING_ADDRESS, true));
+                break;
+            case NOT_PRESENT:
+                structuredArguments.add(kv(BILLING_ADDRESS, false));
+                break;
+            default:
+                break;
+        }
+
+        switch (authorisationRequestSummary.dataFor3ds()) {
+            case PRESENT:
+                structuredArguments.add(kv(DATA_FOR_3DS, true));
+                break;
+            case NOT_PRESENT:
+                structuredArguments.add(kv(DATA_FOR_3DS, false));
+                break;
+            default:
+                break;
+        }
+
+        switch (authorisationRequestSummary.dataFor3ds2()) {
+            case PRESENT:
+                structuredArguments.add(kv(DATA_FOR_3DS2, true));
+                break;
+            case NOT_PRESENT:
+                structuredArguments.add(kv(DATA_FOR_3DS2, false));
+                break;
+            default:
+                break;
+        }
+
+        switch (authorisationRequestSummary.deviceDataCollectionResult()) {
+            case PRESENT:
+                structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true));
+                break;
+            case NOT_PRESENT:
+                structuredArguments.add(kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false));
+                break;
+            default:
+                break;
+        }
+
+        return structuredArguments.toArray(new StructuredArgument[structuredArguments.size()]);
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
@@ -1,0 +1,93 @@
+package uk.gov.pay.connector.gateway.util;
+
+import net.logstash.logback.argument.StructuredArgument;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.ArrayMatching.arrayContaining;
+import static org.hamcrest.collection.IsArrayWithSize.emptyArray;
+import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
+import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.BILLING_ADDRESS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS2;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorisationRequestSummaryStructuredLoggingTest {
+
+    @Mock private AuthorisationRequestSummary mockAuthorisationRequestSummary;
+
+    private final AuthorisationRequestSummaryStructuredLogging structuredLogging = new AuthorisationRequestSummaryStructuredLogging();
+
+    @Test
+    void createArgsWithAllPresent() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(PRESENT);
+
+        StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
+
+        assertThat(result, arrayContaining(
+                kv(BILLING_ADDRESS, true),
+                kv(DATA_FOR_3DS, true),
+                kv(DATA_FOR_3DS2, true),
+                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true)
+        ));
+    }
+
+    @Test
+    void createArgsWithAllNotPresent() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(NOT_PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_PRESENT);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
+
+        StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
+
+        assertThat(result, is(arrayContaining(
+                kv(BILLING_ADDRESS, false),
+                kv(DATA_FOR_3DS, false),
+                kv(DATA_FOR_3DS2, false),
+                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false)
+        )));
+    }
+
+    @Test
+    void createArgsWithAllNotApplicable() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
+
+        StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
+
+        assertThat(result, is(emptyArray()));
+    }
+
+    @Test
+    void createArgsWithMixture() {
+        given(mockAuthorisationRequestSummary.billingAddress()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
+
+        StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
+
+        assertThat(result, is(arrayContaining(
+                kv(BILLING_ADDRESS, true),
+                kv(DATA_FOR_3DS, true),
+                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false)
+        )));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -40,6 +40,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder;
 import uk.gov.pay.connector.gateway.sandbox.SandboxAuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
+import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
@@ -117,7 +118,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private EventService mockEventService;
-    
+
     @Mock
     private RefundService mockRefundService;
 
@@ -126,6 +127,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private AuthorisationRequestSummaryStringifier mockAuthorisationRequestSummaryStringifier;
+
+    @Mock
+    private AuthorisationRequestSummaryStructuredLogging mockAuthorisationRequestSummaryStructuredLogging;
     
     private CardAuthoriseService cardAuthorisationService;
 
@@ -149,6 +153,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 cardAuthoriseBaseService,
                 chargeService,
                 mockAuthorisationRequestSummaryStringifier,
+                mockAuthorisationRequestSummaryStructuredLogging,
                 mockEnvironment);
     }
 


### PR DESCRIPTION
Add structured logging containing information about the authorisation data sent a gateway when we authorise (in addition to the usual stuff available on the charge).

New fields are `"billing_address"` (except sandbox), `"data_for_3ds"` (except sandbox and Stripe), `"data_for_3ds2"` (ePDQ only) and `"worldpay_3ds_flex_device_data_collection_result"` (Worldpay only) and have values of either true or false.

The information will match the prose logging introduced in commit 5923a5eec34351875012343a1bdc29574e2eae29 with the same caveats.