### PR TITLE
PP-7351 @JsonIgnoreProperties for Google Pay and Apple Pay objects

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.wallets.applepay.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -10,6 +11,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplePayAuthRequest implements WalletAuthorisationRequest {
     @NotNull @Valid private WalletPaymentInfo paymentInfo;
     private EncryptedPaymentData encryptedPaymentData;
@@ -32,6 +34,7 @@ public class ApplePayAuthRequest implements WalletAuthorisationRequest {
     }
 
     @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class EncryptedPaymentData {
         private String data;
         private String version;
@@ -66,6 +69,7 @@ public class ApplePayAuthRequest implements WalletAuthorisationRequest {
         }
 
         @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+        @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Header {
             private String publicKeyHash;
             private String ephemeralPublicKey;

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/EncryptedPaymentData.java
@@ -1,8 +1,10 @@
 package uk.gov.pay.connector.wallets.googlepay.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotEmpty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EncryptedPaymentData {
     @NotEmpty(message= "Field [signed_message] must not be empty")
     private final String signedMessage;

--- a/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.wallets.googlepay.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
 import uk.gov.pay.connector.wallets.WalletType;
@@ -11,6 +12,7 @@ import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.Optional;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GooglePayAuthRequest implements WalletAuthorisationRequest, WalletAuthorisationData {
 
     @NotNull @Valid private final WalletPaymentInfo paymentInfo;

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -1,11 +1,13 @@
 package uk.gov.pay.connector.wallets.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WalletPaymentInfo {
     
     private String lastDigitsCardNumber;


### PR DESCRIPTION
Add `@JsonIgnoreProperties(ignoreUnknown = true)` to Google Pay and Apple Pay objects that are deserialised from JSON.