### PR TITLE
PP-6991: Delete non-production code

### DIFF
--- a/src/main/java/uk/gov/pay/connector/util/DnsUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/DnsUtils.java
@@ -7,10 +7,14 @@ import org.slf4j.LoggerFactory;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.InitialDirContext;
-import java.net.InetAddress;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Optional;
 
-import static java.lang.String.*;
+import static java.lang.String.format;
+import static java.lang.String.join;
 
 public class DnsUtils {
     private static final Logger logger = LoggerFactory.getLogger(DnsUtils.class);
@@ -35,15 +39,6 @@ public class DnsUtils {
         } catch (Exception e) {
             logger.error("Reverse DNS Lookup failed: {}", e.getLocalizedMessage());
             return false;
-        }
-    }
-
-    public Optional<String> dnsLookup(String hostName) {
-        try {
-            InetAddress inetAddress = InetAddress.getByName(hostName);
-            return Optional.ofNullable(inetAddress.getHostAddress());
-        } catch (Exception e) {
-            return Optional.empty();
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -8,7 +8,6 @@ import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
-import uk.gov.pay.connector.util.DnsUtils;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
@@ -201,8 +200,7 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
     }
 
     private ValidatableResponse notifyConnector(String payload) {
-        String validIp = new DnsUtils().dnsLookup("build.ci.pymnt.uk").get();
-        String xForwardedForHeader = format("%s, %s", validIp, "8.8.8.8");
+        String xForwardedForHeader = format("%s, %s", "54.194.29.214", "8.8.8.8");
         return given().port(testContext.getPort())
                 .body(payload)
                 .header("X-Forwarded-For", xForwardedForHeader)

--- a/src/test/java/uk/gov/pay/connector/util/DnsUtilsITest.java
+++ b/src/test/java/uk/gov/pay/connector/util/DnsUtilsITest.java
@@ -1,10 +1,7 @@
 package uk.gov.pay.connector.util;
 
-import org.apache.commons.validator.routines.InetAddressValidator;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -16,14 +13,6 @@ public class DnsUtilsITest {
     @Before
     public void setup() {
         dnsUtils = new DnsUtils();
-    }
-
-    @Test
-    public void shouldReturnAnIpAddressForAValidHostname() {
-        InetAddressValidator validator = InetAddressValidator.getInstance();
-        Optional<String> maybeIp = dnsUtils.dnsLookup("build.ci.pymnt.uk");
-        assertThat(maybeIp.isPresent(), is(true));
-        assertThat(validator.isValidInet4Address(maybeIp.get()), is (true));
     }
 
     @Test
@@ -42,11 +31,6 @@ public class DnsUtilsITest {
     public void reverseDnsShouldReturnHostIfIpIsValid() {
         assertThat(dnsUtils.reverseDnsLookup("195.35.90.1").isPresent(), is(true));
         assertThat(dnsUtils.reverseDnsLookup("195.35.90.1").get(), is("hello.worldpay.com."));
-    }
-
-    @Test
-    public void shouldNotReturnAnIpAddressForAnInvalidHostname() {
-        assertThat(dnsUtils.dnsLookup("asdasd").isPresent(), is(false));
     }
 
     @Test


### PR DESCRIPTION
`DnsUtils.dnsLookup` is not actually production code.

This is the first of a few PRs that aims to make the pay-connector build not depend on having a network available.