### PR TITLE
PP-7590 Worldpay 3DS Flex JWT: use Instant instead of ZonedDateTime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.7</eclipselink.version>
         <guice.version>4.2.3</guice.version>
         <jackson.version>2.12.0</jackson.version>
-        <pay-java-commons.version>1.0.20201130170501</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20201224164540</pay-java-commons.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <javax.persistence.version>2.2.1</javax.persistence.version>
         <jooq.version>3.14.4</jooq.version>

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -20,7 +20,6 @@ import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.common.service.PatchRequestBuilder;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccount;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -86,7 +85,7 @@ public class ChargesFrontendResource {
         GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
         var worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials()
                 .orElseThrow(() -> new Worldpay3dsFlexJwtCredentialsException(gatewayAccount.getId()));
-        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, chargeEntity.getCreatedDate());
+        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, chargeEntity.getCreatedDate().toInstant());
 
         return Response.ok().entity(Map.of("jwt", token)).build();
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtService.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.inject.Inject;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +41,7 @@ public class Worldpay3dsFlexJwtService {
      * @see <a href="https://beta.developer.worldpay.com/docs/wpg/directintegration/3ds2#device-data-collection-ddc-"
      * >Worldpay DDC Documentation</a>
      */
-    public String generateDdcToken(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials, ZonedDateTime chargeCreatedTime) {
+    public String generateDdcToken(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials, Instant chargeCreatedTime) {
         validateGatewayIsWorldpay(gatewayAccount);
 
         var claims = generateDdcClaims(gatewayAccount, worldpay3dsFlexCredentials, chargeCreatedTime);
@@ -81,10 +80,10 @@ public class Worldpay3dsFlexJwtService {
         }
     }
     
-    private Map<String, Object> generateDdcClaims(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials, ZonedDateTime chargeCreatedTime) {
+    private Map<String, Object> generateDdcClaims(GatewayAccount gatewayAccount, Worldpay3dsFlexCredentials worldpay3dsFlexCredentials, Instant chargeCreatedTime) {
         Map<String, Object> commonClaims = generateCommonClaims(gatewayAccount.getId(), worldpay3dsFlexCredentials);
         Map<String, Object> claims = new HashMap<>(commonClaims);
-        claims.put("exp", chargeCreatedTime.plusSeconds(tokenExpiryDurationSeconds).toInstant().getEpochSecond());
+        claims.put("exp", chargeCreatedTime.plusSeconds(tokenExpiryDurationSeconds).getEpochSecond());
         return claims;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationService.java
@@ -16,7 +16,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -48,7 +48,7 @@ public class Worldpay3dsFlexCredentialsValidationService {
         }
         
         String ddcToken = worldpay3dsFlexJwtService.generateDdcToken(GatewayAccount.valueOf(gatewayAccountEntity), 
-                flexCredentials, ZonedDateTime.now());
+                flexCredentials, Instant.now());
 
         var formData = new MultivaluedHashMap<String, String>();
         formData.add("JWT", ddcToken);

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -28,12 +28,10 @@ import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntit
 
 import javax.crypto.spec.SecretKeySpec;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
@@ -97,9 +95,9 @@ public class Worldpay3dsFlexJwtServiceTest {
         var worldpay3dsFlexCredentials = new Worldpay3dsFlexCredentials("me", "myOrg", "fa2daee2-1fbb-45ff-4444-52805d5cd9e0", false);
         int paymentCreationTimeEpochSeconds19August2029 = 1881821916;
         int expectedTokenExpirationTimeEpochSeconds = paymentCreationTimeEpochSeconds19August2029 + TOKEN_EXPIRY_DURATION_SECONDS;
-        var paymentCreationZonedDateTime = ZonedDateTime.ofInstant(Instant.ofEpochSecond((long) paymentCreationTimeEpochSeconds19August2029), UTC);
+        var paymentCreationInstant = Instant.ofEpochSecond(paymentCreationTimeEpochSeconds19August2029);
 
-        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, paymentCreationZonedDateTime);
+        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, paymentCreationInstant);
 
         Jws<Claims> jws = Jwts.parser()
                 .setSigningKey(new SecretKeySpec(VALID_CREDENTIALS.get("jwt_mac_id").getBytes(), "HmacSHA256"))
@@ -190,7 +188,7 @@ public class Worldpay3dsFlexJwtServiceTest {
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex JWT for account 1 because the " +
                 "following credential is unavailable: issuer");
 
-        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, ZonedDateTime.now());
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, Instant.now());
     }
 
     @Test
