### PR TITLE
PP-5641: The worldpay 3ds flex creds of a gateway account is optional

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.exception.Worldpay3dsFlexJwtCredentialsException;
 import uk.gov.pay.connector.charge.model.ChargeResponse;
 import uk.gov.pay.connector.charge.model.FrontendChargeResponse;
 import uk.gov.pay.connector.charge.model.NewChargeStatusRequest;
@@ -83,7 +84,8 @@ public class ChargesFrontendResource {
 
         ChargeEntity chargeEntity = chargeService.findChargeByExternalId(chargeId);
         GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
-        Worldpay3dsFlexCredentials worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials();
+        var worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials()
+                .orElseThrow(() -> new Worldpay3dsFlexJwtCredentialsException(gatewayAccount.getId()));
         String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, chargeEntity.getCreatedDate());
 
         return Response.ok().entity(Map.of("jwt", token)).build();

--- a/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
@@ -44,7 +44,6 @@ public class Worldpay3dsFlexJwtService {
      */
     public String generateDdcToken(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials, ZonedDateTime chargeCreatedTime) {
         validateGatewayIsWorldpay(gatewayAccount);
-        validateFlexCredentials(gatewayAccount, worldpay3dsFlexCredentials);
 
         var claims = generateDdcClaims(gatewayAccount, worldpay3dsFlexCredentials, chargeCreatedTime);
         return createJwt(gatewayAccount, worldpay3dsFlexCredentials, claims);
@@ -67,10 +66,10 @@ public class Worldpay3dsFlexJwtService {
 
     private String generateChallengeToken(ChargeEntity chargeEntity) {
         GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
-        Worldpay3dsFlexCredentials worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials();
+        var worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials()
+                .orElseThrow(() -> new Worldpay3dsFlexJwtCredentialsException(gatewayAccount.getId()));
 
         validateGatewayIsWorldpay(gatewayAccount);
-        validateFlexCredentials(gatewayAccount, worldpay3dsFlexCredentials);
 
         var claims = generateChallengeClaims(chargeEntity, gatewayAccount, worldpay3dsFlexCredentials);
         return createJwt(gatewayAccount, worldpay3dsFlexCredentials, claims);
@@ -81,13 +80,7 @@ public class Worldpay3dsFlexJwtService {
             throw new Worldpay3dsFlexJwtPaymentProviderException(gatewayAccount.getId());
         }
     }
-
-    private void validateFlexCredentials(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials) { 
-        if (worldpay3dsFlexCredentials == null) {
-            throw new Worldpay3dsFlexJwtCredentialsException(gatewayAccount.getId());
-        }
-    }
-
+    
     private Map<String, Object> generateDdcClaims(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials, ZonedDateTime chargeCreatedTime) {
         Map<String, Object> commonClaims = generateCommonClaims(gatewayAccount.getId(), worldpay3dsFlexCredentials);
         Map<String, Object> claims = new HashMap<>(commonClaims);

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -222,7 +222,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
                 request.getGatewayAccount().isRequires3ds();
 
-        boolean exemptionEngineEnabled = Optional.ofNullable(request.getGatewayAccount().getWorldpay3dsFlexCredentials())
+        boolean exemptionEngineEnabled = request.getGatewayAccount().getWorldpay3dsFlexCredentials()
                         .map(Worldpay3dsFlexCredentials::isExemptionEngineEnabled)
                         .orElse(false);
         

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -34,6 +34,7 @@ import javax.persistence.Table;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static com.google.common.collect.Lists.newArrayList;
@@ -228,11 +229,8 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @JsonInclude(NON_NULL)
     @JsonProperty("worldpay_3ds_flex")
-    public Worldpay3dsFlexCredentials getWorldpay3dsFlexCredentials() {
-        if (worldpay3dsFlexCredentialsEntity != null) {
-            return Worldpay3dsFlexCredentials.fromEntity(worldpay3dsFlexCredentialsEntity);
-        }
-        return null;
+    public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {
+        return Optional.ofNullable(worldpay3dsFlexCredentialsEntity).map(Worldpay3dsFlexCredentials::fromEntity);
     }
 
     public boolean isRequires3ds() {

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -294,6 +294,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 .withId(1L)
                 .withGatewayName(SMARTPAY.getName())
                 .withCredentials(VALID_CREDENTIALS)
+                .withWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity)
                 .build();
         ChargeEntity chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -458,7 +458,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .get("/v1/frontend/accounts/" + gatewayAccountId)
                 .then()
                 .statusCode(200)
-                .body("$", not(hasKey("worldpay_3ds_flex")));
+                .body("worldpay_3ds_flex", nullValue());
     }
 
     @Test
@@ -484,7 +484,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .get("/v1/frontend/accounts/" + gatewayAccountId)
                 .then()
                 .statusCode(200)
-                .body("$", not(hasKey("worldpay_3ds_flex")));
+                .body("worldpay_3ds_flex", nullValue());
     }
 
     @Test


### PR DESCRIPTION
It is difficult to realise the worldpay 3ds flex creds may not be present in
code. This caused an end-to-end test error for
https://github.com/alphagov/pay-connector/pull/2746.

The effect of this is that the `worldpay_3ds_flex` in the JSON of a gatweay
account is serialised as `"worldpay_3ds_flex": null` rather than it not being
there at all. This could be rectified by placing
`@JsonProperty("worldpay_3ds_flex")` in the GatewayAccountEntity on the
`worldpay3dsFlexCredentialsEntity` field rather than the method
`getWorldpay3dsFlexCredentials`. However this results in a StackOverflow error
in some tests.
