### PR TITLE
BAU: Respond with 200 for notifications for expunged charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -132,7 +132,7 @@ public class WorldpayNotificationService {
                         charge.getExternalId(),
                         kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
                         kv(GATEWAY_ACCOUNT_ID, charge.getGatewayAccountId()));
-                return false;
+                return true;
             }
             chargeNotificationProcessor.invoke(notification.getTransactionId(), charge, CAPTURED, notification.getGatewayEventDate());
         } else if (isRefundNotification(notification)) {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -109,7 +109,7 @@ class WorldpayNotificationServiceTest {
 
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
 
-        assertFalse(result);
+        assertTrue(result);
         verifyNoInteractions(mockChargeNotificationProcessor);
         verifyNoInteractions(mockRefundNotificationProcessor);
     }


### PR DESCRIPTION
## WHAT YOU DID
- For Worldpay notifications for expunged charges, we are responding with 403 which is causing Worldpay to try notification repeatedly. We can respond with 200 (inline with smartpay/epdq notification processing) as charges will only be expunged once they are in terminal state and also an error is logged for notifications for expunged charges.
