### PR TITLE
Revert "PP-6991: Manually set the JVM TTL for DNS Name Lookups"

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -86,8 +86,6 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
 
     @Override
     public void initialize(Bootstrap<ConnectorConfiguration> bootstrap) {
-        java.security.Security.setProperty("networkaddress.cache.ttl" , "15");
-        
         bootstrap.setConfigurationSourceProvider(
                 new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
                         new EnvironmentVariableSubstitutor(NON_STRICT_VARIABLE_SUBSTITUTOR)


### PR DESCRIPTION
I believe this commit was causing a smoke test failure.

Reverts alphagov/pay-connector#2622