### PR TITLE
PP-7590 ChargeEntity: use Instant not ZonedDateTime for createdDate

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -16,6 +16,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -120,7 +121,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .setParameter("provider", provider).getResultList().stream().findFirst();
     }
 
-    public List<ChargeEntity> findBeforeDateWithStatusIn(ZonedDateTime date, List<ChargeStatus> statuses) {
+    public List<ChargeEntity> findBeforeDateWithStatusIn(Instant date, List<ChargeStatus> statuses) {
         CriteriaBuilder cb = entityManager.get().getCriteriaBuilder();
         CriteriaQuery<ChargeEntity> cq = cb.createQuery(ChargeEntity.class);
         Root<ChargeEntity> charge = cq.from(ChargeEntity.class);
@@ -135,7 +136,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
     }
 
     private List<Predicate> buildParamPredicates(CriteriaBuilder cb, Root<ChargeEntity> charge,
-                                                 ZonedDateTime toDate, List<ChargeStatus> internalStates) {
+                                                 Instant toDate, List<ChargeStatus> internalStates) {
         List<Predicate> predicates = new ArrayList<>();
 
         if (internalStates != null && !internalStates.isEmpty()) {
@@ -227,9 +228,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
                 .minus(Duration.ofDays(excludeChargesParityCheckedWithInDays))
                 .withZoneSameInstant(ZoneId.of("UTC"));
 
-        ZonedDateTime createdBeforeDate = ZonedDateTime.now()
-                .minus(Duration.ofDays(minimumAgeOfChargeInDays))
-                .withZoneSameInstant(ZoneId.of("UTC"));
+        Instant createdBeforeDate = Instant.now().minus(Duration.ofDays(minimumAgeOfChargeInDays));
 
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.charge.model.domain;
 
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 import java.util.Optional;
@@ -55,7 +56,7 @@ public class Charge {
                 null, 
                 chargeEntity.getReference().toString(),
                 chargeEntity.getDescription(),
-                chargeEntity.getCreatedDate(),
+                ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC),
                 chargeEntity.getEmail(),
                 chargeEntity.getGatewayAccount().getId(),
                 chargeEntity.getPaymentGatewayName().getName(),

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import net.logstash.logback.argument.StructuredArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 import uk.gov.pay.commons.model.Source;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.SupportedLanguageJpaConverter;
@@ -45,6 +46,7 @@ import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.Valid;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -128,8 +130,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
     private String providerSessionId;
 
     @Column(name = "created_date")
-    @Convert(converter = UTCDateTimeConverter.class)
-    private ZonedDateTime createdDate;
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    private Instant createdDate;
 
     @Column(name = "language", nullable = false)
     @Convert(converter = SupportedLanguageJpaConverter.class)
@@ -175,7 +177,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
             ServicePaymentReference reference,
             GatewayAccountEntity gatewayAccount,
             String email,
-            ZonedDateTime createdDate,
+            Instant createdDate,
             SupportedLanguage language,
             boolean delayedCapture,
             ExternalMetadata externalMetadata,
@@ -242,7 +244,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         return reference;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 
@@ -520,7 +522,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                     reference,
                     gatewayAccount,
                     email,
-                    ZonedDateTime.now(ZoneId.of("UTC")),
+                    Instant.now(),
                     language,
                     delayedCapture,
                     externalMetadata,
@@ -597,7 +599,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                     reference,
                     gatewayAccount,
                     email,
-                    ZonedDateTime.now(ZoneId.of("UTC")),
+                    Instant.now(),
                     SupportedLanguage.ENGLISH,
                     false,
                     externalMetadata,

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -33,6 +33,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -85,7 +87,7 @@ public class ChargesFrontendResource {
         GatewayAccount gatewayAccount = GatewayAccount.valueOf(chargeEntity.getGatewayAccount());
         var worldpay3dsFlexCredentials = chargeEntity.getGatewayAccount().getWorldpay3dsFlexCredentials()
                 .orElseThrow(() -> new Worldpay3dsFlexJwtCredentialsException(gatewayAccount.getId()));
-        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, chargeEntity.getCreatedDate().toInstant());
+        String token = worldpay3dsFlexJwtService.generateDdcToken(gatewayAccount, worldpay3dsFlexCredentials, chargeEntity.getCreatedDate());
 
         return Response.ok().entity(Map.of("jwt", token)).build();
     }
@@ -163,7 +165,7 @@ public class ChargesFrontendResource {
                 .withAmount(charge.getAmount())
                 .withDescription(charge.getDescription())
                 .withGatewayTransactionId(charge.getGatewayTransactionId())
-                .withCreatedDate(charge.getCreatedDate())
+                .withCreatedDate(ZonedDateTime.ofInstant(charge.getCreatedDate(), ZoneOffset.UTC))
                 .withReturnUrl(charge.getReturnUrl())
                 .withEmail(charge.getEmail())
                 .withFee(charge.getFeeAmount().orElse(null))

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.token.dao.TokenDao;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -317,16 +318,16 @@ public class ChargeExpiryService {
                 });
     }
 
-    private ZonedDateTime getExpiryDateForRegularCharges() {
+    private Instant getExpiryDateForRegularCharges() {
         int chargeExpiryWindowSeconds = chargeSweepConfig.getDefaultChargeExpiryThreshold();
         logger.debug("Charge expiry window size in seconds: [{}]", chargeExpiryWindowSeconds);
-        return ZonedDateTime.now().minusSeconds(chargeExpiryWindowSeconds);
+        return Instant.now().minusSeconds(chargeExpiryWindowSeconds);
     }
 
-    private ZonedDateTime getExpiryDateForAwaitingCaptureRequest() {
+    private Instant getExpiryDateForAwaitingCaptureRequest() {
         int chargeExpiryWindowSeconds = chargeSweepConfig.getAwaitingCaptureExpiryThreshold();
         logger.debug("Charge expiry window size for awaiting_delay_capture in seconds: [{}]", chargeExpiryWindowSeconds);
-        return ZonedDateTime.now().minusSeconds(chargeExpiryWindowSeconds);
+        return Instant.now().minusSeconds(chargeExpiryWindowSeconds);
     }
 
     private static String getLegalStatusNames(List<ChargeStatus> legalStatuses) {

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -73,6 +73,7 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.time.Duration;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -440,7 +441,7 @@ public class ChargeService {
                 .withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()))
                 .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
                 .withProviderName(chargeEntity.getGatewayAccount().getGatewayName())
-                .withCreatedDate(chargeEntity.getCreatedDate())
+                .withCreatedDate(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC))
                 .withReturnUrl(chargeEntity.getReturnUrl())
                 .withEmail(chargeEntity.getEmail())
                 .withLanguage(chargeEntity.getLanguage())

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentCreated.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.eventdetails.charge.PaymentCreatedEventDetails;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 public class PaymentCreated extends PaymentEvent {
@@ -24,7 +25,7 @@ public class PaymentCreated extends PaymentEvent {
         return new PaymentCreated(
                 charge.getExternalId(),
                 PaymentCreatedEventDetails.from(charge),
-                charge.getCreatedDate()
+                ZonedDateTime.ofInstant(charge.getCreatedDate(), ZoneOffset.UTC)
         );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
@@ -10,7 +10,8 @@ import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.report.model.GatewayStatusComparison;
 
 import javax.inject.Inject;
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -82,6 +83,6 @@ public class DiscrepancyService {
     }
 
     private boolean chargeAgeInDaysIsGreaterThan(ChargeEntity charge, long minimumAge) {
-        return charge.getCreatedDate().plusDays(minimumAge).isBefore(ZonedDateTime.now());
+        return charge.getCreatedDate().plus(Duration.ofDays(minimumAge)).isBefore(Instant.now());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
+++ b/src/main/java/uk/gov/pay/connector/report/dao/PerformanceReportDao.java
@@ -8,10 +8,12 @@ import uk.gov.pay.connector.report.model.domain.PerformanceReportEntity;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
 import java.util.stream.Stream;
 
+import static java.time.temporal.ChronoUnit.DAYS;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 
@@ -69,8 +71,8 @@ public class PerformanceReportDao extends JpaDao<PerformanceReportEntity> {
   }
 
   public PerformanceReportEntity aggregateNumberAndValueOfPaymentsForAGivenDay(ZonedDateTime date) {
-    ZonedDateTime startDate = date.truncatedTo(ChronoUnit.DAYS);
-    ZonedDateTime endDate = startDate.plus(24, ChronoUnit.HOURS);
+    Instant startDate = date.truncatedTo(DAYS).toInstant();
+    Instant endDate = startDate.plus(Duration.ofHours(24));
 
     return (PerformanceReportEntity) entityManager
       .get()

--- a/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
+++ b/src/main/java/uk/gov/pay/connector/token/model/domain/TokenEntity.java
@@ -15,6 +15,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
@@ -50,7 +51,7 @@ public class TokenEntity extends AbstractVersionedEntity {
     public static TokenEntity generateNewTokenFor(ChargeEntity chargeEntity) {
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChargeEntity(chargeEntity);
-        tokenEntity.setCreatedDate(chargeEntity.getCreatedDate());
+        tokenEntity.setCreatedDate(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC));
         tokenEntity.setToken(UUID.randomUUID().toString());
         tokenEntity.setUsed(false);
 

--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -22,6 +22,8 @@ import uk.gov.service.notify.SendEmailResponse;
 
 import javax.inject.Inject;
 import java.math.BigDecimal;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -172,7 +174,7 @@ public class UserNotificationService {
         HashMap<String, String> map = new HashMap<>();
 
         map.put("serviceReference", charge.getReference().toString());
-        map.put("date", DateTimeUtils.toUserFriendlyDate(charge.getCreatedDate()));
+        map.put("date", DateTimeUtils.toUserFriendlyDate(ZonedDateTime.ofInstant(charge.getCreatedDate(), ZoneOffset.UTC)));
         map.put("amount", formatToPounds(CorporateCardSurchargeCalculator.getTotalAmountFor(charge)));
         map.put("description", charge.getDescription());
         map.put("customParagraph", isBlank(customParagraph) ? "" : "^ " + LITERAL_DOLLAR_REFERENCE.matcher(customParagraph)

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -3,6 +3,7 @@
     <persistence-unit name="ConnectorUnit" transaction-type="RESOURCE_LOCAL">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
         <class>uk.gov.pay.commons.model.SupportedLanguageJpaConverter</class>
+        <class>uk.gov.pay.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter</class>
         <class>uk.gov.pay.commons.jpa.CardExpiryDateConverter</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
     </persistence-unit>

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -19,7 +19,7 @@ import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
 
-import java.time.ZoneId;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,7 +40,7 @@ public class ChargeEntityFixture {
     private ChargeStatus status = ChargeStatus.CREATED;
     private GatewayAccountEntity gatewayAccountEntity = defaultGatewayAccountEntity();
     private String transactionId;
-    private ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+    private Instant createdDate = Instant.now();
     private List<ChargeEventEntity> events = new ArrayList<>();
     private Auth3dsRequiredEntity auth3DsRequiredEntity;
     private String providerSessionId;
@@ -199,7 +199,7 @@ public class ChargeEntityFixture {
     }
 
     public ChargeEntityFixture withCreatedDate(ZonedDateTime createdDate) {
-        this.createdDate = createdDate;
+        this.createdDate = createdDate.toInstant();
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentprocessor.service.QueryService;
 import uk.gov.pay.connector.token.dao.TokenDao;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -352,8 +353,8 @@ public class ChargeExpiryServiceTest {
         when(mockChargeDao.findByExternalId(chargeEntityAuthorisationSuccess.getExternalId())).thenReturn(Optional.of(chargeEntityAuthorisationSuccess));
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
         when(mockPaymentProviders.byName(PaymentGatewayName.WORLDPAY)).thenReturn(mockPaymentProvider);
-        when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS))).thenReturn(singletonList(chargeEntityAwaitingCapture));
-        when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(chargeEntityAuthorisationSuccess));
+        when(mockChargeDao.findBeforeDateWithStatusIn(any(Instant.class), eq(EXPIRABLE_AWAITING_CAPTURE_REQUEST_STATUS))).thenReturn(singletonList(chargeEntityAwaitingCapture));
+        when(mockChargeDao.findBeforeDateWithStatusIn(any(Instant.class), eq(EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(chargeEntityAuthorisationSuccess));
 
         ChargeEntity expiredCharge = mockExpiredChargeEntity();
         when(mockChargeService.transitionChargeState(any(String.class), any())).thenReturn(expiredCharge);
@@ -375,7 +376,7 @@ public class ChargeExpiryServiceTest {
 
         ChargeEntity expiredCharge = mock(ChargeEntity.class);
 
-        when(mockChargeDao.findBeforeDateWithStatusIn(any(ZonedDateTime.class), eq(EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(preAuthorisationCharge));
+        when(mockChargeDao.findBeforeDateWithStatusIn(any(Instant.class), eq(EXPIRABLE_REGULAR_STATUSES))).thenReturn(singletonList(preAuthorisationCharge));
 
         when(mockChargeService.transitionChargeState(any(String.class), any())).thenReturn(expiredCharge);
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -28,7 +28,7 @@ import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 
 import java.net.URI;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -162,7 +162,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getDescription(), is("This is a description"));
         assertThat(createdChargeEntity.getAmount(), is(100L));
         assertThat(createdChargeEntity.getGatewayTransactionId(), is(nullValue()));
-        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneId.of("UTC")))));
+        assertThat(ZonedDateTime.ofInstant(createdChargeEntity.getCreatedDate(), ZoneOffset.UTC),
+                is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneOffset.UTC))));
         assertThat(createdChargeEntity.getLanguage(), is(SupportedLanguage.ENGLISH));
         assertThat(createdChargeEntity.isDelayedCapture(), is(false));
         assertThat(createdChargeEntity.getCorporateSurcharge().isPresent(), is(false));
@@ -511,7 +512,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getDescription(), is("Some description"));
         assertThat(createdChargeEntity.getStatus(), is("CAPTURE SUBMITTED"));
         assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
-        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneId.of("UTC")))));
+        assertThat(ZonedDateTime.ofInstant(createdChargeEntity.getCreatedDate(), ZoneOffset.UTC),
+                is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneOffset.UTC))));
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
@@ -564,7 +566,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getDescription(), is("Some description"));
         assertThat(createdChargeEntity.getStatus(), is("AUTHORISATION REJECTED"));
         assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
