### PR TITLE
PP-7417: Rename WorldpayUpdate3dsFlexCredentialsRequest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsRequest.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.validation.constraints.NotNull;
 
-import static org.apache.commons.lang3.StringUtils.isNoneBlank;
-
-public class WorldpayUpdate3dsFlexCredentialsRequest {
+public class Worldpay3dsFlexCredentialsRequest {
 
     @JsonProperty("issuer")
     @NotNull(message = "Field [issuer] cannot be null")
@@ -20,11 +18,11 @@ public class WorldpayUpdate3dsFlexCredentialsRequest {
     @NotNull(message = "Field [jwt_mac_key] cannot be null")
     private String jwtMacKey;
 
-    public WorldpayUpdate3dsFlexCredentialsRequest() {
+    public Worldpay3dsFlexCredentialsRequest() {
         //Blank Constructor Needed For Instantiation
     }
 
-    private WorldpayUpdate3dsFlexCredentialsRequest(WorldpayUpdate3dsFlexCredentialsRequestBuilder builder) {
+    private Worldpay3dsFlexCredentialsRequest(WorldpayUpdate3dsFlexCredentialsRequestBuilder builder) {
         this.issuer = builder.issuer;
         this.organisationalUnitId = builder.organisationalUnitId;
         this.jwtMacKey = builder.jwtMacKey;
@@ -65,8 +63,8 @@ public class WorldpayUpdate3dsFlexCredentialsRequest {
             return this;
         }
 
-        public WorldpayUpdate3dsFlexCredentialsRequest build() {
-            return new WorldpayUpdate3dsFlexCredentialsRequest(this);
+        public Worldpay3dsFlexCredentialsRequest build() {
+            return new Worldpay3dsFlexCredentialsRequest(this);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccount3dsFlexCredentialsResource.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gatewayaccount.resource;
 
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayUpdate3dsFlexCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.Worldpay3dsFlexCredentialsService;
 
@@ -35,7 +35,7 @@ public class GatewayAccount3dsFlexCredentialsResource {
     @Produces(APPLICATION_JSON)
     @Consumes(APPLICATION_JSON)
     public Response createOrUpdateWorldpay3dsCredentials(@PathParam("accountId") Long gatewayAccountId,
-                                                         @Valid WorldpayUpdate3dsFlexCredentialsRequest worldpay3dsCredentials) {
+                                                         @Valid Worldpay3dsFlexCredentialsRequest worldpay3dsCredentials) {
 
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
                 .filter(gatewayAccountEntity ->

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/Worldpay3dsFlexCredentialsService.java
@@ -4,7 +4,7 @@ import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.dao.Worldpay3dsFlexCredentialsDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.WorldpayUpdate3dsFlexCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
 
 import javax.inject.Inject;
 
@@ -23,18 +23,18 @@ public class Worldpay3dsFlexCredentialsService {
     }
 
     @Transactional
-    public void setGatewayAccountWorldpay3dsFlexCredentials(WorldpayUpdate3dsFlexCredentialsRequest worldpayUpdate3dsFlexCredentialsRequest, GatewayAccountEntity gatewayAccountEntity) {
+    public void setGatewayAccountWorldpay3dsFlexCredentials(Worldpay3dsFlexCredentialsRequest worldpay3DsFlexCredentialsRequest, GatewayAccountEntity gatewayAccountEntity) {
         worldpay3dsFlexCredentialsDao.findByGatewayAccountId(gatewayAccountEntity.getId()).ifPresentOrElse(worldpay3dsFlexCredentialsEntity -> {
-            worldpay3dsFlexCredentialsEntity.setIssuer(worldpayUpdate3dsFlexCredentialsRequest.getIssuer());
-            worldpay3dsFlexCredentialsEntity.setJwtMacKey(worldpayUpdate3dsFlexCredentialsRequest.getJwtMacKey());
-            worldpay3dsFlexCredentialsEntity.setOrganisationalUnitId(worldpayUpdate3dsFlexCredentialsRequest.getOrganisationalUnitId());
+            worldpay3dsFlexCredentialsEntity.setIssuer(worldpay3DsFlexCredentialsRequest.getIssuer());
+            worldpay3dsFlexCredentialsEntity.setJwtMacKey(worldpay3DsFlexCredentialsRequest.getJwtMacKey());
+            worldpay3dsFlexCredentialsEntity.setOrganisationalUnitId(worldpay3DsFlexCredentialsRequest.getOrganisationalUnitId());
             worldpay3dsFlexCredentialsDao.merge(worldpay3dsFlexCredentialsEntity);
         }, () -> {
             var newWorldpay3dsFlexCredentialsEntity = aWorldpay3dsFlexCredentialsEntity()
                     .withGatewayAccountId(gatewayAccountEntity.getId())
-                    .withIssuer(worldpayUpdate3dsFlexCredentialsRequest.getIssuer())
-                    .withJwtMacKey(worldpayUpdate3dsFlexCredentialsRequest.getJwtMacKey())
-                    .withOrganisationalUnitId(worldpayUpdate3dsFlexCredentialsRequest.getOrganisationalUnitId())
+                    .withIssuer(worldpay3DsFlexCredentialsRequest.getIssuer())
+                    .withJwtMacKey(worldpay3DsFlexCredentialsRequest.getJwtMacKey())
+                    .withOrganisationalUnitId(worldpay3DsFlexCredentialsRequest.getOrganisationalUnitId())
                     .build();
             worldpay3dsFlexCredentialsDao.merge(newWorldpay3dsFlexCredentialsEntity);
         });


### PR DESCRIPTION
The structure of Worldpay3dsFlexCredentialsRequest is exactly the same as the
request to validate 3DS Flex credentials in the up-and-coming
`/v1/api/accounts/1/worldpay/check-3ds-flex-config` url, so it makes sense to
rename the class. Note that in the future validation annotations will be added
to make sure the organisational_unit_id and issuer are of 24 hexadecimal
characters and the jwt_mac_key is in UUID format.
