### PR TITLE
PP-7336: Update Stripe to use a list of allowed CIDRs for firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The GOV.UK Pay Connector in Java (Dropwizard)
 | `GDS_CONNECTOR_EPDQ_TEST_URL` | - | Pointing to the TEST gateway URL of ePDQ payment provider. |
 | `GDS_CONNECTOR_EPDQ_LIVE_URL` | - | Pointing to the LIVE gateway URL of ePDQ payment provider. |
 | `COLLECT_FEE_FEATURE_FLAG` | false | enable or disable collecting fees for the Stripe payment gateway. |
-| `STRIPE_ALLOWED_IP_ADDRESSES` | - |  A list of allowed Stripe IP addresses used for IP firewalling on notifications coming from Stripe. |
+| `STRIPE_ALLOWED_CIDRS` | - | A list of allowed Stripe CIDRs used for IP firewalling on notifications coming from Stripe. |
 | `STRIPE_TRANSACTION_FEE_PERCENTAGE` | - | percentage of total charge amount to recover GOV.UK Pay platform costs. |
 | `STRIPE_PLATFORM_ACCOUNT_ID` | - | the account ID for the Stripe Connect GOV.UK Pay platform. |
 | `DISABLE_INTERNAL_HTTPS` | false | disable secure connection for calls to internal APIs |

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             <version>${pay-java-commons.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-net</groupId>
+            <artifactId>commons-net</artifactId>
+            <version>3.7.2</version>
+        </dependency>
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>

--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -40,7 +40,7 @@ public class StripeGatewayConfig extends Configuration {
 
     @Valid
     @NotNull
-    private List<String> allowedIpAddresses;
+    private List<String> allowedCidrs;
 
     public String getUrl() {
         return url;
@@ -70,7 +70,7 @@ public class StripeGatewayConfig extends Configuration {
         return notification3dsWaitDelay;
     }
 
-    public List<String> getAllowedIpAddresses() {
-        return allowedIpAddresses;
+    public List<String> getAllowedCidrs() {
+        return allowedCidrs;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/util/CidrUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/CidrUtils.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.util;
+
+import org.apache.commons.net.util.SubnetUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+public class CidrUtils {
+    public static Set<String> getIpAddresses(Collection<String> cidrs) {
+        return cidrs.stream()
+                .map(SubnetUtils::new)
+                .peek(subnet -> subnet.setInclusiveHostCount(true))
+                .map(SubnetUtils::getInfo)
+                .map(SubnetUtils.SubnetInfo::getAllAddresses)
+                .flatMap(Arrays::stream)
+                .collect(toUnmodifiableSet());
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/util/IpAddressMatcher.java
+++ b/src/main/java/uk/gov/pay/connector/util/IpAddressMatcher.java
@@ -1,14 +1,25 @@
 package uk.gov.pay.connector.util;
 
+import org.apache.commons.validator.routines.InetAddressValidator;
+
 import javax.inject.Singleton;
-import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @Singleton
 public class IpAddressMatcher {
-    public boolean isMatch(String forwardedIpAddresses, List<String> allowedIpAddresses) {
+    private final InetAddressValidator ipAddressValidator;
+
+    public IpAddressMatcher(InetAddressValidator ipAddressValidator) {
+        this.ipAddressValidator = ipAddressValidator;
+    }
+
+    public boolean isMatch(String forwardedIpAddresses, Set<String> allowedIpAddresses) {
         if (Objects.nonNull(forwardedIpAddresses) && Objects.nonNull(allowedIpAddresses)) {
-            return allowedIpAddresses.contains(getFirstIpAddress(forwardedIpAddresses));
+            String ipAddress = getFirstIpAddress(forwardedIpAddresses);
+            if (ipAddressValidator.isValid(ipAddress)) {
+                return allowedIpAddresses.contains(ipAddress);
+            }
         }
         return false;
     }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -88,7 +88,7 @@ epdq:
       readTimeout: 20000ms
 
 stripe:
-  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES}
+  allowedCidrs: ${STRIPE_ALLOWED_CIDRS}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN}

--- a/src/test/java/uk/gov/pay/connector/util/CidrUtilsTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/CidrUtilsTest.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+class CidrUtilsTest {
+    @Test
+    void shouldReturnAnImmutableIpAddressesSet() {
+        Set<String> expectedIpAddresses = Set.of("1.1.1.0", "1.1.1.1", "16.20.108.12");
+
+        Set<String> ipAddresses = CidrUtils.getIpAddresses(Set.of("1.1.1.0/31", "16.20.108.12/32"));
+
+        assertThat(ipAddresses, is(expectedIpAddresses));
+        assertThrows(UnsupportedOperationException.class, () -> ipAddresses.add("9.9.9.9"));
+    }
+
+    @Test
+    void shouldReturnAnEmptyImmutableIpAddressesSetAfterAcceptingAnEmptyList() {
+        Set<String> ipAddresses = CidrUtils.getIpAddresses(Collections.EMPTY_LIST);
+
+        assertThat(ipAddresses, is(Collections.EMPTY_SET));
+    }
+
+    @Test
+    void shouldThrowNullPointerExceptionAfterAcceptingNullValue() {
+       assertThrows(NullPointerException.class, () -> CidrUtils.getIpAddresses(null));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/IpAddressMatcherTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/IpAddressMatcherTest.java
@@ -1,15 +1,19 @@
 package uk.gov.pay.connector.util;
 
+import org.apache.commons.validator.routines.InetAddressValidator;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
+import java.util.Collections;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class IpAddressMatcherTest {
-    private static final List<String> ALLOWED_IP_ADDRESSES = List.of("9.9.9.9", "1.2.3.4", "3.6.9.12");
-    private IpAddressMatcher ipAddressMatcher = new IpAddressMatcher();
+    private static final Set<String> ALLOWED_IP_ADDRESSES = CidrUtils.getIpAddresses(
+            Set.of("9.9.9.9/32", "1.2.3.0/24", "3.6.9.12/32"));
+
+    private IpAddressMatcher ipAddressMatcher = new IpAddressMatcher(new InetAddressValidator());
 
     @Test
     void shouldReturnTrueWhenOnlyOneForwardedIpAddressMatches() {
@@ -50,12 +54,17 @@ class IpAddressMatcherTest {
     }
 
     @Test
+    void shouldReturnFalseWhenForwardedIpAddressIsInBadFormat() {
+        assertFalse(ipAddressMatcher.isMatch("1.2.x.1", ALLOWED_IP_ADDRESSES));
+    }
+
+    @Test
     void shouldReturnFalseWhenListOfAllowedIpAddressesIsNull() {
         assertFalse(ipAddressMatcher.isMatch("1.2.3.4, 102.106.2.1", null));
     }
 
     @Test
     void shouldReturnFalseWhenListOfAllowedIpAddressesIsEmpty() {
-        assertFalse(ipAddressMatcher.isMatch("1.2.3.4, 102.106.2.1", List.of()));
+        assertFalse(ipAddressMatcher.isMatch("1.2.3.4, 102.106.2.1", Collections.emptySet()));
     }
 }

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -59,7 +59,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
-  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
+  allowedCidrs: ${STRIPE_ALLOWED_CIDRS:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -58,7 +58,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
-  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
+  allowedCidrs: ${STRIPE_ALLOWED_CIDRS:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -48,7 +48,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
-  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
+  allowedCidrs: ${STRIPE_ALLOWED_CIDRS:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -54,7 +54,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
-  allowedIpAddresses: ${STRIPE_ALLOWED_IP_ADDRESSES:-[]}
+  allowedCidrs: ${STRIPE_ALLOWED_CIDRS:-[]}
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -53,7 +53,7 @@ epdq:
       readTimeout: 1000ms
 
 stripe:
-  allowedIpAddresses: ["1.2.3.4", "9.9.9.9"]
+  allowedCidrs: ["1.2.3.0/24", "9.9.9.9/32"]
   url: ${GDS_CONNECTOR_STRIPE_URL:-https://api.stripe.com}
   authTokens:
     test: ${GDS_CONNECTOR_STRIPE_AUTH_TOKEN:-sk_test}


### PR DESCRIPTION
## WHAT YOU DID

This change updates Stripe Gateway Config to pick up a list of allowed CIDRs instead of IP addresses because using CIDR helps to reduce a large number of IP addresses needed to be specified in the config file. It also updates IP Address Matcher to validate a forwarded IP address before processing it.

## Code review checklist

### Logging

- [x] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [x] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
I renamed an environment variable from STRIPE_ALLOWED_IP_ADDRESSES to STRIPE_ALLOWED_CIDRS. There is a pull request for this and it needs to be merged before this pull request is merged.

* Added new API / updated existing API definition
No.