-        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneId.of("UTC")))));
+        assertThat(ZonedDateTime.ofInstant(createdChargeEntity.getCreatedDate(), ZoneOffset.UTC),
+                is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneOffset.UTC))));
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
@@ -616,7 +619,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getDescription(), is("Some description"));
         assertThat(createdChargeEntity.getStatus(), is("AUTHORISATION ERROR"));
         assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
-        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneId.of("UTC")))));
+        assertThat(ZonedDateTime.ofInstant(createdChargeEntity.getCreatedDate(), ZoneOffset.UTC),
+                is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, now(ZoneOffset.UTC))));
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
@@ -673,7 +677,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getDescription(), is("Some description"));
         assertThat(createdChargeEntity.getStatus(), is("AUTHORISATION ERROR"));
         assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
-        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, ZonedDateTime.now(ZoneId.of("UTC")))));
+        assertThat(ZonedDateTime.ofInstant(createdChargeEntity.getCreatedDate(), ZoneOffset.UTC),
+                is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, ZonedDateTime.now(ZoneOffset.UTC))));
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));
@@ -729,7 +734,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         assertThat(createdChargeEntity.getDescription(), is("Some description"));
         assertThat(createdChargeEntity.getStatus(), is("AUTHORISATION ERROR"));
         assertThat(createdChargeEntity.getEmail(), is("jane.doe@example.com"));
