### PR TITLE
PP-6991: Manually set the JVM TTL for DNS Name Lookups

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -86,6 +86,8 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
     @Override
     public void initialize(Bootstrap<ConnectorConfiguration> bootstrap) {
+        java.security.Security.setProperty("networkaddress.cache.ttl" , "15");
+        
         bootstrap.setConfigurationSourceProvider(
                 new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
                         new EnvironmentVariableSubstitutor(NON_STRICT_VARIABLE_SUBSTITUTOR)


### PR DESCRIPTION
According to the Worldpay Payment Gateway best practice guide
(https://developer.worldpay.com/docs/wpg/reference/wpgbestpractice), domains
should only be cached "within the published Time To Live, in order to ensure
that you respond to DNS changes in a timely manner". From further
correspondence with Worldpay, the time-to-live of a DNS
record is an attribute of the individual result, and is sent as part of the DNS
lookup protocol. It is not published separately, because it can change from
time to time and from record to record, but it is typically of the order of a
few minutes.

Our current TTL (networkaddress.cache.ttl) is set based on adoptopenjdk docker
image we use, currently set to 15 seconds. This disadvantage of relying on the
adoptopenjdk docker image is that the TTL might fail silently if we switch to
another JDK distro. It therefore seems pertinent to set it manually here.
