### PR TITLE
PP-7255 Parity check task for refunds

### DIFF
--- a/src/main/java/uk/gov/pay/connector/tasks/EventEmitterParamUtil.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/EventEmitterParamUtil.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static uk.gov.pay.connector.tasks.RecordType.fromString;
 
 public class EventEmitterParamUtil {
 
@@ -50,5 +52,15 @@ public class EventEmitterParamUtil {
         return (parameters.get(paramName) == null ||
                 parameters.get(paramName).isEmpty()) ?
                 null : parameters.get(paramName).get(0);
+    }
+
+    public static Optional<RecordType> getRecordType(Map<String, List<String>> parameters) {
+        String recordType = getParameterValue(parameters, "record_type");
+
+        if (isEmpty(recordType)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(fromString(recordType));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterTask.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterTask.java
@@ -15,9 +15,8 @@ import java.util.OptionalLong;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static uk.gov.pay.connector.tasks.EventEmitterParamUtil.getOptionalLongParam;
-import static uk.gov.pay.connector.tasks.EventEmitterParamUtil.getParameterValue;
+import static uk.gov.pay.connector.tasks.EventEmitterParamUtil.getRecordType;
 import static uk.gov.pay.connector.tasks.RecordType.CHARGE;
 
 public class HistoricalEventEmitterTask extends Task {
@@ -53,7 +52,7 @@ public class HistoricalEventEmitterTask extends Task {
         Long startId = getOptionalLongParam(parameters, "start_id").orElse(0);
         final OptionalLong maybeMaxId = getOptionalLongParam(parameters, "max_id");
         final Long doNotRetryEmitUntilDuration = getDoNotRetryEmitUntilDuration(parameters);
-        final RecordType recordType = getRecordType(parameters);
+        final RecordType recordType = getRecordType(parameters).orElse(CHARGE);
 
         logger.info("Execute called start_id={} max_id={} doNotRetryEmitUntilDuration={} - processing",
                 startId, maybeMaxId, doNotRetryEmitUntilDuration);
@@ -72,17 +71,6 @@ public class HistoricalEventEmitterTask extends Task {
             logger.info("Rejected request, worker already running");
             output.println("Rejected request, worker already running");
         }
-    }
-
-    private RecordType getRecordType(Map<String, List<String>> parameters) {
-        String recordType = getParameterValue(parameters, "record_type");
-
-        if (isEmpty(recordType)) {
-            logger.info("Record type is not set available, defaulting to [{}]", CHARGE);
-            return CHARGE;
-        }
-
-        return RecordType.fromString(recordType);
     }
 
     private Long getDoNotRetryEmitUntilDuration(Map<String, List<String>> parameters) {

--- a/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/ParityCheckWorker.java
@@ -13,13 +13,20 @@ import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.tasks.service.ParityCheckService;
 
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.connector.charge.model.domain.ParityCheckStatus.EXISTS_IN_LEDGER;
 import static uk.gov.pay.connector.filters.RestClientLoggingFilter.HEADER_REQUEST_ID;
+import static uk.gov.pay.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+import static uk.gov.pay.logging.LoggingKeys.REFUND_EXTERNAL_ID;
 
 public class ParityCheckWorker {
     private static final int PAGE_SIZE = 100;
@@ -30,6 +37,7 @@ public class ParityCheckWorker {
     private EmittedEventDao emittedEventDao;
     private StateTransitionService stateTransitionService;
     private EventService eventService;
+    private RefundService refundService;
     private RefundDao refundDao;
     private ParityCheckService parityCheckService;
     private HistoricalEventEmitter historicalEventEmitter;
@@ -37,13 +45,14 @@ public class ParityCheckWorker {
 
     @Inject
     public ParityCheckWorker(ChargeDao chargeDao, ChargeService chargeService, EmittedEventDao emittedEventDao,
-                             StateTransitionService stateTransitionService, EventService eventService, RefundDao refundDao,
-                             ParityCheckService parityCheckService) {
+                             StateTransitionService stateTransitionService, EventService eventService,
+                             RefundService refundService, RefundDao refundDao, ParityCheckService parityCheckService) {
         this.chargeDao = chargeDao;
         this.chargeService = chargeService;
         this.emittedEventDao = emittedEventDao;
         this.stateTransitionService = stateTransitionService;
         this.eventService = eventService;
+        this.refundService = refundService;
         this.refundDao = refundDao;
         this.parityCheckService = parityCheckService;
     }
@@ -73,6 +82,27 @@ public class ParityCheckWorker {
         }
 
         logger.info("Terminating");
+    }
+
+    public void executeForRefundsOnly(Long startId, Long maxId, boolean doNotReprocessValidRecords,
+                                      String parityCheckStatus, Long doNotRetryEmitUntilDuration) {
+        String parityCheckRequestId = "ParityCheckWorker-" + RandomUtils.nextLong(0, 10000);
+        try {
+            initializeHistoricalEventEmitter(doNotRetryEmitUntilDuration);
+            MDC.put(HEADER_REQUEST_ID, parityCheckRequestId);
+
+            if (isNotBlank(parityCheckStatus)) {
+                processRefundsByParityCheckStatus(parityCheckStatus, doNotReprocessValidRecords);
+            } else {
+                maxId = ofNullable(maxId).orElseGet(refundDao::findMaxId);
+                processRefundsByIdRange(startId, maxId, doNotReprocessValidRecords);
+            }
+        } catch (Exception e) {
+            logger.error("Error parity checking refunds on job [start={}] [max={}] [error={}]",
+                    startId, maxId, e.getMessage(), e);
+        }
+        logger.info("Terminating");
+        MDC.remove(HEADER_REQUEST_ID);
     }
 
     private void initializeHistoricalEventEmitter(Long doNotRetryEmitUntilDuration) {
@@ -115,10 +145,9 @@ public class ParityCheckWorker {
     @Transactional
     public void checkParityFor(ChargeEntity charge, boolean doNotReprocessValidRecords) {
         try {
-            MDC.put("chargeId", charge.getExternalId());
+            MDC.put(PAYMENT_EXTERNAL_ID, charge.getExternalId());
 
-            if (doNotReprocessValidRecords && ParityCheckStatus.EXISTS_IN_LEDGER.equals(charge.getParityCheckStatus())) {
-                logger.info("transaction parity check skipped [id={},status={}]", charge.getId(), charge.getParityCheckStatus());
+            if (skipParityCheck(charge.getId(), charge.getParityCheckStatus(), doNotReprocessValidRecords)) {
                 return;
             }
 
@@ -126,16 +155,71 @@ public class ParityCheckWorker {
             chargeService.updateChargeParityStatus(charge.getExternalId(), parityCheckStatus);
             logger.info("transaction parity check finished [id={},status={}]", charge.getId(), parityCheckStatus);
 
-            if (!parityCheckStatus.equals(ParityCheckStatus.EXISTS_IN_LEDGER)) {
-                emitHistoricalEvents(charge);
+            if (!parityCheckStatus.equals(EXISTS_IN_LEDGER)) {
+                historicalEventEmitter.processPaymentEvents(charge, true);
             }
         } finally {
             MDC.remove("chargeId");
         }
     }
 
-    private void emitHistoricalEvents(ChargeEntity charge) {
-        historicalEventEmitter.processPaymentEvents(charge, true);
-        historicalEventEmitter.processRefundEvents(charge.getExternalId(), true);
+    @Transactional
+    public void checkParityForRefund(RefundEntity refund, boolean doNotReprocessValidRecords) {
+        try {
+            MDC.put(REFUND_EXTERNAL_ID, refund.getExternalId());
+
+            if (skipParityCheck(refund.getId(), refund.getParityCheckStatus(), doNotReprocessValidRecords)) {
+                return;
+            }
+
+            ParityCheckStatus parityCheckStatus = parityCheckService.getRefundParityCheckStatus(refund);
+            refundService.updateRefundParityStatus(refund.getExternalId(), parityCheckStatus);
+            logger.info("refund transaction parity check finished [id={},status={}]", refund.getId(), parityCheckStatus);
+
+            if (!parityCheckStatus.equals(EXISTS_IN_LEDGER)) {
+                historicalEventEmitter.emitEventsForRefund(refund.getExternalId(), true);
+            }
+        } finally {
+            MDC.remove(REFUND_EXTERNAL_ID);
+        }
+    }
+
+    private void processRefundsByIdRange(long startId, long maxId, boolean doNotReprocessValidRecords) {
+        logger.info("Starting parity check for refunds for IDs from {} up to {}", startId, maxId);
+        for (long refundId = startId; refundId <= maxId; refundId++) {
+            Optional<RefundEntity> mayBeRefund = refundDao.findById(refundId);
+
+            if (mayBeRefund.isPresent()) {
+                checkParityForRefund(mayBeRefund.get(), doNotReprocessValidRecords);
+            } else {
+                logger.info("[{}/{}] - not found", refundId, maxId);
+            }
+        }
+    }
+
+    private void processRefundsByParityCheckStatus(String parityCheckStatus, boolean doNotReprocessValidRecords) {
+        ParityCheckStatus parityStatus = ParityCheckStatus.valueOf(parityCheckStatus);
+        Long lastProcessedId = 0L;
+
+        logger.info("Starting for status {}", parityCheckStatus);
+        while (true) {
+            List<RefundEntity> refunds = refundDao.findByParityCheckStatus(parityStatus, PAGE_SIZE, lastProcessedId);
+
+            if (!refunds.isEmpty()) {
+                logger.info("Processing refunds [last processed id {}, no.of.refunds {}] by parity check status", lastProcessedId, refunds.size());
+                refunds.forEach(refund -> checkParityForRefund(refund, doNotReprocessValidRecords));
+                lastProcessedId = refunds.get(refunds.size() - 1).getId();
+            } else {
+                break;
+            }
+        }
+    }
+
+    private boolean skipParityCheck(Long id, ParityCheckStatus parityCheckStatus, boolean doNotReprocessValidRecords) {
+        if (doNotReprocessValidRecords && EXISTS_IN_LEDGER.equals(parityCheckStatus)) {
+            logger.info("transaction parity check skipped [id={},status={}]", id, parityCheckStatus);
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/RecordType.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/RecordType.java
@@ -3,10 +3,10 @@ package uk.gov.pay.connector.tasks;
 import org.apache.commons.lang3.StringUtils;
 
 public enum RecordType {
-    
+
     CHARGE("charge"),
     REFUND("refund");
-    
+
     String value;
 
     RecordType(String value) {
@@ -21,12 +21,12 @@ public enum RecordType {
         return this.getValue();
     }
 
-    public static RecordType fromString(String status) {
+    public static RecordType fromString(String recordTypeParam) {
         for (RecordType type : values()) {
-            if (StringUtils.equals(type.getValue(), status)) {
+            if (StringUtils.equals(type.getValue(), recordTypeParam)) {
                 return type;
             }
         }
-        throw new IllegalArgumentException("charge status not recognized: " + status);
+        throw new IllegalArgumentException("Record type not recognized: " + recordTypeParam);
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Currently we can parity check charges for a given ID range or parity check status. There is no way to parity check refund(s) using the task. For any fixes to refund parity checker we will have to wait until expunger picks the refund and parity checks the same.
Added functionality to parity check refunds by ID range and parity check status. 