-        assertThat(createdChargeEntity.getCreatedDate(), is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, ZonedDateTime.now(ZoneId.of("UTC")))));
+        assertThat(ZonedDateTime.ofInstant(createdChargeEntity.getCreatedDate(), ZoneOffset.UTC),
+                is(ZonedDateTimeMatchers.within(3, ChronoUnit.SECONDS, ZonedDateTime.now(ZoneOffset.UTC))));
         assertThat(createdChargeEntity.getCardDetails().getLastDigitsCardNumber().toString(), is("1234"));
         assertThat(createdChargeEntity.getCardDetails().getFirstDigitsCardNumber().toString(), is("123456"));
         assertThat(createdChargeEntity.getCardDetails().getCardHolderName(), is("Jane Doe"));

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -61,6 +61,7 @@ import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 
 import javax.ws.rs.core.UriInfo;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -372,7 +373,7 @@ public class ChargeServiceTest {
                 .withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()))
                 .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
                 .withProviderName(chargeEntity.getGatewayAccount().getGatewayName())
-                .withCreatedDate(chargeEntity.getCreatedDate())
+                .withCreatedDate(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC))
                 .withEmail(chargeEntity.getEmail())
                 .withRefunds(refunds)
                 .withSettlement(settlement)

--- a/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/EmittedEventsBackfillServiceTest.java
@@ -32,6 +32,7 @@ import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.tasks.HistoricalEventEmitter;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -101,7 +102,7 @@ public class EmittedEventsBackfillServiceTest {
                 .aValidChargeEntity()
                 .build();
         ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
-                .withTimestamp(chargeEntity.getCreatedDate())
+                .withTimestamp(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC))
                 .withCharge(chargeEntity)
                 .withChargeStatus(ChargeStatus.CREATED)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -348,7 +348,7 @@ public class ChargingITestBase {
     }
 
     private void addCharge(long chargeId, String externalChargeId, ChargeStatus chargeStatus,
-                             ServicePaymentReference reference, ZonedDateTime fromDate, String transactionId) {
+                             ServicePaymentReference reference, ZonedDateTime createdDate, String transactionId) {
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId)
@@ -357,7 +357,7 @@ public class ChargingITestBase {
                 .withStatus(chargeStatus)
                 .withTransactionId(transactionId)
                 .withReference(reference)
-                .withCreatedDate(fromDate)
+                .withCreatedDate(createdDate.toInstant())
                 .withVersion(1)
                 .withLanguage(SupportedLanguage.ENGLISH)
                 .withDelayedCapture(false)

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -21,6 +21,7 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.validation.ConstraintViolationException;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -33,7 +34,6 @@ import java.util.Optional;
 
 import static java.time.ZonedDateTime.now;
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.fail;
 import static org.apache.commons.lang.math.RandomUtils.nextLong;
 import static org.exparity.hamcrest.date.ZonedDateTimeMatchers.within;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
@@ -294,7 +295,7 @@ public class ChargeDaoIT extends DaoITestBase {
 
         // given
         String transactionId = "7826782163";
-        ZonedDateTime createdDate = now(ZoneId.of("UTC"));
+        Instant createdDate = Instant.now();
         Long chargeId = 9999L;
         String externalChargeId = "charge9999";
 
@@ -360,7 +361,7 @@ public class ChargeDaoIT extends DaoITestBase {
     @Test
     public void shouldGetChargeByChargeIdWithCorrectAssociatedAccountId() {
         String transactionId = "7826782163";
-        ZonedDateTime createdDate = now(ZoneId.of("UTC"));
+        Instant createdDate = Instant.now();
         Long chargeId = 876786L;
         String externalChargeId = "charge876786";
 
@@ -447,7 +448,7 @@ public class ChargeDaoIT extends DaoITestBase {
 
         ArrayList<ChargeStatus> chargeStatuses = Lists.newArrayList(CREATED, ENTERING_CARD_DETAILS, AUTHORISATION_SUCCESS);
 
-        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(now().minusHours(1), chargeStatuses);
+        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(Instant.now().minus(Duration.ofHours(1)), chargeStatuses);
 
         assertThat(charges.size(), is(1));
         assertEquals(charges.get(0).getId(), charge.getChargeId());
@@ -466,7 +467,7 @@ public class ChargeDaoIT extends DaoITestBase {
 
         ArrayList<ChargeStatus> chargeStatuses = Lists.newArrayList(CAPTURE_READY, SYSTEM_CANCELLED);
 
-        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(now().minusHours(1), chargeStatuses);
+        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(Instant.now().minus(Duration.ofHours(1)), chargeStatuses);
 
         assertThat(charges.size(), is(0));
     }
@@ -484,7 +485,7 @@ public class ChargeDaoIT extends DaoITestBase {
 
         ArrayList<ChargeStatus> chargeStatuses = Lists.newArrayList(CREATED, ENTERING_CARD_DETAILS, AUTHORISATION_SUCCESS);
 
-        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(now().minusHours(1), chargeStatuses);
+        List<ChargeEntity> charges = chargeDao.findBeforeDateWithStatusIn(Instant.now().minus(Duration.ofHours(1)), chargeStatuses);
 
         assertThat(charges.size(), is(0));
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
 
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -526,7 +527,7 @@ public class DatabaseFixtures {
         SupportedLanguage language = SupportedLanguage.ENGLISH;
         boolean delayedCapture = false;
         Long corporateCardSurcharge = null;
-        ZonedDateTime createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+        Instant createdDate = Instant.now();
         TestAccount testAccount;
         TestCardDetails cardDetails;
         WalletType walletType;
@@ -583,8 +584,13 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestCharge withCreatedDate(ZonedDateTime createdDate) {
+        public TestCharge withCreatedDate(Instant createdDate) {
             this.createdDate = createdDate;
+            return this;
+        }
+
+        public TestCharge withCreatedDate(ZonedDateTime createdDate) {
+            this.createdDate = createdDate.toInstant();
             return this;
         }
 
@@ -685,7 +691,7 @@ public class DatabaseFixtures {
             return email;
         }
 
-        public ZonedDateTime getCreatedDate() {
+        public Instant getCreatedDate() {
             return createdDate;
         }
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/TokenDaoJpaIT.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 
@@ -47,7 +48,8 @@ public class TokenDaoJpaIT extends DaoITestBase {
     @Test
     public void persist_shouldInsertAToken() {
 
-        ChargeEntity defaultChargeTestEntity = new ChargeEntity();
+        ChargeEntityFixture chargeEntityFixture = new ChargeEntityFixture();
+        ChargeEntity defaultChargeTestEntity = chargeEntityFixture.build();
         defaultChargeTestEntity.setId(defaultTestCharge.getChargeId());
 
         TokenEntity tokenEntity = TokenEntity.generateNewTokenFor(defaultChargeTestEntity);
@@ -97,7 +99,8 @@ public class TokenDaoJpaIT extends DaoITestBase {
     public void deleteByCutOffDate_shouldDeleteOlderTokens() {
         ZonedDateTime today = ZonedDateTime.now(ZoneId.of("UTC"));
 
-        ChargeEntity chargeTestEntity = new ChargeEntity();
+        ChargeEntityFixture chargeEntityFixture = new ChargeEntityFixture();
+        ChargeEntity chargeTestEntity = chargeEntityFixture.build();
         chargeTestEntity.setId(defaultTestCharge.getChargeId());
         
         TokenEntity presentDayToken = TokenEntity.generateNewTokenFor(chargeTestEntity);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ExpungeResourceIT.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,7 +93,7 @@ public class ExpungeResourceIT {
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withChargeId(chargedId)
-                .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC).minusDays(91))))
+                .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC).minusDays(91))).toInstant())
                 .withTestAccount(defaultTestAccount)
                 .withExternalChargeId("external_charge_id")
                 .withTransactionId("gateway_transaction_id")
@@ -120,7 +121,7 @@ public class ExpungeResourceIT {
     private void insertChargeEvent(DatabaseFixtures.TestCharge charge) {
         DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper).aTestChargeEvent()
                 .withChargeStatus(CREATED)
-                .withDate(charge.getCreatedDate())
+                .withDate(ZonedDateTime.ofInstant(charge.getCreatedDate(), UTC))
                 .withChargeId(charge.getChargeId())
                 .withTestCharge(charge)
                 .insert();
@@ -130,7 +131,7 @@ public class ExpungeResourceIT {
     public void shouldUpdateTheParityCheckedDateOfNonCriteriaMatchedCharge() throws JsonProcessingException {
         var chargedId = ThreadLocalRandom.current().nextLong();
         ledgerStub = new LedgerStub();
-        var date = parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC).minusDays(91)));
+        var date = parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC).minusDays(91))).toInstant();
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withChargeId(chargedId)
@@ -161,7 +162,7 @@ public class ExpungeResourceIT {
                 .aTestCharge()
                 .withChargeId(chargedId)
                 .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC)
-                        .minusDays(89))))
+                        .minusDays(89))).toInstant())
                 .withTestAccount(defaultTestAccount)
                 .withExternalChargeId("external_charge_id_2")
                 .withTransactionId("gateway_transaction_id")
