### PR TITLE
Revert "PP-5641: Add exemption to authorisation request summary"

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -3,13 +3,9 @@ package uk.gov.pay.connector.gateway.model;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
 
 public interface AuthorisationRequestSummary {
-    
+
     enum Presence {
         PRESENT, NOT_PRESENT, NOT_APPLICABLE
-    }
-    
-    default Presence exemptionRequest() {
-        return NOT_APPLICABLE;
     }
 
     default Presence billingAddress() {

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -53,17 +53,6 @@ public class AuthorisationRequestSummaryStringifier {
                 break;
         }
 
-        switch (authorisationRequestSummary.exemptionRequest()) {
-            case PRESENT:
-                stringJoiner.add("with exemption");
-                break;
-            case NOT_PRESENT:
-                stringJoiner.add("without exemption");
-                break;
-            default:
-                break;
-        }
-
         return stringJoiner.toString();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.gateway.worldpay;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
@@ -13,15 +12,11 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     private final Presence billingAddress;
     private final Presence dataFor3ds;
     private final Presence deviceDataCollectionResult;
-    private final Presence exemptionRequest;
 
     public WorldpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
-        GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
-        dataFor3ds = (deviceDataCollectionResult == PRESENT || gatewayAccount.isRequires3ds()) ? PRESENT : NOT_PRESENT;
-        exemptionRequest = gatewayAccount.isRequires3ds() && 
-                gatewayAccount.getWorldpay3dsFlexCredentials().isExemptionEngineEnabled() ? PRESENT : NOT_PRESENT;
+        dataFor3ds = (deviceDataCollectionResult == PRESENT || chargeEntity.getGatewayAccount().isRequires3ds()) ? PRESENT : NOT_PRESENT;
     }
 
     @Override
@@ -39,8 +34,4 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
         return deviceDataCollectionResult;
     }
 
-    @Override
-    public Presence exemptionRequest() {
-        return exemptionRequest;
-    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -26,11 +26,10 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
-        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(PRESENT);
-        
+
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
         
-        assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption"));
+        assertThat(result, is(" with billing address and with 3DS data and without device data collection result"));
     }
 
     @Test
@@ -39,7 +38,6 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
-        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
@@ -4,12 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.stubbing.Answer;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import java.util.Optional;
 
@@ -27,35 +25,6 @@ class WorldpayAuthorisationRequestSummaryTest {
     @Mock private ChargeEntity mockChargeEntity;
     @Mock private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock private AuthCardDetails mockAuthCardDetails;
-    @Mock private Worldpay3dsFlexCredentials mockWorldpay3dsFlexCredentials;
-
-    @Test
-    void requires3ds_true_and_exemption_engine_enabled_means_exemption_request_present() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
-        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
-        given(mockGatewayAccountEntity.getWorldpay3dsFlexCredentials()).willReturn(mockWorldpay3dsFlexCredentials);
-        given(mockWorldpay3dsFlexCredentials.isExemptionEngineEnabled()).willReturn(true);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
-        assertThat(worldpayAuthorisationRequestSummary.exemptionRequest(), is(PRESENT));
-    }
-
-    @Test
-    void requires3ds_true_and_exemption_engine_not_enabled_means_exemption_request_not_present() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
-        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
-        given(mockGatewayAccountEntity.getWorldpay3dsFlexCredentials()).willReturn(mockWorldpay3dsFlexCredentials);
-        given(mockWorldpay3dsFlexCredentials.isExemptionEngineEnabled()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
-        assertThat(worldpayAuthorisationRequestSummary.exemptionRequest(), is(NOT_PRESENT));
-    }
-
-    @Test
-    void requires3ds_false_means_exemption_request_not_present() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
-        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
-        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
-        assertThat(worldpayAuthorisationRequestSummary.exemptionRequest(), is(NOT_PRESENT));
-    }
 
     @Test
     void billingAddressPresent() {
@@ -77,8 +46,6 @@ class WorldpayAuthorisationRequestSummaryTest {
     void requires3dsTrueMeansDataFor3dsPresent() {
         given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
-        given(mockGatewayAccountEntity.getWorldpay3dsFlexCredentials()).willReturn(mockWorldpay3dsFlexCredentials);
-        given(mockWorldpay3dsFlexCredentials.isExemptionEngineEnabled()).willReturn(false);
         var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
     }
@@ -93,7 +60,6 @@ class WorldpayAuthorisationRequestSummaryTest {
 
     @Test
     void deviceDataCollectionResultPresentMeansDataFor3dsPresent() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
         var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
@@ -101,7 +67,6 @@ class WorldpayAuthorisationRequestSummaryTest {
 
     @Test
     void deviceDataCollectionResultPresent() {
-        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
         var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(PRESENT));


### PR DESCRIPTION
This original failure was causing end-to-end test failures in `uk.gov.pay.endtoend.tests.card.Make3dsPaymentIT.shouldAllowUserToMakeAPayment`. I haven't been able to see from the connector logs by searching for a `NullPointerException` but I suspect the test breaks because `gatewayAccount.getWorldpay3dsFlexCredentials()` can be null.
Reverts alphagov/pay-connector#2746