### PR TITLE
PP-6989 Include card details on payment created event for expired/user cancelled charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -12,8 +12,11 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.USER_CANCELLED;
 
 public class PaymentCreatedEventDetails extends EventDetails {
 
@@ -96,7 +99,10 @@ public class PaymentCreatedEventDetails extends EventDetails {
 
     private static boolean containsPostAuthorisationReadyStatus(ChargeStatus status) {
         return PaymentGatewayStateTransitions.getInstance()
-                .getNextStatus(AUTHORISATION_READY).contains(status);
+                .getNextStatus(AUTHORISATION_READY)
+                .stream().filter(chargeStatus -> !(chargeStatus.equals(EXPIRED) || chargeStatus.equals(USER_CANCELLED)))
+                .collect(Collectors.toList())
+                .contains(status);
     }
 
     private static void addCardDetailsIfExist(ChargeEntity charge, Builder builder) {

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -71,14 +71,24 @@ public class PaymentCreatedTest {
         assertThat(paymentCreatedEvent, hasJsonPath("$.event_details.email", equalTo("test@email.gov.uk")));
     }
 
+
+    private Object[] eventStatusesForNonCreatedAndNonAuthWithCardDetails() {
+        return new Object[]{
+                new Object[]{ChargeStatus.USER_CANCELLED},
+                new Object[]{ChargeStatus.SYSTEM_CANCELLED},
+                new Object[]{ChargeStatus.EXPIRED}
+        };
+    }
+
     @Test
-    public void serializesPayloadForNonCreatedWithCardDetails() throws JsonProcessingException {
+    @Parameters(method = "eventStatusesForNonCreatedAndNonAuthWithCardDetails")
+    public void serializesPayloadForNonCreatedWithCardDetails(ChargeStatus status) throws JsonProcessingException {
         chargeEntityFixture
-                .withStatus(ChargeStatus.SYSTEM_CANCELLED)
+                .withStatus(ChargeStatus.USER_CANCELLED)
                 .withCardDetails(anAuthCardDetails().getCardDetailsEntity())
                 .withEvents(List.of(
                         aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.CREATED).withUpdated(ZonedDateTime.now().minusHours(3)).build(),
-                        aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.SYSTEM_CANCELLED).withUpdated(ZonedDateTime.now().minusHours(3)).build()
+                        aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(status).withUpdated(ZonedDateTime.now().minusHours(3)).build()
                 ));
 
         var paymentCreatedEvent = preparePaymentCreatedEvent();


### PR DESCRIPTION
## WHAT

- When a service prefills billing address, card holder details are included in payment created event details.
  During the backfilling, we only include card holder details on payment created events if charge has not gone through authorisation to avoid including details when not necessary.
  Payment state transition graph is used to get possible states post authorisation which also included USER_CANCELLED and EXPIRED states. But these states are also possible before any authorisation activity and to be excluded as states post authorisation

