### PR TITLE
PP-7549 Downgrade Worldpay error notification for test accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -138,10 +138,20 @@ public class WorldpayNotificationService {
         } else if (isRefundNotification(notification)) {
             refundNotificationProcessor.invoke(PaymentGatewayName.WORLDPAY, newRefundStatus(notification), gatewayAccountEntity,
                     notification.getReference(), notification.getTransactionId(), charge);
+        } else if (isErrorNotification(notification)) {
+            if (gatewayAccountEntity.isLive()) {
+                logger.error("{} error notification received for live account {}", PAYMENT_GATEWAY_NAME, notification);
+            } else {
+                logger.info("{} error notification received for test account {}", PAYMENT_GATEWAY_NAME, notification);
+            }
         } else {
             logger.error("{} notification {} unknown", PAYMENT_GATEWAY_NAME, notification);
         }
         return true;
+    }
+
+    private boolean isErrorNotification(WorldpayNotification notification) {
+        return "ERROR".equals(notification.getStatus());
     }
 
     private RefundStatus newRefundStatus(WorldpayNotification notification) {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
@@ -228,6 +229,21 @@ class WorldpayNotificationServiceTest {
             verifyNoInteractions(mockChargeNotificationProcessor);
             verifyNoInteractions(mockRefundNotificationProcessor);
         }
+    }
+
+    @Test
+    void shouldCheckGatewayAccountTypeAndReturnTrue_forErrorNotification() {
+        GatewayAccountEntity mockGatewayAccountEntity = Mockito.mock(GatewayAccountEntity.class);
+        when(mockGatewayAccountEntity.isLive()).thenReturn(true);
+        setUpChargeServiceToReturnCharge(Optional.of(charge));
+        setUpGatewayAccountServiceToReturnGatewayAccountEntity(Optional.of(mockGatewayAccountEntity));
+
+        final String payload = sampleWorldpayNotification(transactionId, referenceId, "ERROR");
+
+        assertTrue(notificationService.handleNotificationFor(ipAddress, payload));
+        verify(mockGatewayAccountEntity, times(1)).isLive();
+        verifyNoInteractions(mockChargeNotificationProcessor);
+        verifyNoInteractions(mockRefundNotificationProcessor);
     }
 
     @Test


### PR DESCRIPTION
If we receive an "ERROR" notification from Worldpay and it is for a test
account then log it at "INFO" rather than "ERROR".

## WHAT YOU DID
Highlighted by a Sentry error:
https://sentry.io/organizations/govuk-pay/issues/1976709606/?project=5480144&referrer=slack

These all relate to a test gateway account: https://toolbox.payments.service.gov.uk/gateway_accounts/520
Splunk search showing occurrences and how they're all on the same Merchant Code relating to the test account
https://gds.splunkcloud.com/en-GB/app/gds-004-pay/search?q=search%20index%3Dpay_application%20%22worldpay%20notification%20WorldpayNotification%22%20%22unknown%22%0A%7C%20rex%20%22merchantCode%3D%27(%3F%3CmerchantCode%3E.%5B%5E%27%5D*)%22%0A%7C%20rex%20%22status%3D%27(%3F%3Cstatus%3E.%5B%5E%27%5D*)%22%0A%7C%20stats%20count%20by%20status%2C%20merchantCode&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-30d%40d&latest=now&display.page.search.tab=statistics&display.general.type=statistics&sid=1607589886.113684