### PR TITLE
bau: Refactor WorldpayPaymentProvider

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-14T18:23:55Z",
+  "generated_at": "2020-12-15T18:11:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -184,7 +184,7 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 240,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import com.google.inject.name.Named;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -9,6 +10,7 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import javax.inject.Inject;
 import java.net.URI;
 import java.util.Map;
 
@@ -26,7 +28,9 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
     private final GatewayClient authoriseClient;
     private final Map<String, URI> gatewayUrlMap;
 
-    public WorldpayAuthoriseHandler(GatewayClient authoriseClient, Map<String, URI> gatewayUrlMap) {
+    @Inject
+    public WorldpayAuthoriseHandler(@Named("WorldpayAuthoriseGatewayClient") GatewayClient authoriseClient,
+                                    @Named("WorldpayGatewayUrlMap") Map<String, URI> gatewayUrlMap) {
         this.authoriseClient = authoriseClient;
         this.gatewayUrlMap = gatewayUrlMap;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import com.google.inject.name.Named;
 import uk.gov.pay.connector.gateway.CaptureHandler;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
@@ -7,6 +8,7 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 
+import javax.inject.Inject;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -23,7 +25,9 @@ public class WorldpayCaptureHandler implements CaptureHandler {
     private final GatewayClient client;
     private final Map<String, URI> gatewayUrlMap;
 
-    public WorldpayCaptureHandler(GatewayClient client, Map<String, URI> gatewayUrlMap) {
+    @Inject
+    public WorldpayCaptureHandler(@Named("WorldpayCaptureGatewayClient") GatewayClient client,
+                                  @Named("WorldpayGatewayUrlMap") Map<String, URI> gatewayUrlMap) {
         this.client = client;
         this.gatewayUrlMap = gatewayUrlMap;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
+import com.google.inject.name.Named;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -7,6 +8,7 @@ import uk.gov.pay.connector.gateway.RefundHandler;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 
+import javax.inject.Inject;
 import java.net.URI;
 import java.util.Map;
 
@@ -21,7 +23,9 @@ public class WorldpayRefundHandler implements RefundHandler {
     private final GatewayClient client;
     private final Map<String, URI> gatewayUrlMap;
 
-    public WorldpayRefundHandler(GatewayClient client, Map<String, URI> gatewayUrlMap) {
+    @Inject
+    public WorldpayRefundHandler(@Named("WorldpayRefundGatewayClient") GatewayClient client,
+                                 @Named("WorldpayGatewayUrlMap") Map<String, URI> gatewayUrlMap) {
         this.client = client;
         this.gatewayUrlMap = gatewayUrlMap;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.worldpay.wallets;
 
+import com.google.inject.name.Named;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
@@ -10,6 +11,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayGatewayResponseGenerator;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.WalletAuthorisationHandler;
 
+import javax.inject.Inject;
 import java.net.URI;
 import java.util.Map;
 
@@ -22,7 +24,9 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
     private final GatewayClient authoriseClient;
     private final Map<String, URI> gatewayUrlMap;
 
-    public WorldpayWalletAuthorisationHandler(GatewayClient authoriseClient, Map<String, URI> gatewayUrlMap) {
+    @Inject
+    public WorldpayWalletAuthorisationHandler(@Named("WorldpayAuthoriseGatewayClient") GatewayClient authoriseClient,
+                                              @Named("WorldpayGatewayUrlMap") Map<String, URI> gatewayUrlMap) {
         this.authoriseClient = authoriseClient;
         this.gatewayUrlMap = gatewayUrlMap;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
@@ -1,0 +1,104 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.model.OrderRequestType;
+import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.model.domain.RefundEntityFixture;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+
+@ExtendWith(MockitoExtension.class)
+class WorldpayRefundHandlerTest {
+
+    private final URI WORLDPAY_URL = URI.create("http://worldpay.url");
+
+    private final Map<String, URI> GATEWAY_URL_MAP = Map.of(TEST.toString(), WORLDPAY_URL);
+    
+    private ChargeEntityFixture chargeEntityFixture;
+
+    private GatewayAccountEntity gatewayAccountEntity;
+    
+    private WorldpayRefundHandler worldpayRefundHandler;
+    
+    @Mock private GatewayClient refundGatewayClient;
+    
+    @BeforeEach
+    void setup() {
+        gatewayAccountEntity = aServiceAccount();
+        chargeEntityFixture = aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity);
+        
+        worldpayRefundHandler = new WorldpayRefundHandler(refundGatewayClient, GATEWAY_URL_MAP);
+    }
+    
+    @Test
+    void test_refund_request_contains_reference() throws Exception {
+        ChargeEntity chargeEntity = chargeEntityFixture.withTransactionId("transaction-id").build();
+        RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity().build();
+
+        when(refundGatewayClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
+                .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
+
+        worldpayRefundHandler.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity));
+
+        String expectedRefundRequest =
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                        "<!DOCTYPE paymentService PUBLIC \"-//WorldPay//DTD WorldPay PaymentService v1//EN\"\n" +
+                        "        \"http://dtd.worldpay.com/paymentService_v1.dtd\">\n" +
+                        "<paymentService version=\"1.4\" merchantCode=\"MERCHANTCODE\">\n" +
+                        "    <modify>\n" +
+                        "        <orderModification orderCode=\"transaction-id\">\n" +
+                        "            <refund reference=\"" + refundEntity.getExternalId() + "\">\n" +
+                        "                <amount currencyCode=\"GBP\" exponent=\"2\" value=\"500\"/>\n" +
+                        "            </refund>\n" +
+                        "        </orderModification>\n" +
+                        "    </modify>\n" +
+                        "</paymentService>\n" +
+                        "";
+
+        verify(refundGatewayClient).postRequestFor(
+                eq(WORLDPAY_URL),
+                eq(gatewayAccountEntity),
+                argThat(argument -> argument.getPayload().equals(expectedRefundRequest) &&
+                        argument.getOrderRequestType().equals(OrderRequestType.REFUND)),
+                anyMap());
+    }
+
+    private GatewayAccountEntity aServiceAccount() {
+        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+        gatewayAccount.setId(1L);
+        gatewayAccount.setGatewayName("worldpay");
+        gatewayAccount.setRequires3ds(false);
+        gatewayAccount.setCredentials(Map.of(
+                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                CREDENTIALS_USERNAME, "worldpay-password",
+                CREDENTIALS_PASSWORD, "password"
+        ));
+        gatewayAccount.setType(TEST);
+        return gatewayAccount;
+    }
+}


### PR DESCRIPTION
Initialise WorldpayPaymentProvider with its required dependencies, rather than
creating them within its constructor. This will make it easier to test future
functionality. For example, an authorisation request will need to be retried if
worldpay soft declines an exemption request. In this case all we'd need to test
is that `WorldpayAuthoriseHandler.authorise` is called twice.

It also improves on what we had before, where we had to mock internal
dependencies which is bad practice and makes reading tests difficult.