@@ -195,7 +196,7 @@ public class ExpungeResourceIT {
                 .aTestCharge()
                 .withChargeId(chargedId)
                 .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC)
-                        .minusDays(89))))
+                        .minusDays(89))).toInstant())
                 .withTestAccount(defaultTestAccount)
                 .withExternalChargeId("external_charge_id_10")
                 .withTransactionId("gateway_transaction_id")
@@ -216,7 +217,7 @@ public class ExpungeResourceIT {
                 .aTestCharge()
                 .withChargeId(chargedId2)
                 .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC)
-                        .minusDays(91))))
+                        .minusDays(91))).toInstant())
                 .withTestAccount(defaultTestAccount)
                 .withExternalChargeId("external_charge_id_11")
                 .withTransactionId("gateway_transaction_id")
@@ -237,7 +238,7 @@ public class ExpungeResourceIT {
                 .aTestCharge()
                 .withChargeId(chargedId3)
                 .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC)
-                        .minusDays(88))))
+                        .minusDays(88))).toInstant())
                 .withTestAccount(defaultTestAccount)
                 .withExternalChargeId("external_charge_id_12")
                 .withTransactionId("gateway_transaction_id")
@@ -258,7 +259,7 @@ public class ExpungeResourceIT {
                 .aTestCharge()
                 .withChargeId(chargedId4)
                 .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC)
