### PR TITLE
PP-7352 - Add additional details to Google Pay 3DS when IP address is sent

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -29,7 +29,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.gateway.worldpay.applepay.WorldpayWalletAuthorisationHandler;
+import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
@@ -13,7 +13,11 @@
                     <signedMessage>${walletAuthorisationData.encryptedPaymentData.signedMessage?xml}</signedMessage>
                 </PAYWITHGOOGLE-SSL>
                 <#if requires3ds>
+                <#if payerIpAddress??>
+                <session id="${sessionId?xml}" shopperIPAddress="${payerIpAddress?xml}"/>
+                <#else>
                 <session id="${sessionId?xml}"/>
+                </#if>
                 </#if>
             </paymentDetails>
             <#if requires3ds>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilderTest.java
@@ -35,6 +35,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE;
@@ -281,7 +282,7 @@ public class WorldpayOrderRequestBuilderTest {
     }
 
     @Test
-    public void shouldGenerateValidAuthoriseGooglePay3DSOrderRequestWithoutIpAddress() throws Exception {
+    public void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWithoutIpAddress() throws Exception {
         GooglePayAuthRequestFixture validGooglePay3dsData = anGooglePayAuthRequestFixture()
                 .withGooglePaymentInfo(new WalletPaymentInfo(
                         "4242",
@@ -308,6 +309,67 @@ public class WorldpayOrderRequestBuilderTest {
                 .build();
 
         assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWithIpAddress() throws Exception {
+        GooglePayAuthRequestFixture validGooglePay3dsData = anGooglePayAuthRequestFixture()
+                .withGooglePaymentInfo(new WalletPaymentInfo(
+                                "4242",
+                                "visa",
+                                PayersCardType.DEBIT,
+                                "Example Name",
+                                "example@test.example",
+                                GOOGLE_PAY_ACCEPT_HEADER,
+                                GOOGLE_PAY_USER_AGENT_HEADER,
+                                "8.8.8.8"
+                        )
+                );
+
+        GatewayOrder actualRequest = aWorldpayAuthoriseWalletOrderRequestBuilder(WalletType.GOOGLE_PAY)
+                .withWalletTemplateData(validGooglePay3dsData)
+                .with3dsRequired(true)
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
+                .withAcceptHeader(GOOGLE_PAY_ACCEPT_HEADER)
+                .withUserAgentHeader(GOOGLE_PAY_USER_AGENT_HEADER)
+                .withPayerIpAddress("8.8.8.8")
+                .withTransactionId("MyUniqueTransactionId!")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthoriseGooglePay3dsOrderRequestWhen3dsDisabled() throws Exception {
+        GooglePayAuthRequestFixture validGooglePay3dsData = anGooglePayAuthRequestFixture()
+                .withGooglePaymentInfo(new WalletPaymentInfo(
+                                "4242",
+                                "visa",
+                                PayersCardType.DEBIT,
+                                "Example Name",
+                                "example@test.example",
+                                GOOGLE_PAY_ACCEPT_HEADER,
+                                GOOGLE_PAY_USER_AGENT_HEADER,
+                                "8.8.8.8"
+                        )
+                );
+
+        GatewayOrder actualRequest = aWorldpayAuthoriseWalletOrderRequestBuilder(WalletType.GOOGLE_PAY)
+                .withWalletTemplateData(validGooglePay3dsData)
+                .with3dsRequired(false)
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of("uniqueSessionId"))
+                .withTransactionId("MyUniqueTransactionId!")
+                .withMerchantCode("MERCHANTCODE")
+                .withDescription("This is the description")
+                .withAmount("500")
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE_GOOGLE_PAY, actualRequest.getOrderRequestType());
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayAuthoriseGooglePayIT.java
@@ -84,7 +84,7 @@ public class WorldpayAuthoriseGooglePayIT extends ChargingITestBase {
         worldpayMockClient.mockAuthorisationRequires3ds();
 
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
-        JsonNode googlePayload = Jackson.getObjectMapper().readTree(fixture("googlepay/example-auth-request.json"));
+        JsonNode googlePayload = Jackson.getObjectMapper().readTree(fixture("googlepay/example-3ds-auth-request.json"));
 
         givenSetup()
                 .body(googlePayload)

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -28,6 +28,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-without-ip-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-ip-address.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-with-ip-address.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-with-ip-address.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <PAYWITHGOOGLE-SSL>
+                    <protocolVersion>ECv1</protocolVersion>
+                    <signature>MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl</signature>
+                    <signedMessage>aSignedMessage</signedMessage>
+                </PAYWITHGOOGLE-SSL>
+                <session id="uniqueSessionId" shopperIPAddress="8.8.8.8"/>
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36</userAgentHeader>
+                </browser>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
Description:
- When 3DS is enabled and the setting to send the IP address to Worldpay is enabled on the gateway account then the XML element contains a session element with id and shopperIpAddress attribute value as well as a userAgentHeader and acceptHeader
- When 3DS isn't enable then none of the following are present in the XML
- I modified the WorldpayAuthoriseGooglePayIT to use the Google Pay 3DS JSON payload