### PR TITLE
PP-5641: Fix e2e build

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -64,7 +64,7 @@ public class WorldpayAuthoriseHandler implements AuthoriseHandler, WorldpayGatew
             
             logger.info("Unrecognised response status when authorising. Charge_id={}, status={}, response={}",
                     request.getChargeExternalId(), e.getStatus(), e.getResponseFromGateway());
-            throw new RuntimeException("Unrecognised response status when authorising.");
+            return responseBuilder().withGatewayError(e.toGatewayError()).build();
             
         } catch (GatewayException.GatewayConnectionTimeoutException | GatewayException.GenericGatewayException e) {
             


### PR DESCRIPTION
If a non 4xx or 5xx response occurs, for example when worldpay returns a
malformed exception, rather than throw a RuntimeException, a GatewayResponse
with GatewayError should be returned in order for the CardAuthoriseService to
map what the new charge status should be correctly.
