### PR TITLE
bau: Simplify and rename CardAuthoriseBaseService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationExecutor.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationExecutor.java
@@ -1,13 +1,9 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-
-import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.setup.Environment;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.gateway.GatewayException;
@@ -25,16 +21,14 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus;
 
-public class CardAuthoriseBaseService {
+public class AuthorisationExecutor {
     
     private final CardExecutorService cardExecutorService;
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final MetricRegistry metricRegistry;
 
     @Inject
-    public CardAuthoriseBaseService(CardExecutorService cardExecutorService, Environment environment) {
+    public AuthorisationExecutor(CardExecutorService cardExecutorService) {
         this.cardExecutorService = cardExecutorService;
-        this.metricRegistry = environment.metrics();
     }
  
     public <T> T executeAuthorise(String chargeId, Supplier<T> authorisationSupplier) {
@@ -60,16 +54,6 @@ public class CardAuthoriseBaseService {
         }
 
         return transactionId;
-    }
-
-    void emitAuthorisationMetric(ChargeEntity charge, String operation) {
-        metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.%s.result.%s",
-                charge.getGatewayAccount().getGatewayName(),
-                charge.getGatewayAccount().getType(),
-                charge.getGatewayAccount().getId(),
-                operation,
-                charge.getStatus())
-        ).inc();
     }
     
     public static ChargeStatus mapFromGatewayErrorException(GatewayException e) {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -99,9 +99,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, northAmericanRegionMapper);
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationExecutor authorisationExecutor = new AuthorisationExecutor(mockExecutorService);
 
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService, mockConfiguration);
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationExecutor, mockConfiguration, mockEnvironment);
     }
 
     public void setupMockExecutorServiceMock() {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -146,11 +146,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper);
 
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationExecutor authorisationExecutor = new AuthorisationExecutor(mockExecutorService);
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao,
                 mockedProviders,
-                cardAuthoriseBaseService,
+                authorisationExecutor,
                 chargeService,
                 mockAuthorisationRequestSummaryStringifier,
                 mockAuthorisationRequestSummaryStructuredLogging,

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -24,7 +24,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
-import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
+import uk.gov.pay.connector.paymentprocessor.service.AuthorisationExecutor;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
@@ -86,11 +86,11 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
                 .when(mockExecutorService).execute(any(Supplier.class));
         
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationExecutor authorisationExecutor = new AuthorisationExecutor(mockExecutorService);
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,
-                cardAuthoriseBaseService,
+                authorisationExecutor,
                 mockEnvironment);
         
         when(chargeService.lockChargeForProcessing(anyString(), any(OperationType.class))).thenReturn(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -40,7 +40,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
-import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
+import uk.gov.pay.connector.paymentprocessor.service.AuthorisationExecutor;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
@@ -148,14 +148,14 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationExecutor authorisationExecutor = new AuthorisationExecutor(mockExecutorService);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,
-                cardAuthoriseBaseService,
+                authorisationExecutor,
                 mockEnvironment);
 
         setUpLogging();


### PR DESCRIPTION
It was clear from https://github.com/alphagov/pay-connector/pull/2673 that
there is some refactoring that could be done to remove code duplication between
WalletAuthoriseService and CardAuthoriseService. As there are still slight
authorisation implementation differences between the two it is envisaged there
will be a common AuthoriseService. However looking at the current code there is
a plethora of authorise services:

CardAuthoriseService
CardAuthoriseBaseService
Card3dsResponseAuthService
WalletAuthoriseService

The term "BaseService" is quite annoying in the sense that it doesn't really mean anything,
so is a candidate for simplification and renaming. This would be a good first
step before unifying the WalletAuthoriseService and CardAuthoriseService.
