### PR TITLE
PP-7422: Add mocked Worldpay DDC server for PACT

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -13,6 +13,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
+import uk.gov.pay.commons.testing.port.PortFactory;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -45,9 +46,13 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ContractTest {
+    public static final int WORLDPAY_DDC_PORT_NUMBER = PortFactory.findFreePort();
 
     @ClassRule
-    public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule(ConfigOverride.config("captureProcessConfig.backgroundProcessingEnabled", "false"));
+    public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule(
+            ConfigOverride.config("captureProcessConfig.backgroundProcessingEnabled", "false"),
+            ConfigOverride.config("worldpay.threeDsFlexDdcUrls.test", String.format("http://localhost:%s/shopper/3ds/ddc.html", WORLDPAY_DDC_PORT_NUMBER)),
+            ConfigOverride.config("worldpay.threeDsFlexDdcUrls.live", String.format("http://localhost:%s/shopper/3ds/ddc.html", WORLDPAY_DDC_PORT_NUMBER)));
 
     @ClassRule
     public static WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);

--- a/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
@@ -4,7 +4,14 @@ import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
 import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.runner.RunWith;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 @RunWith(PactRunner.class)
 @Provider("connector")
@@ -12,4 +19,11 @@ import org.junit.runner.RunWith;
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
 public class SelfServiceContractTest extends ContractTest {
+    @ClassRule
+    public static WireMockClassRule worldpayDeviceDataCollectionRule = new WireMockClassRule(WORLDPAY_DDC_PORT_NUMBER);
+
+    @BeforeClass
+    public static void setUpBeforeClass() {
+        worldpayDeviceDataCollectionRule.stubFor(post(urlPathEqualTo("/shopper/3ds/ddc.html")).willReturn(aResponse().withStatus(200)));
+    }
 }


### PR DESCRIPTION
This change adds mocked Worldpay Device Data Collection (DDC) server to Self Service Contract test. This will allow us to perform PACT test on Worldpay 3DS Flex credentials verification between Self Service and Connector applications.

I ran Self Service Contract Test locally and it passed all tests without errors.