### PR TITLE
PP-7329: Verify auth 3ds required response to a google payment

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
@@ -7,30 +7,27 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Appender;
 import com.amazonaws.util.json.Jackson;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 
@@ -55,7 +52,7 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
     }
 
     @Test
-    public void authoriseChargeSuccess() throws IOException {
+    public void authorise_charge_success() throws Exception {
         worldpayMockClient.mockAuthorisationSuccess();
         
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
@@ -74,5 +71,21 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
         verify(mockAppender, times(1)).doAppend(loggingEventArgumentCaptor.capture());
         List<LoggingEvent> logEvents = loggingEventArgumentCaptor.getAllValues();
         assertThat(logEvents.stream().anyMatch(e -> e.getFormattedMessage().contains("Received encrypted payload for charge with id")), is(true));
+    }
+    
+    @Test
+    public void verify_auth_3ds_required_in_response_to_a_google_pay_request() throws Exception {
+        worldpayMockClient.mockAuthorisationRequires3ds();
+
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(fixture("googlepay/example-auth-request.json"));
+
+        givenSetup()
+                .body(googlePayload)
+                .post(authoriseChargeUrlForGooglePay(chargeId))
+                .then()
+                .statusCode(200);
+
+        assertFrontendChargeStatusIs(chargeId, AUTHORISATION_3DS_REQUIRED.getValue());
     }
 }


### PR DESCRIPTION
Verify connector successfully unmarshals the XML response and returns 200 with
AUTHORISATION_3DS_REQUIRED.