### PR TITLE
PP-7352 - Add additional 3DS details for Google Pay domain object

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -17,6 +17,9 @@ public class WalletPaymentInfo {
     private String cardholderName;
     @Length(max = 254, message = "Email must be a maximum of 254 chars")
     private String email;
+    private String acceptHeader;
+    private String userAgentHeader;
+    private String ipAddress;
 
     public WalletPaymentInfo() {
     }
@@ -47,6 +50,18 @@ public class WalletPaymentInfo {
 
     public PayersCardType getCardType() {
         return cardType;
+    }
+
+    public String getAcceptHeader() {
+        return acceptHeader;
+    }
+
+    public String getUserAgentHeader() {
+        return userAgentHeader;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
     }
 
     @Override

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -39,7 +39,6 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
 
 public class WorldpayOrderRequestBuilderTest {
-
     private AppleDecryptedPaymentData validData =
             anApplePayDecryptedPaymentData()
                     .withApplePaymentInfo(

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -16,21 +16,24 @@ public class GooglePayAuthRequestTest {
     @Test
     public void shouldDeserializeFromJsonCorrectly() throws IOException {
         ObjectMapper objectMapper = Jackson.getObjectMapper();
-        
-        JsonNode expected = objectMapper.readTree(fixture("googlepay/example-auth-request.json"));
+
+        JsonNode expected = objectMapper.readTree(fixture("googlepay/example-3ds-auth-request.json"));
         GooglePayAuthRequest actual = objectMapper.readValue(
-                fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
+                fixture("googlepay/example-3ds-auth-request.json"), GooglePayAuthRequest.class);
 
         JsonNode paymentInfo = expected.get("payment_info");
         assertThat(actual.getPaymentInfo().getCardholderName(), is(paymentInfo.get("cardholder_name").asText()));
         assertThat(actual.getPaymentInfo().getLastDigitsCardNumber(), is(paymentInfo.get("last_digits_card_number").asText()));
         assertThat(actual.getPaymentInfo().getBrand(), is(paymentInfo.get("brand").asText()));
         assertThat(actual.getPaymentInfo().getEmail(), is(paymentInfo.get("email").asText()));
+        assertThat(actual.getPaymentInfo().getAcceptHeader(), is(paymentInfo.get("accept_header").asText()));
+        assertThat(actual.getPaymentInfo().getUserAgentHeader(), is(paymentInfo.get("user_agent_header").asText()));
+        assertThat(actual.getPaymentInfo().getIpAddress(), is(paymentInfo.get("ip_address").asText()));
 
         JsonNode encryptedPaymentData = expected.get("encrypted_payment_data");
         assertThat(actual.getEncryptedPaymentData().getSignature(), is(encryptedPaymentData.get("signature").asText()));
         assertThat(actual.getEncryptedPaymentData().getProtocolVersion(), is(encryptedPaymentData.get("protocol_version").asText()));
         assertThat(actual.getEncryptedPaymentData().getSignedMessage(), is(encryptedPaymentData.get("signed_message").asText()));
-        
+
     }
 }

--- a/src/test/resources/googlepay/example-3ds-auth-request.json
+++ b/src/test/resources/googlepay/example-3ds-auth-request.json
@@ -1,0 +1,16 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "4242",
+    "brand": "visa",
+    "cardholder_name": "Example Name",
+    "email": "example@test.example",
+    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8",
+    "user_agent_header": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36",
+    "ip_address": "8.8.8.8"
+  },
+  "encrypted_payment_data": {
+    "signature": "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl",
+    "protocol_version": "ECv1",
+    "signed_message": "aSignedMessage"
+  }
+}


### PR DESCRIPTION
Description:
- This PR adds accept_header, user_agent_header and ip_address to WalletPaymentInfo object so that when Connector receives a JSON payload from Frontend for a Google Pay 3DS authorisation it can correctly deserialize