-                        .minusDays(92))))
+                        .minusDays(92))).toInstant())
                 .withTestAccount(defaultTestAccount)
                 .withExternalChargeId("external_charge_id_13")
                 .withTransactionId("gateway_transaction_id")
@@ -297,7 +298,7 @@ public class ExpungeResourceIT {
         expungeableCharge1 = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withChargeId(chargedId)
-                .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC).minusDays(91))))
+                .withCreatedDate(parse(ISO_INSTANT_MILLISECOND_PRECISION.format(now(UTC).minusDays(91))).toInstant())
                 .withTestAccount(defaultTestAccount)
                 .withExternalChargeId("external_charge_id")
                 .withTransactionId("gateway_transaction_id")

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -25,6 +25,8 @@ import uk.gov.pay.connector.rules.SQSMockClient;
 import uk.gov.pay.connector.util.AddChargeParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Map;
@@ -90,7 +92,7 @@ public class ContractTest {
                 .withReturnUrl("https://somewhere.gov.uk/rainbow/1")
                 .withDescription("Test description")
                 .withReference(ServicePaymentReference.of("aReference"))
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withEmail("test@test.com")
                 .withDelayedCapture(false)
                 .withExternalMetadata(new ExternalMetadata(objectMapper.readValue(params.get("metadata"), Map.class)))
@@ -113,13 +115,13 @@ public class ContractTest {
                 .withTransactionId(params.get("gateway_transaction_id"))
                 .withDescription("Test description")
                 .withReference(ServicePaymentReference.of("aReference"))
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withEmail("test@test.com")
                 .withDelayedCapture(false)
                 .build());
     }
 
