### PR TITLE
bau: Use single instance of ObjectMapper

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-15T18:11:35Z",
+  "generated_at": "2020-12-17T11:38:55Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -168,14 +168,14 @@
         "hashed_secret": "c2baab12724c0f29014dc172042a17ebbd9b60d4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 99,
+        "line_number": 108,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "4991aba1cb28cabc042aa415f2689cf359bb4af2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 109,
         "type": "Secret Keyword"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
@@ -14,6 +14,8 @@ import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIEL
 
 public class JsonPatchRequest {
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     private JsonPatchOp op;
     private String path;
     private JsonNode value;
@@ -55,7 +57,7 @@ public class JsonPatchRequest {
         if (value != null) {
             if ((value.isTextual() && !isEmpty(value.asText())) || (!value.isNull() && value.isObject())) {
                 try {
-                    return new ObjectMapper().readValue(value.traverse(), new TypeReference<Map<String, String>>() {});
+                    return objectMapper.readValue(value.traverse(), new TypeReference<Map<String, String>>() {});
                 } catch (IOException e) {
                     throw new RuntimeException("Malformed JSON object in value", e);
                 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
@@ -38,6 +38,7 @@ public class SmartpayNotificationService {
     private final RefundNotificationProcessor refundNotificationProcessor;
     private final IpAddressMatcher ipAddressMatcher;
     private final Set<String> allowedSmartpayIpAddresses;
+    private final ObjectMapper objectMapper;
 
     private static final String PAYMENT_GATEWAY_NAME = SMARTPAY.getName();
 
@@ -47,13 +48,15 @@ public class SmartpayNotificationService {
                                        RefundNotificationProcessor refundNotificationProcessor,
                                        GatewayAccountService gatewayAccountService,
                                        IpAddressMatcher ipAddressMatcher,
-                                       @Named("AllowedSmartpayIpAddresses") Set<String> allowedSmartpayIpAddresses) {
+                                       @Named("AllowedSmartpayIpAddresses") Set<String> allowedSmartpayIpAddresses, 
+                                       ObjectMapper objectMapper) {
         this.chargeService = chargeService;
         this.chargeNotificationProcessor = chargeNotificationProcessor;
         this.refundNotificationProcessor = refundNotificationProcessor;
         this.gatewayAccountService = gatewayAccountService;
         this.ipAddressMatcher = ipAddressMatcher;
         this.allowedSmartpayIpAddresses = allowedSmartpayIpAddresses;
+        this.objectMapper = objectMapper;
     }
 
     @Transactional
@@ -169,14 +172,12 @@ public class SmartpayNotificationService {
 
     private List<SmartpayNotification> parseNotification(String payload) throws SmartpayParseException {
         try {
-            ObjectMapper objectMapper = new ObjectMapper();
             // TODO for authorisation notifications, this does the wrong thing
             // Transaction ID is pspReference, not originalReference as the code below assumes
             // https://www.barclaycard.co.uk/business/files/SmartPay_Notifications_Guide.pdf
             // We will set the transaction ID to blank, which makes the notification effectively useless
             // This is OK at the moment because we ignore authorisation notifications for Smartpay
-            return objectMapper.readValue(payload, SmartpayNotificationList.class)
-                    .getNotifications();
+            return objectMapper.readValue(payload, SmartpayNotificationList.class).getNotifications();
         } catch (Exception e) {
             throw new SmartpayParseException(e);
         }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationService.java
@@ -94,12 +94,13 @@ public class StripeNotificationService {
                                      PayoutReconcileQueue payoutReconcileQueue,
                                      PayoutEmitterService payoutEmitterService,
                                      IpAddressMatcher ipAddressMatcher,
-                                     @Named("AllowedStripeIpAddresses") Set<String> allowedStripeIpAddresses) {
+                                     @Named("AllowedStripeIpAddresses") Set<String> allowedStripeIpAddresses,
+                                     ObjectMapper objectMapper) {
         this.card3dsResponseAuthService = card3dsResponseAuthService;
         this.chargeService = chargeService;
         this.stripeAccountUpdatedHandler = stripeAccountUpdatedHandler;
         this.payoutReconcileQueue = payoutReconcileQueue;
-        objectMapper = new ObjectMapper();
+        this.objectMapper = objectMapper;
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.payoutEmitterService = payoutEmitterService;
         this.ipAddressMatcher = ipAddressMatcher;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/util/CredentialsConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/util/CredentialsConverter.java
@@ -13,12 +13,15 @@ import java.util.Map;
 
 @Converter
 public class CredentialsConverter implements AttributeConverter<Map<String,String>, PGobject> {
+    
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public PGobject convertToDatabaseColumn(Map<String,String> credentials) {
         PGobject pgCredentials = new PGobject();
         pgCredentials.setType("json");
         try {
-            pgCredentials.setValue(new ObjectMapper().writeValueAsString(credentials));
+            pgCredentials.setValue(objectMapper.writeValueAsString(credentials));
         } catch (SQLException | JsonProcessingException e) {
             throw new RuntimeException(e);
         }
@@ -28,7 +31,7 @@ public class CredentialsConverter implements AttributeConverter<Map<String,Strin
     @Override
     public Map<String,String> convertToEntityAttribute(PGobject dbCredentials) {
         try {
-            return new ObjectMapper().readValue(dbCredentials.toString(), new TypeReference<Map<String, String>>() {});
+            return objectMapper.readValue(dbCredentials.toString(), new TypeReference<>() {});
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/util/JsonToMapConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/util/JsonToMapConverter.java
@@ -15,13 +15,16 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 @Converter
 public class JsonToMapConverter implements AttributeConverter<Map<String, String>, PGobject> {
+    
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public PGobject convertToDatabaseColumn(Map<String, String> keyValueMap) {
         PGobject pGobject = new PGobject();
         pGobject.setType("json");
         if(null != keyValueMap && !keyValueMap.isEmpty()) {
             try {
-                pGobject.setValue(new ObjectMapper().writeValueAsString(keyValueMap));
+                pGobject.setValue(objectMapper.writeValueAsString(keyValueMap));
             } catch (SQLException | JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
@@ -33,7 +36,7 @@ public class JsonToMapConverter implements AttributeConverter<Map<String, String
     public Map<String, String> convertToEntityAttribute(PGobject pgObject) {
         try {
             if (pgObject != null && !isEmpty(pgObject.toString())) {
-                return new ObjectMapper().readValue(pgObject.toString(), new TypeReference<Map<String, String>>() {});
+                return objectMapper.readValue(pgObject.toString(), new TypeReference<Map<String, String>>() {});
             }
             return null;
 

--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -30,6 +30,8 @@ import static uk.gov.pay.connector.model.domain.RefundTransactionsForPaymentFixt
 
 public class LedgerStub {
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
     public void returnLedgerTransaction(String externalId, DatabaseFixtures.TestCharge testCharge, DatabaseFixtures.TestFee testFee) throws JsonProcessingException {
         Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge, testFee);
         stubResponse(externalId, ledgerTransactionFields);
@@ -39,7 +41,7 @@ public class LedgerStub {
         ResponseDefinitionBuilder response = aResponse()
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                 .withStatus(200)
-                .withBody(new ObjectMapper().writeValueAsString(ledgerTransaction));
+                .withBody(objectMapper.writeValueAsString(ledgerTransaction));
         stubFor(
                 get(urlPathEqualTo(format("/v1/transaction/%s", externalId)))
                         .withQueryParam("override_account_id_restriction", equalTo("true"))
@@ -77,7 +79,7 @@ public class LedgerStub {
         Map<String, Object> ledgerTransactionFields = testChargeToLedgerTransactionJson(testCharge, null);
         String body = null;
 
-        new ObjectMapper().writeValueAsString(ledgerTransactionFields);
+        objectMapper.writeValueAsString(ledgerTransactionFields);
 
         stubResponseForProviderAndGatewayTransactionId(testCharge.getTransactionId(),
                 paymentProvider,
@@ -93,7 +95,7 @@ public class LedgerStub {
         ResponseDefinitionBuilder response = aResponse()
                 .withStatus(200)
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)
-                .withBody(new ObjectMapper().writeValueAsString(refundTransactionsForPayment));
+                .withBody(objectMapper.writeValueAsString(refundTransactionsForPayment));
 
         String url = format("/v1/transaction/%s/transaction", chargeExternalId);
         stubFor(WireMock.get(urlPathEqualTo(url))
@@ -115,7 +117,7 @@ public class LedgerStub {
                 .withStatus(status);
 
         if (nonNull(ledgerTransactionFields) && ledgerTransactionFields.size() > 0) {
-            responseDefBuilder.withBody(new ObjectMapper().writeValueAsString(ledgerTransactionFields));
+            responseDefBuilder.withBody(objectMapper.writeValueAsString(ledgerTransactionFields));
         }
         stubFor(
                 get(urlPathEqualTo(format("/v1/transaction/gateway-transaction/%s", gatewayTransactionId)))
@@ -130,7 +132,7 @@ public class LedgerStub {
         ResponseDefinitionBuilder responseDefBuilder = aResponse()
                 .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                 .withStatus(200)
-                .withBody(new ObjectMapper().writeValueAsString(ledgerTransactionFields));
+                .withBody(objectMapper.writeValueAsString(ledgerTransactionFields));
         stubFor(
                 get(urlPathEqualTo(format("/v1/transaction/%s", externalId)))
                         .withQueryParam("override_account_id_restriction", equalTo("true"))

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,8 +81,8 @@ class SmartpayNotificationServiceTest {
                 mockRefundNotificationProcessor,
                 mockGatewayAccountService,
                 new IpAddressMatcher(new InetAddressValidator()),
-                ALLOWED_IP_ADDRESSES
-        );
+                ALLOWED_IP_ADDRESSES,
+                new ObjectMapper());
         charge = Charge.from(ChargeEntityFixture.aValidChargeEntity()
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -77,6 +77,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYOUT
 class StripeNotificationServiceTest {
     private static final String FORWARDED_IP_ADDRESSES = "1.2.3.4, 102.108.0.6";
     private static final Set<String> ALLOWED_IP_ADDRESSES = CidrUtils.getIpAddresses(Set.of("1.2.3.0/24", "9.9.9.9/32"));
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     private StripeNotificationService notificationService;
 
@@ -101,7 +102,7 @@ class StripeNotificationServiceTest {
     @Captor
     private ArgumentCaptor<Payout> payoutArgumentCaptor;
 
-    private StripeAccountUpdatedHandler stripeAccountUpdatedHandler = new StripeAccountUpdatedHandler(new ObjectMapper());
+    private StripeAccountUpdatedHandler stripeAccountUpdatedHandler = new StripeAccountUpdatedHandler(objectMapper);
 
     private final String externalId = "external-id";
     private final String sourceId = "source-id";
@@ -118,7 +119,8 @@ class StripeNotificationServiceTest {
                 mockPayoutReconcileQueue,
                 mockPayoutEmitterService,
                 new IpAddressMatcher(new InetAddressValidator()),
-                ALLOWED_IP_ADDRESSES);
+                ALLOWED_IP_ADDRESSES,
+                objectMapper);
 
         lenient().when(stripeGatewayConfig.getWebhookSigningSecrets()).thenReturn(List.of(webhookLiveSigningSecret, webhookTestSigningSecret));
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gatewayaccount.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
@@ -30,13 +29,11 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.FIELD_NOT
 public class GatewayAccountRequestValidatorTest {
 
     private GatewayAccountRequestValidator validator;
-
-    private ObjectMapper objectMapper;
+    private ObjectMapper objectMapper = new ObjectMapper();
 
     @Before
     public void before() {
         validator = new GatewayAccountRequestValidator(new RequestValidator());
-        objectMapper = new ObjectMapper();
     }
 
     @Test
@@ -81,7 +78,7 @@ public class GatewayAccountRequestValidatorTest {
 
         if (value != null) patch.put(FIELD_VALUE, value);
 
-        JsonNode jsonNode = new ObjectMapper().valueToTree(patch);
+        JsonNode jsonNode = objectMapper.valueToTree(patch);
         try {
             validator.validatePatchRequest(jsonNode);
             fail("Expected ValidationException");
@@ -93,9 +90,8 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenFieldsAreMissing() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
-                        FIELD_OPERATION_PATH, "notify_settings"));
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace", FIELD_OPERATION_PATH, "notify_settings"));
         try {
             validator.validatePatchRequest(jsonNode);
             fail("Expected ValidationException");
@@ -108,10 +104,10 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenFieldsNotValidInValue() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
                         FIELD_OPERATION_PATH, "notify_settings",
-                        FIELD_VALUE, ImmutableMap.of("timbuktu", "anapitoken",
+                        FIELD_VALUE, Map.of("timbuktu", "anapitoken",
                                 "colombo", "atemplateid")));
         try {
             validator.validatePatchRequest(jsonNode);
@@ -127,7 +123,7 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenInvalidPathOnOperation() {
-        JsonNode jsonNode = objectMapper.valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(Map.of(FIELD_OPERATION, "replace",
                 FIELD_OPERATION_PATH, "service_name"));
         try {
             validator.validatePatchRequest(jsonNode);
@@ -140,9 +136,8 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenEmailCollectionModeIsInvalid() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
                         FIELD_OPERATION_PATH, "email_collection_mode",
                         FIELD_VALUE, "someValue"));
         try {
@@ -156,10 +151,10 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldNotThrow_whenAllValidationsPassed() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
                         FIELD_OPERATION_PATH, "notify_settings",
-                        FIELD_VALUE, ImmutableMap.of(
+                        FIELD_VALUE, Map.of(
                                 FIELD_NOTIFY_API_TOKEN, "anapitoken",
                                 FIELD_NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID, "atemplateid",
                                 FIELD_NOTIFY_REFUND_ISSUED_TEMPLATE_ID, "anothertemplateid")));
@@ -169,9 +164,8 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldNotThrow_whenPathIsValidEmailCollectionMode() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace", 
                         FIELD_OPERATION_PATH, "email_collection_mode",
                         FIELD_VALUE, "MANDATORY"));
         validator.validatePatchRequest(jsonNode);
@@ -179,10 +173,10 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenInvalidOperation() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "delete",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "delete",
                         FIELD_OPERATION_PATH, "notify_settings",
-                        FIELD_VALUE, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "anapitoken",
+                        FIELD_VALUE, Map.of(FIELD_NOTIFY_API_TOKEN, "anapitoken", 
                                 FIELD_NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID, "atemplateid")));
         try {
             validator.validatePatchRequest(jsonNode);
@@ -195,17 +189,17 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldIgnoreEmptyOrMissingValue_whenRemoveOperation() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "remove",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "remove",
                         FIELD_OPERATION_PATH, "notify_settings",
-                        FIELD_VALUE, ImmutableMap.of(FIELD_NOTIFY_API_TOKEN, "")));
+                        FIELD_VALUE, Map.of(FIELD_NOTIFY_API_TOKEN, "")));
         validator.validatePatchRequest(jsonNode);
     }
 
     @Test
     public void shouldThrow_whenCorporateCreditSurchargeAmountIsInvalid() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
                         FIELD_OPERATION_PATH, "corporate_credit_card_surcharge_amount",
                         FIELD_VALUE, -100));
         try {
@@ -219,8 +213,8 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenIncorrectOperationForCorporateDebitSurchargeAmount() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "remove",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "remove",
                         FIELD_OPERATION_PATH, "corporate_debit_card_surcharge_amount",
                         FIELD_VALUE, 250));
         try {
@@ -235,8 +229,8 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenInvalidValueForCorporatePrepaidCreditSurchargeAmount() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
                         FIELD_OPERATION_PATH, "corporate_prepaid_credit_card_surcharge_amount",
                         FIELD_VALUE, "not zero or a positive number that can be represented as a long"));
         try {
@@ -251,9 +245,8 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenMissingValueForCorporatePrepaidDebitSurchargeAmount() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
-                        FIELD_OPERATION_PATH, "corporate_prepaid_debit_card_surcharge_amount"));
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace", FIELD_OPERATION_PATH, "corporate_prepaid_debit_card_surcharge_amount"));
         try {
             validator.validatePatchRequest(jsonNode);
             fail("Expected ValidationException");
@@ -269,7 +262,7 @@ public class GatewayAccountRequestValidatorTest {
         valueMap.put("op", "replace");
         valueMap.put("path", "corporate_prepaid_debit_card_surcharge_amount");
         valueMap.put("value", null);
-        JsonNode jsonNode = new ObjectMapper().valueToTree(valueMap);
+        JsonNode jsonNode = objectMapper.valueToTree(valueMap);
         try {
             validator.validatePatchRequest(jsonNode);
             fail("Expected ValidationException");
@@ -281,8 +274,8 @@ public class GatewayAccountRequestValidatorTest {
 
     @Test
     public void shouldThrow_whenEmptyValueForCorporatePrepaidDebitSurchargeAmount() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(FIELD_OPERATION, "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of(FIELD_OPERATION, "replace",
                         FIELD_OPERATION_PATH, "corporate_prepaid_debit_card_surcharge_amount",
                         FIELD_VALUE, ""));
         try {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gatewayaccount.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,10 +26,9 @@ import static org.mockito.Mockito.when;
 public class GatewayAccountResourceValidationTest {
 
     private static ConnectorConfiguration mockConnectorConfiguration = mock(ConnectorConfiguration.class);
-
     private static WorldpayConfig mockWorldpayConfig = mock(WorldpayConfig.class);
-
     private static GatewayConfig mockGatewayConfig = mock(GatewayConfig.class);
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     static {
         when(mockWorldpayConfig.getCredentials()).thenReturn(List.of());
@@ -60,7 +58,7 @@ public class GatewayAccountResourceValidationTest {
     @Test
     public void shouldReturn422_whenProviderAccountTypeIsInvalid() {
 
-        Map<String, Object> payload = ImmutableMap.of("type", "invalid");
+        Map<String, Object> payload = Map.of("type", "invalid");
 
         Response response = resources.client()
                 .target("/v1/api/accounts")
@@ -76,7 +74,7 @@ public class GatewayAccountResourceValidationTest {
     @Test
     public void shouldReturn422_whenPaymentProviderIsInvalid() {
 
-        Map<String, Object> payload = ImmutableMap.of("payment_provider", "blockchain");
+        Map<String, Object> payload = Map.of("payment_provider", "blockchain");
 
         Response response = resources.client()
                 .target("/v1/api/accounts")
@@ -91,8 +89,8 @@ public class GatewayAccountResourceValidationTest {
 
     @Test
     public void shouldReturn400_whenCorporateDebitCardSurchargeOperationIsInvalid() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of("op", "add",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of("op", "add",
                         "path", "corporate_debit_card_surcharge_amount",
                         "value", 250));
         Response response = resources.client()
@@ -106,10 +104,8 @@ public class GatewayAccountResourceValidationTest {
 
     @Test
     public void shouldReturn400_whenCorporatePrepaidCreditCardSurchargeOperationIsMissing() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        "path", "corporate_prepaid_credit_card_surcharge_amount",
-                        "value", 250));
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of("path", "corporate_prepaid_credit_card_surcharge_amount","value", 250));
         Response response = resources.client()
                 .target("/v1/api/accounts/12")
                 .request()
@@ -121,8 +117,8 @@ public class GatewayAccountResourceValidationTest {
 
     @Test
     public void shouldReturn400_whenCorporateCreditCardSurchargeAmountIsNegativeValue() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of("op", "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of("op", "replace",
                         "path", "corporate_credit_card_surcharge_amount",
                         "value", -100));
         Response response = resources.client()
@@ -137,8 +133,8 @@ public class GatewayAccountResourceValidationTest {
 
     @Test
     public void shouldReturn400_whenCorporateDebditCardSurchargeAmountIsInvalidValue() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of("op", "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of("op", "replace",
                         "path", "corporate_debit_card_surcharge_amount",
                         "value", "not zero or a positive number that can be represented as a long"));
         Response response = resources.client()
@@ -153,9 +149,8 @@ public class GatewayAccountResourceValidationTest {
 
     @Test
     public void shouldReturn400_whenCorporatePrepaidCreditCardSurchargeAmountValueIsMissing() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of("op", "replace",
-                        "path", "corporate_prepaid_credit_card_surcharge_amount"));
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of("op", "replace","path", "corporate_prepaid_credit_card_surcharge_amount"));
         Response response = resources.client()
                 .target("/v1/api/accounts/12")
                 .request()
@@ -167,8 +162,8 @@ public class GatewayAccountResourceValidationTest {
 
     @Test
     public void shouldReturn400_whenCorporateCreditCardSurchargeAmountValueIsEmpty() {
-        JsonNode jsonNode = new ObjectMapper()
-                .valueToTree(ImmutableMap.of("op", "replace",
+        JsonNode jsonNode = objectMapper.valueToTree(
+                Map.of("op", "replace",
                         "path", "corporate_credit_card_surcharge_amount",
                         "value", ""));
         Response response = resources.client()
@@ -187,7 +182,7 @@ public class GatewayAccountResourceValidationTest {
         valueMap.put("op", "replace");
         valueMap.put("path", "corporate_prepaid_debit_card_surcharge_amount");
         valueMap.put("value", null);
-        JsonNode jsonNode = new ObjectMapper().valueToTree(valueMap);
+        JsonNode jsonNode = objectMapper.valueToTree(valueMap);
         Response response = resources.client()
                 .target("/v1/api/accounts/12")
                 .request()
@@ -203,7 +198,7 @@ public class GatewayAccountResourceValidationTest {
         valueMap.put("op", "replace");
         valueMap.put("path", "allow_zero_amount");
         valueMap.put("value", null);
-        JsonNode jsonNode = new ObjectMapper().valueToTree(valueMap);
+        JsonNode jsonNode = objectMapper.valueToTree(valueMap);
         Response response = resources.client()
                 .target("/v1/api/accounts/12")
                 .request()
@@ -219,7 +214,7 @@ public class GatewayAccountResourceValidationTest {
         valueMap.put("op", "replace");
         valueMap.put("path", "allow_zero_amount");
         valueMap.put("value", "false");
-        JsonNode jsonNode = new ObjectMapper().valueToTree(valueMap);
+        JsonNode jsonNode = objectMapper.valueToTree(valueMap);
         Response response = resources.client()
                 .target("/v1/api/accounts/12")
                 .request()

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.gatewayaccount.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
@@ -25,6 +24,7 @@ import static org.junit.Assert.assertThrows;
 public class StripeAccountSetupRequestValidatorTest {
 
     private final StripeAccountSetupRequestValidator validator = new StripeAccountSetupRequestValidator(new RequestValidator());
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Parameters({
             "replace, bank_account, true",
@@ -38,7 +38,7 @@ public class StripeAccountSetupRequestValidatorTest {
     })
     @Test
     public void shouldAllowReplaceOperationForValidPathsAndValues(String operation, String path, boolean value) {
-        JsonNode jsonNode = new ObjectMapper().valueToTree(Collections.singletonList(ImmutableMap.of(
+        JsonNode jsonNode = objectMapper.valueToTree(Collections.singletonList(Map.of(
                 "op", operation,
                 "path", path,
                 "value", value)));
@@ -92,21 +92,21 @@ public class StripeAccountSetupRequestValidatorTest {
             params.put("value", data.get("value"));
         }
 
-        return new ObjectMapper().valueToTree(Collections.singletonList(params));
+        return objectMapper.valueToTree(Collections.singletonList(params));
     }
 
     @Test
     public void multipleUpdatesAreValid() {
-        JsonNode jsonNode = new ObjectMapper().valueToTree(Arrays.asList(
-                ImmutableMap.of(
+        JsonNode jsonNode = objectMapper.valueToTree(Arrays.asList(
+                Map.of(
                         "op", "replace",
                         "path", "bank_account",
                         "value", true),
-                ImmutableMap.of(
+                Map.of(
                         "op", "replace",
                         "path", "responsible_person",
                         "value", false),
-                ImmutableMap.of(
+                Map.of(
                         "op", "replace",
                         "path", "vat_number",
                         "value", true)
@@ -117,7 +117,7 @@ public class StripeAccountSetupRequestValidatorTest {
 
     @Test
     public void notAnArrayIsInvalid() {
-        JsonNode jsonNode = new ObjectMapper().valueToTree(ImmutableMap.of(
+        JsonNode jsonNode = objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "bank_account",
                 "value", true));

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.it.contract;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -26,7 +25,6 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
-import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import static java.util.UUID.randomUUID;
 import static junit.framework.TestCase.assertTrue;
@@ -54,7 +52,6 @@ public class StripePaymentProviderTest {
 
     private static final Long chargeAmount = 500L;
     private GatewayAccountEntity gatewayAccountEntity;
-    private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
 
     @Before
     public void setup() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.it.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import io.restassured.response.Response;
 import junitparams.Parameters;
 import org.apache.http.HttpStatus;
@@ -33,12 +32,14 @@ import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class ChargesApiResourceAllowWebPaymentsIT {
     
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     private String accountId;
     private String chargeId;
 
     @DropwizardTestContext
     protected TestContext testContext;
-    
+
     @Before
     public void setup() {
         accountId = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
@@ -85,7 +86,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
     @Test
     public void assertBadRequestResponseIfPatchingMerchantIdWithNoGatewayAccountCredentials() throws JsonProcessingException {
         String accountIdWithoutGatewayAccountCredentials = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "worldpay"));
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "add",
                 "path", "credentials/gateway_merchant_id",
                 "value", "94b53bf6b12b6c5"));
         given().port(testContext.getPort()).contentType(JSON)
@@ -100,7 +101,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
     @Test
     public void assertBadRequestResponseIfPatchingDigitalWalletWithNonSupportedGateway() throws JsonProcessingException {
         String accountIdWithNotDigitalWalletSupportedGateway = extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "epdq"));
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "allow_apple_pay",
                 "value", true));
         given().port(testContext.getPort()).contentType(JSON)
@@ -114,7 +115,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
     }
 
     private void allowWebPaymentsOnGatewayAccount(String path) throws JsonProcessingException {
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", path,
                 "value", true));
 
@@ -126,7 +127,7 @@ public class ChargesApiResourceAllowWebPaymentsIT {
     }
     
     private void addGatewayMerchantIdToGatewayAccount(String accountId) throws JsonProcessingException {
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "add",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "add",
                 "path", "credentials/gateway_merchant_id",
                 "value", "94b53bf6b12b6c5"));
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.it.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import io.restassured.http.ContentType;
 import org.hamcrest.core.Is;
 import org.junit.Test;
@@ -12,6 +11,8 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+
+import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -31,6 +32,9 @@ import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
+    
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     private DatabaseFixtures.TestAccount defaultTestAccount;
 
     @Test
@@ -365,7 +369,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void createValidNotificationCredentials_responseShouldBe200_Ok() {
         String gatewayAccountId = createAGatewayAccountFor("smartpay");
         givenSetup()
-                .body(toJson(ImmutableMap.of("username", "bob", "password", "bobsbigsecret")))
+                .body(toJson(Map.of("username", "bob", "password", "bobsbigsecret")))
                 .post("/v1/api/accounts/" + gatewayAccountId + "/notification-credentials")
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -375,7 +379,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void patchGatewayAccountAnalyticsId_responseShouldBe200_Ok() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
         givenSetup()
-                .body(toJson(ImmutableMap.of("analytics_id", "new-id")))
+                .body(toJson(Map.of("analytics_id", "new-id")))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/description-analytics-id")
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -391,7 +395,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void patchGatewayAccountDescription_responseShouldBe200_Ok() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
         givenSetup()
-                .body(toJson(ImmutableMap.of("description", "new-desc")))
+                .body(toJson(Map.of("description", "new-desc")))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/description-analytics-id")
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -407,7 +411,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void patchGatewayAccountDescriptionAndAnalyticsId_responseShouldBe200_Ok() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
         givenSetup()
-                .body(toJson(ImmutableMap.of("analytics_id", "new-id", "description", "new-desc")))
+                .body(toJson(Map.of("analytics_id", "new-id", "description", "new-desc")))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/description-analytics-id")
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -424,7 +428,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void patchGatewayAccountDescriptionAndAnalyticsIdEmpty_responseShouldReturn400() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
         givenSetup()
-                .body(toJson(ImmutableMap.of()))
+                .body(toJson(Map.of()))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/description-analytics-id")
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
@@ -440,7 +444,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void shouldToggle3dsToTrue() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
         givenSetup()
-                .body(toJson(ImmutableMap.of("toggle_3ds", true)))
+                .body(toJson(Map.of("toggle_3ds", true)))
                 .patch("/v1/frontend/accounts/" + gatewayAccountId + "/3ds-toggle")
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -491,7 +495,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void shouldToggle3dsToFalse() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "old-desc", "old-id");
         givenSetup()
-                .body(toJson(ImmutableMap.of("toggle_3ds", false)))
+                .body(toJson(Map.of("toggle_3ds", false)))
                 .patch("/v1/frontend/accounts/" + gatewayAccountId + "/3ds-toggle")
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -508,7 +512,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
         String maestroCardTypeId = databaseTestHelper.getCardTypeId("maestro", "DEBIT");
 
         givenSetup()
-                .body(toJson(ImmutableMap.of("toggle_3ds", true)))
+                .body(toJson(Map.of("toggle_3ds", true)))
                 .patch("/v1/frontend/accounts/" + gatewayAccountId + "/3ds-toggle")
                 .then()
                 .statusCode(OK.getStatusCode());
@@ -520,7 +524,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .statusCode(OK.getStatusCode());
 
         givenSetup()
-                .body(toJson(ImmutableMap.of("toggle_3ds", false)))
+                .body(toJson(Map.of("toggle_3ds", false)))
                 .patch("/v1/frontend/accounts/" + gatewayAccountId + "/3ds-toggle")
                 .then()
                 .statusCode(CONFLICT.getStatusCode());
@@ -530,7 +534,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void whenNotificationCredentialsInvalidKeys_shouldReturn400() {
         String gatewayAccountId = createAGatewayAccountFor("smartpay");
         givenSetup()
-                .body(toJson(ImmutableMap.of("bob", "bob", "bobby", "bobsbigsecret")))
+                .body(toJson(Map.of("bob", "bob", "bobby", "bobsbigsecret")))
                 .post("/v1/api/accounts/" + gatewayAccountId + "/notification-credentials")
                 .then()
                 .statusCode(BAD_REQUEST.getStatusCode());
@@ -540,7 +544,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void whenNotificationCredentialsInvalidValues_shouldReturn400() {
         String gatewayAccountId = createAGatewayAccountFor("smartpay");
         givenSetup()
-                .body(toJson(ImmutableMap.of("username", "bob", "password", "tooshort")))
+                .body(toJson(Map.of("username", "bob", "password", "tooshort")))
                 .post("/v1/api/accounts/" + gatewayAccountId + "/notification-credentials")
                 .then()
                 .contentType(ContentType.JSON)
@@ -552,9 +556,9 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn200_whenNotifySettingsIsUpdated() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "notify_settings",
-                "value", ImmutableMap.of("api_token", "anapitoken",
+                "value", Map.of("api_token", "anapitoken",
                         "template_id", "atemplateid",
                         "refund_issued_template_id", "anothertemplate")));
         givenSetup()
@@ -567,9 +571,9 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn400_whenNotifySettingsIsUpdated_withWrongOp() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "insert",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "insert",
                 "path", "notify_settings",
-                "value", ImmutableMap.of("api_token", "anapitoken",
+                "value", Map.of("api_token", "anapitoken",
                         "template_id", "atemplateid")));
         givenSetup()
                 .body(payload)
@@ -581,7 +585,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn200_whenBlockPrepaidCardsIsUpdated() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "block_prepaid_cards",
                 "value", true));
         givenSetup()
@@ -600,7 +604,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn200_whenEmailCollectionModeIsUpdated() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "email_collection_mode",
                 "value", "OFF"));
         givenSetup()
@@ -613,7 +617,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn400_whenEmailCollectionModeIsUpdated_withWrongValue() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "email_collection_mode",
                 "value", "nope"));
         givenSetup()
@@ -626,9 +630,9 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn404ForNotifySettings_whenGatewayAccountIsNonExistent() throws Exception {
         String gatewayAccountId = "1000023";
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "notify_settings",
-                "value", ImmutableMap.of("api_token", "anapitoken",
+                "value", Map.of("api_token", "anapitoken",
                         "template_id", "atemplateid",
                         "refund_issued_template_id", "anothertemplate")));
         givenSetup()
@@ -641,9 +645,9 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn200_whenNotifySettingsIsRemoved() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "notify_settings",
-                "value", ImmutableMap.of("api_token", "anapitoken",
+                "value", Map.of("api_token", "anapitoken",
                         "template_id", "atemplateid",
                         "refund_issued_template_id", "anothertemplate")));
         givenSetup()
@@ -652,7 +656,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .then()
                 .statusCode(OK.getStatusCode());
 
-        payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "remove",
+        payload = objectMapper.writeValueAsString(Map.of("op", "remove",
                 "path", "notify_settings"));
 
         givenSetup()
@@ -665,7 +669,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn400_whenNotifySettingsIsRemoved_withWrongPath() throws Exception {
         String gatewayAccountId = createAGatewayAccountFor("worldpay");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "insert",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "insert",
                 "path", "notify_setting"));
         givenSetup()
                 .body(payload)
@@ -677,7 +681,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void patchGatewayAccount_forCorporateCreditCardSurcharge() throws JsonProcessingException {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "corporate_credit_card_surcharge_amount",
                 "value", 100));
         givenSetup()
@@ -704,7 +708,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void patchGatewayAccount_forCorporateDebitCardSurcharge() throws JsonProcessingException {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "corporate_debit_card_surcharge_amount",
                 "value", 200));
         givenSetup()
@@ -731,7 +735,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void patchGatewayAccount_forCorporatePrepaidCreditCardSurcharge() throws JsonProcessingException {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "corporate_prepaid_credit_card_surcharge_amount",
                 "value", 300));
         givenSetup()
@@ -758,7 +762,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void patchGatewayAccount_forCorporatePrepaidDebitCardSurcharge() throws JsonProcessingException {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "corporate_prepaid_debit_card_surcharge_amount",
                 "value", 400));
         givenSetup()
@@ -785,7 +789,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     @Test
     public void shouldReturn404ForCorporateSurcharge_whenGatewayAccountIsNonExistent() throws Exception {
         String gatewayAccountId = "1000023";
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", "replace",
+        String payload = objectMapper.writeValueAsString(Map.of("op", "replace",
                 "path", "corporate_credit_card_surcharge_amount",
                 "value", 100));
         givenSetup()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayMerchantIdIT.java
@@ -26,6 +26,8 @@ import static uk.gov.pay.connector.it.util.ChargeUtils.createChargePostBody;
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class GatewayMerchantIdIT {
+    
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @DropwizardTestContext
     protected TestContext testContext;
@@ -86,7 +88,7 @@ public class GatewayMerchantIdIT {
     }
 
     private void patch(String accountId, String gatewayMerchantId, String op) throws JsonProcessingException {
-        String payload = new ObjectMapper().writeValueAsString(ImmutableMap.of("op", op,
+        String payload = objectMapper.writeValueAsString(ImmutableMap.of("op", op,
                 "path", "credentials/gateway_merchant_id",
                 "value", gatewayMerchantId));
         

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqCardResourceIT.java
@@ -36,6 +36,8 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class EpdqCardResourceIT extends ChargingITestBase {
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     private String authorisationDetails = buildJsonAuthorisationDetailsFor("4444333322221111", "visa");
     private String validApplePayAuthorisationDetails = buildJsonApplePayAuthorisationDetails("mr payment", "mr@payment.test");
 
@@ -86,7 +88,7 @@ public class EpdqCardResourceIT extends ChargingITestBase {
         Map<String, String> payload = ImmutableMap.of("auth_3ds_result", AUTHORISED.name());
 
         givenSetup()
-                .body(new ObjectMapper().writeValueAsString(payload))
+                .body(objectMapper.writeValueAsString(payload))
                 .post(authorise3dsChargeUrlFor(chargeId))
                 .then()
                 .statusCode(200);

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayCardResourceIT.java
@@ -43,6 +43,8 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml", withDockerSQS = true)
 public class SmartpayCardResourceIT extends ChargingITestBase {
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     private String validCardDetails = buildCardDetailsWith("737");
     private String validApplePayAuthorisationDetails = buildJsonApplePayAuthorisationDetails("mr payment", "mr@payment.test");
 
@@ -101,7 +103,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
         smartpayMockClient.mock3dsAuthorisationSuccess();
 
         givenSetup()
-                .body(new ObjectMapper().writeValueAsString(get3dsPayload()))
+                .body(objectMapper.writeValueAsString(get3dsPayload()))
                 .post(authorise3dsChargeUrlFor(chargeId))
                 .then()
                 .statusCode(200);
@@ -116,7 +118,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
         smartpayMockClient.mock3dsAuthorisationFailure();
 
         givenSetup()
-                .body(new ObjectMapper().writeValueAsString(get3dsPayload()))
+                .body(objectMapper.writeValueAsString(get3dsPayload()))
                 .post(authorise3dsChargeUrlFor(chargeId))
                 .then()
                 .statusCode(400);
@@ -131,7 +133,7 @@ public class SmartpayCardResourceIT extends ChargingITestBase {
         smartpayMockClient.mockServerFault();
 
         givenSetup()
-                .body(new ObjectMapper().writeValueAsString(get3dsPayload()))
+                .body(objectMapper.writeValueAsString(get3dsPayload()))
                 .post(authorise3dsChargeUrlFor(chargeId))
                 .then()
                 .statusCode(500);

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
@@ -11,7 +11,6 @@ import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.gateway.stripe.StripeNotificationType;
 import uk.gov.pay.connector.gateway.stripe.StripeNotificationUtilTest;
-import uk.gov.pay.connector.junit.ConfigOverride;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.junit.DropwizardTestContext;
@@ -196,7 +195,7 @@ public class StripeNotificationResourceIT {
 
         String payload = sampleStripeNotification(STRIPE_NOTIFICATION_3DS_SOURCE,
                 transactionId, SOURCE_CANCELED);
-        String response = notifyConnectorWithHeader(payload, "invalid-header")
+        notifyConnectorWithHeader(payload, "invalid-header")
                 .then()
                 .statusCode(500)
                 .extract().body()

--- a/src/test/java/uk/gov/pay/connector/model/domain/JsonToMapConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/JsonToMapConverterTest.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.model.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.postgresql.util.PGobject;
@@ -16,29 +15,28 @@ import static org.junit.Assert.assertThat;
 
 public class JsonToMapConverterTest {
 
-    private JsonToMapConverter jsonToMapConverter;
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
+    private JsonToMapConverter jsonToMapConverter = new JsonToMapConverter();
     private PGobject pGobject;
 
     @Before
     public void setUp(){
-        jsonToMapConverter = new JsonToMapConverter();
         pGobject = new PGobject();
         pGobject.setType("json");
     }
 
     @Test
     public void shouldReturnAMapContainingTheValuesOfAPGObject() throws Exception {
-        JsonNode payload = new ObjectMapper()
-                .valueToTree(ImmutableMap.of(
-                        "json_field_1", "json_value_1",
-                        "json_field_2", "json_value_2"));
+        JsonNode payload = objectMapper.valueToTree(
+                Map.of("json_field_1", "json_value_1","json_field_2", "json_value_2"));
 
-        Map<String, String> values = ImmutableMap.of("json_field_1", "json_value_1", "json_field_2", "json_value_2");
-        pGobject.setValue(new ObjectMapper().writeValueAsString(values));
+        Map<String, String> values = Map.of("json_field_1", "json_value_1", "json_field_2", "json_value_2");
+        pGobject.setValue(objectMapper.writeValueAsString(values));
 
         Map<String, String> jsonValues = jsonToMapConverter.convertToEntityAttribute(pGobject);
 
-        assertThat(new ObjectMapper().writeValueAsString(jsonValues), is(payload.toString()));
+        assertThat(objectMapper.writeValueAsString(jsonValues), is(payload.toString()));
     }
 
     @Test
@@ -51,17 +49,16 @@ public class JsonToMapConverterTest {
 
     @Test
     public void shouldReturnPGObjectContainingPredifinedValues() throws Exception {
-        Map<String, String> values = ImmutableMap.of("json_field_1", "json_value_1", "json_field_2", "json_value_2");
+        Map<String, String> values = Map.of("json_field_1", "json_value_1", "json_field_2", "json_value_2");
         pGobject = jsonToMapConverter.convertToDatabaseColumn(values);
 
         assertThat(pGobject.getType(), is("json"));
-        assertThat(pGobject.getValue(), is(new ObjectMapper().writeValueAsString(values)));
+        assertThat(pGobject.getValue(), is(objectMapper.writeValueAsString(values)));
     }
 
     @Test
     public void shouldReturnNullWhenEmptyMap() {
-        Map<String, String> values = ImmutableMap.of();
-        pGobject = jsonToMapConverter.convertToDatabaseColumn(values);
+        pGobject = jsonToMapConverter.convertToDatabaseColumn(Map.of());
         assertThat(pGobject.getValue(), is(nullValue()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/CaptureQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/CaptureQueueTest.java
@@ -35,7 +35,7 @@ public class CaptureQueueTest {
     @Mock
     ConnectorConfiguration connectorConfiguration;
 
-    private ObjectMapper objectMapper;
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Before
     public void setUp() throws Exception {
@@ -45,7 +45,6 @@ public class CaptureQueueTest {
         List<QueueMessage> messages = Arrays.asList(
                 QueueMessage.of(messageResult, validJsonMessage)
         );
-        objectMapper = new ObjectMapper();
         CaptureProcessConfig captureProcessConfig = mock(CaptureProcessConfig.class);
         SqsConfig sqsConfig = mock(SqsConfig.class);
         when(sqsConfig.getCaptureQueueUrl()).thenReturn("");

--- a/src/test/java/uk/gov/pay/connector/queue/payout/PayoutReconcileQueueTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/payout/PayoutReconcileQueueTest.java
@@ -29,6 +29,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class PayoutReconcileQueueTest {
 
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    
     @Mock
     private SqsQueueService sqsQueueService;
     @Mock
@@ -43,7 +45,6 @@ public class PayoutReconcileQueueTest {
         when(connectorConfiguration.getSqsConfig()).thenReturn(sqsConfig);
         when(connectorConfiguration.getPayoutReconcileProcessConfig()).thenReturn(payoutReconcileProcessConfig);
 
-        ObjectMapper objectMapper = new ObjectMapper();
         payoutReconcileQueue = new PayoutReconcileQueue(sqsQueueService, connectorConfiguration, objectMapper);
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -52,6 +52,7 @@ public class GatewayAccountServiceTest {
     private GatewayAccountService gatewayAccountService;
     
     private static final Long GATEWAY_ACCOUNT_ID = 100L;
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Before
     public void setUp() {
@@ -90,7 +91,7 @@ public class GatewayAccountServiceTest {
         Map<String, String> settings = Map.of(
                 "api_token", "anapitoken",
                 "template_id", "atemplateid");
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "notify_settings",
                 "value", settings)));
@@ -106,7 +107,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateNotifySettingsWhenRemove() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of("op", "replace",
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of("op", "replace",
                 "path", "notify_settings")));
 
         when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
@@ -120,7 +121,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateEmailCollectionMode() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "email_collection_mode",
                 "value", "off")));
@@ -137,7 +138,7 @@ public class GatewayAccountServiceTest {
     
     @Test
     public void shouldUpdateCorporateCreditCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "corporate_credit_card_surcharge_amount",
                 "value", 100)));
@@ -151,7 +152,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateCorporateDebitCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "corporate_debit_card_surcharge_amount",
                 "value", 100)));
@@ -165,7 +166,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateCorporatePrepaidDebitCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "corporate_prepaid_debit_card_surcharge_amount",
                 "value", 100)));
@@ -179,7 +180,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateCorporatePrepaidCreditCardSurchargeAmount() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "corporate_prepaid_credit_card_surcharge_amount",
                 "value", 100)));
@@ -193,7 +194,7 @@ public class GatewayAccountServiceTest {
 
     @Test(expected = DigitalWalletNotSupportedGatewayException.class)
     public void shouldNotAllowDigitalWalletForUnsupportedGateways() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "add",
                 "path", "allow_apple_pay",
                 "value", "true")));
@@ -206,7 +207,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowZeroAmountTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "allow_zero_amount",
                 "value", true)));
@@ -221,7 +222,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowZeroAmountFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "allow_zero_amount",
                 "value", false)));
@@ -235,7 +236,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateBlockPrepaidCardsTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "block_prepaid_cards",
                 "value", true)));
@@ -249,7 +250,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateBlockPrepaidCardsFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "block_prepaid_cards",
                 "value", false)));
@@ -263,7 +264,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowMotoTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "allow_moto",
                 "value", true)));
@@ -278,7 +279,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateAllowMotoFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "allow_moto",
                 "value", false)));
@@ -292,7 +293,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateMotoMaskCardNumberInputTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "moto_mask_card_number_input",
                 "value", true)));
@@ -306,7 +307,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateMotoMaskCardNumberInputFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "moto_mask_card_number_input",
                 "value", false)));
@@ -320,7 +321,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateMotoMaskCardSecurityCodeInputTrue() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "moto_mask_card_security_code_input",
                 "value", true)));
@@ -334,7 +335,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateMotoMaskCardSecurityCodeInputFalse() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "moto_mask_card_security_code_input",
                 "value", false)));
@@ -348,7 +349,7 @@ public class GatewayAccountServiceTest {
 
     @Test
     public void shouldUpdateIntegrationVersion3ds() {
-        JsonPatchRequest request = JsonPatchRequest.from(new ObjectMapper().valueToTree(Map.of(
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",
                 "path", "integration_version_3ds",
                 "value", 2


### PR DESCRIPTION
ObjectMapper is an expensive object that can affect performance if there are
multiple instances of it and we should endeavor to use a single
instance of it in the application.
