### PR TITLE
bau: Rename CardAuthoriseBaseService

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
@@ -25,14 +25,14 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;
 import static uk.gov.pay.connector.paymentprocessor.service.CardExecutorService.ExecutionStatus;
 
-public class CardAuthoriseBaseService {
+public class AuthorisationService {
     
     private final CardExecutorService cardExecutorService;
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final MetricRegistry metricRegistry;
 
     @Inject
-    public CardAuthoriseBaseService(CardExecutorService cardExecutorService, Environment environment) {
+    public AuthorisationService(CardExecutorService cardExecutorService, Environment environment) {
         this.cardExecutorService = cardExecutorService;
         this.metricRegistry = environment.metrics();
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthService.java
@@ -27,23 +27,23 @@ public class Card3dsResponseAuthService {
     private static final Logger LOGGER = LoggerFactory.getLogger(Card3dsResponseAuthService.class);
 
     private final ChargeService chargeService;
-    private final CardAuthoriseBaseService cardAuthoriseBaseService;
+    private final AuthorisationService authorisationService;
     private final PaymentProviders providers;
     private final Authorisation3dsConfig authorisation3dsConfig;
 
     @Inject
     public Card3dsResponseAuthService(PaymentProviders providers,
                                       ChargeService chargeService,
-                                      CardAuthoriseBaseService cardAuthoriseBaseService,
+                                      AuthorisationService authorisationService,
                                       ConnectorConfiguration config) {
         this.providers = providers;
         this.chargeService = chargeService;
-        this.cardAuthoriseBaseService = cardAuthoriseBaseService;
+        this.authorisationService = authorisationService;
         this.authorisation3dsConfig = config.getAuthorisation3dsConfig();
     }
 
     public Gateway3DSAuthorisationResponse process3DSecureAuthorisation(String chargeId, Auth3dsResult auth3DsResult) {
-        return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
+        return authorisationService.executeAuthorise(chargeId, () -> {
 
             final ChargeEntity charge = chargeService.lockChargeForProcessing(chargeId, AUTHORISATION_3DS);
             return authoriseAndProcess3DS(auth3DsResult, charge);
@@ -51,7 +51,7 @@ public class Card3dsResponseAuthService {
     }
 
     public Gateway3DSAuthorisationResponse process3DSecureAuthorisationWithoutLocking(String chargeId, Auth3dsResult auth3DsResult) {
-        return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
+        return authorisationService.executeAuthorise(chargeId, () -> {
             final ChargeEntity charge = chargeService.findChargeByExternalId(chargeId);
             return authoriseAndProcess3DS(auth3DsResult, charge);
         });
@@ -121,6 +121,6 @@ public class Card3dsResponseAuthService {
 
         LOGGER.info(logMessage, structuredLoggingArguments);
 
-        cardAuthoriseBaseService.emitAuthorisationMetric(updatedCharge, "authorise-3ds");
+        authorisationService.emitAuthorisationMetric(updatedCharge, "authorise-3ds");
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -38,7 +38,7 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 public class CardAuthoriseService {
 
     private final CardTypeDao cardTypeDao;
-    private final CardAuthoriseBaseService cardAuthoriseBaseService;
+    private final AuthorisationService authorisationService;
     private final ChargeService chargeService;
     private final PaymentProviders providers;
     private final AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier;
@@ -49,13 +49,13 @@ public class CardAuthoriseService {
     @Inject
     public CardAuthoriseService(CardTypeDao cardTypeDao,
                                 PaymentProviders providers,
-                                CardAuthoriseBaseService cardAuthoriseBaseService,
+                                AuthorisationService authorisationService,
                                 ChargeService chargeService,
                                 AuthorisationRequestSummaryStringifier authorisationRequestSummaryStringifier,
                                 AuthorisationRequestSummaryStructuredLogging authorisationRequestSummaryStructuredLogging,
                                 Environment environment) {
         this.providers = providers;
-        this.cardAuthoriseBaseService = cardAuthoriseBaseService;
+        this.authorisationService = authorisationService;
         this.chargeService = chargeService;
         this.metricRegistry = environment.metrics();
         this.authorisationRequestSummaryStringifier = authorisationRequestSummaryStringifier;
@@ -64,7 +64,7 @@ public class CardAuthoriseService {
     }
 
     public AuthorisationResponse doAuthorise(String chargeId, AuthCardDetails authCardDetails) {
-        return cardAuthoriseBaseService.executeAuthorise(chargeId, () -> {
+        return authorisationService.executeAuthorise(chargeId, () -> {
 
             final ChargeEntity charge = prepareChargeForAuthorisation(chargeId, authCardDetails);
             GatewayResponse<BaseAuthoriseResponse> operationResponse;
@@ -79,12 +79,12 @@ public class CardAuthoriseService {
                 if (operationResponse.getBaseResponse().isEmpty()) operationResponse.throwGatewayError();
 
                 newStatus = operationResponse.getBaseResponse().get().authoriseStatus().getMappedChargeStatus();
-                transactionId = cardAuthoriseBaseService.extractTransactionId(charge.getExternalId(), operationResponse);
+                transactionId = authorisationService.extractTransactionId(charge.getExternalId(), operationResponse);
                 auth3dsDetailsEntity = extractAuth3dsRequiredDetails(operationResponse);
                 sessionIdentifier = operationResponse.getSessionIdentifier();
 
             } catch (GatewayException e) {
-                newStatus = CardAuthoriseBaseService.mapFromGatewayErrorException(e);
+                newStatus = AuthorisationService.mapFromGatewayErrorException(e);
                 operationResponse = GatewayResponse.GatewayResponseBuilder.responseBuilder().withGatewayError(e.toGatewayError()).build();
             }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -99,9 +99,9 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, northAmericanRegionMapper);
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
 
-        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, cardAuthoriseBaseService, mockConfiguration);
+        card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationService, mockConfiguration);
     }
 
     public void setupMockExecutorServiceMock() {

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -146,11 +146,11 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
                 null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper);
 
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao,
                 mockedProviders,
-                cardAuthoriseBaseService,
+                authorisationService,
                 chargeService,
                 mockAuthorisationRequestSummaryStringifier,
                 mockAuthorisationRequestSummaryStructuredLogging,

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceForGooglePay3dsTest.java
@@ -24,7 +24,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.paymentprocessor.model.OperationType;
-import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
+import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
@@ -86,11 +86,11 @@ public class WalletAuthoriseServiceForGooglePay3dsTest {
         doAnswer(invocation -> Pair.of(COMPLETED, ((Supplier) invocation.getArguments()[0]).get()))
                 .when(mockExecutorService).execute(any(Supplier.class));
         
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,
-                cardAuthoriseBaseService,
+                authorisationService,
                 mockEnvironment);
         
         when(chargeService.lockChargeForProcessing(anyString(), any(OperationType.class))).thenReturn(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -40,7 +40,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
-import uk.gov.pay.connector.paymentprocessor.service.CardAuthoriseBaseService;
+import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
@@ -148,14 +148,14 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
 
         ChargeEventEntity chargeEventEntity = mock(ChargeEventEntity.class);
         when(mockedChargeEventDao.persistChargeEventOf(any(), any())).thenReturn(chargeEventEntity);
-        CardAuthoriseBaseService cardAuthoriseBaseService = new CardAuthoriseBaseService(mockExecutorService, mockEnvironment);
+        AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,
-                cardAuthoriseBaseService,
+                authorisationService,
                 mockEnvironment);
 
         setUpLogging();


### PR DESCRIPTION
The term "BaseService" is quite annoying in the sense that it doesn't really
mean anything. CardAuthoriseBaseService has been renamed to 
"AuthorisationService" and the intention is it will handle both Card and 
Wallet authorisations in up-and-coming PRs.
