### PR TITLE
PP-7416 Remove code that toggles 3DS Flex based on credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayUpdate3dsFlexCredentialsRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayUpdate3dsFlexCredentialsRequest.java
@@ -42,20 +42,12 @@ public class WorldpayUpdate3dsFlexCredentialsRequest {
         return jwtMacKey;
     }
 
-    public boolean hasAllCredentials() {
-        return isNoneBlank(issuer, organisationalUnitId, jwtMacKey);
-    }
-
     public static final class WorldpayUpdate3dsFlexCredentialsRequestBuilder {
         private String issuer;
         private String organisationalUnitId;
         private String jwtMacKey;
 
         private WorldpayUpdate3dsFlexCredentialsRequestBuilder() {
-        }
-
-        public static WorldpayUpdate3dsFlexCredentialsRequestBuilder aWorldpayUpdate3dsFlexCredentialsRequest() {
-            return new WorldpayUpdate3dsFlexCredentialsRequestBuilder();
         }
 
         public WorldpayUpdate3dsFlexCredentialsRequestBuilder withIssuer(String issuer) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
@@ -38,10 +38,5 @@ public class Worldpay3dsFlexCredentialsService {
                     .build();
             worldpay3dsFlexCredentialsDao.merge(newWorldpay3dsFlexCredentialsEntity);
         });
-        gatewayAccountEntity.setIntegrationVersion3ds(
-                worldpayUpdate3dsFlexCredentialsRequest.hasAllCredentials() ?
-                        IntegrationVersion3DS.TWO.getValue() :
-                        IntegrationVersion3DS.ONE.getValue());
-        gatewayAccountDao.merge(gatewayAccountEntity);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResourceIT.java
@@ -70,9 +70,6 @@ public class GatewayAccount3dsFlexCredentialsResourceIT {
         assertThat(result.get("issuer"), is("testissuer"));
         assertThat(result.get("organisational_unit_id"), is("hihihi"));
         assertThat(result.get("jwt_mac_key"), is("hihihihihi"));
-
-        result = databaseTestHelper.getGatewayAccount(accountId);
-        assertThat(result.get("integration_version_3ds"), is(2));
     }
 
     @Test
@@ -101,9 +98,6 @@ public class GatewayAccount3dsFlexCredentialsResourceIT {
         assertThat(result.get("issuer"), is("updated_issuer"));
         assertThat(result.get("organisational_unit_id"), is("updated_organisational_unit_id"));
         assertThat(result.get("jwt_mac_key"), is("updated_jwt_mac_key"));
-
-        result = databaseTestHelper.getGatewayAccount(accountId);
-        assertThat(result.get("integration_version_3ds"), is(2));
     }
 
     @Test
@@ -200,24 +194,4 @@ public class GatewayAccount3dsFlexCredentialsResourceIT {
                 .body("message[0]", is("Not a Worldpay gateway account"));
     }
 
-    @Test
-    public void setIntegrationVersion3DSTo1WhenCredentialsAreBlank() throws JsonProcessingException {
-        String payload = new ObjectMapper().writeValueAsString(Map.of(
-                "issuer", "",
-                "organisational_unit_id", "hihihi",
-                "jwt_mac_key", "hihihihihi"
-        ));
-        givenSetup()
-                .body(payload)
-                .post(format(ACCOUNTS_API_URL,testAccount.getAccountId()))
-                .then()
-                .statusCode(200);
-        var result = databaseTestHelper.getWorldpay3dsFlexCredentials(accountId);
-        assertThat(result.get("issuer"), is(""));
-        assertThat(result.get("organisational_unit_id"), is("hihihi"));
-        assertThat(result.get("jwt_mac_key"), is("hihihihihi"));
-
-        result = databaseTestHelper.getGatewayAccount(accountId);
-        assertThat(result.get("integration_version_3ds"), is(1));
-    }
 }


### PR DESCRIPTION
Remove code that toggles Worldpay 3DS Flex based on whether there are 3DS Flex credentials after the 3DS Flex credentials have been updated. We now have a button to toggle 3DS Flex and don’t want this behaviour any more