### PR TITLE
PP-7590 Use Instant not ZonedDateTime for createdDate in Charge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -2,8 +2,7 @@ package uk.gov.pay.connector.charge.model.domain;
 
 import uk.gov.pay.connector.client.ledger.model.LedgerTransaction;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -18,7 +17,7 @@ public class Charge {
     private String refundAvailabilityStatus;
     private String reference;
     private String description;
-    private ZonedDateTime createdDate;
+    private Instant createdDate;
     private String email;
     private Long gatewayAccountId;
     private String paymentGatewayName;
@@ -26,7 +25,7 @@ public class Charge {
 
     public Charge(String externalId, Long amount, String status, String externalStatus, String gatewayTransactionId,
                   Long corporateSurcharge, String refundAvailabilityStatus, String reference,
-                  String description, ZonedDateTime createdDate, String email, Long gatewayAccountId, String paymentGatewayName, boolean historic) {
+                  String description, Instant createdDate, String email, Long gatewayAccountId, String paymentGatewayName, boolean historic) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
@@ -56,7 +55,7 @@ public class Charge {
                 null, 
                 chargeEntity.getReference().toString(),
                 chargeEntity.getDescription(),
-                ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC),
+                chargeEntity.getCreatedDate(),
                 chargeEntity.getEmail(),
                 chargeEntity.getGatewayAccount().getId(),
                 chargeEntity.getPaymentGatewayName().getName(),
@@ -85,7 +84,7 @@ public class Charge {
                 externalRefundState,
                 transaction.getReference(),
                 transaction.getDescription(),
-                ZonedDateTime.parse(transaction.getCreatedDate()),
+                Instant.parse(transaction.getCreatedDate()),
                 transaction.getEmail(),
                 Long.valueOf(transaction.getGatewayAccountId()),
                 transaction.getPaymentProvider(),
@@ -129,7 +128,7 @@ public class Charge {
         return description;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/usernotification/service/UserNotificationService.java
@@ -22,8 +22,6 @@ import uk.gov.service.notify.SendEmailResponse;
 
 import javax.inject.Inject;
 import java.math.BigDecimal;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -174,7 +172,7 @@ public class UserNotificationService {
         HashMap<String, String> map = new HashMap<>();
 
         map.put("serviceReference", charge.getReference().toString());
-        map.put("date", DateTimeUtils.toUserFriendlyDate(ZonedDateTime.ofInstant(charge.getCreatedDate(), ZoneOffset.UTC)));
+        map.put("date", DateTimeUtils.toUserFriendlyDate(charge.getCreatedDate()));
         map.put("amount", formatToPounds(CorporateCardSurchargeCalculator.getTotalAmountFor(charge)));
         map.put("description", charge.getDescription());
         map.put("customParagraph", isBlank(customParagraph) ? "" : "^ " + LITERAL_DOLLAR_REFERENCE.matcher(customParagraph)

--- a/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.util;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -16,8 +15,10 @@ import static java.util.Objects.isNull;
 public class DateTimeUtils {
 
     private static final ZoneId UTC = ZoneId.of("Z");
+    private static final ZoneId EUROPE_LONDON = ZoneId.of("Europe/London");
     private static DateTimeFormatter dateTimeFormatterAny = DateTimeFormatter.ISO_ZONED_DATE_TIME;
     private static DateTimeFormatter localDateFormatter = DateTimeFormatter.ISO_DATE;
+    private static final DateTimeFormatter USER_FRIENDLY_DATE = DateTimeFormatter.ofPattern("d MMMM yyyy - HH:mm:ss");
 
     /**
      * Converts any valid ZonedDateTime String (ISO_8601) representation to a UTC ZonedDateTime
@@ -78,12 +79,8 @@ public class DateTimeUtils {
         return zonedDateTime.withZoneSameInstant(ZoneOffset.UTC).toLocalDate().format(localDateFormatter);
     }
 
-
-    public static String toUserFriendlyDate(ZonedDateTime zonedDateTime) {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy - HH:mm:ss");
-
-        LocalDateTime localDateTime = zonedDateTime.withZoneSameInstant(ZoneId.of("Europe/London")).toLocalDateTime();
-
-        return localDateTime.format(dateTimeFormatter);
+    public static String toUserFriendlyDate(Instant instant) {
+        return ZonedDateTime.ofInstant(instant, EUROPE_LONDON).format(USER_FRIENDLY_DATE);
     }
+
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
@@ -17,8 +17,7 @@ import uk.gov.pay.connector.token.model.domain.TokenEntity;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.net.URI;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -282,7 +281,7 @@ public class ChargeServiceFindTest extends ChargeServiceTest {
         LedgerTransaction transaction = new LedgerTransaction();
         transaction.setTransactionId(chargeEntity.getExternalId());
         transaction.setAmount(chargeEntity.getAmount());
-        transaction.setCreatedDate(ZonedDateTime.now(ZoneId.of("UTC")).toString());
+        transaction.setCreatedDate(Instant.now().toString());
         transaction.setGatewayAccountId(String.valueOf(GATEWAY_ACCOUNT_ID));
         when(mockedChargeDao.findByExternalIdAndGatewayAccount(chargeEntity.getExternalId(), GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
 
@@ -323,7 +322,7 @@ public class ChargeServiceFindTest extends ChargeServiceTest {
         LedgerTransaction transaction = new LedgerTransaction();
         transaction.setTransactionId(chargeEntity.getExternalId());
         transaction.setAmount(chargeEntity.getAmount());
-        transaction.setCreatedDate(ZonedDateTime.now(ZoneId.of("UTC")).toString());
+        transaction.setCreatedDate(Instant.now().toString());
         transaction.setGatewayAccountId(String.valueOf(GATEWAY_ACCOUNT_ID));
         when(mockedChargeDao.findByProviderAndTransactionId(
                 "sandbox",

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -66,7 +66,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.refund.service.RefundService;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -361,7 +361,7 @@ public class EventFactoryTest {
         transaction.setRefundSummary(refundSummary);
         transaction.setAmount(charge.getAmount());
         transaction.setTotalAmount(charge.getAmount());
-        transaction.setCreatedDate(ZonedDateTime.now().toString());
+        transaction.setCreatedDate(Instant.now().toString());
         transaction.setGatewayAccountId(charge.getGatewayAccount().getId().toString());
         when(chargeService.findCharge(transaction.getTransactionId())).thenReturn(Optional.of(Charge.from(transaction)));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -8,9 +8,9 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
+import java.time.Instant;
 import java.util.Optional;
 
-import static java.time.ZonedDateTime.now;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -228,7 +228,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     
     private Charge getCharge(boolean isHistoric){
         return new Charge("external-id", 10L, null, null, "transaction-id",
-                10L, null, "ref-1", "desc", now(),
+                10L, null, "ref-1", "desc", Instant.now(),
                 "test@example.org", 123L, "epdq", isHistoric);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -10,13 +10,13 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.Maps.newHashMap;
-import static java.time.ZonedDateTime.now;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
@@ -156,7 +156,7 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
 
     private Charge getHistoricCharge(ExternalChargeRefundAvailability availability) {
         return new Charge("external-id", 500L, null, "success", "transaction-id",
-                0L, availability.getStatus(), "ref-1", "desc", now(),
+                0L, availability.getStatus(), "ref-1", "desc", Instant.now(),
                 "test@example.org", 123L, "epdq", true);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -38,8 +38,7 @@ import uk.gov.pay.connector.refund.service.ChargeRefundResponse;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -182,7 +181,7 @@ public class RefundServiceTest {
         transaction.setReference("reference");
         transaction.setDescription("description");
         transaction.setGatewayAccountId(String.valueOf(accountId));
-        transaction.setCreatedDate(ZonedDateTime.now(ZoneId.of("UTC")).toString());
+        transaction.setCreatedDate(Instant.now().toString());
 
         RefundEntity refundEntity = aValidRefundEntity().withChargeExternalId(externalChargeId).withAmount(refundAmount).build();
         RefundEntity spiedRefundEntity = spy(refundEntity);

--- a/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/DateTimeUtilsTest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.util;
 
 import org.junit.Test;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -56,10 +57,9 @@ public class DateTimeUtilsTest {
 
     @Test
     public void toUserFriendlyDateShouldFormatAsDateInLondonTimezone() {
-        String aDate = "2016-07-07T23:24:48Z";
-        Optional<ZonedDateTime> zonedDateTime = DateTimeUtils.toUTCZonedDateTime(aDate);
+        Instant instant = Instant.parse("2016-07-07T23:24:48Z");
 
-        String result = DateTimeUtils.toUserFriendlyDate(zonedDateTime.get());
+        String result = DateTimeUtils.toUserFriendlyDate(instant);
 
         assertThat(result, is("8 July 2016 - 00:24:48"));
     }


### PR DESCRIPTION
Update the `Charge` class so that the `createdDate` field is an `Instant` rather than a `ZonedDateTime`, which is line with `ChargeEntity`.

When creating a `Charge` from a `LedgerTransaction`, where we obtain the `createdDate` by parsing a string, we now use `Instant.parse(…)` rather than `ZonedDateTime.parse(…)`. This accepts a narrower range of formats but everything ledger gives us should be an ISO 8601 string, which is compatible with `Instant.parse(…)`. Some tests have been updated to not use `ZonedDateTime`s in the default time zone to reflect this.

Also change `DateTimeUtils.toUserFriendlyDate(…)` to take an `Instant` rather than a `ZonedDateTime` because all the callers have `Instant`s now.