### PR TITLE
PP-5641: Build auth order in response to soft decline

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -27,10 +27,10 @@ import static java.util.Collections.emptyList;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
 import static javax.ws.rs.core.Response.Status.Family.familyOf;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
-import static javax.ws.rs.core.Response.Status.OK;
 
 public class GatewayClient {
-    private static final Logger logger = LoggerFactory.getLogger(GatewayClient.class);
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(GatewayClient.class);
 
     private final Client client;
     private final MetricRegistry metricRegistry;
@@ -62,7 +62,7 @@ public class GatewayClient {
 
         Stopwatch responseTimeStopwatch = Stopwatch.createStarted();
         try {
-            logger.info("POSTing request for account '{}' with type '{}'", account.getGatewayName(), account.getType());
+            LOGGER.info("POSTing request for account '{}' with type '{}'", account.getGatewayName(), account.getType());
 
             Builder requestBuilder = client.target(url).request();
             headers.keySet().forEach(headerKey -> requestBuilder.header(headerKey, headers.get(headerKey)));
@@ -74,11 +74,11 @@ public class GatewayClient {
                 return gatewayResponse;
             } else {
                 if (statusCode >= INTERNAL_SERVER_ERROR.getStatusCode()) {
-                    logger.error("Gateway returned unexpected status code: {}, for gateway url={} with type {} with order request type {}",
+                    LOGGER.error("Gateway returned unexpected status code: {}, for gateway url={} with type {} with order request type {}",
                             statusCode, url, account.getType(), request.getOrderRequestType());
                     incrementFailureCounter(metricRegistry, metricsPrefix);
                 } else {
-                    logger.info("Gateway returned non-success status code: {}, for gateway url={} with type {} with order request type {}",
+                    LOGGER.info("Gateway returned non-success status code: {}, for gateway url={} with type {} with order request type {}",
                             statusCode, url, account.getType(), request.getOrderRequestType());
                 }
                 throw new GatewayErrorException("Non-success HTTP status code " + statusCode + " from gateway", gatewayResponse.getEntity(), statusCode);
@@ -87,17 +87,17 @@ public class GatewayClient {
             incrementFailureCounter(metricRegistry, metricsPrefix);
             if (pe.getCause() != null) {
                 if (pe.getCause() instanceof SocketTimeoutException) {
-                    logger.error(format("Connection timed out error for gateway url=%s", url), pe);
+                    LOGGER.error(format("Connection timed out error for gateway url=%s", url), pe);
                     throw new GatewayConnectionTimeoutException("Gateway connection timeout error");
                 }
             }
-            logger.error(format("Exception for gateway url=%s, error message: %s", url, pe.getMessage()), pe);
+            LOGGER.error(format("Exception for gateway url=%s, error message: %s", url, pe.getMessage()), pe);
             throw new GenericGatewayException(pe.getMessage());
         } catch (GatewayErrorException e) {
             throw e;
         } catch (Exception e) {
             incrementFailureCounter(metricRegistry, metricsPrefix);
-            logger.error(format("Exception for gateway url=%s", url), e);
+            LOGGER.error(format("Exception for gateway url=%s", url), e);
             throw new GatewayException.GenericGatewayException(e.getMessage());
         } finally {
             responseTimeStopwatch.stop();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -2,15 +2,12 @@ package uk.gov.pay.connector.gateway.worldpay;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.gateway.AuthoriseHandler;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
-import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import java.net.URI;
 import java.util.Map;
@@ -18,16 +15,14 @@ import java.util.Map;
 import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
-import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static uk.gov.pay.connector.gateway.model.GatewayError.gatewayConnectionError;
 import static uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayResponseBuilder.responseBuilder;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
-public class WorldpayAuthoriseHandler implements AuthoriseHandler, WorldpayGatewayResponseGenerator {
+public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerator {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorldpayAuthoriseHandler.class);
+    
     private final GatewayClient authoriseClient;
     private final Map<String, URI> gatewayUrlMap;
 
@@ -36,25 +31,31 @@ public class WorldpayAuthoriseHandler implements AuthoriseHandler, WorldpayGatew
         this.gatewayUrlMap = gatewayUrlMap;
     }
 
-    @Override
     public GatewayResponse<WorldpayOrderStatusResponse> authorise(CardAuthorisationGatewayRequest request) {
+        return authorise(request, false);
+    }
+    
+    public GatewayResponse<WorldpayOrderStatusResponse> authorise(CardAuthorisationGatewayRequest request, 
+                                                                  boolean withoutExemptionEngine) {
 
+        logMissingDdcResultFor3dsFlexIntegration(request);
+        
         try {
             GatewayClient.Response response = authoriseClient.postRequestFor(
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
                     request.getGatewayAccount(),
-                    buildAuthoriseOrder(request),
+                    WorldpayOrderBuilder.buildAuthoriseOrder(request, withoutExemptionEngine),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
 
             if (response.getEntity().contains("request3DSecure")) {
-                logger.info(format("Worldpay authorisation response when 3ds required for %s: %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
+                LOGGER.info(format("Worldpay authorisation response when 3ds required for %s: %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
             }
             return getWorldpayGatewayResponse(response);
         } catch (GatewayException.GatewayErrorException e) {
             
             if (e.getStatus().isPresent() && (e.getFamily() == CLIENT_ERROR || e.getFamily() == SERVER_ERROR)) {
                 
-                logger.error("Authorisation failed for charge {} due to an internal error. Reason: {}. Status code from Worldpay: {}.",
+                LOGGER.error("Authorisation failed for charge {} due to an internal error. Reason: {}. Status code from Worldpay: {}.",
                         request.getChargeExternalId(), e.getMessage(), e.getStatus().map(String::valueOf).orElse("no status code"));
                 
                 GatewayError gatewayError = gatewayConnectionError(format("Non-success HTTP status code %s from gateway", e.getStatus().get()));
@@ -62,13 +63,13 @@ public class WorldpayAuthoriseHandler implements AuthoriseHandler, WorldpayGatew
                 return responseBuilder().withGatewayError(gatewayError).build();
             }
             
-            logger.info("Unrecognised response status when authorising. Charge_id={}, status={}, response={}",
+            LOGGER.info("Unrecognised response status when authorising. Charge_id={}, status={}, response={}",
                     request.getChargeExternalId(), e.getStatus(), e.getResponseFromGateway());
             throw new RuntimeException("Unrecognised response status when authorising.");
             
         } catch (GatewayException.GatewayConnectionTimeoutException | GatewayException.GenericGatewayException e) {
             
-            logger.error("GatewayException occurred for charge external id {}, error:\n {}", request.getChargeExternalId(), e);
+            LOGGER.error("GatewayException occurred for charge external id {}, error:\n {}", request.getChargeExternalId(), e);
 
             return responseBuilder().withGatewayError(e.toGatewayError()).build();
         }
@@ -77,40 +78,12 @@ public class WorldpayAuthoriseHandler implements AuthoriseHandler, WorldpayGatew
     private String sanitiseMessage(String message) {
         return message.replaceAll("<cardHolderName>.*</cardHolderName>", "<cardHolderName>REDACTED</cardHolderName>");
     }
-
-    private GatewayOrder buildAuthoriseOrder(CardAuthorisationGatewayRequest request) {
-        logMissingDdcResultFor3dsFlexIntegration(request);
-
-        boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
-                request.getGatewayAccount().isRequires3ds();
-
-        boolean exemptionEngineEnabled = request.getGatewayAccount().getWorldpay3dsFlexCredentials()
-                .map(Worldpay3dsFlexCredentials::isExemptionEngineEnabled)
-                .orElse(false);
-
-        var builder = aWorldpayAuthoriseOrderRequestBuilder()
-                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
-                .with3dsRequired(is3dsRequired)
-                .withExemptionEngine(exemptionEngineEnabled);
-
-        if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
-            request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);
-        }
-
-        return builder
-                .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
-                .withDescription(request.getDescription())
-                .withAmount(request.getAmount())
-                .withAuthorisationDetails(request.getAuthCardDetails())
-                .build();
-    }
-
+    
     private void logMissingDdcResultFor3dsFlexIntegration(CardAuthorisationGatewayRequest request) {
         GatewayAccountEntity gatewayAccount = request.getGatewayAccount();
         if (gatewayAccount.isRequires3ds() && gatewayAccount.getIntegrationVersion3ds() == 2 &&
                 request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isEmpty()) {
-            logger.info("[3DS Flex] Missing device data collection result for {}", gatewayAccount.getId());
+            LOGGER.info("[3DS Flex] Missing device data collection result for {}", gatewayAccount.getId());
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
+
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+
+public interface WorldpayOrderBuilder {
+    
+    static WorldpayOrderRequestBuilder buildAuthoriseOrder(WorldpayOrderRequestBuilder builder, 
+                                                           CardAuthorisationGatewayRequest request) {
+
+        boolean exemptionEngineEnabled = request.getGatewayAccount().getWorldpay3dsFlexCredentials()
+                .map(Worldpay3dsFlexCredentials::isExemptionEngineEnabled)
+                .orElse(false);
+
+        return buildAuthoriseOrderWithoutExemptionEngine(builder, request).withExemptionEngine(exemptionEngineEnabled);
+    }
+    
+    static WorldpayOrderRequestBuilder buildAuthoriseOrderWithoutExemptionEngine(WorldpayOrderRequestBuilder builder, 
+                                                                                 CardAuthorisationGatewayRequest request) {
+        
+        if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
+            request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);
+        }
+        
+        boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
+                request.getGatewayAccount().isRequires3ds();
+
+        return (WorldpayOrderRequestBuilder) builder
+                .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
+                .with3dsRequired(is3dsRequired)
+                .withTransactionId(request.getTransactionId().orElse(""))
+                .withMerchantCode(request.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withDescription(request.getDescription())
+                .withAmount(request.getAmount())
+                .withAuthorisationDetails(request.getAuthCardDetails());
+    }
+    
+    static GatewayOrder buildAuthoriseOrder(CardAuthorisationGatewayRequest request, boolean withoutExemptionEngine) {
+        if (withoutExemptionEngine) {
+            return buildAuthoriseOrderWithoutExemptionEngine(aWorldpayAuthoriseOrderRequestBuilder(), request).build();
+        } else {
+            return buildAuthoriseOrder(aWorldpayAuthoriseOrderRequestBuilder(), request).build();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -30,8 +30,6 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -56,16 +54,15 @@ import static uk.gov.pay.connector.gateway.GatewayOperation.REFUND;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpay3dsResponseAuthOrderRequestBuilder;
-import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayCancelOrderRequestBuilder;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayInquiryRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 
 public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGatewayResponseGenerator {
 
-    public static final String WORLDPAY_MACHINE_COOKIE_NAME = "machine";
-
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    static final String WORLDPAY_MACHINE_COOKIE_NAME = "machine";
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorldpayPaymentProvider.class);
+    
     private final GatewayClient authoriseClient;
     private final GatewayClient cancelClient;
     private final GatewayClient inquiryClient;
@@ -163,7 +160,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials()));
             GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getWorldpayGatewayResponse(response);
 
-            logger.info(format("Worldpay 3ds authorisation response for %s : %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
+            LOGGER.info(format("Worldpay 3ds authorisation response for %s : %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));
 
             if (gatewayResponse.getBaseResponse().isEmpty()) {
                 gatewayResponse.throwGatewayError();

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -62,6 +62,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_IP_ADDRESS;
@@ -222,6 +223,23 @@ class WorldpayAuthoriseHandlerTest {
         assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@type", document), is("OP"));
         assertThat(xPath.evaluate("/paymentService/submit/order/exemption/@placement", document), is("AUTHORISATION"));
     }
+    
+    @Test
+    void should_not_include_exemption_element_if_account_has_exemption_engine_set_to_true_but_the_authorisation_is_made_in_response_to_a_soft_decline() throws Exception {
+
+        when(authorisationSuccessResponse.getEntity()).thenReturn(load(WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESPONSE));
+        when(authoriseClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
+                .thenReturn(authorisationSuccessResponse);
+
+        gatewayAccountEntity.setRequires3ds(true);
+        gatewayAccountEntity.setIntegrationVersion3ds(1);
+        gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
+        chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
+        var cardAuthorisationGatewayRequest = new CardAuthorisationGatewayRequest(chargeEntityFixture.build(), getValidTestCard());
+        worldpayAuthoriseHandler.authorise(cardAuthorisationGatewayRequest, true);
+
+        verifyNoExemptionRequestInAuthorisationRequest();
+    }
 
     @Test
     void should_not_include_exemption_element_if_account_has_exemption_engine_set_to_true_but_3ds_is_not_enabled() throws Exception {
@@ -324,7 +342,7 @@ class WorldpayAuthoriseHandlerTest {
         Client mockClient = mockWorldpaySuccessfulOrderSubmitResponse();
 
         var handlerWithRealJerseyClient = new WorldpayAuthoriseHandler(createGatewayClient(mockClient), GATEWAY_URL_MAP);
-        
+
         GatewayResponse response = handlerWithRealJerseyClient.authorise(getCardAuthorisationRequest(chargeEntityFixture.build()));
         assertTrue(response.isSuccessful());
         assertTrue(response.getSessionIdentifier().isPresent());

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -11,6 +11,7 @@ public class TestTemplateResourceLoader {
 
     public static final String WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-success-response.xml";
     public static final String WORLDPAY_EXEMPTION_REQUEST_HONOURED_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-honoured-response.xml";
+    public static final String WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESPONSE = WORLDPAY_BASE_NAME + "/exemption-request-soft-decline-response.xml";
     static final String WORLDPAY_AUTHORISATION_ERROR_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-error-response.xml";
     public static final String WORLDPAY_AUTHORISATION_FAILED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-failed-response.xml";
     static final String WORLDPAY_AUTHORISATION_CANCELLED_RESPONSE = WORLDPAY_BASE_NAME + "/authorisation-cancelled-response.xml";

--- a/src/test/resources/templates/worldpay/exemption-request-soft-decline-response.xml
+++ b/src/test/resources/templates/worldpay/exemption-request-soft-decline-response.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <reply>
+        <orderStatus orderCode="transaction-id">
+            <payment>
+                <paymentMethod>VISA_CREDIT-SSL</paymentMethod>
+                <amount value="100" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
+                <lastEvent>REFUSED</lastEvent>
+                <balance accountType="IN_PROCESS_AUTHORISED">
+                    <amount value="100" currencyCode="EUR" exponent="2" debitCreditIndicator="credit"/>
+                </balance>
+                <cardNumber>4444********1111</cardNumber>
+            </payment>
+            <exemptionResponse result="REJECTED" reason="HIGH_RISK">
+                <exemption type="LV" placement="AUTHENTICATION"/>
+            </exemptionResponse>
+        </orderStatus>
+    </reply>
+</paymentService>


### PR DESCRIPTION
In the event where Worldpay responds to an exemption request with a soft
decline, the auth request should be sent again with no `<exemption>` element.
This commit doesn't contain code to retry the auth request, but to ensure an
auth request without an `<exemption>` element can be created even for a gateway
account with exemption engine enabled.