@@ -203,7 +201,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 "Cannot generate Worldpay 3ds Flex JWT for account 1 because the following credential is " +
                         "unavailable: organisational_unit_id");
 
-        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, ZonedDateTime.now());
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, Instant.now());
     }
 
     @Test
@@ -215,7 +213,7 @@ public class Worldpay3dsFlexJwtServiceTest {
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex JWT for account 1 because the " +
                 "following credential is unavailable: jwt_mac_key");
 
-        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, ZonedDateTime.now());
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, Instant.now());
     }
 
     @Test
@@ -227,7 +225,7 @@ public class Worldpay3dsFlexJwtServiceTest {
         expectedException.expectMessage("Cannot provide a Worldpay 3ds flex JWT for account 1 because the " +
                 "Payment Provider is not Worldpay.");
 
-        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, ZonedDateTime.now());
+        worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, Instant.now());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
@@ -29,7 +29,7 @@ import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.Response;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -46,8 +46,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 
 @ExtendWith(MockitoExtension.class)
 class Worldpay3dsFlexCredentialsValidationServiceTest {
@@ -104,7 +104,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
         when(response.getStatus()).thenReturn(HttpStatus.SC_OK);
         when(client.target(threeDsFlexDdcUrls.get(type))).thenReturn(webTarget);
         when(worldpay3dsFlexJwtService.generateDdcToken(eq(GatewayAccount.valueOf(gatewayAccount)), eq(flexCredentials), 
-                any(ZonedDateTime.class))).thenReturn(DDC_TOKEN);
+                any(Instant.class))).thenReturn(DDC_TOKEN);
         var expectedFormData = new MultivaluedHashMap<String, String>(){{add("JWT", DDC_TOKEN);}};
         when(invocationBuilder.post(argThat(new EntityMatcher(Entity.form(expectedFormData))))).thenReturn(response);
         
@@ -125,7 +125,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
         when(response.getStatus()).thenReturn(HttpStatus.SC_BAD_REQUEST);
         when(client.target(threeDsFlexDdcUrls.get(type))).thenReturn(webTarget);
         when(worldpay3dsFlexJwtService.generateDdcToken(eq(GatewayAccount.valueOf(gatewayAccount)), eq(flexCredentials),
-                any(ZonedDateTime.class))).thenReturn(DDC_TOKEN);
+                any(Instant.class))).thenReturn(DDC_TOKEN);
         var expectedFormData = new MultivaluedHashMap<String, String>(){{add("JWT", DDC_TOKEN);}};
         when(invocationBuilder.post(argThat(new EntityMatcher(Entity.form(expectedFormData))))).thenReturn(response);
 
@@ -141,7 +141,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
         when(response.getStatus()).thenReturn(responseCode);
         when(client.target(threeDsFlexDdcUrls.get("live"))).thenReturn(webTarget);
         when(worldpay3dsFlexJwtService.generateDdcToken(eq(GatewayAccount.valueOf(gatewayAccount)), eq(flexCredentials),
-                any(ZonedDateTime.class))).thenReturn(DDC_TOKEN);
+                any(Instant.class))).thenReturn(DDC_TOKEN);
         var expectedFormData = new MultivaluedHashMap<String, String>(){{add("JWT", DDC_TOKEN);}};
         when(invocationBuilder.post(argThat(new EntityMatcher(Entity.form(expectedFormData))))).thenReturn(response);
 
@@ -158,7 +158,7 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
 
         when(client.target(threeDsFlexDdcUrls.get("live"))).thenReturn(webTarget);
         when(worldpay3dsFlexJwtService.generateDdcToken(eq(GatewayAccount.valueOf(gatewayAccount)), eq(flexCredentials),
-                any(ZonedDateTime.class))).thenReturn(DDC_TOKEN);
+                any(Instant.class))).thenReturn(DDC_TOKEN);
         var expectedFormData = new MultivaluedHashMap<String, String>(){{add("JWT", DDC_TOKEN);}};
         when(invocationBuilder.post(argThat(new EntityMatcher(Entity.form(expectedFormData)))))
                 .thenThrow(new ProcessingException("Some I/O failure"));


### PR DESCRIPTION
Use `Instant`s instead of `ZonedDateTime`s in the code that creates JWTs for Worldpay 3DS Flex.