### PR TITLE
PP-7336: Update Stripe notification service to perform IP firewalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 | `GDS_CONNECTOR_EPDQ_TEST_URL` | - | Pointing to the TEST gateway URL of ePDQ payment provider. |
 | `GDS_CONNECTOR_EPDQ_LIVE_URL` | - | Pointing to the LIVE gateway URL of ePDQ payment provider. |
 | `COLLECT_FEE_FEATURE_FLAG` | false | enable or disable collecting fees for the Stripe payment gateway. |
+| `STRIPE_ALLOWED_IP_ADDRESSES` | - |  A list of allowed Stripe IP addresses used for IP firewalling on notifications coming from Stripe. |
 | `STRIPE_TRANSACTION_FEE_PERCENTAGE` | - | percentage of total charge amount to recover GOV.UK Pay platform costs. |
 | `STRIPE_PLATFORM_ACCOUNT_ID` | - | the account ID for the Stripe Connect GOV.UK Pay platform. |
 | `DISABLE_INTERNAL_HTTPS` | false | disable secure connection for calls to internal APIs |

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -25,6 +25,7 @@ import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionQueue;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
 import uk.gov.pay.connector.util.HashUtil;
+import uk.gov.pay.connector.util.IpAddressMatcher;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.util.ReverseDnsLookup;
 import uk.gov.pay.connector.util.XrayUtils;
@@ -53,6 +54,7 @@ public class ConnectorModule extends AbstractModule {
         bind(HashUtil.class);
         bind(RequestValidator.class);
         bind(GatewayAccountRequestValidator.class).in(Singleton.class);
+        bind(IpAddressMatcher.class).in(Singleton.class);
 
         install(jpaModule(configuration));
         install(new FactoryModuleBuilder().build(GatewayAccountServicesFactory.class));

--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -38,6 +38,10 @@ public class StripeGatewayConfig extends Configuration {
     @Min(1)
     private int notification3dsWaitDelay;
 
+    @Valid
+    @NotNull
+    private List<String> allowedIpAddresses;
+
     public String getUrl() {
         return url;
     }
@@ -64,5 +68,9 @@ public class StripeGatewayConfig extends Configuration {
 
     public int getNotification3dsWaitDelay() {
         return notification3dsWaitDelay;
+    }
+
+    public List<String> getAllowedIpAddresses() {
+        return allowedIpAddresses;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/util/IpAddressMatcher.java
+++ b/src/main/java/uk/gov/pay/connector/util/IpAddressMatcher.java
@@ -1,0 +1,19 @@
+package uk.gov.pay.connector.util;
+
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.Objects;
+
+@Singleton
+public class IpAddressMatcher {
+    public boolean isMatch(String forwardedIpAddresses, List<String> allowedIpAddresses) {
+        if (Objects.nonNull(forwardedIpAddresses) && Objects.nonNull(allowedIpAddresses)) {
+            return allowedIpAddresses.contains(getFirstIpAddress(forwardedIpAddresses));
+        }
+        return false;
+    }
+
+    private String getFirstIpAddress(String forwardedIpAddresses) {
+       return forwardedIpAddresses.split(",")[0];
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -88,6 +88,7 @@ epdq:
       readTimeout: 20000ms
 
 stripe:
+  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN}

--- a/src/test/java/uk/gov/pay/connector/util/IpAddressMatcherTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/IpAddressMatcherTest.java
@@ -1,0 +1,61 @@
+package uk.gov.pay.connector.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IpAddressMatcherTest {
+    private static final List<String> ALLOWED_IP_ADDRESSES = List.of("9.9.9.9", "1.2.3.4", "3.6.9.12");
+    private IpAddressMatcher ipAddressMatcher = new IpAddressMatcher();
+
+    @Test
+    void shouldReturnTrueWhenOnlyOneForwardedIpAddressMatches() {
+        String ipAddress = "9.9.9.9";
+
+        assertTrue(ipAddressMatcher.isMatch(ipAddress, ALLOWED_IP_ADDRESSES));
+    }
+
+    @Test
+    void shouldReturnFalseWhenOnlyOneForwardedIpAddressDoesNotMatch() {
+        String ipAddress = "1.1.1.1";
+
+        assertFalse(ipAddressMatcher.isMatch(ipAddress, ALLOWED_IP_ADDRESSES));
+    }
+
+    @Test
+    void shouldReturnTrueWhenFirstOfForwardedIpAddressesMatches() {
+        String ipAddresses = "1.2.3.4, 102.106.2.1";
+
+        assertTrue(ipAddressMatcher.isMatch(ipAddresses, ALLOWED_IP_ADDRESSES));
+    }
+
+    @Test
+    void shouldReturnFalseWhenFirstOfForwardedIpAddressesDoesNotMatch() {
+        String ipAddresses = "1.1.1.1, 102.106.2.1";
+
+        assertFalse(ipAddressMatcher.isMatch(ipAddresses, ALLOWED_IP_ADDRESSES));
+    }
+
+    @Test
+    void shouldReturnFalseWhenForwardedIpAddressIsNull() {
+        assertFalse(ipAddressMatcher.isMatch(null, ALLOWED_IP_ADDRESSES));
+    }
+
+    @Test
+    void shouldReturnFalseWhenForwardedIpAddressIsEmpty() {
+        assertFalse(ipAddressMatcher.isMatch("", ALLOWED_IP_ADDRESSES));
+    }
+
+    @Test
+    void shouldReturnFalseWhenListOfAllowedIpAddressesIsNull() {
+        assertFalse(ipAddressMatcher.isMatch("1.2.3.4, 102.106.2.1", null));
+    }
+
+    @Test
+    void shouldReturnFalseWhenListOfAllowedIpAddressesIsEmpty() {
+        assertFalse(ipAddressMatcher.isMatch("1.2.3.4, 102.106.2.1", List.of()));
+    }
+}

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -59,6 +59,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
+  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -58,6 +58,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
+  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -48,6 +48,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
+  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -54,6 +54,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
+  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -53,6 +53,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
+  allowedIpAddresses: ["1.2.3.4", "9.9.9.9"]
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}


### PR DESCRIPTION
## WHAT YOU DID
This pull requests contains 3 commits.

1. The first commit adds IP Address Matcher. It is responsible for matching IP address with one of allowed IP addresses.
2. The second commit updates Stripe Notification Service to perform IP firewalling so that only requests coming from Stripe can be processed. It adds unit tests and an integration test to ensure that Stripe Notification Service can process requests coming from Stripe and reject other requests which are not from Stripe.
3. The third commit adds "STRIPE_ALLOWED_IP_ADDRESSES" environment variable to README for Connector application. Connector application uses this environment variable containing a list of allowed Stripe IP addresses so that it can perform IP firewalling on incoming notifications from Stripe. 

I have tested the changes locally and found them working fine. Stripe Notification Service can accept notifications coming from IP address present in the allowed list and reject notifications coming from IP address not present in the allowed list.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
Yes

* Added new API / updated existing API definition
No