### PR TITLE
PP-7590 Use Instant for created_date in API responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
+import uk.gov.pay.commons.api.json.ApiResponseInstantSerializer;
 import uk.gov.pay.commons.api.json.ExternalMetadataSerialiser;
 import uk.gov.pay.commons.model.SupportedLanguage;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
@@ -19,6 +20,7 @@ import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.net.URI;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
@@ -76,8 +78,8 @@ public class ChargeResponse {
     private String providerId;
 
     @JsonProperty("created_date")
-    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
-    private ZonedDateTime createdDate;
+    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    private Instant createdDate;
 
     @JsonProperty("authorised_date")
     @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
@@ -268,7 +270,7 @@ public class ChargeResponse {
         return providerId;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.net.URI;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +27,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected String returnUrl;
     protected String description;
     protected String telephoneNumber;
-    protected ZonedDateTime createdDate;
+    protected Instant createdDate;
     protected ZonedDateTime authorisedDate;
     protected List<Map<String, Object>> links = new ArrayList<>();
     protected ServicePaymentReference reference;
@@ -111,7 +112,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return thisObject();
     }
 
-    public T withCreatedDate(ZonedDateTime createdDate) {
+    public T withCreatedDate(Instant createdDate) {
         this.createdDate = createdDate;
         return thisObject();
     }
@@ -245,7 +246,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return description;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -33,8 +33,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -165,7 +163,7 @@ public class ChargesFrontendResource {
                 .withAmount(charge.getAmount())
                 .withDescription(charge.getDescription())
                 .withGatewayTransactionId(charge.getGatewayTransactionId())
-                .withCreatedDate(ZonedDateTime.ofInstant(charge.getCreatedDate(), ZoneOffset.UTC))
+                .withCreatedDate(charge.getCreatedDate())
                 .withReturnUrl(charge.getReturnUrl())
                 .withEmail(charge.getEmail())
                 .withFee(charge.getFeeAmount().orElse(null))

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -73,7 +73,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.time.Duration;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -400,7 +399,7 @@ public class ChargeService {
             }
 
             if (externalMetadata.getMetadata().get("created_date") != null) {
-                builderOfResponse.withCreatedDate(ZonedDateTime.parse(((String) externalMetadata.getMetadata().get("created_date"))));
+                builderOfResponse.withCreatedDate(ZonedDateTime.parse(((String) externalMetadata.getMetadata().get("created_date"))).toInstant());
             }
 
             builderOfResponse
@@ -441,7 +440,7 @@ public class ChargeService {
                 .withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()))
                 .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
                 .withProviderName(chargeEntity.getGatewayAccount().getGatewayName())
-                .withCreatedDate(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC))
+                .withCreatedDate(chargeEntity.getCreatedDate())
                 .withReturnUrl(chargeEntity.getReturnUrl())
                 .withEmail(chargeEntity.getEmail())
                 .withLanguage(chargeEntity.getLanguage())

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -61,7 +61,6 @@ import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
 
 import javax.ws.rs.core.UriInfo;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -373,7 +372,7 @@ public class ChargeServiceTest {
                 .withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()))
                 .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
                 .withProviderName(chargeEntity.getGatewayAccount().getGatewayName())
-                .withCreatedDate(ZonedDateTime.ofInstant(chargeEntity.getCreatedDate(), ZoneOffset.UTC))
+                .withCreatedDate(chargeEntity.getCreatedDate())
                 .withEmail(chargeEntity.getEmail())
                 .withRefunds(refunds)
                 .withSettlement(settlement)


### PR DESCRIPTION
In `ChargeResponse` (the Java model that represents the JSON for a charge sent in API responses), change the Java type of the `created_date` property from `ZonedDateTime` to `Instant`, which necessitates switching from `ApiResponseDateTimeSerializer` to `ApiResponseInstantSerializer`.

This will not change how the `created_date` for a charge appears as a JSON string in API responses.