### PR TITLE
PP-7524 Refactor getGatewayAccountCredentialsAsAuthHeader

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-04T10:50:18Z",
+  "generated_at": "2020-12-07T10:28:33Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -39,7 +39,7 @@ public class EpdqCaptureHandler implements CaptureHandler {
                     url, 
                     request.getGatewayAccount(), 
                     buildCaptureOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, EpdqCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -117,7 +117,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 url, 
                 request.getGatewayAccount(), 
                 buildAuthoriseOrder(request, frontendUrl), 
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
         return getEpdqGatewayResponse(response, EpdqAuthorisationResponse.class);
     }
 
@@ -145,7 +145,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 url, 
                 request.getGatewayAccount(), 
                 buildCancelOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
         return getEpdqGatewayResponse(response, EpdqCancelResponse.class);
     }
 
@@ -160,7 +160,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 url, 
                 charge.getGatewayAccount(), 
                 buildQueryOrderRequestFor(charge),
-                getGatewayAccountCredentialsAsAuthHeader(charge.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(charge.getGatewayAccount().getCredentials()));
         GatewayResponse<EpdqQueryResponse> epdqGatewayResponse = getUninterpretedEpdqGatewayResponse(response, EpdqQueryResponse.class);
 
         return epdqGatewayResponse.getBaseResponse()
