### PR TITLE
PP-7352 - Add additional details to Google Pay 3DS when no IP address is set

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/applepay/WorldpayWalletAuthorisationHandler.java
@@ -40,9 +40,14 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
     }
 
     private GatewayOrder buildWalletAuthoriseOrder(WalletAuthorisationGatewayRequest request) {
+
         return aWorldpayAuthoriseWalletOrderRequestBuilder(request.getWalletAuthorisationData().getWalletType())
                 .withWalletTemplateData(request.getWalletAuthorisationData())
+                .with3dsRequired(request.getGatewayAccount().isRequires3ds())
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
+                .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getUserAgentHeader())
+                .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getAcceptHeader())
+                .withPayerIpAddress(request.getWalletAuthorisationData().getPaymentInfo().getIpAddress())
                 .withTransactionId(request.getTransactionId().orElse(""))
                 .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withDescription(request.getDescription())

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -32,6 +32,20 @@ public class WalletPaymentInfo {
         this.email = email;
     }
 
+    public WalletPaymentInfo(String lastDigitsCardNumber, 
+                             String brand,
+                             PayersCardType cardType, 
+                             String cardholderName,
+                             String email,
+                             String acceptHeader, 
+                             String userAgentHeader, 
+                             String ipAddress) {
+        this(lastDigitsCardNumber, brand, cardType, cardholderName, email);
+        this.acceptHeader = acceptHeader;
+        this.userAgentHeader = userAgentHeader;
+        this.ipAddress = ipAddress;
+    }
+
     public String getCardholderName() {
         return cardholderName;
     }

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
@@ -12,7 +12,18 @@
                     <signature>${walletAuthorisationData.encryptedPaymentData.signature?xml}</signature>
                     <signedMessage>${walletAuthorisationData.encryptedPaymentData.signedMessage?xml}</signedMessage>
                 </PAYWITHGOOGLE-SSL>
+                <#if requires3ds>
+                <session id="${sessionId?xml}"/>
+                </#if>
             </paymentDetails>
+            <#if requires3ds>
+            <shopper>
+                <browser>
+                    <acceptHeader>${walletAuthorisationData.paymentInfo.acceptHeader?xml}</acceptHeader>
+                    <userAgentHeader>${walletAuthorisationData.paymentInfo.userAgentHeader?xml}</userAgentHeader>
+                </browser>
+            </shopper>
+            </#if>
         </order>
     </submit>
 </paymentService>

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
@@ -139,6 +139,20 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
     }
 
     @Test
