### PR TITLE
PP-7559 If we need to send an email but the charge doesn't have one log

### DIFF
--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -84,6 +84,11 @@ public class UserNotificationService {
             return CompletableFuture.completedFuture(Optional.empty());
         }
 
+        if (charge.getEmail() == null) {
+            logger.warn("Cannot send email for charge_external_id = {} because the charge does not have an email address", charge.getExternalId());
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
+
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
         return executorService.submit(() -> {
             try {

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
@@ -229,6 +229,17 @@ public class UserNotificationServiceTest {
     }
 
     @Test
+    public void shouldNotSendEmail_IfEmailEnabledButChargeDoesNotHaveAnEmailAddress() throws Exception {
+        when(mockNotifyConfiguration.isEmailNotifyEnabled()).thenReturn(true);
+        Charge chargeWithoutEmail = Charge.from(ChargeEntityFixture.aValidChargeEntity().withEmail(null).build());
+        userNotificationService = new UserNotificationService(mockNotifyClientFactory, mockConfig, mockEnvironment);
+        Future<Optional<String>> idF = userNotificationService.sendRefundIssuedEmail(refundEntity, chargeWithoutEmail, gatewayAccountEntity);
+        idF.get(1000, TimeUnit.SECONDS);
+
+        verifyNoInteractions(mockNotifyClient);
+    }
+
+    @Test
     public void shouldNotSendPaymentConfirmedEmail_whenConfirmationEmailNotificationsAreDisabledForService() {
         chargeEntity.getGatewayAccount()
                 .getEmailNotifications()


### PR DESCRIPTION
We are logging an error when we need to send an email based on the
current gateway account email collection settings but the charge doesn't
have an email address on it. This appears to happen for Telephone payments
which can be created without an email address despite the gateway accounts
email collection settings.

## WHAT YOU DID
[Here's a splunk search showing recent occurrences in the last 7 days ](https://gds.splunkcloud.com/en-GB/app/gds-004-pay/search?q=search%20index%3Dpay_application%20container%3Dconnector%20%22Failed%20to%20send%22%20%22email%22%20%0A%7C%20rex%20field%3Dmessage%20%22Failed%20to%20send%20(%3F%3Cemail_type%3E%5BA-Z_%5D%2B)%20email%22%20%0A%7C%20rex%20field%3Dmessage%20%22charge_external_id%3D(%3F%3Cpayment_external_id%3E.%2B)%22%0A%7C%20rex%20field%3Dstack_trace%20%22%5C%22message%5C%22%3A(%3F%3Cerror_message%3E.%2B)%7D%22%0A%7C%20table%20email_type%2C%20payment_external_id%2C%20error_message%0A%7C%20join%20payment_external_id%20type%3Dinner%20max%3D0%20%0A%20%20%20%20%5B%20search%20index%3Dpay_application%20container%3Dconnector%20gateway_account_id%3D*%20%0A%20%20%20%20%7C%20stats%20count%20by%20payment_external_id%2C%20gateway_account_id%20%0A%20%20%20%20%7C%20table%20payment_external_id%2C%20gateway_account_id%20%5D&display.page.search.mode=verbose&dispatch.sample_ratio=1&earliest=-7d%40h&latest=now&display.page.search.tab=statistics&display.general.type=statistics&display.statistics.sortColumn=gateway_account_id&display.statistics.sortDirection=desc&sid=1607696052.69343)

```
email_type	payment_external_id	error_message	gateway_account_id
PAYMENT_CONFIRMED	1sjgv35lhpm6k92e55j6ru0ggk	"email_address Not a valid email address"}],"status_code":400	2287
REFUND_ISSUED	1sjgv35lhpm6k92e55j6ru0ggk	"email_address Not a valid email address"}],"status_code":400	2287
REFUND_ISSUED	5mdo0r9ko2cg8rts8tueummvtn	"email_address is a required property"}],"status_code":400	2140
REFUND_ISSUED	75aq214d7e1b6kk1dm8l4kdujc	"email_address is a required property"}],"status_code":400	2140
REFUND_ISSUED	ku670fir17lbffr28t25r6hqrk	"email_address is a required property"}],"status_code":400	2140
REFUND_ISSUED	jqkqod8m95000g5gh1o59kl3mi	"email_address is a required property"}],"status_code":400	2140
REFUND_ISSUED	fieupd1ga6kpl3ffvp6dt5fei1	"email_address is a required property"}],"status_code":400	2140
```

I think for the instances where the charge doesn't have an email on these are Telephone payments all on this account https://toolbox.payments.service.gov.uk/gateway_accounts/2140. Here's an example payment from above: https://toolbox.payments.service.gov.uk/transactions/ku670fir17lbffr28t25r6hqrk

There doesn’t appear to be any validation when creating a telephone payment that the create charge request includes an email address.  https://github.com/alphagov/pay-publicapi/blob/a7a523f1e72858f428f485a71cda55dda3ba5d59/src/main/java/uk/gov/pay/api/resources/telephone/TelephonePaymentNotificationResource.java#L42

The check to send a notification email is based on the gateway account setting. So although this account had email collection mode mandatory not all payments it creates have an email address. https://github.com/alphagov/pay-connector/blob/af80415c86fc48ffa8b5dcaf85e73e6f6a8ea79c/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java#L82. 

We might want to address the validation on creating telephone payments as well but once the payment gets here without an email address there is nothing we can do so should log as a warning rather than an error.