@@ -194,7 +194,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                     url, 
                     request.getGatewayAccount(), 
                     buildQueryOrderRequestFor(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getEpdqGatewayResponse(response, EpdqAuthorisationResponse.class);
             BaseAuthoriseResponse.AuthoriseStatus authoriseStatus = gatewayResponse.getBaseResponse()
                     .map(BaseAuthoriseResponse::authoriseStatus).orElse(ERROR);

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -41,7 +41,7 @@ public class EpdqRefundHandler implements RefundHandler {
                     url, 
                     request.getGatewayAccount(), 
                     buildRefundOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, EpdqRefundResponse.class), PENDING);
         } catch (GenericGatewayException | GatewayException.GatewayConnectionTimeoutException | GatewayErrorException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -32,7 +32,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
                     gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                     request.getGatewayAccount(), 
                     buildCaptureOrderFor(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, SmartpayCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -88,7 +88,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
                 gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                 request.getGatewayAccount(), 
                 buildAuthoriseOrderFor(request), 
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
         return getSmartpayGatewayResponse(response, SmartpayAuthorisationResponse.class);
     }
 
@@ -107,7 +107,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
         try {
             GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                     request.getGatewayAccount(), build3dsResponseAuthOrderFor(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getSmartpayGatewayResponse(response, Smartpay3dsAuthorisationResponse.class);
             
             if (gatewayResponse.getBaseResponse().isEmpty())
@@ -142,7 +142,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GenericGatewayException, GatewayErrorException, GatewayConnectionTimeoutException {
         GatewayClient.Response response = client.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                 request.getGatewayAccount(), buildCancelOrderFor(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
         return getSmartpayGatewayResponse(response, SmartpayCancelResponse.class);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -33,7 +33,7 @@ public class SmartpayRefundHandler implements RefundHandler {
                     gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                     request.getGatewayAccount(), 
                     buildRefundOrderFor(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, SmartpayRefundResponse.class), PENDING);
         } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -1,11 +1,10 @@
 package uk.gov.pay.connector.gateway.util;
 
 import com.google.common.collect.ImmutableMap;
-import java.util.Base64;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.Base64;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -30,8 +29,8 @@ public class AuthUtil {
         );
     }
 
-    public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(GatewayAccountEntity gae) {
-        String value = encode(gae.getCredentials().get(CREDENTIALS_USERNAME), gae.getCredentials().get(CREDENTIALS_PASSWORD));
+    public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, String> gatewayCredentials) {
+        String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME), gatewayCredentials.get(CREDENTIALS_PASSWORD));
         return ImmutableMap.of(AUTHORIZATION, value);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -35,7 +35,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
                     gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                     request.getGatewayAccount(), 
                     buildCaptureOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, WorldpayCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -30,7 +30,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
@@ -107,7 +106,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 gatewayUrlMap.get(charge.getGatewayAccount().getType()),
                 charge.getGatewayAccount(),
                 buildQuery(charge),
-                getGatewayAccountCredentialsAsAuthHeader(charge.getGatewayAccount())
+                getGatewayAccountCredentialsAsAuthHeader(charge.getGatewayAccount().getCredentials())
         );
         GatewayResponse<WorldpayQueryResponse> worldpayGatewayResponse = getWorldpayGatewayResponse(response, WorldpayQueryResponse.class);
 
@@ -145,7 +144,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 gatewayUrlMap.get(request.getGatewayAccount().getType()),
                 request.getGatewayAccount(),
                 buildAuthoriseOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
 
         if (response.getEntity().contains("request3DSecure")) {
             logger.info(format("Worldpay authorisation response when 3ds required for %s: %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
@@ -165,7 +164,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     request.getGatewayAccount(),
                     build3dsResponseAuthOrder(request),
                     cookies,
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getWorldpayGatewayResponse(response);
 
             logger.info(format("Worldpay 3ds authorisation response for %s : %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
@@ -202,7 +201,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     public GatewayResponse<BaseCancelResponse> cancel(CancelGatewayRequest request) throws GatewayException {
         GatewayClient.Response response = cancelClient.postRequestFor(gatewayUrlMap.get(request.getGatewayAccount().getType()),
                 request.getGatewayAccount(), buildCancelOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
         return getWorldpayGatewayResponse(response);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -33,7 +33,7 @@ public class WorldpayRefundHandler implements RefundHandler {
                     gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                     request.getGatewayAccount(), 
                     buildRefundOrder(request), 
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             return GatewayRefundResponse.fromBaseRefundResponse(unmarshallResponse(response, WorldpayRefundResponse.class), PENDING);
         } catch (GatewayException e) {
             return GatewayRefundResponse.fromGatewayError(e.toGatewayError());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -34,7 +34,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
                 gatewayUrlMap.get(request.getGatewayAccount().getType()), 
                 request.getGatewayAccount(), 
                 buildWalletAuthoriseOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount()));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
         
         return getWorldpayGatewayResponse(response);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.gateway.worldpay;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.junit.Before;
 import org.junit.Test;
@@ -132,13 +131,14 @@ public class WorldpayPaymentProviderTest {
     GatewayClient mockGatewayClient;
 
     private static final URI WORLDPAY_URL = URI.create("http://worldpay.url");
-    private Map<String, String> urlMap = ImmutableMap.of(TEST.toString(), WORLDPAY_URL.toString());
+    private Map<String, String> urlMap = Map.of(TEST.toString(), WORLDPAY_URL.toString());
 
     private WorldpayPaymentProvider providerWithMockedGatewayClient;
     private WorldpayPaymentProvider providerWithRealGatewayClient;
 
     private ChargeEntityFixture chargeEntityFixture;
     protected GatewayAccountEntity gatewayAccountEntity;
+    private Map<String, String> gatewayAccountCredentials = Map.of("merchant_id", "MERCHANTCODE");
     private GatewayClient.Response authorisationSuccessResponse;
 
     @Before
@@ -159,7 +159,7 @@ public class WorldpayPaymentProviderTest {
         providerWithRealGatewayClient = new WorldpayPaymentProvider(configuration, gatewayClientFactory, environment);
 
         gatewayAccountEntity = aServiceAccount();
-        gatewayAccountEntity.setCredentials(ImmutableMap.of("merchant_id", "MERCHANTCODE"));
+        gatewayAccountEntity.setCredentials(gatewayAccountCredentials);
         chargeEntityFixture = aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity);
 
         authorisationSuccessResponse = mock(GatewayClient.Response.class);
@@ -448,7 +448,7 @@ public class WorldpayPaymentProviderTest {
                 headers.capture());
 
         assertThat(headers.getValue().size(), is(1));
-        assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity)));
+        assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
     }
 
     @Test
@@ -569,7 +569,7 @@ public class WorldpayPaymentProviderTest {
         gatewayAccount.setId(1L);
         gatewayAccount.setGatewayName("worldpay");
         gatewayAccount.setRequires3ds(false);
-        gatewayAccount.setCredentials(ImmutableMap.of(
+        gatewayAccount.setCredentials(Map.of(
                 CREDENTIALS_MERCHANT_ID, "worlpay-merchant",
                 CREDENTIALS_USERNAME, "worldpay-password",
                 CREDENTIALS_PASSWORD, "password"

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay.wallets;
 
 import com.amazonaws.util.json.Jackson;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,13 +9,13 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayErrorException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
@@ -50,6 +49,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Mock
     private GatewayClient mockGatewayClient;
     private GatewayAccountEntity gatewayAccountEntity;
+    private Map<String, String> gatewayAccountCredentials = Map.of("merchant_id", "MERCHANTCODE");
     private WorldpayWalletAuthorisationHandler worldpayWalletAuthorisationHandler;
     private ChargeEntity chargeEntity;
 
@@ -64,12 +64,12 @@ public class WorldpayWalletAuthorisationHandlerTest {
 
     @Before
     public void setUp() throws Exception {
-        worldpayWalletAuthorisationHandler = new WorldpayWalletAuthorisationHandler(mockGatewayClient, ImmutableMap.of(TEST.toString(), WORLDPAY_URL));
+        worldpayWalletAuthorisationHandler = new WorldpayWalletAuthorisationHandler(mockGatewayClient, Map.of(TEST.toString(), WORLDPAY_URL));
         chargeEntity = ChargeEntityFixture.aValidChargeEntity().withDescription("This is the description").build();
         gatewayAccountEntity = new GatewayAccountEntity("worldpay", new HashMap<>(), TEST);
         chargeEntity.setGatewayTransactionId("MyUniqueTransactionId!");
         chargeEntity.setGatewayAccount(gatewayAccountEntity);
-        gatewayAccountEntity.setCredentials(ImmutableMap.of("merchant_id", "MERCHANTCODE"));
+        gatewayAccountEntity.setCredentials(gatewayAccountCredentials);
         when(mockGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
                 .thenThrow(new GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
     }
@@ -82,7 +82,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity)));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
         }
     }
 
@@ -94,7 +94,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity)));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
         }
     }
 
@@ -106,7 +106,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity)));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
         }
     }
 
@@ -118,7 +118,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity)));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
         }
     }
 
@@ -130,7 +130,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
-            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity)));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java
@@ -66,7 +66,7 @@ public class GooglePayForWorldpayTest {
                 URI.create("https://secure-test.worldpay.com/jsp/merchant/xml/paymentService.jsp"), 
                 gatewayAccount, 
                 gatewayOrder, 
-                getGatewayAccountCredentialsAsAuthHeader(gatewayAccount));
+                getGatewayAccountCredentialsAsAuthHeader(gatewayAccount.getCredentials()));
         assertThat(response.getStatus(), is(HttpStatus.SC_OK));
         String entity = response.getEntity();
         System.out.println(entity);


### PR DESCRIPTION
To help remove the coupling between our database and API layer remove
the need for the GatewayAccountEntity when constructing the auth header
to call a payment provider. It only needs a map of credentials. This
will help use to reuse our PaymentProvider interface for charges which
have been expunged from Connector.

## WHAT YOU DID
Removing the need for a GatewayAccountEntity when query the payment status is going to take a bit of refactoring so breaking it down into small pieces.