### PR TITLE
PP-6948 - Add structured logging for 3DS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -479,7 +479,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.14.3</version>
+            <version>1.15.0-rc2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 
 import javax.inject.Inject;
+import java.util.Locale;
 import java.util.Optional;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
@@ -106,7 +107,7 @@ public class Card3dsResponseAuthService {
                 operationResponse.getProviderSessionIdentifier().orElse(null)
         );
 
-        LOGGER.info("3DS response authorisation for {} ({} {}) for {} ({}) - {} .'. {} -> {}",
+        var logMessage = String.format(Locale.UK, "3DS response authorisation for %s (%s %s) for %s (%s) - %s .'. %s -> %s",
                 updatedCharge.getExternalId(),
                 updatedCharge.getPaymentGatewayName().getName(),
                 updatedCharge.getGatewayTransactionId(),
@@ -114,8 +115,11 @@ public class Card3dsResponseAuthService {
                 updatedCharge.getGatewayAccount().getId(),
                 operationResponse,
                 oldChargeStatus,
-                updatedCharge.getStatus()
-        );
+                updatedCharge.getStatus());
+
+        var structuredLoggingArguments = updatedCharge.getStructuredLoggingArgs();
+
+        LOGGER.info(logMessage, structuredLoggingArguments);
 
         cardAuthoriseBaseService.emitAuthorisationMetric(updatedCharge, "authorise-3ds");
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -80,7 +80,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
 
         getCharge(chargeId)
                 .body("settlement_summary.capture_submit_time", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
-                .body("settlement_summary.capture_submit_time", isWithin(10, SECONDS))
+                .body("settlement_summary.capture_submit_time", isWithin(20, SECONDS))
                 .body("settlement_summary.captured_date", equalTo(expectedDayOfCapture));
     }
 


### PR DESCRIPTION
Description:
- This adds structured logging for the 3DS response we receive from the payment gateway
- This is necessary so we can log out whether the 3DS request is 3DS1 or 3DS Flex for Worldpay