### PR TITLE
BAU: Update testcontainers to v1.15.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.15.0</version>
+            <version>1.15.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This change updates testcontainers from v1.15.0 to v1.15.1 to work with new Docker 20.10. The release note taken from https://github.com/testcontainers/testcontainers-java/releases/tag/1.15.1 says

```Docker 20.10 introduced a new version of the API, 1.41, where they removed quite a few deprecations, and we were using one of them. If you were getting "No such image: testcontainers/ryuk:0.3.0" - that's the cause.```

This resolves the following error.

```Caused by: com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"No such image: testcontainers/ryuk:0.3.0"}```
