### PR TITLE
PP-7363 Add logging for refund state changes

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -64,7 +64,7 @@ public class RefundNotificationProcessor {
         RefundEntity refundEntity = optionalRefundEntity.get();
         RefundStatus oldStatus = refundEntity.getStatus();
 
-        refundService.transitionRefundState(refundEntity, newStatus);
+        refundService.transitionRefundState(refundEntity, gatewayAccountEntity, newStatus);
 
         if (RefundStatus.REFUNDED.equals(newStatus)) {
             userNotificationService.sendRefundIssuedEmail(refundEntity, charge, gatewayAccountEntity);

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -28,6 +28,7 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @SqlResultSetMapping(
         name = "RefundEntityHistoryMapping",
@@ -150,6 +151,10 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     public boolean hasStatus(RefundStatus... status) {
         return Arrays.stream(status).anyMatch(s -> equalsIgnoreCase(s.getValue(), getStatus().getValue()));
+    }
+
+    public boolean hasStatus() {
+        return isNotBlank(status);
     }
 
     public Long getId() {

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -249,7 +249,7 @@ public class RefundServiceTest {
             return null;
         }).when(mockRefundDao).persist(any(RefundEntity.class));
 
-        RefundEntity refundEntity = refundService.createRefundEntity(new RefundRequest(refundAmount, chargeEntity.getAmount(), userExternalId), Charge.from(chargeEntity));
+        RefundEntity refundEntity = refundService.createRefundEntity(new RefundRequest(refundAmount, chargeEntity.getAmount(), userExternalId), account, Charge.from(chargeEntity));
 
         assertThat(refundEntity.getAmount(), is(refundAmount));
         assertThat(refundEntity.getStatus(), is(CREATED));
@@ -665,7 +665,7 @@ public class RefundServiceTest {
                 .build();
         RefundEntity refundEntity = aValidRefundEntity().withAmount(100L).build();
 
-        refundService.transitionRefundState(refundEntity, CREATED);
+        refundService.transitionRefundState(refundEntity, charge.getGatewayAccount(), CREATED);
         verify(mockStateTransitionService).offerRefundStateTransition(refundEntity, CREATED);
     }
 


### PR DESCRIPTION
## WHAT YOU DID
- Added logging for refund state changes so we can use it to understand refund states. Refund status can be changed to refunded immediately or when we receive notification. Currently we only have detailed (with gateway account info) logs for notifications but not when refund is succeeded immediately.
