### PR TITLE
PP-7255 Add DAO method to find refunds by parity check status

### DIFF
--- a/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
+++ b/src/main/java/uk/gov/pay/connector/refund/dao/RefundDao.java
@@ -198,4 +198,14 @@ public class RefundDao extends JpaDao<RefundEntity> {
                 .setParameter(3, externalId)
                 .executeUpdate();
     }
+
+    public List<RefundEntity> findByParityCheckStatus(ParityCheckStatus parityCheckStatus, int pageSize, Long lastProcessedId) {
+        return entityManager.get()
+                .createQuery("SELECT r FROM RefundEntity r WHERE r.id > :lastProcessedId " +
+                        " AND r.parityCheckStatus = :parityCheckStatus ORDER BY r.id", RefundEntity.class)
+                .setParameter("parityCheckStatus", parityCheckStatus)
+                .setParameter("lastProcessedId", lastProcessedId)
+                .setMaxResults(pageSize)
+                .getResultList();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -68,7 +68,6 @@ public class ChargeDaoIT extends DaoITestBase {
     private ChargeDao chargeDao;
 
     private DatabaseFixtures.TestAccount defaultTestAccount;
-    private DatabaseFixtures.TestRefund defaultTestRefund;
     private DatabaseFixtures.TestCharge defaultTestCharge;
     private DatabaseFixtures.TestCardDetails defaultTestCardDetails;
 
@@ -868,7 +867,7 @@ public class ChargeDaoIT extends DaoITestBase {
     }
 
     private void insertTestRefund() {
-        this.defaultTestRefund = DatabaseFixtures
+        DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestRefund()
                 .withTestCharge(defaultTestCharge)


### PR DESCRIPTION
## WHAT YOU DID
- Added DAO method to find refunds by parity check status. This is to be used to invoke parity check task on refunds for a given parity check status
