### PR TITLE
PP-6991: Make reverse dns lookup more stringent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -26,6 +26,7 @@ import uk.gov.pay.connector.queue.statetransition.StateTransitionQueue;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.pay.connector.util.HashUtil;
 import uk.gov.pay.connector.util.JsonObjectMapper;
+import uk.gov.pay.connector.util.ReverseDnsLookup;
 import uk.gov.pay.connector.util.XrayUtils;
 import uk.gov.pay.connector.wallets.applepay.ApplePayDecrypter;
 
@@ -96,6 +97,16 @@ public class ConnectorModule extends AbstractModule {
         return new XrayUtils(connectorConfiguration.isXrayEnabled());
     }
 
+    @Provides
+    @Singleton
+    public ReverseDnsLookup reverseDnsLookup() {
+        return getReverseDnsLookup();
+    }
+    
+    protected ReverseDnsLookup getReverseDnsLookup() {
+        return new ReverseDnsLookup();
+    }
+    
     @Provides
     public SignatureGenerator signatureGenerator() {
         return new EpdqSha512SignatureGenerator();

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -37,7 +37,7 @@ worldpay:
     test: ${GDS_CONNECTOR_WORLDPAY_TEST_URL}
     live: ${GDS_CONNECTOR_WORLDPAY_LIVE_URL}
   secureNotificationEnabled: ${SECURE_WORLDPAY_NOTIFICATION_ENABLED:-false}
-  notificationDomain: ${SECURE_WORLDPAY_NOTIFICATION_DOMAIN:-worldpay.com}
+  notificationDomain: ${SECURE_WORLDPAY_NOTIFICATION_DOMAIN:-.worldpay.com}
   credentials: ['username','password','merchant_id']
   applePay:
     privateKey: ${APPLE_PAY_PAYMENT_PROCESSING_PRIVATE_KEY:-privateKeyWhichShouldBeBase64Encoded}

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -9,7 +9,6 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.junit.ConfigOverride;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
@@ -27,7 +26,6 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_APPROVED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL_SUCCESS;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildCorporateJsonAuthorisationDetailsFor;


### PR DESCRIPTION
Incoming traffic from worldpay will always be from the domain `*.worldpay.com`.
It was possible for us to receive traffic from `somebadattackerurlworldpay.com`
before.

There will be another pay-infra PR.