### PR TITLE
PP-5641: Add exemption to authorisation request summary

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -3,9 +3,13 @@ package uk.gov.pay.connector.gateway.model;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_APPLICABLE;
 
 public interface AuthorisationRequestSummary {
-
+    
     enum Presence {
         PRESENT, NOT_PRESENT, NOT_APPLICABLE
+    }
+    
+    default Presence exemptionRequest() {
+        return NOT_APPLICABLE;
     }
 
     default Presence billingAddress() {

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -53,6 +53,17 @@ public class AuthorisationRequestSummaryStringifier {
                 break;
         }
 
+        switch (authorisationRequestSummary.exemptionRequest()) {
+            case PRESENT:
+                stringJoiner.add("with exemption");
+                break;
+            case NOT_PRESENT:
+                stringJoiner.add("without exemption");
+                break;
+            default:
+                break;
+        }
+
         return stringJoiner.toString();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gateway.worldpay;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.NOT_PRESENT;
 import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Presence.PRESENT;
@@ -12,11 +14,16 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     private final Presence billingAddress;
     private final Presence dataFor3ds;
     private final Presence deviceDataCollectionResult;
+    private final Presence exemptionRequest;
 
     public WorldpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
-        dataFor3ds = (deviceDataCollectionResult == PRESENT || chargeEntity.getGatewayAccount().isRequires3ds()) ? PRESENT : NOT_PRESENT;
+        GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
+        dataFor3ds = (deviceDataCollectionResult == PRESENT || gatewayAccount.isRequires3ds()) ? PRESENT : NOT_PRESENT;
+        exemptionRequest = gatewayAccount.isRequires3ds() && 
+                gatewayAccount.getWorldpay3dsFlexCredentials().map(Worldpay3dsFlexCredentials::isExemptionEngineEnabled).orElse(false) 
+                ? PRESENT : NOT_PRESENT;
     }
 
     @Override
@@ -34,4 +41,8 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
         return deviceDataCollectionResult;
     }
 
+    @Override
+    public Presence exemptionRequest() {
+        return exemptionRequest;
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -26,10 +26,11 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
-
+        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(PRESENT);
+        
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
         
-        assertThat(result, is(" with billing address and with 3DS data and without device data collection result"));
+        assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption"));
     }
 
     @Test
@@ -38,6 +39,7 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_APPLICABLE);
+        given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(NOT_APPLICABLE);
 
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummaryTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import java.util.Optional;
 
@@ -25,6 +26,43 @@ class WorldpayAuthorisationRequestSummaryTest {
     @Mock private ChargeEntity mockChargeEntity;
     @Mock private GatewayAccountEntity mockGatewayAccountEntity;
     @Mock private AuthCardDetails mockAuthCardDetails;
+    @Mock private Worldpay3dsFlexCredentials mockWorldpay3dsFlexCredentials;
+
+    @Test
+    void requires3ds_true_and_Worldpay3dsFlexCredentials_not_present_means_exemption_request_not_present() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.exemptionRequest(), is(NOT_PRESENT));
+    }
+    
+    @Test
+    void requires3ds_true_and_exemption_engine_enabled_means_exemption_request_present() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        given(mockGatewayAccountEntity.getWorldpay3dsFlexCredentials()).willReturn(Optional.of(mockWorldpay3dsFlexCredentials));
+        given(mockWorldpay3dsFlexCredentials.isExemptionEngineEnabled()).willReturn(true);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.exemptionRequest(), is(PRESENT));
+    }
+
+    @Test
+    void requires3ds_true_and_exemption_engine_not_enabled_means_exemption_request_not_present() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        given(mockGatewayAccountEntity.getWorldpay3dsFlexCredentials()).willReturn(Optional.of(mockWorldpay3dsFlexCredentials));
+        given(mockWorldpay3dsFlexCredentials.isExemptionEngineEnabled()).willReturn(false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.exemptionRequest(), is(NOT_PRESENT));
+    }
+
+    @Test
+    void requires3ds_false_means_exemption_request_not_present() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
+        given(mockGatewayAccountEntity.isRequires3ds()).willReturn(false);
+        var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
+        assertThat(worldpayAuthorisationRequestSummary.exemptionRequest(), is(NOT_PRESENT));
+    }
 
     @Test
     void billingAddressPresent() {
@@ -46,6 +84,8 @@ class WorldpayAuthorisationRequestSummaryTest {
     void requires3dsTrueMeansDataFor3dsPresent() {
         given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockGatewayAccountEntity.isRequires3ds()).willReturn(true);
+        given(mockGatewayAccountEntity.getWorldpay3dsFlexCredentials()).willReturn(Optional.of(mockWorldpay3dsFlexCredentials));
+        given(mockWorldpay3dsFlexCredentials.isExemptionEngineEnabled()).willReturn(false);
         var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
     }
@@ -60,6 +100,7 @@ class WorldpayAuthorisationRequestSummaryTest {
 
     @Test
     void deviceDataCollectionResultPresentMeansDataFor3dsPresent() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
         var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.dataFor3ds(), is(PRESENT));
@@ -67,6 +108,7 @@ class WorldpayAuthorisationRequestSummaryTest {
 
     @Test
     void deviceDataCollectionResultPresent() {
+        given(mockChargeEntity.getGatewayAccount()).willReturn(mockGatewayAccountEntity);
         given(mockAuthCardDetails.getWorldpay3dsFlexDdcResult()).willReturn(Optional.of("DDC Result"));
         var worldpayAuthorisationRequestSummary = new WorldpayAuthorisationRequestSummary(mockChargeEntity, mockAuthCardDetails);
         assertThat(worldpayAuthorisationRequestSummary.deviceDataCollectionResult(), is(PRESENT));


### PR DESCRIPTION
Essentially the same as https://github.com/alphagov/pay-connector/pull/2746, but with an added `WorldpayAuthorisationRequestSummaryTest.requires3ds_true_and_Worldpay3dsFlexCredentials_not_present_means_exemption_request_not_present`. Hopefully this doesn't break the end-to-end tests 🤞 