### PR TITLE
PP-7524 Add account type to GatewayAccount class

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-10-28T12:20:20Z",
+  "generated_at": "2020-12-04T10:50:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -223,7 +223,7 @@
         "hashed_secret": "0eb769315deba70a52cf0292f6f163580aed36ab",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 40,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -30,6 +30,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
@@ -19,11 +19,13 @@ public class GatewayAccount {
     private Long id;
     private String gatewayName;
     private Map<String, String> credentials;
+    private GatewayAccountType type;
 
-    public GatewayAccount(Long id, String gatewayName, Map<String, String> credentials) {
+    public GatewayAccount(Long id, String gatewayName, Map<String, String> credentials, GatewayAccountType type) {
         this.id = id;
         this.gatewayName = gatewayName;
         this.credentials = credentials;
+        this.type = type;
     }
 
     @JsonProperty("gateway_account_id")
@@ -47,7 +49,7 @@ public class GatewayAccount {
     }
 
     public static GatewayAccount valueOf(GatewayAccountEntity entity) {
-        return new GatewayAccount(entity.getId(), entity.getGatewayName(), entity.getCredentials());
+        return new GatewayAccount(entity.getId(), entity.getGatewayName(), entity.getCredentials(), GatewayAccountType.fromString(entity.getType()));
     }
 
     @Override
@@ -63,5 +65,9 @@ public class GatewayAccount {
     @Override
     public int hashCode() {
         return Objects.hash(id, gatewayName, credentials);
+    }
+
+    public GatewayAccountType getType() {
+        return type;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 
 @Entity
 @Table(name = "gateway_accounts")
@@ -58,7 +59,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
-    private Type type;
+    private GatewayAccountType type;
 
     @Column(name = "credentials", columnDefinition = "json")
     @Convert(converter = CredentialsConverter.class)
@@ -146,7 +147,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     public GatewayAccountEntity() {
     }
 
-    public GatewayAccountEntity(String gatewayName, Map<String, String> credentials, Type type) {
+    public GatewayAccountEntity(String gatewayName, Map<String, String> credentials, GatewayAccountType type) {
         this.gatewayName = gatewayName;
         this.credentials = credentials;
         this.type = type;
@@ -195,7 +196,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @JsonProperty("type")
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public String getType() {
-        return type.value;
+        return type.toString();
     }
 
     @JsonProperty("service_name")
@@ -346,7 +347,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         this.requires3ds = requires3ds;
     }
 
-    public void setType(Type type) {
+    public void setType(GatewayAccountType type) {
         this.type = type;
     }
 
@@ -380,7 +381,7 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     }
 
     public boolean isLive() {
-        return Type.LIVE.equals(type);
+        return LIVE.equals(type);
     }
 
     public void setCorporateCreditCardSurchargeAmount(long corporateCreditCardSurchargeAmount) {
@@ -451,26 +452,4 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         }
     }
 
-    public enum Type {
-        TEST("test"), LIVE("live");
-
-        private final String value;
-
-        Type(String value) {
-            this.value = value;
-        }
-
-        public String toString() {
-            return value;
-        }
-
-        public static Type fromString(String type) {
-            for (Type typeEnum : Type.values()) {
-                if (typeEnum.toString().equalsIgnoreCase(type)) {
-                    return typeEnum;
-                }
-            }
-            throw new IllegalArgumentException("gateway account type has to be one of (test, live)");
-        }
-    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -11,7 +11,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -61,7 +61,7 @@ public class GatewayAccountRequest {
     @JsonIgnore
     public boolean isValidProviderAccountType() {
         try {
-            GatewayAccountEntity.Type.fromString(providerAccountType);
+            GatewayAccountType.fromString(providerAccountType);
             return true;
         } catch (IllegalArgumentException iae) {
             return false;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -24,7 +24,7 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("payment_provider")
     private String paymentProvider;
 
-    private GatewayAccountEntity.Type type;
+    private GatewayAccountType type;
 
     private String description;
 
@@ -88,7 +88,7 @@ public class GatewayAccountResourceDTO {
     public GatewayAccountResourceDTO(long accountId,
                                      String externalId,
                                      String paymentProvider,
-                                     GatewayAccountEntity.Type type,
+                                     GatewayAccountType type,
                                      String description,
                                      String serviceName,
                                      String analyticsId,
@@ -136,7 +136,7 @@ public class GatewayAccountResourceDTO {
                 gatewayAccountEntity.getId(),
                 gatewayAccountEntity.getExternalId(),
                 gatewayAccountEntity.getGatewayName(),
-                GatewayAccountEntity.Type.fromString(gatewayAccountEntity.getType()),
+                GatewayAccountType.fromString(gatewayAccountEntity.getType()),
                 gatewayAccountEntity.getDescription(),
                 gatewayAccountEntity.getServiceName(),
                 gatewayAccountEntity.getAnalyticsId(),

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -130,7 +130,7 @@ public class GatewayAccountSearchParams {
             queryMap.put(REQUIRES_3DS_SQL_FIELD, Boolean.valueOf(requires3ds));
         }
         if (StringUtils.isNotEmpty(type)) {
-            queryMap.put(TYPE_SQL_FIELD, GatewayAccountEntity.Type.fromString(type));
+            queryMap.put(TYPE_SQL_FIELD, GatewayAccountType.fromString(type));
         }
         if (StringUtils.isNotEmpty(paymentProvider)) {
             queryMap.put(PAYMENT_PROVIDER_SQL_FIELD, paymentProvider);

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountType.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountType.java
@@ -1,0 +1,24 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+public enum GatewayAccountType {
+    TEST("test"), LIVE("live");
+
+    private final String value;
+
+    GatewayAccountType(String value) {
+        this.value = value;
+    }
+
+    public String toString() {
+        return value;
+    }
+
+    public static GatewayAccountType fromString(String type) {
+        for (GatewayAccountType typeEnum : GatewayAccountType.values()) {
+            if (typeEnum.toString().equalsIgnoreCase(type)) {
+                return typeEnum;
+            }
+        }
+        throw new IllegalArgumentException("gateway account type has to be one of (test, live)");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gatewayaccount.service;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
@@ -23,7 +24,7 @@ public class GatewayAccountObjectConverter {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity(
                 gatewayAccountRequest.getPaymentProvider(), 
                 credentials,
-                GatewayAccountEntity.Type.fromString(gatewayAccountRequest.getProviderAccountType()));
+                GatewayAccountType.fromString(gatewayAccountRequest.getProviderAccountType()));
 
         gatewayAccountEntity.setExternalId(randomUuid());
 

--- a/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
@@ -13,7 +13,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 
 @Transactional
 public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 public class ChargeEntityFixture {
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -98,7 +98,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity.ChargeEventEntityBuilder.aChargeEventEntity;
 import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability.EXTERNAL_AVAILABLE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.paymentprocessor.model.OperationType.AUTHORISATION_3DS;
 
 @RunWith(JUnitParamsRunner.class)

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -18,13 +18,13 @@ import uk.gov.pay.connector.charge.exception.Worldpay3dsFlexJwtCredentialsExcept
 import uk.gov.pay.connector.charge.exception.Worldpay3dsFlexJwtPaymentProviderException;
 import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.util.JwtGenerator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 
 import javax.crypto.spec.SecretKeySpec;
 import java.time.Instant;
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.Auth3dsRequiredEntityFixture.anAuth3dsRequiredEntity;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -92,7 +93,7 @@ public class Worldpay3dsFlexJwtServiceTest {
 
     @Test
     public void shouldCreateCorrectTokenForWorldpay3dsFlexDdc() {
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), VALID_CREDENTIALS);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), VALID_CREDENTIALS, TEST);
         var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", "myOrg", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
         int paymentCreationTimeEpochSeconds19August2029 = 1881821916;
         int expectedTokenExpirationTimeEpochSeconds = paymentCreationTimeEpochSeconds19August2029 + TOKEN_EXPIRY_DURATION_SECONDS;
@@ -183,7 +184,7 @@ public class Worldpay3dsFlexJwtServiceTest {
     @Test
     public void generateDdcToken_shouldThrowExceptionForMissingIssuer() {
         var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials(null, "myOrg", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null, TEST);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex JWT for account 1 because the " +
@@ -195,7 +196,7 @@ public class Worldpay3dsFlexJwtServiceTest {
     @Test
     public void generateDdcToken_shouldThrowExceptionForMissingOrgId() {
         var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", null, "fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null, TEST);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
         expectedException.expectMessage(
@@ -208,7 +209,7 @@ public class Worldpay3dsFlexJwtServiceTest {
     @Test
     public void generateDdcToken_shouldThrowExceptionForMissingJwtMacId() {
         var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", "myOrg", null);
-        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null);
+        var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null, TEST);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex JWT for account 1 because the " +
@@ -220,7 +221,7 @@ public class Worldpay3dsFlexJwtServiceTest {
     @Test
     public void generateDdcToken_shouldThrowExceptionForNonWorldpayAccount() {
         var worldpay3dsFlexCredentials = mock(Worldpay3dsFlexCredentials.class);
-        var gatewayAccount = new GatewayAccount(1L, SMARTPAY.getName(), VALID_CREDENTIALS);
+        var gatewayAccount = new GatewayAccount(1L, SMARTPAY.getName(), VALID_CREDENTIALS, TEST);
 
         expectedException.expect(Worldpay3dsFlexJwtPaymentProviderException.class);
         expectedException.expectMessage("Cannot provide a Worldpay 3ds flex JWT for account 1 because the " +

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -56,7 +56,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_ERROR_RESPONSE;

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -31,7 +31,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 @RunWith(JUnitParamsRunner.class)
 public class ChargeNotificationProcessorTest {

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
@@ -26,7 +26,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 public abstract class BaseSmartpayPaymentProviderTest {
 

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
@@ -35,7 +35,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_CAPTURE_SUCCESS_RESPONSE;
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -51,7 +51,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -20,6 +20,7 @@ import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripeTransferReversalRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
@@ -60,7 +61,7 @@ public class StripeRefundHandlerTest {
 
         gatewayAccount.setId(123L);
         gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
-        gatewayAccount.setType(GatewayAccountEntity.Type.LIVE);
+        gatewayAccount.setType(GatewayAccountType.LIVE);
         gatewayAccount.setGatewayName("stripe");
 
         RefundEntity refundEntity = RefundEntityFixture

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
@@ -18,7 +18,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.worldpay.exception.NotAWorldpayGatewayAccountException;
 import uk.gov.pay.connector.gateway.worldpay.exception.ThreeDsFlexDdcServiceUnavailableException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import javax.ws.rs.ProcessingException;
@@ -46,7 +46,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @ExtendWith(MockitoExtension.class)
@@ -96,7 +96,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
     @ValueSource(strings = { "test", "live" })
     void should_return_true_if_account_credentials_are_valid_for_a_gateway_account(String type) {
         var gatewayAccount = aGatewayAccountEntity()
-                .withType(GatewayAccountEntity.Type.fromString(type))
+                .withType(GatewayAccountType.fromString(type))
                 .withGatewayName("worldpay")
                 .build();
         Worldpay3dsFlexCredentials flexCredentials = getValid3dsFlexCredentials();
@@ -116,7 +116,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
     void should_return_true_false_account_credentials_are_invalid_for_a_live_gateway_account(String type) {
         var gatewayAccount = aGatewayAccountEntity()
                 .withGatewayName("worldpay")
-                .withType(GatewayAccountEntity.Type.fromString(type)).build();
+                .withType(GatewayAccountType.fromString(type)).build();
         var invalidIssuer = "54i0917n10va4428b69l5id0";
         var invalidOrgUnitId = "57992i087n0v4849895alid2";
         var invalidJwtMacKey = "4inva5l2-0133-4i82-d0e5-2024dbeddaa9";
@@ -181,7 +181,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
     }
 
     private Worldpay3dsFlexCredentials getValid3dsFlexCredentials() {
-        var validIssuer = "53f0917f101a4428b69d5fb0";
+        var validIssuer = "53f0917f101a4428b69d5fb0"; //pragma: allowlist secret
         var validOrgUnitId = "57992a087a0c4849895ab8a2";
         var validJwtMacKey = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9";
         return new Worldpay3dsFlexCredentials(validIssuer, validOrgUnitId, validJwtMacKey);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -40,7 +40,7 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -86,7 +86,7 @@ import static uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider.WORL
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_3DS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_PARES_PARSE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE;

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -38,7 +38,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS;

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -11,12 +11,12 @@ import java.util.Map;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 public final class GatewayAccountEntityFixture {
     private Long id = 1L;
     private String gatewayName = SANDBOX.getName();
-    private GatewayAccountEntity.Type type = TEST;
+    private GatewayAccountType type = TEST;
     private Map<String, String> credentials = Map.of();
     private String serviceName = "Test Service";
     private String description;
@@ -55,7 +55,7 @@ public final class GatewayAccountEntityFixture {
         return this;
     }
 
-    public GatewayAccountEntityFixture withType(GatewayAccountEntity.Type type) {
+    public GatewayAccountEntityFixture withType(GatewayAccountType type) {
         this.type = type;
         return this;
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -20,7 +20,7 @@ public class GatewayAccountResourceDTOTest {
         entity.setId(100L);
         entity.setExternalId("some-external-id");
         entity.setGatewayName("testGatewayName");
-        entity.setType(GatewayAccountEntity.Type.fromString("test"));
+        entity.setType(GatewayAccountType.fromString("test"));
         entity.setDescription("aDescription");
         entity.setServiceName("aServiceName");
         entity.setAnalyticsId("123");

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -12,7 +12,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsMapWithSize.aMapWithSize;
 import static org.hamcrest.collection.IsMapWithSize.anEmptyMap;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 
 public class GatewayAccountSearchParamsTest {
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.AuthoriseStatus.REQUIRES_3DS;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.util.SystemUtils.envOrThrow;

--- a/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 
 import javax.ws.rs.client.ClientBuilder;
@@ -48,7 +49,7 @@ public class GooglePayForWorldpayTest {
     public void sendPaymentToWorldpay() throws Exception {
         GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
         gatewayAccount.setCredentials(ImmutableMap.of(CREDENTIALS_USERNAME, worldpayUsername, CREDENTIALS_PASSWORD, worldpayPassword));
-        gatewayAccount.setType(GatewayAccountEntity.Type.TEST);
+        gatewayAccount.setType(GatewayAccountType.TEST);
 
         String payload = load("templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml")
                 .replace("${amount}", "100")

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -55,7 +55,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;
 import static uk.gov.pay.connector.util.SystemUtils.envOrThrow;

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -50,7 +50,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userEmail;

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoCardDetailsIT.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 
 import java.util.HashMap;
@@ -118,7 +119,7 @@ public class ChargeDaoCardDetailsIT extends DaoITestBase {
 
     @Test
     public void persist_shouldStoreCardDetails() {
-        GatewayAccountEntity testAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), GatewayAccountEntity.Type.TEST);
+        GatewayAccountEntity testAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), GatewayAccountType.TEST);
         testAccount.setExternalId(randomUuid());
         gatewayAccountDao.persist(testAccount);
 
@@ -135,7 +136,7 @@ public class ChargeDaoCardDetailsIT extends DaoITestBase {
 
     @Test
     public void persist_shouldStoreNullCardTypeDetails() {
-        GatewayAccountEntity testAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), GatewayAccountEntity.Type.TEST);
+        GatewayAccountEntity testAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), GatewayAccountType.TEST);
         testAccount.setExternalId(randomUuid());
         gatewayAccountDao.persist(testAccount);
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -55,7 +55,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_READ
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.SYSTEM_CANCELLED;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.Auth3dsRequiredEntityFixture.anAuth3dsRequiredEntity;
 
 public class ChargeDaoIT extends DaoITestBase {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -12,7 +12,7 @@ import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
@@ -326,7 +326,7 @@ public class DatabaseFixtures {
                         EmailNotificationType.PAYMENT_CONFIRMED, new TestEmailNotification(),
                         EmailNotificationType.REFUND_ISSUED, new TestEmailNotification()
                 );
-        private GatewayAccountEntity.Type type = TEST;
+        private GatewayAccountType type = TEST;
         private List<TestCardType> cardTypes = new ArrayList<>();
         private long corporateCreditCardSurchargeAmount;
         private long corporateDebitCardSurchargeAmount;
@@ -429,7 +429,7 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestAccount withType(GatewayAccountEntity.Type type) {
+        public TestAccount withType(GatewayAccountType type) {
             this.type = type;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
@@ -9,6 +9,7 @@ import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
@@ -22,8 +23,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.text.IsEmptyString.isEmptyString;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.LIVE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -191,7 +192,7 @@ public class CreateGatewayAccountResourceIT extends GatewayAccountResourceTestBa
         assertGettingAccountReturnsProviderName(testContext.getPort(), response, "worldpay", TEST);
     }
 
-    private void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountEntity.Type type) {
+    private void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type) {
         assertCorrectCreateResponse(response, type, null, null, null);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 @RunWith(DropwizardJUnitRunner.class)

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -6,7 +6,7 @@ import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.junit.After;
 import org.junit.Before;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
@@ -110,7 +110,7 @@ public class GatewayAccountResourceTestBase {
                 .statusCode(200);
     }
 
-    public static void assertGettingAccountReturnsProviderName(int port, ValidatableResponse response, String providerName, GatewayAccountEntity.Type providerUrlType) {
+    public static void assertGettingAccountReturnsProviderName(int port, ValidatableResponse response, String providerName, GatewayAccountType providerUrlType) {
         given().port(port)
                 .contentType(JSON)
                 .get(response.extract().header("Location").replace("https", "http")) //Scheme on links back are forced to be https
@@ -122,7 +122,7 @@ public class GatewayAccountResourceTestBase {
                 .body("type", is(providerUrlType.toString()));
     }
 
-    public static void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountEntity.Type type, String description, String analyticsId, String name) {
+    public static void assertCorrectCreateResponse(ValidatableResponse response, GatewayAccountType type, String description, String analyticsId, String name) {
         String accountId = response.extract().path("gateway_account_id");
         String urlSlug = "api/accounts/" + accountId;
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -42,6 +42,7 @@ import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
@@ -458,7 +459,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         CardTypeEntity cardTypeEntity = new CardTypeEntity();
         cardTypeEntity.setRequires3ds(true);
         cardTypeEntity.setBrand(authCardDetails.getCardBrand());
-        gatewayAccountEntity.setType(GatewayAccountEntity.Type.LIVE);
+        gatewayAccountEntity.setType(GatewayAccountType.LIVE);
         gatewayAccountEntity.setGatewayName("worldpay");
         gatewayAccountEntity.setRequires3ds(false);
 

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.events.model.refund.RefundIncludedInPayout;
 import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
@@ -103,7 +104,7 @@ public class PayoutReconcileProcessTest {
 
     @Before
     public void setUp() throws Exception {
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(GatewayAccountEntity.Type.TEST).build();
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().withType(GatewayAccountType.TEST).build();
         when(gatewayAccountDao.findByCredentialsKeyValue(StripeCredentials.STRIPE_ACCOUNT_ID_KEY, stripeAccountId))
                 .thenReturn(Optional.of(gatewayAccountEntity));
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);

--- a/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoIT.java
@@ -4,7 +4,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.it.dao.DaoITestBase;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.report.model.domain.GatewayAccountPerformanceReportEntity;
@@ -31,7 +31,7 @@ public class PerformanceReportDaoIT extends DaoITestBase {
         testAccountFixture = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
-                .withType(GatewayAccountEntity.Type.LIVE)
+                .withType(GatewayAccountType.LIVE)
                 .insert();
     }
 
@@ -63,13 +63,13 @@ public class PerformanceReportDaoIT extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
                 .withAccountId(173L)
-                .withType(GatewayAccountEntity.Type.LIVE)
+                .withType(GatewayAccountType.LIVE)
                 .insert();
         DatabaseFixtures.TestAccount anotherGatewayAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
                 .withAccountId(174L)
-                .withType(GatewayAccountEntity.Type.LIVE)
+                .withType(GatewayAccountType.LIVE)
                 .insert();
         insertCharge(gatewayAccount, 10L, ZonedDateTime.now());
         insertCharge(gatewayAccount, 2L, ZonedDateTime.now());

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -6,8 +6,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.util.Arrays;
@@ -141,14 +141,14 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
     }
 
     private Charge chargeEntity(ChargeStatus status) {
-        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
+        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountType.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build()
         );
     }
 
     private Charge chargeEntity(ChargeStatus status, long amount) {
-        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
+        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountType.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build()
         );

--- a/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/EpdqExternalRefundAvailabilityCalculatorTest.java
@@ -2,16 +2,14 @@ package uk.gov.pay.connector.service;
 
 import org.junit.Test;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -136,14 +134,14 @@ public class EpdqExternalRefundAvailabilityCalculatorTest {
     }
 
     private static Charge chargeEntity(ChargeStatus status) {
-        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
+        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountType.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).build()
         );
     }
 
     private static Charge chargeEntity(ChargeStatus status, long amount) {
-        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountEntity.Type.TEST);
+        GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity("sandbox", newHashMap(), GatewayAccountType.TEST);
         return Charge.from(
                 aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity).withStatus(status).withAmount(amount).build()
         );

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -56,6 +56,7 @@ public class GatewayAccountServiceTest {
     @Before
     public void setUp() {
         gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao);
+        when(mockGatewayAccountEntity.getType()).thenReturn("test");
         when(getMockGatewayAccountEntity1.getType()).thenReturn("test");
         when(getMockGatewayAccountEntity1.getServiceName()).thenReturn("service one");
         when(getMockGatewayAccountEntity2.getType()).thenReturn("test");

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -67,7 +67,7 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailabi
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.userExternalId;

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.connector.util;
 
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 
 import java.util.Map;
 
 import static uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode.MANDATORY;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity.Type.TEST;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class AddGatewayAccountParams {
@@ -15,7 +15,7 @@ public class AddGatewayAccountParams {
     private String paymentGateway;
     private Map<String, String> credentials;
     private String serviceName;
-    private GatewayAccountEntity.Type type;
+    private GatewayAccountType type;
     private String description;
     private String analyticsId;
     private EmailCollectionMode emailCollectionMode;
@@ -55,7 +55,7 @@ public class AddGatewayAccountParams {
         return serviceName;
     }
 
-    public GatewayAccountEntity.Type getType() {
+    public GatewayAccountType getType() {
         return type;
     }
 
@@ -116,7 +116,7 @@ public class AddGatewayAccountParams {
         private String paymentGateway = "provider";
         private Map<String, String> credentials;
         private String serviceName = "service name";
-        private GatewayAccountEntity.Type type = TEST;
+        private GatewayAccountType type = TEST;
         private String description = "description";
         private String analyticsId;
         private EmailCollectionMode emailCollectionMode = MANDATORY;
@@ -160,7 +160,7 @@ public class AddGatewayAccountParams {
             return this;
         }
 
-        public AddGatewayAccountParamsBuilder withType(GatewayAccountEntity.Type type) {
+        public AddGatewayAccountParamsBuilder withType(GatewayAccountType type) {
             this.type = type;
             return this;
         }


### PR DESCRIPTION
To enable refactoring of PaymentProvider#queryPaymentStatue to not
require database entities this adds gatewayaccount type to the
GatewayAccount class.
