### PR TITLE
PP-7596 Rename `toggle_3ds` to `requires3ds`

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -231,7 +231,7 @@ Content-Type: application/json
     "block_prepaid_cards": false,
     "allow_zero_amount": false,
     "email_collection_mode": "MANDATORY",
-    "toggle_3ds": false,
+    "requires3ds": false,
     "allow_moto": false,
     "moto_mask_card_number_input": false,
     "moto_mask_card_security_code_input": false,
@@ -269,7 +269,7 @@ Content-Type: application/json
 | `block_prepaid_cards`                            | X              | Whether pre-paid card are allowed as a payment method for this gateway account. The default value is `false`. |
 | `allow_zero_amount`                              | X              | Whether the account supports charges with a zero amount. The default value is `false`.                        |
 | `email_collection_mode`                          | X              | Whether email address is required from paying users. Can be `MANDATORY`, `OPTIONAL` or `OFF`                  |
-| `toggle_3ds`                                     | X              | Whether 3DS is enabled. The default value is `false`.                                                         |
+| `requires3ds`                                   | X              | Whether 3DS is enabled. The default value is `false`.                                                         |
 | `allow_moto`                                     | X              | Whether Mail Order and Telephone Order (MOTO) payments are allowed. The default value is `false`.             |
 | `moto_mask_card_number_input`                    | X              | Whether the card number is masked when being input for MOTO payments. The default value is `false`.           |
 | `moto_mask_card_security_code_input`             | X              | Whether the card security code is masked when being input for MOTO payments. The default value is `false`.    |
@@ -319,7 +319,7 @@ Content-Type: application/json
       "block_prepaid_cards": false,
       "allow_zero_amount": false,
       "email_collection_mode": "MANDATORY",
-      "toggle_3ds": false,
+      "requires3ds": false,
       "allow_moto": false,
       "moto_mask_card_number_input": false,
       "moto_mask_card_security_code_input": false,
@@ -357,7 +357,7 @@ Content-Type: application/json
       "block_prepaid_cards": false,
       "allow_zero_amount": false,
       "email_collection_mode": "MANDATORY",
-      "toggle_3ds": false,
+      "requires3ds": false,
       "allow_moto": false,
       "moto_mask_card_number_input": false,
       "moto_mask_card_security_code_input": false,
@@ -394,7 +394,7 @@ Content-Type: application/json
       "block_prepaid_cards": false,
       "allow_zero_amount": false,
       "email_collection_mode": "MANDATORY",
-      "toggle_3ds": false,
+      "requires3ds": false,
       "allow_moto": false,
       "moto_mask_card_number_input": false,
       "moto_mask_card_security_code_input": false,
@@ -440,7 +440,7 @@ Content-Type: application/json
 | `block_prepaid_cards`                            | X              | Whether pre-paid card are allowed as a payment method for this gateway account. The default value is `false`. |
 | `allow_zero_amount`                              | X              | Whether the account supports charges with a zero amount. The default value is `false`.                        |
 | `email_collection_mode`                          | X              | Whether email address is required from paying users. Can be `MANDATORY`, `OPTIONAL` or `OFF`                  |
-| `toggle_3ds`                                     | X              | Whether 3DS is enabled. The default value is `false`.                                                         |
+| `requires3ds`                                     | X              | Whether 3DS is enabled. The default value is `false`.                                                         |
 | `allow_moto`                                     | X              | Whether Mail Order and Telephone Order (MOTO) payments are allowed. The default value is `false`.             |
 | `moto_mask_card_number_input`                    | X              | Whether the card number is masked when being input for MOTO payments. The default value is `false`.           |
 | `moto_mask_card_security_code_input`             | X              | Whether the card security code is masked when being input for MOTO payments. The default value is `false`.    |

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -64,7 +64,7 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("email_collection_mode")
     private EmailCollectionMode emailCollectionMode = EmailCollectionMode.MANDATORY;
 
-    @JsonProperty("toggle_3ds")
+    @JsonProperty("requires3ds")
     private boolean requires3ds;
 
     @JsonProperty("allow_zero_amount")

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -106,7 +106,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .get(ACCOUNTS_API_URL + gatewayAccountId)
                 .then()
                 .statusCode(200)
-                .body("toggle_3ds", is(true));
+                .body("requires3ds", is(true));
     }
 
     @Test
@@ -452,7 +452,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()
-                .body("toggle_3ds", is(true));
+                .body("requires3ds", is(true));
     }
 
     @Test
@@ -503,7 +503,7 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId)
                 .then()
-                .body("toggle_3ds", is(false));
+                .body("requires3ds", is(false));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- We currently return `requires_3ds` (from database) as two different fields in API.
    Most of the endpoints returns field as `toggle_3ds` and `/v1/frontend/accounts/{accountId}` returns field as `requires3ds`.

     Endpoints that return `toggle_3ds`

     `/v1/api/accounts/{accountId}`
     `/v1/api/accounts`
     `/v1/api/accounts/external-id/{externalId}`
     `/v1/frontend/accounts`

- Renamed `toggle_3ds` to `requires3ds` for consistency and the field is currently used only used by toolbox (to be updated to use `requires3ds`).