### PR TITLE
PP-5640: Add exemption request to authorisation order

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-09T11:36:01Z",
+  "generated_at": "2020-12-09T13:05:03Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -184,7 +184,7 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 506,
+        "line_number": 583,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-09T14:38:21Z",
+  "generated_at": "2020-12-09T17:10:56Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -184,7 +184,7 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 609,
+        "line_number": 593,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-09T13:05:03Z",
+  "generated_at": "2020-12-09T14:38:21Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -184,7 +184,7 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 583,
+        "line_number": 609,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -31,7 +31,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         private String paResponse3ds;
         private String payerIpAddress;
         private String state;
-        private boolean exemptionEngine;
+        private boolean exemptionEngineEnabled;
 
         public String getReference() {
             return reference;
@@ -115,12 +115,12 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
             this.state = state;
         }
 
-        public boolean isExemptionEngine() {
-            return exemptionEngine;
+        public boolean isExemptionEngineEnabled() {
+            return exemptionEngineEnabled;
         }
 
-        public void setExemptionEngine(boolean exemptionEngine) {
-            this.exemptionEngine = exemptionEngine;
+        public void setExemptionEngineEnabled(boolean exemptionEngineEnabled) {
+            this.exemptionEngineEnabled = exemptionEngineEnabled;
         }
     }
 
@@ -212,7 +212,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     }
     
     public WorldpayOrderRequestBuilder withExemptionEngine(boolean exemptionEngine) {
-        worldpayTemplateData.setExemptionEngine(exemptionEngine);
+        worldpayTemplateData.setExemptionEngineEnabled(exemptionEngine);
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -31,6 +31,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         private String paResponse3ds;
         private String payerIpAddress;
         private String state;
+        private boolean exemptionEngine;
 
         public String getReference() {
             return reference;
@@ -112,6 +113,14 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
         public void setState(String state) {
             this.state = state;
+        }
+
+        public boolean isExemptionEngine() {
+            return exemptionEngine;
+        }
+
+        public void setExemptionEngine(boolean exemptionEngine) {
+            this.exemptionEngine = exemptionEngine;
         }
     }
 
@@ -199,6 +208,11 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
     public WorldpayOrderRequestBuilder with3dsRequired(boolean requires3ds) {
         logger.info("3DS requirement is: " + requires3ds + " for " + worldpayTemplateData.sessionId);
         worldpayTemplateData.setRequires3ds(requires3ds);
+        return this;
+    }
+    
+    public WorldpayOrderRequestBuilder withExemptionEngine(boolean exemptionEngine) {
+        worldpayTemplateData.setExemptionEngine(exemptionEngine);
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -222,16 +222,14 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
                 request.getGatewayAccount().isRequires3ds();
 
-        boolean exemptionEngine = request.getGatewayAccount().isRequires3ds() ? 
-                Optional.ofNullable(request.getGatewayAccount().getWorldpay3dsFlexCredentials())
-                        .map(Worldpay3dsFlexCredentials::isExemptionEngine)
-                        .orElse(false) 
-                : false;
+        boolean exemptionEngineEnabled = Optional.ofNullable(request.getGatewayAccount().getWorldpay3dsFlexCredentials())
+                        .map(Worldpay3dsFlexCredentials::isExemptionEngineEnabled)
+                        .orElse(false);
         
         var builder = aWorldpayAuthoriseOrderRequestBuilder()
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
                 .with3dsRequired(is3dsRequired)
-                .withExemptionEngine(exemptionEngine);
+                .withExemptionEngine(exemptionEngineEnabled);
 
         if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
             request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalcul
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -221,9 +222,13 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
                 request.getGatewayAccount().isRequires3ds();
 
+        boolean exemptionEngine = Optional.ofNullable(request.getGatewayAccount().getWorldpay3dsFlexCredentials())
+                .map(Worldpay3dsFlexCredentials::isExemptionEngine).orElse(false);
+        
         var builder = aWorldpayAuthoriseOrderRequestBuilder()
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
-                .with3dsRequired(is3dsRequired);
+                .with3dsRequired(is3dsRequired)
+                .withExemptionEngine(exemptionEngine);
 
         if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
             request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -222,8 +222,11 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
                 request.getGatewayAccount().isRequires3ds();
 
-        boolean exemptionEngine = Optional.ofNullable(request.getGatewayAccount().getWorldpay3dsFlexCredentials())
-                .map(Worldpay3dsFlexCredentials::isExemptionEngine).orElse(false);
+        boolean exemptionEngine = request.getGatewayAccount().isRequires3ds() ? 
+                Optional.ofNullable(request.getGatewayAccount().getWorldpay3dsFlexCredentials())
+                        .map(Worldpay3dsFlexCredentials::isExemptionEngine)
+                        .orElse(false) 
+                : false;
         
         var builder = aWorldpayAuthoriseOrderRequestBuilder()
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
@@ -14,11 +14,23 @@ public class Worldpay3dsFlexCredentials {
 
     @JsonIgnore
     private String jwtMacKey;
+    private boolean exemptionEngine;
+
+    public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey, boolean exemptionEngine) {
+        this.issuer = issuer;
+        this.organisationalUnitId = organisationalUnitId;
+        this.jwtMacKey = jwtMacKey;
+        this.exemptionEngine = exemptionEngine;
+    }
 
     public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey) {
         this.issuer = issuer;
         this.organisationalUnitId = organisationalUnitId;
         this.jwtMacKey = jwtMacKey;
+    }
+
+    public boolean isExemptionEngine() {
+        return exemptionEngine;
     }
 
     public String getIssuer() {
@@ -34,7 +46,8 @@ public class Worldpay3dsFlexCredentials {
     }
 
     public static Worldpay3dsFlexCredentials fromEntity(Worldpay3dsFlexCredentialsEntity entity) {
-        return new Worldpay3dsFlexCredentials(entity.getIssuer(), entity.getOrganisationalUnitId(), entity.getJwtMacKey());
+        return new Worldpay3dsFlexCredentials(entity.getIssuer(), entity.getOrganisationalUnitId(), 
+                entity.getJwtMacKey(), entity.isExemptionEngine());
     }
     
     public static Worldpay3dsFlexCredentials from(Worldpay3dsFlexCredentialsRequest credentialsRequest) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
@@ -22,13 +22,7 @@ public class Worldpay3dsFlexCredentials {
         this.jwtMacKey = jwtMacKey;
         this.exemptionEngineEnabled = exemptionEngineEnabled;
     }
-
-    public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey) {
-        this.issuer = issuer;
-        this.organisationalUnitId = organisationalUnitId;
-        this.jwtMacKey = jwtMacKey;
-    }
-
+    
     public boolean isExemptionEngineEnabled() {
         return exemptionEngineEnabled;
     }
@@ -52,7 +46,7 @@ public class Worldpay3dsFlexCredentials {
     
     public static Worldpay3dsFlexCredentials from(Worldpay3dsFlexCredentialsRequest credentialsRequest) {
         return new Worldpay3dsFlexCredentials(credentialsRequest.getIssuer(), 
-                credentialsRequest.getOrganisationalUnitId(), credentialsRequest.getJwtMacKey());
+                credentialsRequest.getOrganisationalUnitId(), credentialsRequest.getJwtMacKey(), false);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentials.java
@@ -14,13 +14,13 @@ public class Worldpay3dsFlexCredentials {
 
     @JsonIgnore
     private String jwtMacKey;
-    private boolean exemptionEngine;
+    private boolean exemptionEngineEnabled;
 
-    public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey, boolean exemptionEngine) {
+    public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey, boolean exemptionEngineEnabled) {
         this.issuer = issuer;
         this.organisationalUnitId = organisationalUnitId;
         this.jwtMacKey = jwtMacKey;
-        this.exemptionEngine = exemptionEngine;
+        this.exemptionEngineEnabled = exemptionEngineEnabled;
     }
 
     public Worldpay3dsFlexCredentials(String issuer, String organisationalUnitId, String jwtMacKey) {
@@ -29,8 +29,8 @@ public class Worldpay3dsFlexCredentials {
         this.jwtMacKey = jwtMacKey;
     }
 
-    public boolean isExemptionEngine() {
-        return exemptionEngine;
+    public boolean isExemptionEngineEnabled() {
+        return exemptionEngineEnabled;
     }
 
     public String getIssuer() {
@@ -47,7 +47,7 @@ public class Worldpay3dsFlexCredentials {
 
     public static Worldpay3dsFlexCredentials fromEntity(Worldpay3dsFlexCredentialsEntity entity) {
         return new Worldpay3dsFlexCredentials(entity.getIssuer(), entity.getOrganisationalUnitId(), 
-                entity.getJwtMacKey(), entity.isExemptionEngine());
+                entity.getJwtMacKey(), entity.isExemptionEngineEnabled());
     }
     
     public static Worldpay3dsFlexCredentials from(Worldpay3dsFlexCredentialsRequest credentialsRequest) {
@@ -62,11 +62,12 @@ public class Worldpay3dsFlexCredentials {
         Worldpay3dsFlexCredentials that = (Worldpay3dsFlexCredentials) o;
         return Objects.equals(issuer, that.issuer) &&
                 Objects.equals(organisationalUnitId, that.organisationalUnitId) &&
+                Objects.equals(exemptionEngineEnabled, that.exemptionEngineEnabled) &&
                 Objects.equals(jwtMacKey, that.jwtMacKey);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(issuer, organisationalUnitId, jwtMacKey);
+        return Objects.hash(issuer, organisationalUnitId, jwtMacKey, exemptionEngineEnabled);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
@@ -38,7 +38,7 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
     private String jwtMacKey;
 
     @Column(name = "exemption_engine")
-    private boolean exemptionEngine;
+    private boolean exemptionEngineEnabled;
 
     public Worldpay3dsFlexCredentialsEntity() {
         super();
@@ -52,8 +52,8 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
         this.jwtMacKey = jwtMacKey;
     }
 
-    public boolean isExemptionEngine() {
-        return exemptionEngine;
+    public boolean isExemptionEngineEnabled() {
+        return exemptionEngineEnabled;
     }
 
     public Long getId() { return id; }
@@ -139,7 +139,7 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
             worldpay3dsFlexCredentialsEntity.gatewayAccountId = this.gatewayAccountId;
             worldpay3dsFlexCredentialsEntity.organisationalUnitId = this.organisationalUnitId;
             worldpay3dsFlexCredentialsEntity.issuer = this.issuer;
-            worldpay3dsFlexCredentialsEntity.exemptionEngine = this.exemptionEngine;
+            worldpay3dsFlexCredentialsEntity.exemptionEngineEnabled = this.exemptionEngine;
             return worldpay3dsFlexCredentialsEntity;
         }
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
@@ -43,15 +43,7 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
     public Worldpay3dsFlexCredentialsEntity() {
         super();
     }
-
-    public Worldpay3dsFlexCredentialsEntity(Long gatewayAccountId, String issuer, String organisationalUnitId, String jwtMacKey) {
-        super();
-        this.gatewayAccountId = gatewayAccountId;
-        this.issuer = issuer;
-        this.organisationalUnitId = organisationalUnitId;
-        this.jwtMacKey = jwtMacKey;
-    }
-
+    
     public boolean isExemptionEngineEnabled() {
         return exemptionEngineEnabled;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
@@ -37,6 +37,9 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
     @Column(name = "jwt_mac_key")
     private String jwtMacKey;
 
+    @Column(name = "exemption_engine")
+    private boolean exemptionEngine;
+
     public Worldpay3dsFlexCredentialsEntity() {
         super();
     }
@@ -47,6 +50,10 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
         this.issuer = issuer;
         this.organisationalUnitId = organisationalUnitId;
         this.jwtMacKey = jwtMacKey;
+    }
+
+    public boolean isExemptionEngine() {
+        return exemptionEngine;
     }
 
     public Long getId() { return id; }
@@ -92,6 +99,7 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
         private String issuer;
         private String organisationalUnitId;
         private String jwtMacKey;
+        private boolean exemptionEngine;
 
         private Worldpay3dsFlexCredentialsEntityBuilder() {
         }
@@ -120,12 +128,18 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
             return this;
         }
 
+        public Worldpay3dsFlexCredentialsEntityBuilder withExemptionEngine(boolean exemptionEngine) {
+            this.exemptionEngine = exemptionEngine;
+            return this;
+        }
+        
         public Worldpay3dsFlexCredentialsEntity build() {
             Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity = new Worldpay3dsFlexCredentialsEntity();
             worldpay3dsFlexCredentialsEntity.jwtMacKey = this.jwtMacKey;
             worldpay3dsFlexCredentialsEntity.gatewayAccountId = this.gatewayAccountId;
             worldpay3dsFlexCredentialsEntity.organisationalUnitId = this.organisationalUnitId;
             worldpay3dsFlexCredentialsEntity.issuer = this.issuer;
+            worldpay3dsFlexCredentialsEntity.exemptionEngine = this.exemptionEngine;
             return worldpay3dsFlexCredentialsEntity;
         }
     }

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -46,15 +46,15 @@
                     <userAgentHeader>${authCardDetails.userAgentHeader?xml}</userAgentHeader>
                 </browser>
             </shopper>
+            <#if exemptionEngineEnabled>
+            <exemption type="OP" placement="AUTHORISATION"/>
+            </#if>
             <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>
             <additional3DSData
                 dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()}"
                 challengeWindowSize="390x400" challengePreference="noPreference"
             />
             </#if>
-            </#if>
-            <#if exemptionEngine>
-                <exemption type="OP" placement="AUTHORISATION"/>
             </#if>
         </order>
     </submit>

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -53,6 +53,9 @@
             />
             </#if>
             </#if>
+            <#if exemptionEngine>
+                <exemption type="OP" placement="AUTHORISATION"/>
+            </#if>
         </order>
     </submit>
 </paymentService>

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -94,7 +94,7 @@ public class Worldpay3dsFlexJwtServiceTest {
     @Test
     public void shouldCreateCorrectTokenForWorldpay3dsFlexDdc() {
         var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), VALID_CREDENTIALS, TEST);
-        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", "myOrg", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
+        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", "myOrg", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0", false);
         int paymentCreationTimeEpochSeconds19August2029 = 1881821916;
         int expectedTokenExpirationTimeEpochSeconds = paymentCreationTimeEpochSeconds19August2029 + TOKEN_EXPIRY_DURATION_SECONDS;
         var paymentCreationZonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochSecond((long) paymentCreationTimeEpochSeconds19August2029), UTC);
@@ -183,7 +183,7 @@ public class Worldpay3dsFlexJwtServiceTest {
 
     @Test
     public void generateDdcToken_shouldThrowExceptionForMissingIssuer() {
-        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials(null, "myOrg", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
+        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials(null, "myOrg", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0", false);
         var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null, TEST);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
@@ -195,7 +195,7 @@ public class Worldpay3dsFlexJwtServiceTest {
 
     @Test
     public void generateDdcToken_shouldThrowExceptionForMissingOrgId() {
-        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", null, "fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
+        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", null, "fa2daee2-1fbb-45ff-4444-52805d5cd9e0", false);
         var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null, TEST);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
@@ -208,7 +208,7 @@ public class Worldpay3dsFlexJwtServiceTest {
 
     @Test
     public void generateDdcToken_shouldThrowExceptionForMissingJwtMacId() {
-        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", "myOrg", null);
+        var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", "myOrg", null, false);
         var gatewayAccount = new GatewayAccount(1L, WORLDPAY.getName(), null, TEST);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
@@ -120,7 +120,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
         var invalidIssuer = "54i0917n10va4428b69l5id0";
         var invalidOrgUnitId = "57992i087n0v4849895alid2";
         var invalidJwtMacKey = "4inva5l2-0133-4i82-d0e5-2024dbeddaa9";
-        var flexCredentials = new Worldpay3dsFlexCredentials(invalidIssuer, invalidOrgUnitId, invalidJwtMacKey);
+        var flexCredentials = new Worldpay3dsFlexCredentials(invalidIssuer, invalidOrgUnitId, invalidJwtMacKey, false);
 
         when(response.getStatus()).thenReturn(HttpStatus.SC_BAD_REQUEST);
         when(client.target(threeDsFlexDdcUrls.get(type))).thenReturn(webTarget);
@@ -184,7 +184,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
         var validIssuer = "53f0917f101a4428b69d5fb0"; //pragma: allowlist secret
         var validOrgUnitId = "57992a087a0c4849895ab8a2";
         var validJwtMacKey = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9";
-        return new Worldpay3dsFlexCredentials(validIssuer, validOrgUnitId, validJwtMacKey);
+        return new Worldpay3dsFlexCredentials(validIssuer, validOrgUnitId, validJwtMacKey, false);
     }
     
     private void mockJerseyClient() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -347,17 +347,7 @@ public class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         providerWithMockedGatewayClient.authorise(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), getValidTestCard()));
 
-        ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
-
-        verify(mockGatewayClient).postRequestFor(
-                eq(WORLDPAY_URL),
-                eq(gatewayAccountEntity),
-                gatewayOrderArgumentCaptor.capture(),
-                anyMap());
-
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        assertThat(getNodeListFromExpression(document, "/paymentService/submit/order/exemption").getLength(),
-                is(0));
+        verifyNoExemptionRequestInAuthorisationRequest();
     }
     
     @Test
@@ -373,17 +363,7 @@ public class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         providerWithMockedGatewayClient.authorise(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), getValidTestCard()));
 
-        ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
-
-        verify(mockGatewayClient).postRequestFor(
-                eq(WORLDPAY_URL),
-                eq(gatewayAccountEntity),
-                gatewayOrderArgumentCaptor.capture(),
-                anyMap());
-
-        Document document = XPathUtils.getDocumentXmlString(gatewayOrderArgumentCaptor.getValue().getPayload());
-        assertThat(getNodeListFromExpression(document, "/paymentService/submit/order/exemption").getLength(),
-                is(0));
+        verifyNoExemptionRequestInAuthorisationRequest();
     }
 
     @Test
@@ -426,6 +406,10 @@ public class WorldpayPaymentProviderTest {
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         providerWithMockedGatewayClient.authorise(new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), getValidTestCard()));
 
+        verifyNoExemptionRequestInAuthorisationRequest();
+    }
+
+    private void verifyNoExemptionRequestInAuthorisationRequest() throws Exception {
         ArgumentCaptor<GatewayOrder> gatewayOrderArgumentCaptor = ArgumentCaptor.forClass(GatewayOrder.class);
 
         verify(mockGatewayClient).postRequestFor(


### PR DESCRIPTION
An exemption request should be added to the authorisation order if:
- Worldpay gateway account has exemption_engine set to true in the
  worldpay_3ds_flex_credentials table
- the gateway account has 3-D Secure enabled

This PR actually covers all the scenarios in PP-5640.