### PR TITLE
PP-6500 Wait for processing of payouts or charge captures before exit

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/managed/PayoutReconcileMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/PayoutReconcileMessageReceiver.java
@@ -54,7 +54,26 @@ public class PayoutReconcileMessageReceiver implements Managed {
 
     @Override
     public void stop() {
+        LOGGER.info("Shutting down payout reconciliation service");
         payoutReconcileMessageExecutorService.shutdown();
+        try {
+            // Wait for existing payouts to finish being captured
+            if (payoutReconcileMessageExecutorService.awaitTermination(15, TimeUnit.SECONDS)) {
+                LOGGER.info("payout reconciliation service shut down cleanly");
+            } else {
+                // If the existing payouts being captured didn't terminate within the allowed time then force them to.
+                LOGGER.error("Payouts still being captured after shutdown wait time will now be forcefully stopped");
+                payoutReconcileMessageExecutorService.shutdownNow();
+                if (!payoutReconcileMessageExecutorService.awaitTermination(12, TimeUnit.SECONDS)){
+                    LOGGER.error("Payout reconciliation service could not be forced stopped");
+                }
+            }
+        } catch (InterruptedException ex) {
+            LOGGER.error("Failed to shutdown payout reconciliation service cleanly as the wait was interrupted.");
+            payoutReconcileMessageExecutorService.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+        }
     }
 
     private void processPayouts() {


### PR DESCRIPTION
Wait to finish processing payouts and charge captures before exiting.
The `ExecutorService.shutdown` method only stops scheduling new tasks
and it doesn't wait for existing tasks to complete. Use
`awaitTermination` with a 15 second wait for any inflight payout or
charge processing to finish.

## WHAT YOU DID
The solution is based up on the example from the `ExecutorService` documentation https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html#awaitTermination

Details of the investigation can be found in the Jira ticket here: https://payments-platform.atlassian.net/browse/PP-6500

#### Isn't there a bit of duplication?
Yes. This could be factored into some static method on a utility class which accepts an `ExecutorService` but the log entires are different and I'm not sure it makes things any simpler. Happy to be convinced otherwise.