-    private void setUpCharges(int numberOfCharges, String accountId, ZonedDateTime createdDate) {
+    private void setUpCharges(int numberOfCharges, String accountId, Instant createdDate) {
         for (int i = 0; i < numberOfCharges; i++) {
             long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
             setUpSingleCharge(accountId, chargeId, Long.toString(chargeId), ChargeStatus.CREATED, createdDate, false);
@@ -127,7 +129,7 @@ public class ContractTest {
     }
 
     private void setUpSingleCharge(String accountId, Long chargeId, String chargeExternalId, ChargeStatus chargeStatus,
-                                   ZonedDateTime createdDate, boolean delayedCapture, String cardHolderName,
+                                   Instant createdDate, boolean delayedCapture, String cardHolderName,
                                    String lastDigitsCardNumber, String firstDigitsCardNumber, String gatewayTransactionId) {
         dbHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
@@ -149,7 +151,7 @@ public class ContractTest {
                 "aFirstAddress", "aSecondLine", "aPostCode", "aCity", "aCounty", "aCountry");
     }
 
-    private void setUpSingleCharge(String accountId, Long chargeId, String chargeExternalId, ChargeStatus chargeStatus, ZonedDateTime createdDate, boolean delayedCapture) {
+    private void setUpSingleCharge(String accountId, Long chargeId, String chargeExternalId, ChargeStatus chargeStatus, Instant createdDate, boolean delayedCapture) {
         sqsMockClient.mockSuccessfulSendChargeToQueue(chargeExternalId);
         setUpSingleCharge(accountId, chargeId, chargeExternalId, chargeStatus, createdDate, delayedCapture, "aName", "0001", "123456", "aGatewayTransactionId");
     }
@@ -172,7 +174,7 @@ public class ContractTest {
         Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
-        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CREATED, ZonedDateTime.now(), false);
+        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CREATED, Instant.now(), false);
         cancelCharge(gatewayAccountId, chargeExternalId);
     }
 
@@ -260,7 +262,7 @@ public class ContractTest {
         String chargeExternalId = params.get("charge_id");
 
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
-        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CAPTURED, ZonedDateTime.now(), false);
+        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CAPTURED, Instant.now(), false);
         dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphanumeric(10));
     }
 
