### PR TITLE
PP-7382: Store 3ds details for wallet payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -411,7 +411,10 @@ public class ChargeService {
         return builderOfResponse;
     }
 
-    public <T extends AbstractChargeResponseBuilder<T, R>, R> AbstractChargeResponseBuilder<T, R> populateResponseBuilderWith(AbstractChargeResponseBuilder<T, R> responseBuilder, UriInfo uriInfo, ChargeEntity chargeEntity) {
+    public <T extends AbstractChargeResponseBuilder<T, R>, R> AbstractChargeResponseBuilder<T, R> populateResponseBuilderWith(
+            AbstractChargeResponseBuilder<T, R> responseBuilder, 
+            UriInfo uriInfo, 
+            ChargeEntity chargeEntity) {
         String chargeId = chargeEntity.getExternalId();
         PersistedCard persistedCard = null;
         if (chargeEntity.getCardDetails() != null) {
@@ -498,8 +501,9 @@ public class ChargeService {
                                                             ProviderSessionIdentifier sessionIdentifier,
                                                             AuthCardDetails authCardDetails,
                                                             WalletType walletType,
-                                                            String emailAddress) {
-        return updateChargeAndEmitEventPostAuthorisation(chargeExternalId, status, authCardDetails, transactionId, null, sessionIdentifier,
+                                                            String emailAddress,
+                                                            Optional<Auth3dsRequiredEntity> auth3dsRequiredDetails) {
+        return updateChargeAndEmitEventPostAuthorisation(chargeExternalId, status, authCardDetails, transactionId, auth3dsRequiredDetails.orElse(null), sessionIdentifier,
                 walletType, emailAddress);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayGatewayResponseGenerator.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
@@ -14,8 +12,6 @@ import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshal
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORLDPAY_MACHINE_COOKIE_NAME;
 
 public interface WorldpayGatewayResponseGenerator {
-
-    Logger logger = LoggerFactory.getLogger(WorldpayGatewayResponseGenerator.class);
 
     default GatewayResponse getWorldpayGatewayResponse(GatewayClient.Response response) throws GatewayErrorException {
         return getWorldpayGatewayResponse(response, WorldpayOrderStatusResponse.class);

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -186,6 +186,9 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         if (StringUtils.isNotBlank(issuerUrl)) {
             joiner.add("issuerURL: " + issuerUrl);
         }
+        if (StringUtils.isNotBlank(paRequest)) {
+            joiner.add("paRequest: present");
+        }
         if (StringUtils.isNotBlank(challengeAcsUrl)) {
             joiner.add("threeDSChallengeDetails acsUrl: " + challengeAcsUrl);
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -82,6 +82,14 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         this.challengeAcsUrl = challengeAcsUrl != null ? challengeAcsUrl.trim() : null;
     }
 
+    public String getPaRequest() {
+        return paRequest;
+    }
+
+    public String getIssuerUrl() {
+        return issuerUrl;
+    }
+
     public String getLastEvent() {
         return lastEvent;
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardServiceTest.java
@@ -13,7 +13,6 @@ import uk.gov.pay.connector.chargeevent.dao.ChargeEventDao;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.refund.dao.RefundDao;
 
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -24,14 +23,17 @@ import static uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity.Ch
 public abstract class CardServiceTest {
 
     protected final PaymentProvider mockedPaymentProvider = mock(PaymentProvider.class);
-    protected PaymentProviders mockedProviders = mock(PaymentProviders.class);
+    @Mock
+    protected PaymentProviders mockedProviders;
     @Mock
     protected MetricRegistry mockMetricRegistry;
-    protected ChargeDao mockedChargeDao = mock(ChargeDao.class);
+    @Mock
+    protected ChargeDao mockedChargeDao;
     protected ChargeService chargeService;
-    protected ChargeEventDao mockedChargeEventDao = mock(ChargeEventDao.class);
-    protected CardTypeDao mockedCardTypeDao = mock(CardTypeDao.class);
-    protected RefundDao mockedRefundDao = mock(RefundDao.class);
+    @Mock
+    protected ChargeEventDao mockedChargeEventDao;
+    @Mock
+    protected CardTypeDao mockedCardTypeDao;
 
     protected ChargeEntity createNewChargeWith(Long chargeId, ChargeStatus status) {
         ChargeEntity entity = ChargeEntityFixture

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -1,0 +1,136 @@
+package uk.gov.pay.connector.wallets;
+
+import com.amazonaws.util.json.Jackson;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.setup.Environment;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.PaymentProvider;
+import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.paymentprocessor.model.OperationType;
+import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
+import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
+import uk.gov.pay.connector.util.TestTemplateResourceLoader;
+import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
+import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static io.dropwizard.testing.FixtureHelpers.fixture;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
+import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus.COMPLETED;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class WalletAuthoriseServiceForGooglePay3dsTest {
+
+    private WalletAuthoriseService walletAuthoriseService;
+    
+    @Mock
+    private PaymentProviders mockedProviders;
+    
+    @Mock
+    private PaymentProvider mockedPaymentProvider;
+    
+    @Mock
+    private ChargeService chargeService;
+
+    @Mock
+    private Environment mockEnvironment;
+
+    @Mock
+    protected MetricRegistry mockMetricRegistry;
+
+    @Mock
+    private CardExecutorService mockExecutorService;
+
+    @Mock
+    private Counter mockCounter;
+
+    @Captor
+    private ArgumentCaptor<Optional<Auth3dsRequiredEntity>> auth3dsRequiredEntityArgumentCaptor;
+    
+    private ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+    
+    @Before
+    public void setup() {
+        when(mockedProviders.byName(any())).thenReturn(mockedPaymentProvider);
+        when(mockMetricRegistry.counter(anyString())).thenReturn(mockCounter);
+        when(mockEnvironment.metrics()).thenReturn(mockMetricRegistry);
+
+        doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
+                .when(mockExecutorService).execute(any(Supplier.class));
+        
+        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        walletAuthoriseService = new WalletAuthoriseService(
+                mockedProviders,
+                chargeService,
+                cardAuthoriseBaseService,
+                mockEnvironment);
+        
+        when(chargeService.lockChargeForProcessing(anyString(), any(OperationType.class))).thenReturn(chargeEntity);
+        when(chargeService.updateChargePostWalletAuthorisation(anyString(), any(ChargeStatus.class), anyString(), 
+                isNull(), any(AuthCardDetails.class), any(WalletType.class), any(), 
+                any(Optional.class))
+        ).thenReturn(chargeEntity);
+    }
+
+    @Test
+    public void the_charge_service_should_be_called_with_auth3dsRequiredDetails_when_3ds_is_required_for_a_google_payment() throws Exception {
+        String successPayload = TestTemplateResourceLoader.load(WORLDPAY_3DS_RESPONSE);
+        WorldpayOrderStatusResponse worldpayOrderStatusResponse = XMLUnmarshaller.unmarshall(successPayload, WorldpayOrderStatusResponse.class);
+        providerRequestsFor3dsAuthorisation(worldpayOrderStatusResponse);
+
+        WalletAuthorisationData authorisationData =
+                Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
+
+        walletAuthoriseService.doAuthorise(chargeEntity.getExternalId(), authorisationData);
+
+        verify(chargeService).updateChargePostWalletAuthorisation(
+                anyString(),
+                any(ChargeStatus.class),
+                anyString(),
+                isNull(),
+                any(AuthCardDetails.class),
+                any(WalletType.class),
+                anyString(),
+                auth3dsRequiredEntityArgumentCaptor.capture());
+        
+        assertThat(auth3dsRequiredEntityArgumentCaptor.getValue().isPresent(), is(true));
+        assertThat(auth3dsRequiredEntityArgumentCaptor.getValue().get().getIssuerUrl(), is(worldpayOrderStatusResponse.getIssuerUrl()));
+        assertThat(auth3dsRequiredEntityArgumentCaptor.getValue().get().getPaRequest(), is(worldpayOrderStatusResponse.getPaRequest()));
+    }
+
+    private GatewayResponse providerRequestsFor3dsAuthorisation(WorldpayOrderStatusResponse worldpayOrderStatusResponse) throws Exception {
+        GatewayResponse.GatewayResponseBuilder<WorldpayOrderStatusResponse> responseBuilder = responseBuilder();
+        responseBuilder.withResponse(worldpayOrderStatusResponse);
+        GatewayResponse authResponse = responseBuilder.build();
+        when(mockedPaymentProvider.authoriseWallet(any(WalletAuthorisationGatewayRequest.class))).thenReturn(authResponse);
+        return authResponse;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -111,10 +111,13 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private EventQueue eventQueue;
+    
     @Mock
     private EmittedEventDao emittedEventDao;
+    
     @Mock
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
+    
     @Mock
     private RefundService mockRefundService;
 
@@ -126,7 +129,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
                             anApplePayPaymentInfo().build())
                     .build();
 
+    @Mock
     private Appender<ILoggingEvent> mockAppender;
+    
     @InjectMocks
     private EventService mockEventService;
 
@@ -158,7 +163,6 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
     private void setUpLogging() {
         Logger root = (Logger) LoggerFactory.getLogger(WalletAuthoriseService.class);
-        mockAppender = mock(Appender.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
     }
@@ -479,7 +483,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
                 .when(mockExecutorService).execute(any(Supplier.class));
     }
-
+    
     private GatewayResponse providerWillAuthorise() throws Exception {
         GatewayResponse authResponse = mockAuthResponse(TRANSACTION_ID, AuthoriseStatus.AUTHORISED, null);
         when(mockedPaymentProvider.authoriseWallet(any(WalletAuthorisationGatewayRequest.class))).thenReturn(authResponse);


### PR DESCRIPTION
Until Worldpay returned a 3ds required response for a Google Payment, we
weren't updating the charge with the auth3ds details, which meant the issuerURL
and paResponse from Worldpay weren't being stored in the database for the
charge.

Against best practices, I have chosen to include an `Optional<Auth3dsRequiredEntity>` parameter to the `ChargeService.updateChargePostWalletAuthorisation` method. This is because having an overloaded method (i.e. a `updateChargePostWalletAuthorisation` with no `Auth3dsRequiredEntity` parameter would cause the code in `WalletAuthoriseService.processGatewayAuthorisationResponse` to be unnecessarily lengthy to read. So from this
```
    private void processGatewayAuthorisationResponse(
            String chargeExternalId,
            ChargeStatus oldChargeStatus,
            WalletAuthorisationData walletAuthorisationData,
            String responseFromGateway,
            String transactionId,
            ProviderSessionIdentifier sessionIdentifier,
            ChargeStatus status,
            Optional<Auth3dsRequiredEntity> auth3dsRequiredDetails) {

        logger.info("Processing gateway auth response for {}", walletAuthorisationData.getWalletType().toString());
        AuthCardDetails authCardDetailsToBePersisted = authCardDetailsFor(walletAuthorisationData);
        ChargeEntity updatedCharge = chargeService.updateChargePostWalletAuthorisation(
                chargeExternalId,
                status,
                transactionId,
                sessionIdentifier,
                authCardDetailsToBePersisted,
                walletAuthorisationData.getWalletType(),
                walletAuthorisationData.getPaymentInfo().getEmail(),
                auth3dsRequiredDetails);
```
to this
```
    private void processGatewayAuthorisationResponse(
            String chargeExternalId,
            ChargeStatus oldChargeStatus,
            WalletAuthorisationData walletAuthorisationData,
            String responseFromGateway,
            String transactionId,
            ProviderSessionIdentifier sessionIdentifier,
            ChargeStatus status,
            Optional<Auth3dsRequiredEntity> auth3dsRequiredDetails) {

        logger.info("Processing gateway auth response for {}", walletAuthorisationData.getWalletType().toString());
        AuthCardDetails authCardDetailsToBePersisted = authCardDetailsFor(walletAuthorisationData);

        if (auth3dsRequiredDetails.isPresent()) {
            ChargeEntity updatedCharge = chargeService.updateChargePostWalletAuthorisation(
                    chargeExternalId,
                    status,
                    transactionId,
                    sessionIdentifier,
                    authCardDetailsToBePersisted,
                    walletAuthorisationData.getWalletType(),
                    walletAuthorisationData.getPaymentInfo().getEmail(),
                    auth3dsRequiredDetails);
        } else {
            ChargeEntity updatedCharge = chargeService.updateChargePostWalletAuthorisation(
                    chargeExternalId,
                    status,
                    transactionId,
                    sessionIdentifier,
                    authCardDetailsToBePersisted,
                    walletAuthorisationData.getWalletType(),
                    walletAuthorisationData.getPaymentInfo().getEmail());
        }
```

I also created a brand new test class `WalletAuthoriseServiceForGooglePay3dsTest` instead of putting the test in `WalletAuthoriseServiceTest` as `WalletAuthoriseServiceTest` is too complicated and involves setting up a `ChargeService` using a mockito spy.

This PR also contains some minor formatting changes.