+    public void shouldReturnBadRequestResponseWhenTryingToAuthoriseAnApplePayPayment() {
+        String chargeId = createNewChargeWithNoTransactionId(ChargeStatus.ENTERING_CARD_DETAILS);
+
+        given().port(testContext.getPort())
+                .contentType(JSON)
+                .body(validApplePayAuthorisationDetails)
+                .post(authoriseChargeUrlForApplePay(chargeId))
+                .then()
+                .statusCode(400)
+                .body("message", contains("Wallets are not supported for Smartpay"))
+                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
+    }
+
+    @Test
     public void shouldCaptureCardPayment_IfChargeWasPreviouslyAuthorised() {
         String chargeId = authoriseNewCharge();
 
@@ -151,20 +165,6 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
 
         assertFrontendChargeStatusIs(chargeId, CAPTURE_APPROVED.getValue());
         assertApiStateIs(chargeId, EXTERNAL_SUCCESS.getStatus());
-    }
-
-    @Test
-    public void shouldReturnBadRequestResponseWhenTryingToAuthoriseAnApplePayPayment() {
-        String chargeId = createNewChargeWithNoTransactionId(ChargeStatus.ENTERING_CARD_DETAILS);
-
-        given().port(testContext.getPort())
-                .contentType(JSON)
-                .body(validApplePayAuthorisationDetails)
-                .post(authoriseChargeUrlForApplePay(chargeId))
-                .then()
-                .statusCode(400)
-                .body("message", contains("Wallets are not supported for Smartpay"))
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/model/domain/googlepay/GooglePayAuthRequestFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/googlepay/GooglePayAuthRequestFixture.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.connector.model.domain.googlepay;
+
+import uk.gov.pay.connector.gateway.model.PayersCardType;
+import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
+import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.pay.connector.wallets.googlepay.api.EncryptedPaymentData;
+import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
+import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public class GooglePayAuthRequestFixture implements WalletAuthorisationRequest, WalletAuthorisationData {
+    
+    private WalletPaymentInfo paymentInfo = new WalletPaymentInfo(
+            "4242",
+            "visa",
+            PayersCardType.DEBIT,
+            "Example Name",
+            "example@test.example"
+    ); 
+    
+    private EncryptedPaymentData encryptedPaymentData = new EncryptedPaymentData(
+            "aSignedMessage",
+            "ECv1",
+            "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl"
+    );
+
+    private GooglePayAuthRequestFixture() {
+    }
+    
+    public static GooglePayAuthRequestFixture anGooglePayAuthRequestFixture() {
+        return new GooglePayAuthRequestFixture();
+        
+    }
+    
+    public WalletPaymentInfo getPaymentInfo() {
+        return paymentInfo;
+    }
+
+    @Override
+    public Optional<LocalDate> getCardExpiryDate() {
+        return Optional.empty();
+    }
+
+    public EncryptedPaymentData getEncryptedPaymentData() {
+        return encryptedPaymentData;
+    }
+
+    @Override
+    public String getLastDigitsCardNumber() {
+        return getPaymentInfo().getLastDigitsCardNumber();
+    }
+
+    @Override
+    public WalletType getWalletType() {
+        return WalletType.GOOGLE_PAY;
+    }
+    
+    public GooglePayAuthRequestFixture withGooglePaymentInfo(WalletPaymentInfo googlePaymentInfo) {
+        this.paymentInfo = googlePaymentInfo;
+        return this;
+    }
+
+    public GooglePayAuthRequestFixture withEncryptedCardData(EncryptedPaymentData encryptedCardData) {
+        this.encryptedPaymentData = encryptedCardData;
+        return this;
+    }
+    
+    public GooglePayAuthRequestFixture build() {
+        return this;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -27,6 +27,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-min-data.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-without-ip-address.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";

--- a/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/googlepay/api/GooglePayAuthRequestTest.java
@@ -16,7 +16,6 @@ public class GooglePayAuthRequestTest {
     @Test
     public void shouldDeserializeFromJsonCorrectly() throws IOException {
         ObjectMapper objectMapper = Jackson.getObjectMapper();
-
         JsonNode expected = objectMapper.readTree(fixture("googlepay/example-3ds-auth-request.json"));
         GooglePayAuthRequest actual = objectMapper.readValue(
                 fixture("googlepay/example-3ds-auth-request.json"), GooglePayAuthRequest.class);
@@ -34,6 +33,5 @@ public class GooglePayAuthRequestTest {
         assertThat(actual.getEncryptedPaymentData().getSignature(), is(encryptedPaymentData.get("signature").asText()));
         assertThat(actual.getEncryptedPaymentData().getProtocolVersion(), is(encryptedPaymentData.get("protocol_version").asText()));
         assertThat(actual.getEncryptedPaymentData().getSignedMessage(), is(encryptedPaymentData.get("signed_message").asText()));
-
     }
 }

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-without-ip-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-without-ip-address.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <PAYWITHGOOGLE-SSL>
+                    <protocolVersion>ECv1</protocolVersion>
+                    <signature>MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl</signature>
+                    <signedMessage>aSignedMessage</signedMessage>
+                </PAYWITHGOOGLE-SSL>
+                <session id="uniqueSessionId" />
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36</userAgentHeader>
+                </browser>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
Description:
- This PR adds the acceptHeader, userAgentHeader and the session id to the XML payload to send to Worldpay for a Google Pay 3DS1 payment
- Since the GooglePayAuthRequest doesn't have any setters I created a fixture object specifically for this purpose