### PR TITLE
PP-6990 Reduce time before charge is expunged to 2 days

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -245,11 +245,11 @@ expungeConfig:
   excludeChargesOrRefundsParityCheckedWithInDays: ${EXPUNGE_EXCLUDE_CHARGES_OR_REFUNDS_PARITY_CHECKED_WITHIN_DAYS:-7}
   expungeChargesEnabled: ${EXPUNGE_CHARGES_ENABLED:-false}
   numberOfChargesToExpunge: ${EXPUNGE_NO_OF_CHARGES_PER_TASK_RUN:-15000}
-  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-7}
+  minimumAgeOfChargeInDays: ${EXPUNGE_CHARGES_OLDER_THAN_DAYS:-2}
   minimumAgeForHistoricChargeExceptions: ${EXPUNGE_HISTORIC_CHARGE_EXCEPTIONS_OLDER_THAN_DAYS:-90}
   expungeRefundsEnabled: ${EXPUNGE_REFUNDS_ENABLED:-false}
   numberOfRefundsToExpunge: ${EXPUNGE_NO_OF_REFUNDS_PER_TASK_RUN:-1000}
-  minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-7}
+  minimumAgeOfRefundInDays: ${EXPUNGE_REFUNDS_OLDER_THAN_DAYS:-2}
   minimumAgeForHistoricRefundExceptions: ${EXPUNGE_HISTORIC_REFUND_EXCEPTIONS_OLDER_THAN_DAYS:-90}
 
 authorisation3dsConfig:


### PR DESCRIPTION
## WHAT YOU DID
- Reduce the number of days connector retains charges to 2 days. This is the minimum we need so daily stats can be reported to performance platform. We can reduce to inflight payments/refunds only when all the reporting is moved to ledger.