@@ -270,7 +272,7 @@ public class ContractTest {
         Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
-        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CREATED, ZonedDateTime.now(), true);
+        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CREATED, Instant.now(), true);
     }
 
     @State("a charge exists")
@@ -291,7 +293,7 @@ public class ContractTest {
                 .withDescription("Test description")
                 .withReference(ServicePaymentReference.of("aReference"))
                 .withExternalMetadata(new ExternalMetadata(objectMapper.readValue("{\"ledger_code\":123, \"some_key\":\"key\"}", Map.class)))
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withEmail("test@test.com")
                 .withDelayedCapture(true)
                 .build());
@@ -304,7 +306,7 @@ public class ContractTest {
         Long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
         String chargeExternalId = params.get("charge_id");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
-        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.AWAITING_CAPTURE_REQUEST, ZonedDateTime.now(), true);
+        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.AWAITING_CAPTURE_REQUEST, Instant.now(), true);
     }
 
     @State("Gateway account 42 exists and has a charge for £1 with id abc123")
@@ -329,7 +331,7 @@ public class ContractTest {
         String chargeExternalId = "abc123";
         long chargeId = ThreadLocalRandom.current().nextLong(100, 100000);
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
-        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CREATED, ZonedDateTime.now(), false);
+        setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CREATED, Instant.now(), false);
 
         dbHelper.addEvent(chargeId, ChargeStatus.CREATED.toString());
         dbHelper.addEvent(chargeId, ChargeStatus.AUTHORISATION_REJECTED.toString());
@@ -345,7 +347,7 @@ public class ContractTest {
         String firstDigitsCardNumber = params.get("first_digits_card_number");
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CREATED,
-                ZonedDateTime.parse("2018-09-22T10:13:16.067Z"), true, cardHolderName, lastDigitsCardNumber,
+                Instant.parse("2018-09-22T10:13:16.067Z"), true, cardHolderName, lastDigitsCardNumber,
                 firstDigitsCardNumber, params.get("gateway_transaction_id"));
     }
 
@@ -356,7 +358,7 @@ public class ContractTest {
 
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(accountId));
         long chargeId = 1234L;
-        setUpSingleCharge(accountId, chargeId, chargeExternalId, ChargeStatus.CAPTURED, ZonedDateTime.now(), false);
+        setUpSingleCharge(accountId, chargeId, chargeExternalId, ChargeStatus.CAPTURED, Instant.now(), false);
         setUpRefunds(1, chargeId, ZonedDateTime.parse("2016-01-25T13:23:55Z"), REFUNDED, chargeExternalId);
         setUpRefunds(1, chargeId, ZonedDateTime.parse("2016-01-25T16:23:55Z"), REFUND_ERROR, chargeExternalId);
     }
@@ -379,10 +381,11 @@ public class ContractTest {
                 .withStatus(ChargeStatus.CREATED)
                 .withReturnUrl("aReturnUrl")
                 .withReference(ServicePaymentReference.of("aReference"))
-                .withCreatedDate(ZonedDateTime.now().minusHours(12))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(12)))
                 .withTransactionId("aTransactionId")
                 .withEmail("test@test.com")
                 .build());
+
         dbHelper.addRefund(refundId, 100L, REFUNDED,
                 randomAlphanumeric(10), createdDate,
                 Long.toString(paymentId));
