### PR TITLE
PP-7280 - Use connector timestamp for USER_EMAIL_COLLECTED event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -50,8 +50,8 @@ import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.common.model.domain.PrefilledAddress;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.events.EventService;
-import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
+import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
@@ -83,6 +83,8 @@ import java.util.stream.Stream;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
+import static java.time.ZonedDateTime.now;
 import static javax.ws.rs.HttpMethod.GET;
 import static javax.ws.rs.HttpMethod.POST;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
@@ -321,7 +323,7 @@ public class ChargeService {
                 .map(chargeEntity -> {
                     if (chargePatchRequest.getPath().equals(ChargesApiResource.EMAIL_KEY)) {
                         chargeEntity.setEmail(sanitize(chargePatchRequest.getValue()));
-                        eventService.emitAndRecordEvent(UserEmailCollected.from(chargeEntity));
+                        eventService.emitAndRecordEvent(UserEmailCollected.from(chargeEntity, now(UTC)));
                     }
                     return Optional.of(chargeEntity);
                 })
@@ -412,8 +414,8 @@ public class ChargeService {
     }
 
     public <T extends AbstractChargeResponseBuilder<T, R>, R> AbstractChargeResponseBuilder<T, R> populateResponseBuilderWith(
-            AbstractChargeResponseBuilder<T, R> responseBuilder, 
-            UriInfo uriInfo, 
+            AbstractChargeResponseBuilder<T, R> responseBuilder,
+            UriInfo uriInfo,
             ChargeEntity chargeEntity) {
         String chargeId = chargeEntity.getExternalId();
         PersistedCard persistedCard = null;

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentDetailsEnteredEventDetails.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     private final Long corporateSurcharge;
+    private final String email;
     private final String cardType;
     private final String cardBrand;
     private final String cardBrandLabel;
@@ -36,6 +37,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
     private PaymentDetailsEnteredEventDetails(Builder builder) {
 
         this.corporateSurcharge = builder.corporateSurcharge;
+        this.email = builder.email;
         this.cardType = builder.cardType;
         this.cardBrand = builder.cardBrand;
         this.cardBrandLabel = builder.cardBrandLabel;
@@ -57,6 +59,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     public static PaymentDetailsEnteredEventDetails from(ChargeEntity charge) {
         Builder builder = new Builder()
+                .withEmail(charge.getEmail())
                 .withGatewayTransactionId(charge.getGatewayTransactionId())
                 .withCorporateSurcharge(charge.getCorporateSurcharge().orElse(null))
                 .withTotalAmount(CorporateCardSurchargeCalculator.getTotalAmountFor(charge))
@@ -90,6 +93,10 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     public Long getCorporateSurcharge() {
         return corporateSurcharge;
+    }
+
+    public String getEmail() {
+        return email;
     }
 
     public String getCardType() {
@@ -166,6 +173,7 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
         if (o == null || getClass() != o.getClass()) return false;
         PaymentDetailsEnteredEventDetails that = (PaymentDetailsEnteredEventDetails) o;
         return Objects.equals(corporateSurcharge, that.corporateSurcharge) &&
+                Objects.equals(email, that.email) &&
                 Objects.equals(cardType, that.cardType) &&
                 Objects.equals(cardBrand, that.cardBrand) &&
                 Objects.equals(firstDigitsCardNumber, that.firstDigitsCardNumber) &&
@@ -186,13 +194,14 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
     @Override
     public int hashCode() {
-        return Objects.hash(corporateSurcharge, cardType, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
+        return Objects.hash(corporateSurcharge, email, cardType, cardBrand, firstDigitsCardNumber, lastDigitsCardNumber,
                 gatewayTransactionId, cardholderName, expiryDate, addressLine1, addressLine2, addressPostcode,
                 addressCounty, addressStateProvince, addressCountry, wallet, totalAmount);
     }
 
     private static class Builder {
         private Long corporateSurcharge;
+        private String email;
         private String cardType;
         private String cardBrand;
         private String cardBrandLabel;
@@ -213,6 +222,11 @@ public class PaymentDetailsEnteredEventDetails extends EventDetails {
 
         Builder withCorporateSurcharge(Long corporateSurcharge) {
             this.corporateSurcharge = corporateSurcharge;
+            return this;
+        }
+
+        Builder withEmail(String email) {
+            this.email = email;
             return this;
         }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.common.model.domain.PaymentGatewayStateTransitions;
 import uk.gov.pay.connector.events.eventdetails.charge.RefundAvailabilityUpdatedEventDetails;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.events.exception.EventCreationException;
+import uk.gov.pay.connector.events.model.charge.BackfillerRecreatedUserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.CancelledByUser;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
@@ -20,7 +21,6 @@ import uk.gov.pay.connector.events.model.charge.PaymentEvent;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
 import uk.gov.pay.connector.events.model.charge.UnexpectedGatewayErrorDuringAuthorisation;
-import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByService;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByUser;
 import uk.gov.pay.connector.events.model.refund.RefundError;
@@ -135,8 +135,8 @@ public class EventFactory {
                 return PaymentNotificationCreated.from(chargeEvent);
             } else if (eventClass == CancelledByUser.class) {
                 return CancelledByUser.from(chargeEvent);
-            } else if (eventClass == UserEmailCollected.class) {
-                return UserEmailCollected.from(chargeEvent.getChargeEntity());
+            } else if (eventClass == BackfillerRecreatedUserEmailCollected.class) {
+                return BackfillerRecreatedUserEmailCollected.from(chargeEvent.getChargeEntity());
             } else {
                 return eventClass.getConstructor(String.class, ZonedDateTime.class).newInstance(
                         chargeEvent.getChargeEntity().getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollected.java
@@ -1,0 +1,39 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import uk.gov.pay.connector.charge.exception.ChargeEventNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.UserEmailCollectedEventDetails;
+
+import java.time.ZonedDateTime;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+
+/**
+ * `UserEmailCollected` event is emitted with connector instance timestamp (as event date) when email is updated for
+ *  a charge (using PATCH endpoint) and there is no associated charge event.
+ *  This (`BackfillerRecreatedUserEmailCollected`) event is equivalent to `UserEmailCollected` event but used during
+ *  backfilling charge and uses timestamp of CREATED/ENTERING_CARD_DETAILS event as event date.
+ */
+public class BackfillerRecreatedUserEmailCollected extends PaymentEvent {
+
+    public BackfillerRecreatedUserEmailCollected(String resourceExternalId,
+                                                 UserEmailCollectedEventDetails eventDetails,
+                                                 ZonedDateTime timestamp) {
+        super(resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static BackfillerRecreatedUserEmailCollected from(ChargeEntity charge) {
+        ZonedDateTime lastEventDate = charge.getEvents().stream()
+                .filter(e -> e.getStatus() == ENTERING_CARD_DETAILS ||  e.getStatus() == CREATED)
+                .map(ChargeEventEntity::getUpdated)
+                .max(ZonedDateTime::compareTo)
+                .orElseThrow(() -> new ChargeEventNotFoundRuntimeException(charge.getExternalId()));
+
+        return new BackfillerRecreatedUserEmailCollected(
+                charge.getExternalId(),
+                UserEmailCollectedEventDetails.from(charge),
+                lastEventDate);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/UserEmailCollected.java
@@ -1,14 +1,9 @@
 package uk.gov.pay.connector.events.model.charge;
 
-import uk.gov.pay.connector.charge.exception.ChargeEventNotFoundRuntimeException;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.UserEmailCollectedEventDetails;
 
 import java.time.ZonedDateTime;
-
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
-import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 
 public class UserEmailCollected extends PaymentEvent {
 
@@ -18,16 +13,10 @@ public class UserEmailCollected extends PaymentEvent {
         super(resourceExternalId, eventDetails, timestamp);
     }
 
-    public static UserEmailCollected from(ChargeEntity charge) {
-        ZonedDateTime lastEventDate = charge.getEvents().stream()
-                .filter(e -> e.getStatus() == ENTERING_CARD_DETAILS ||  e.getStatus() == CREATED)
-                .map(ChargeEventEntity::getUpdated)
-                .max(ZonedDateTime::compareTo)
-                .orElseThrow(() -> new ChargeEventNotFoundRuntimeException(charge.getExternalId()));
-
+    public static UserEmailCollected from(ChargeEntity charge, ZonedDateTime eventDate) {
         return new UserEmailCollected(
                 charge.getExternalId(),
                 UserEmailCollectedEventDetails.from(charge),
-                lastEventDate);
+                eventDate);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
@@ -15,7 +15,7 @@ import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.EventFactory;
-import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
+import uk.gov.pay.connector.events.model.charge.BackfillerRecreatedUserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.events.model.refund.RefundEvent;
 import uk.gov.pay.connector.queue.statetransition.PaymentStateTransition;
@@ -272,9 +272,9 @@ public class HistoricalEventEmitter {
                     .stream().anyMatch(event -> ENTERING_CARD_DETAILS.equals(event.getStatus()));
 
             if (hasEnteringCardDetailsEvent) {
-                UserEmailCollected emailEnteredEvent = UserEmailCollected.from(charge);
-                if (forceEmission || !emittedEventDao.hasBeenEmittedBefore(emailEnteredEvent)) {
-                    eventService.emitAndRecordEvent(emailEnteredEvent, getDoNotRetryEmitUntilDate());
+                BackfillerRecreatedUserEmailCollected userEmailCollectedEvent = BackfillerRecreatedUserEmailCollected.from(charge);
+                if (forceEmission || !emittedEventDao.hasBeenEmittedBefore(userEmailCollectedEvent)) {
+                    eventService.emitAndRecordEvent(userEmailCollectedEvent, getDoNotRetryEmitUntilDate());
                 }
             }
         }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollectedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollectedTest.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity.ChargeEventEntityBuilder.aChargeEventEntity;
+
+public class BackfillerRecreatedUserEmailCollectedTest {
+
+    private final String time = "2018-03-12T16:25:01.123456Z";
+
+    private ChargeEntityFixture chargeEntityFixture;
+
+    @Before
+    public void setUp() {
+        ZonedDateTime latestDateTime = ZonedDateTime.parse(time);
+
+        List<ChargeEventEntity> list = List.of(
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.CREATED).withUpdated(latestDateTime.minusHours(3)).build(),
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.ENTERING_CARD_DETAILS).withUpdated(latestDateTime).build(),
+                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.USER_CANCELLED).withUpdated(latestDateTime.plusHours(1)).build()
+        );
+
+        String paymentId = "jweojfewjoifewj";
+        chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
+                .withCreatedDate(ZonedDateTime.parse(time))
+                .withStatus(ChargeStatus.USER_CANCELLED)
+                .withExternalId(paymentId)
+                .withAmount(100L)
+                .withEvents(list);
+    }
+
+    @Test
+    public void serializesEventDetailsGivenChargeEvent() throws JsonProcessingException {
+        ChargeEntity chargeEntity = chargeEntityFixture.build();
+        String actual = BackfillerRecreatedUserEmailCollected.from(chargeEntity).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("BACKFILLER_RECREATED_USER_EMAIL_COLLECTED")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
+        assertThat(actual, hasJsonPath("$.event_details.email", equalTo(chargeEntity.getEmail())));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -64,6 +64,7 @@ public class PaymentDetailsEnteredTest {
         assertThat(actual, hasJsonPath("$.description", equalTo("The event happens when the payment details are entered")));
 
         assertThat(actual, hasJsonPath("$.event_details.corporate_surcharge", equalTo(10)));
+        assertThat(actual, hasJsonPath("$.event_details.email", equalTo("test@email.invalid")));
         assertThat(actual, hasJsonPath("$.event_details.total_amount", equalTo(110)));
         assertThat(actual, hasJsonPath("$.event_details.card_type", equalTo("DEBIT")));
         assertThat(actual, hasJsonPath("$.event_details.card_brand", equalTo("visa")));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
@@ -1,53 +1,26 @@
 package uk.gov.pay.connector.events.model.charge;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Before;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 
 import java.time.ZonedDateTime;
-import java.util.List;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity.ChargeEventEntityBuilder.aChargeEventEntity;
 
 public class UserEmailCollectedTest {
 
-    private final String paymentId = "jweojfewjoifewj";
-    private final String time = "2018-03-12T16:25:01.123456Z";
-    private final String validTransactionId = "validTransactionId";
-
-    private ChargeEntityFixture chargeEntityFixture;
-
-    @Before
-    public void setUp() {
-        ZonedDateTime latestDateTime = ZonedDateTime.parse(time);
-
-        List<ChargeEventEntity> list = List.of(
-                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.CREATED).withUpdated(latestDateTime.minusHours(3)).build(),
-                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.ENTERING_CARD_DETAILS).withUpdated(latestDateTime).build(),
-                aChargeEventEntity().withChargeEntity(new ChargeEntity()).withStatus(ChargeStatus.USER_CANCELLED).withUpdated(latestDateTime.plusHours(1)).build()
-        );
-
-        chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.parse(time))
-                .withStatus(ChargeStatus.USER_CANCELLED)
-                .withExternalId(paymentId)
-                .withAmount(100L)
-                .withEvents(list);
-    }
-
     @Test
-    public void serializesEventDetailsGivenChargeEvent() throws JsonProcessingException {
-        ChargeEntity chargeEntity = chargeEntityFixture.build();
-        String actual = UserEmailCollected.from(chargeEntity).toJsonString();
+    public void serializesEventDetailsForChargeAndEventDate() throws JsonProcessingException {
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity().build();
+        ZonedDateTime eventDate = ZonedDateTime.now(UTC);
+        String actual = UserEmailCollected.from(chargeEntity, eventDate).toJsonString();
 
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(time)));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(eventDate.toString())));
         assertThat(actual, hasJsonPath("$.event_type", equalTo("USER_EMAIL_COLLECTED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.events.model.charge.AuthorisationCancelled;
 import uk.gov.pay.connector.events.model.charge.AuthorisationErrorCheckedWithGatewayChargeWasMissing;
 import uk.gov.pay.connector.events.model.charge.AuthorisationErrorCheckedWithGatewayChargeWasRejected;
 import uk.gov.pay.connector.events.model.charge.AuthorisationRejected;
+import uk.gov.pay.connector.events.model.charge.BackfillerRecreatedUserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.CancelByExpirationFailed;
 import uk.gov.pay.connector.events.model.charge.CancelByExternalServiceFailed;
 import uk.gov.pay.connector.events.model.charge.CancelByExternalServiceSubmitted;
@@ -51,7 +52,6 @@ import uk.gov.pay.connector.events.model.charge.PaymentExpired;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
 import uk.gov.pay.connector.events.model.charge.UnexpectedGatewayErrorDuringAuthorisation;
-import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
@@ -422,7 +422,7 @@ public class EventFactoryTest {
     }
 
     @Test
-    public void shouldCreatedCorrectEventForUserEmailCollected() throws Exception {
+    public void shouldCreatedCorrectEventForBackfillRecreatedUserEmailCollectedEvent() throws Exception {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withStatus(ChargeStatus.USER_CANCELLED)
                 .withEmail("test@example.org")
@@ -438,13 +438,14 @@ public class EventFactoryTest {
         when(chargeEventDao.findById(ChargeEventEntity.class, chargeEventEntityId)).thenReturn(
                 Optional.of(chargeEventEntity)
         );
-        PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, UserEmailCollected.class);
+        PaymentStateTransition paymentStateTransition = new PaymentStateTransition(chargeEventEntityId, 
+                BackfillerRecreatedUserEmailCollected.class);
         List<Event> events = eventFactory.createEvents(paymentStateTransition);
 
         assertThat(events.size(), is(1));
 
-        UserEmailCollected event = (UserEmailCollected) events.get(0);
-        assertThat(event, is(instanceOf(UserEmailCollected.class)));
+        BackfillerRecreatedUserEmailCollected event = (BackfillerRecreatedUserEmailCollected) events.get(0);
+        assertThat(event, is(instanceOf(BackfillerRecreatedUserEmailCollected.class)));
 
         assertThat(event.getEventDetails(), instanceOf(UserEmailCollectedEventDetails.class));
         assertThat(event.getResourceExternalId(), is(chargeEventEntity.getChargeEntity().getExternalId()));

--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -20,13 +20,13 @@ import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.dao.EmittedEventDao;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.charge.AuthorisationSucceeded;
+import uk.gov.pay.connector.events.model.charge.BackfillerRecreatedUserEmailCollected;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
 import uk.gov.pay.connector.events.model.charge.GatewayRequires3dsAuthorisation;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.events.model.charge.PaymentStarted;
-import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.events.model.refund.RefundCreatedByService;
 import uk.gov.pay.connector.events.model.refund.RefundSucceeded;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
@@ -209,7 +209,7 @@ public class HistoricalEventEmitterWorkerTest {
 
         worker.execute(1L, OptionalLong.empty(), 1L);
 
-        verify(eventService, times(1)).emitAndRecordEvent(any(UserEmailCollected.class), isNotNull());
+        verify(eventService, times(1)).emitAndRecordEvent(any(BackfillerRecreatedUserEmailCollected.class), isNotNull());
     }
 
     @Test
@@ -393,7 +393,7 @@ public class HistoricalEventEmitterWorkerTest {
         ArgumentCaptor<Event> daoArgumentCaptor = ArgumentCaptor.forClass(Event.class);
         verify(eventService, times(2)).emitAndRecordEvent(daoArgumentCaptor.capture(), isNotNull());
         assertThat(daoArgumentCaptor.getAllValues().get(0).getEventType(), is("PAYMENT_DETAILS_ENTERED"));
-        assertThat(daoArgumentCaptor.getAllValues().get(1).getEventType(), is("USER_EMAIL_COLLECTED"));
+        assertThat(daoArgumentCaptor.getAllValues().get(1).getEventType(), is("BACKFILLER_RECREATED_USER_EMAIL_COLLECTED"));
     }
 
     @Test


### PR DESCRIPTION
## WHY
- We currently emit `USER_EMAIL_COLLECTED` event to ledger with the timestamp of ENTERING_CARD_DETAILS/CREATED event.
  This was done as there is no charge event associated when frontend patches charge for email. We didn't also want to rely on connector timestamp as it may not be in sync with database or even other instances and can lead to out of order ledger events.
  `email` field has been removed from PAYMENT_DETAILS_ENTERED event due to new event USER_EMAIL_COLLECTED.

  This led to following issues:
  - Frontend can patch email multiple times and connector emits USER_EMAIL_COLLECTED events to ledger with same timestamp. But ledger processes only one event and ignores the rest as they are treated as duplicate events due to same event_name and timestamp. This is resulting in incorrect email address in ledger for transactions.
  - Wallet payments: It seems that for wallet payments, frontend doesn't patch charge, so email is not included in any event emitted to ledger. However, when connector tries to expunge charge, parity check fails on email field and a new event (`USER_EMAIL_COLLECTED`) is emitted. Until then ledger transactions will not have associated email address.

## WHAT
 - Use connector instance timestamp when `USER_EMAIL_COLLECTED` event is emitted. This ensures different events are emitted every time email is patched and ledger processes them all.
 - For backfilling we can continue to use ENTERING_CARD_DETAILS/CREATED charge event date. Emits event `BACKFILLER_RECREATED_USER_EMAIL_COLLECTED` to distinguish USER_EMAIL_COLLECTED events that happens when frontend patches charge with `email`
 - Added `email` back to PAYMENT_DETAILS_ENTERED event. This ensures `email` is emitted to ledger for wallet payments. There will be some duplication for card payments, as email will be included in both `USER_EMAIL_COLLECTED` and `PAYMENT_DETAILS_ENTERED` events. If we would like to avoid this, we can add email to PAYMENT_DETAILS_ENTERED event only for wallet payments.
