### PR TITLE
PP-5642: Set exemption_3ds for a charge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.charge.model.telephone.PaymentOutcome;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.wallets.WalletType;
 
@@ -130,6 +131,9 @@ public class ChargeResponse {
     @JsonProperty("moto")
     private boolean moto;
 
+    @JsonProperty("exemption_3ds")
+    private Exemption3ds exemption3ds;
+    
     ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
         this.dataLinks = builder.getLinks();
         this.chargeId = builder.getChargeId();
@@ -162,6 +166,7 @@ public class ChargeResponse {
         this.walletType = builder.getWalletType();
         this.externalMetadata = builder.getExternalMetadata();
         this.moto = builder.isMoto();
+        this.exemption3ds = builder.getExemption3ds();
     }
 
     public List<Map<String, Object>> getDataLinks() {

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.charge.model.telephone.PaymentOutcome;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.net.URI;
@@ -48,6 +49,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected WalletType walletType;
     protected ExternalMetadata externalMetadata;
     protected boolean moto;
+    protected Exemption3ds exemption3ds;
 
     protected abstract T thisObject();
 
@@ -216,6 +218,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         this.moto = moto;
         return thisObject();
     }
+    
+    public T withExemption3ds(Exemption3ds exemption3ds) {
+        this.exemption3ds = exemption3ds;
+        return thisObject();
+    }
 
     public String getChargeId() {
         return chargeId;
@@ -341,5 +348,9 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public boolean isMoto() {
         return moto;
+    }
+
+    public Exemption3ds getExemption3ds() {
+        return exemption3ds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.UnspecifiedEvent;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
 
@@ -161,6 +162,9 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     @Column(name = "moto")
     private boolean moto;
+
+    @Column(name = "exemption_3ds")
+    private Exemption3ds exemption3ds;
 
     public ChargeEntity() {
         //for jpa
@@ -328,6 +332,10 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+    
+    public void setExemption3ds(Exemption3ds exemption3ds) {
+        this.exemption3ds = exemption3ds;
     }
 
     public void setProviderSessionId(String providerSessionId) {

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -338,6 +338,10 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         this.exemption3ds = exemption3ds;
     }
 
+    public Exemption3ds getExemption3ds() {
+        return exemption3ds;
+    }
+
     public void setProviderSessionId(String providerSessionId) {
         this.providerSessionId = providerSessionId;
     }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -453,7 +453,8 @@ public class ChargeService {
                 .withLink("self", GET, selfUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeId))
                 .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()))
                 .withWalletType(chargeEntity.getWalletType())
-                .withMoto(chargeEntity.isMoto());
+                .withMoto(chargeEntity.isMoto())
+                .withExemption3ds(chargeEntity.getExemption3ds());
 
         chargeEntity.getFeeAmount().ifPresent(builderOfResponse::withFee);
         chargeEntity.getExternalMetadata().ifPresent(builderOfResponse::withExternalMetadata);

--- a/src/main/java/uk/gov/pay/connector/charge/service/UpdateChargePostAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/UpdateChargePostAuthorisation.java
@@ -1,0 +1,135 @@
+package uk.gov.pay.connector.charge.service;
+
+import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
+
+import java.util.Objects;
+
+public class UpdateChargePostAuthorisation {
+
+    private String chargeExternalId;
+    private ChargeStatus status;
+    private String transactionId;
+    private Auth3dsRequiredEntity auth3dsRequiredDetails;
+    private ProviderSessionIdentifier sessionIdentifier;
+    private AuthCardDetails authCardDetails;
+    private Exemption3ds exemption3ds;
+
+    public String getChargeExternalId() {
+        return chargeExternalId;
+    }
+
+    public ChargeStatus getStatus() {
+        return status;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    public Auth3dsRequiredEntity getAuth3dsRequiredDetails() {
+        return auth3dsRequiredDetails;
+    }
+
+    public ProviderSessionIdentifier getSessionIdentifier() {
+        return sessionIdentifier;
+    }
+
+    public AuthCardDetails getAuthCardDetails() {
+        return authCardDetails;
+    }
+
+    public Exemption3ds getExemption3ds() {
+        return exemption3ds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UpdateChargePostAuthorisation that = (UpdateChargePostAuthorisation) o;
+        return Objects.equals(chargeExternalId, that.chargeExternalId) &&
+                status == that.status &&
+                Objects.equals(transactionId, that.transactionId) &&
+                Objects.equals(auth3dsRequiredDetails, that.auth3dsRequiredDetails) &&
+                Objects.equals(sessionIdentifier, that.sessionIdentifier) &&
+                Objects.equals(authCardDetails, that.authCardDetails) &&
+                exemption3ds == that.exemption3ds;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(chargeExternalId, status, transactionId, auth3dsRequiredDetails, sessionIdentifier, authCardDetails, exemption3ds);
+    }
+
+    public static final class UpdateChargePostAuthorisationBuilder {
+        private String chargeExternalId;
+        private ChargeStatus status;
+        private String transactionId;
+        private Auth3dsRequiredEntity auth3dsRequiredDetails;
+        private ProviderSessionIdentifier sessionIdentifier;
+        private AuthCardDetails authCardDetails;
+        private Exemption3ds exemption3ds;
+
+        private UpdateChargePostAuthorisationBuilder() {
+        }
+
+        public static UpdateChargePostAuthorisationBuilder anUpdateChargePostAuthorisation() {
+            return new UpdateChargePostAuthorisationBuilder();
+        }
+
+        public UpdateChargePostAuthorisationBuilder withChargeExternalId(String chargeExternalId) {
+            this.chargeExternalId = chargeExternalId;
+            return this;
+        }
+
+        public UpdateChargePostAuthorisationBuilder withStatus(ChargeStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public UpdateChargePostAuthorisationBuilder withTransactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public UpdateChargePostAuthorisationBuilder withAuth3dsRequiredDetails(Auth3dsRequiredEntity auth3dsRequiredDetails) {
+            this.auth3dsRequiredDetails = auth3dsRequiredDetails;
+            return this;
+        }
+
+        public UpdateChargePostAuthorisationBuilder withSessionIdentifier(ProviderSessionIdentifier sessionIdentifier) {
+            this.sessionIdentifier = sessionIdentifier;
+            return this;
+        }
+
+        public UpdateChargePostAuthorisationBuilder withAuthCardDetails(AuthCardDetails authCardDetails) {
+            this.authCardDetails = authCardDetails;
+            return this;
+        }
+
+        public UpdateChargePostAuthorisationBuilder withExemption3ds(Exemption3ds exemption3ds) {
+            this.exemption3ds = exemption3ds;
+            return this;
+        }
+
+        public UpdateChargePostAuthorisation build() {
+            Objects.requireNonNull(status);
+            Objects.requireNonNull(authCardDetails);
+            Objects.requireNonNull(chargeExternalId);
+            
+            UpdateChargePostAuthorisation updateChargePostAuthorisation = new UpdateChargePostAuthorisation();
+            updateChargePostAuthorisation.transactionId = this.transactionId;
+            updateChargePostAuthorisation.status = this.status;
+            updateChargePostAuthorisation.sessionIdentifier = this.sessionIdentifier;
+            updateChargePostAuthorisation.authCardDetails = this.authCardDetails;
+            updateChargePostAuthorisation.auth3dsRequiredDetails = this.auth3dsRequiredDetails;
+            updateChargePostAuthorisation.chargeExternalId = this.chargeExternalId;
+            updateChargePostAuthorisation.exemption3ds = this.exemption3ds;
+            return updateChargePostAuthorisation;
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -102,6 +102,10 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
     public void setExemptionResponseResult(String exemptionResponseResult) {
         this.exemptionResponseResult = exemptionResponseResult;
     }
+    
+    public boolean hasExemptionResponse() {
+        return exemptionResponseResult != null && exemptionResponseReason != null;
+    }
 
     public String getPaRequest() {
         return paRequest;

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/model/Exemption3ds.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/model/Exemption3ds.java
@@ -1,0 +1,32 @@
+package uk.gov.pay.connector.paymentprocessor.model;
+
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+
+import java.util.Set;
+
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_CANCELLED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_SUCCESS;
+
+public enum Exemption3ds {
+    
+    EXEMPTION_NOT_REQUESTED;
+    
+    private static final Set<ChargeStatus> EXEMPTION_NOT_REQUESTED_STATUSES = 
+            Set.of(AUTHORISATION_SUCCESS, AUTHORISATION_REJECTED, AUTHORISATION_CANCELLED, AUTHORISATION_ERROR);
+
+    public static Exemption3ds calculateExemption3ds(BaseAuthoriseResponse baseResponse, ChargeStatus status) {
+        if (baseResponse instanceof WorldpayOrderStatusResponse) {
+            
+            var worldpayOrderStatusResponse = (WorldpayOrderStatusResponse) baseResponse;
+            
+            if (!worldpayOrderStatusResponse.hasExemptionResponse() && EXEMPTION_NOT_REQUESTED_STATUSES.contains(status)) {
+                return EXEMPTION_NOT_REQUESTED;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -37,7 +37,7 @@ import static uk.gov.pay.connector.paymentprocessor.model.Exemption3ds.calculate
 public class CardAuthoriseService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CardAuthoriseService.class);
-    
+
     private final CardTypeDao cardTypeDao;
     private final AuthorisationService authorisationService;
     private final ChargeService chargeService;
@@ -50,7 +50,7 @@ public class CardAuthoriseService {
                                 PaymentProviders providers,
                                 AuthorisationService authorisationService,
                                 ChargeService chargeService,
-                                AuthorisationLogger authorisationLogger, 
+                                AuthorisationLogger authorisationLogger,
                                 Environment environment) {
         this.providers = providers;
         this.authorisationService = authorisationService;
@@ -83,21 +83,21 @@ public class CardAuthoriseService {
 
             Optional<String> transactionId = authorisationService.extractTransactionId(charge.getExternalId(), operationResponse);
             Optional<ProviderSessionIdentifier> sessionIdentifier = operationResponse.getSessionIdentifier();
-            Optional<Auth3dsRequiredEntity> auth3dsDetailsEntity = 
+            Optional<Auth3dsRequiredEntity> auth3dsDetailsEntity =
                     operationResponse.getBaseResponse().flatMap(BaseAuthoriseResponse::extractAuth3dsRequiredDetails);
-            
+
             ChargeEntity updatedCharge = chargeService.updateChargePostCardAuthorisation(
                     getUpdateChargePostAuthorisation(
-                            charge.getExternalId(), 
-                            newStatus, 
-                            transactionId.orElse(null), 
-                            auth3dsDetailsEntity.orElse(null), 
-                            sessionIdentifier.orElse(null), 
-                            authCardDetails, 
+                            charge.getExternalId(),
+                            newStatus,
+                            transactionId.orElse(null),
+                            auth3dsDetailsEntity.orElse(null),
+                            sessionIdentifier.orElse(null),
+                            authCardDetails,
                             operationResponse));
 
             var authorisationRequestSummary = generateAuthorisationRequestSummary(charge, authCardDetails);
-            
+
             authorisationLogger.logChargeAuthorisation(
                     LOGGER,
                     authorisationRequestSummary,
@@ -107,7 +107,7 @@ public class CardAuthoriseService {
                     charge.getChargeStatus(),
                     newStatus
             );
-            
+
             metricRegistry.counter(String.format(
                     "gateway-operations.%s.%s.%s.authorise.%s.result.%s",
                     updatedCharge.getGatewayAccount().getGatewayName(),
@@ -119,14 +119,15 @@ public class CardAuthoriseService {
             return new AuthorisationResponse(operationResponse);
         });
     }
-    
-    private UpdateChargePostAuthorisation getUpdateChargePostAuthorisation(String chargeExternalId, 
-                                                                           ChargeStatus newStatus, 
-                                                                           String transactionId, 
-                                                                           Auth3dsRequiredEntity auth3dsRequiredEntity, 
-                                                                           ProviderSessionIdentifier sessionIdentifier, 
-                                                                           AuthCardDetails authCardDetails, 
-                                                                           GatewayResponse<BaseAuthoriseResponse> operationResponse) {
+
+    private UpdateChargePostAuthorisation getUpdateChargePostAuthorisation(
+            String chargeExternalId,
+            ChargeStatus newStatus,
+            String transactionId,
+            Auth3dsRequiredEntity auth3dsRequiredEntity,
+            ProviderSessionIdentifier sessionIdentifier,
+            AuthCardDetails authCardDetails,
+            GatewayResponse<BaseAuthoriseResponse> operationResponse) {
         return anUpdateChargePostAuthorisation()
                 .withChargeExternalId(chargeExternalId)
                 .withStatus(newStatus)
@@ -167,7 +168,7 @@ public class CardAuthoriseService {
     private GatewayResponse<BaseAuthoriseResponse> authorise(ChargeEntity charge, AuthCardDetails authCardDetails) throws GatewayException {
         return getPaymentProviderFor(charge).authorise(CardAuthorisationGatewayRequest.valueOf(charge, authCardDetails));
     }
-    
+
     private PaymentProvider getPaymentProviderFor(ChargeEntity chargeEntity) {
         return providers.byName(chargeEntity.getPaymentGatewayName());
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -442,7 +442,7 @@ public class ChargeServiceTest {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo("1234567890");
         service.updateChargeAndEmitEventPostAuthorisation(chargeSpy.getExternalId(), ENTERING_CARD_DETAILS,
-                authCardDetails, null, null, null, null, null);
+                authCardDetails, null, null, null, null, null, null);
 
         verify(mockEventService).emitAndRecordEvent(PaymentDetailsEntered.from(chargeSpy));
     }
@@ -466,7 +466,7 @@ public class ChargeServiceTest {
         when(chargeSpy.getEvents()).thenReturn(List.of(chargeEvent));
 
         service.updateChargeAndEmitEventPostAuthorisation(chargeSpy.getExternalId(), ENTERING_CARD_DETAILS,
-                authCardDetails, null, null, null, null, null);
+                authCardDetails, null, null, null, null, null, null);
 
         verify(mockEventService).emitAndRecordEvent(PaymentDetailsEntered.from(chargeSpy));
     }
@@ -490,7 +490,7 @@ public class ChargeServiceTest {
         when(chargeSpy.getEvents()).thenReturn(List.of(chargeEvent));
 
         service.updateChargeAndEmitEventPostAuthorisation(chargeSpy.getExternalId(), ENTERING_CARD_DETAILS,
-                authCardDetails, null, null, null, null, null);
+                authCardDetails, null, null, null, null, null, null);
 
         assertThat(chargeSpy.getCardDetails().getBillingAddress().get().getStateOrProvince(), is("DC"));
     }
@@ -513,7 +513,7 @@ public class ChargeServiceTest {
         when(chargeSpy.getEvents()).thenReturn(List.of(chargeEvent));
 
         service.updateChargeAndEmitEventPostAuthorisation(chargeSpy.getExternalId(), ENTERING_CARD_DETAILS,
-                authCardDetails, null, null, null, null, null);
+                authCardDetails, null, null, null, null, null, null);
 
         assertThat(chargeSpy.getCardDetails().getBillingAddress().get().getStateOrProvince(), is(nullValue()));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponseTest.java
@@ -27,4 +27,10 @@ class WorldpayOrderStatusResponseTest {
 
         assertFalse(worldpayOrderStatusResponse.isSoftDecline());
     }
+    
+    @Test
+    void exemption_response_result_should_not_be_present() {
+        var worldpayOrderStatusResponse = new WorldpayOrderStatusResponse();
+        assertFalse(worldpayOrderStatusResponse.hasExemptionResponse());
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 
 import static io.restassured.http.ContentType.JSON;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
@@ -24,6 +25,7 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeState.EXTERNAL
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildCorporateJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithFullAddress;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -107,6 +109,30 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
                 .statusCode(200);
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
+    }
+    
+    /* 
+    The gateway account set up ChargingITestBase does not have exemption engine enabled by default 
+    */
+    @Test
+    public void should_set_exemption_not_requested_when_request_made_without_an_exemption() {
+
+        String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
+        worldpayMockClient.mockAuthorisationSuccess();
+
+        String authDetails = buildJsonAuthorisationDetailsWithFullAddress();
+
+        givenSetup()
+                .body(authDetails)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .body("status", is(AUTHORISATION_SUCCESS.toString()))
+                .statusCode(200);
+
+        connectorRestApiClient
+                .withChargeId(chargeId)
+                .getCharge()
+                .body("exemption_3ds", is(Exemption3ds.EXEMPTION_NOT_REQUESTED.name()));
     }
 
     @Test


### PR DESCRIPTION
Set exemption_3ds for a charge to EXEMPTION_NOT_REQUESTED if:

- The auth request is for Worldpay
- The charge's status resulting from the auth request is updated to either
  AUTHORISATION SUCCESS, AUTHORISATION REJECTED, AUTHORISATION CANCELLED or
AUTHORISATION ERROR

Also added an integration test which is useful to verify all the persistence code has been wired correctly.

ChargeService looks quite bloated but any refactoring will be saved for another PR.