@@ -417,8 +420,8 @@ public class ContractTest {
         dbHelper.insertWorldpay3dsFlexCredential(
                 Long.valueOf(worldpayGatewayAccountId),
                 "fa2daee2-1fbb-45ff-4444-52805d5cd9e0",
-                "5bd9e0e4444dce153428c940",
-                "5bd9b55e4444761ac0af1c80",
+                "5bd9e0e4444dce153428c940", // pragma: allowlist secret
+                "5bd9b55e4444761ac0af1c80", // pragma: allowlist secret
                 1L);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -18,7 +18,7 @@ import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Collections;
 
 import static org.apache.commons.lang3.RandomUtils.nextLong;
@@ -80,7 +80,7 @@ public class FrontendContractTest {
                 .withTransactionId(chargeExternalId)
                 .withReference(ServicePaymentReference.of("aReference"))
                 .withDescription("Test description")
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withEmail("test@test.com")
                 .withDelayedCapture(false)
                 .build());

--- a/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/HistoricalEventEmitterWorkerTest.java
@@ -39,6 +39,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -91,7 +92,7 @@ public class HistoricalEventEmitterWorkerTest {
                 .withCardDetails(cardDetails)
                 .build();
         ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
-                .withTimestamp(chargeEntity.getCreatedDate())
+                .withTimestamp(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC))
                 .withCharge(chargeEntity)
                 .withChargeStatus(ChargeStatus.CREATED)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
+++ b/src/test/java/uk/gov/pay/connector/tasks/ParityCheckWorkerTest.java
@@ -30,6 +30,8 @@ import uk.gov.pay.connector.tasks.service.ChargeParityChecker;
 import uk.gov.pay.connector.tasks.service.ParityCheckService;
 import uk.gov.pay.connector.tasks.service.RefundParityChecker;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -112,7 +114,7 @@ public class ParityCheckWorkerTest {
                 .withDelayedCapture(true)
                 .build();
         ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture.aValidChargeEventEntity()
-                .withTimestamp(chargeEntity.getCreatedDate())
+                .withTimestamp(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC))
                 .withCharge(chargeEntity)
                 .withChargeStatus(ChargeStatus.CREATED)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -7,12 +7,11 @@ import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-
-import static java.time.ZonedDateTime.now;
 
 public class AddChargeParams {
     private final Long chargeId;
@@ -24,7 +23,7 @@ public class AddChargeParams {
     private final String transactionId;
     private final String description;
     private final ServicePaymentReference reference;
-    private final ZonedDateTime createdDate;
+    private final Instant createdDate;
     private final long version;
     private final String email;
     private final String providerId;
@@ -95,7 +94,7 @@ public class AddChargeParams {
         return reference;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 
@@ -149,7 +148,7 @@ public class AddChargeParams {
         private String transactionId;
         private String description = "Test description";
         private ServicePaymentReference reference = ServicePaymentReference.of("Test reference");
-        private ZonedDateTime createdDate = now();
+        private Instant createdDate = Instant.now();
         private long version = 1;
         private String email = "test@example.com";
         private String providerId = "providerId";
@@ -213,7 +212,7 @@ public class AddChargeParams {
             return this;
         }
 
-        public AddChargeParamsBuilder withCreatedDate(ZonedDateTime createdDate) {
+        public AddChargeParamsBuilder withCreatedDate(Instant createdDate) {
             this.createdDate = createdDate;
             return this;
         }

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -21,7 +21,9 @@ import uk.gov.pay.connector.wallets.WalletType;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +119,7 @@ public class DatabaseTestHelper {
                         .bind("return_url", addChargeParams.getReturnUrl())
                         .bind("gateway_transaction_id", addChargeParams.getTransactionId())
                         .bind("description", addChargeParams.getDescription())
-                        .bind("created_date", Timestamp.from(addChargeParams.getCreatedDate().toInstant()))
+                        .bind("created_date", LocalDateTime.ofInstant(addChargeParams.getCreatedDate(), ZoneOffset.UTC))
                         .bind("reference", addChargeParams.getReference().toString())
                         .bind("version", addChargeParams.getVersion())
                         .bind("email", addChargeParams.getEmail())


### PR DESCRIPTION
Update the `ChargeEntity` class so that the `createdDate` field is an `Instant` rather than a `ZonedDateTime`.

`Instant` is a better fit than `ZonedDateTime` because it represents an exact moment in time but without the complexity of time zones. When instantiating a `ZonedDateTime` to assign to a `createdDate` field, we usually used the UTC time zone (e.g. `ZonedDateTime.now(ZoneOffset.UTC))`) but sometimes relied on the default time zone (UTC for the deployed application servers, possibly not elsewhere). Since an `Instant` does not have a time zone, we can avoid this brain tax while losing nothing of value, since we never relied on being able to have different `createdDate` fields using different time zones (we basically always wanted UTC, even if we did not explicitly ask for it).

Use `InstantToUtcTimestampWithoutTimeZoneConverter` instead of `UTCDateTimeConverter` to persist the `createdDate` to the `created_date` `TIMESTAMP WITHOUT TIME ZONE` column in the `charges` table of the database (see commit `f3d40f91e6b309ea6f14e10e6229f8086c050dcd` in pay-java-commons for more information). This will actually store the `created_date` as a date and time in the UTC time zone, rather than the default time zone. Since the default time zone of the deployed application servers is UTC, this won’t make a difference. This may cause a behaviour change when running with a default time zone that is not UTC (including changing how existing dates and times in the database are interpreted) but since this only happens when running locally for development and testing purposes, this should not be a real problem. Indeed, from now on, UTC will always be used, regardless of the default time zone, making the behaviour less environment-specific and more predictable.

In order to minimise the number of changes, we convert the `Instant` to a `ZonedDateTime` (using UTC), or convert a `ZonedDateTime` to an `Instant`, in some parts of the code. This is intended to be temporary, with `Instant` eventually being used everywhere to represent charge creation dates.

There are no changes to how the `createdDate` becomes the `created_date` in JSON responses (we convert to a `ZonedDateTime` in UTC and use the existing serialisation code).