### PR TITLE
PP-7590 Use Instant for created date in charge test fixtures

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -20,7 +20,6 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
 
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -198,8 +197,8 @@ public class ChargeEntityFixture {
         return this;
     }
 
-    public ChargeEntityFixture withCreatedDate(ZonedDateTime createdDate) {
-        this.createdDate = createdDate.toInstant();
+    public ChargeEntityFixture withCreatedDate(Instant createdDate) {
+        this.createdDate = createdDate;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -33,8 +33,8 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.paymentprocessor.service.QueryService;
 import uk.gov.pay.connector.token.dao.TokenDao;
 
+import java.time.Duration;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -138,7 +138,7 @@ public class ChargeExpiryServiceTest {
         var status = ChargeStatus.fromString(chargeStatus);
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withStatus(status)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -161,7 +161,7 @@ public class ChargeExpiryServiceTest {
         var status = ChargeStatus.fromString(chargeStatus);
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withStatus(status)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -187,7 +187,7 @@ public class ChargeExpiryServiceTest {
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withStatus(status)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -225,7 +225,7 @@ public class ChargeExpiryServiceTest {
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withStatus(status)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -264,7 +264,7 @@ public class ChargeExpiryServiceTest {
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withStatus(status)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -289,7 +289,7 @@ public class ChargeExpiryServiceTest {
     public void shouldUpdateStatusToMatchGatewayStatus_whenNormalStateTransitionAllowed() throws Exception {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withStatus(AUTHORISATION_3DS_READY)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -313,7 +313,7 @@ public class ChargeExpiryServiceTest {
     public void shouldUpdateStatusWhenCancellationFails() throws Exception {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now())
+                .withCreatedDate(Instant.now())
                 .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -335,14 +335,14 @@ public class ChargeExpiryServiceTest {
     public void shouldSweepAndExpireCharges() throws Exception {
         ChargeEntity chargeEntityAwaitingCapture = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(AWAITING_CAPTURE_REQUEST)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
         ChargeEntity chargeEntityAuthorisationSuccess = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(AUTHORISATION_SUCCESS)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -369,7 +369,7 @@ public class ChargeExpiryServiceTest {
     public void shouldCancelChargeWithGatewayWhenChargeInPreAuthorisedStateAndExistsWithGateway() throws Exception {
         ChargeEntity preAuthorisationCharge = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -391,7 +391,7 @@ public class ChargeExpiryServiceTest {
     public void forceCancelShouldReturnSuccess_whenCancelStateIsCancelled() throws Exception {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -408,7 +408,7 @@ public class ChargeExpiryServiceTest {
     public void forceCancelShouldReturnSuccess_whenCancelStateIsSubmitted() throws Exception {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -425,7 +425,7 @@ public class ChargeExpiryServiceTest {
     public void forceCancelShouldReturnFailure_whenCancelStateIsError() throws Exception {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
@@ -442,7 +442,7 @@ public class ChargeExpiryServiceTest {
     public void forceCancelShouldReturnFailure_whenGatewayResponseHasError() throws Exception {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withAmount(200L)
-                .withCreatedDate(ZonedDateTime.now().minusHours(48L).plusMinutes(1L))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollectedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/BackfillerRecreatedUserEmailCollectedTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -34,7 +35,7 @@ public class BackfillerRecreatedUserEmailCollectedTest {
 
         String paymentId = "jweojfewjoifewj";
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.parse(time))
+                .withCreatedDate(Instant.parse(time))
                 .withStatus(ChargeStatus.USER_CANCELLED)
                 .withExternalId(paymentId)
                 .withAmount(100L)

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/CancelledByUserTest.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.events.eventdetails.charge.CancelledByUserEventDetails;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
@@ -27,7 +28,7 @@ public class CancelledByUserTest {
     @Before
     public void setUp() {
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.parse(time))
+                .withCreatedDate(Instant.parse(time))
                 .withStatus(ChargeStatus.USER_CANCELLED)
                 .withExternalId(paymentId)
                 .withTransactionId(transactionId)

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -31,7 +32,7 @@ public class PaymentCreatedTest {
     private final String time = "2018-03-12T16:25:01.123456Z";
 
     private final ChargeEntityFixture chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
-            .withCreatedDate(ZonedDateTime.parse(time))
+            .withCreatedDate(Instant.parse(time))
             .withExternalId(paymentId)
             .withDescription("new passport")
             .withReference(ServicePaymentReference.of("myref"))

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentDetailsEnteredTest.java
@@ -11,6 +11,7 @@ import uk.gov.pay.connector.gateway.model.PayersCardType;
 import uk.gov.pay.connector.northamericaregion.UsState;
 import uk.gov.pay.connector.wallets.WalletType;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -40,7 +41,7 @@ public class PaymentDetailsEnteredTest {
         );
 
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.parse(time))
+                .withCreatedDate(Instant.parse(time))
                 .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
                 .withExternalId(paymentId)
                 .withTransactionId(validTransactionId)

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
@@ -10,7 +10,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Map;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
@@ -33,7 +33,7 @@ public class PaymentNotificationCreatedTest {
     @Before
     public void setUp() {
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.parse(time))
+                .withCreatedDate(Instant.parse(time))
                 .withStatus(ChargeStatus.PAYMENT_NOTIFICATION_CREATED)
                 .withExternalId(paymentId)
                 .withTransactionId(providerId)

--- a/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
@@ -18,7 +18,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.tasks.service.ParityCheckService;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -105,7 +106,7 @@ public class ChargeExpungeServiceTest {
         when(mockExpungeConfig.getMinimumAgeForHistoricChargeExceptions()).thenReturn(2);
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(5))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(5)))
                 .withStatus(CAPTURE_SUBMITTED)
                 .build();
         when(mockExpungeConfig.isExpungeChargesEnabled()).thenReturn(true);
@@ -125,7 +126,7 @@ public class ChargeExpungeServiceTest {
         when(mockExpungeConfig.getMinimumAgeForHistoricChargeExceptions()).thenReturn(8);
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(5))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(5)))
                 .withStatus(CAPTURE_SUBMITTED)
                 .build();
         when(mockExpungeConfig.isExpungeChargesEnabled()).thenReturn(true);
@@ -162,7 +163,7 @@ public class ChargeExpungeServiceTest {
     @Parameters({"AUTHORISATION_ERROR", "AUTHORISATION_TIMEOUT", "AUTHORISATION_UNEXPECTED_ERROR"})
     public void shouldNotExpungeEpdqChargeWithState(String state) {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(5))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(5)))
                 .withStatus(ChargeStatus.valueOf(state))
                 .withGatewayAccountEntity(aGatewayAccountEntity().withGatewayName("epdq").build())
                 .build();
@@ -183,7 +184,7 @@ public class ChargeExpungeServiceTest {
     @Parameters({"USER_CANCELLED", "EXPIRED", "CAPTURE_ERROR", "AUTHORISATION_REJECTED"})
     public void shouldExpungeEpdqChargesWithState(String state) {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(5))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(5)))
                 .withStatus(ChargeStatus.valueOf(state))
                 .withGatewayAccountEntity(aGatewayAccountEntity().withGatewayName("epdq").build())
                 .build();

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -443,7 +443,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .insert();
 
         ArrayList<ChargeStatus> chargeStatuses = Lists.newArrayList(CREATED, ENTERING_CARD_DETAILS, AUTHORISATION_SUCCESS);
@@ -462,7 +462,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .insert();
 
         ArrayList<ChargeStatus> chargeStatuses = Lists.newArrayList(CAPTURE_READY, SYSTEM_CANCELLED);
@@ -480,7 +480,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now().minusMinutes(30))
+                .withCreatedDate(Instant.now().minus(Duration.ofMinutes(30)))
                 .insert();
 
         ArrayList<ChargeStatus> chargeStatuses = Lists.newArrayList(CREATED, ENTERING_CARD_DETAILS, AUTHORISATION_SUCCESS);
@@ -498,7 +498,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now())
+                .withCreatedDate(Instant.now())
                 .withAmount(300L)
                 .insert();
 
@@ -534,7 +534,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED)
                 .insert();
         DatabaseFixtures
@@ -543,7 +543,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
                 .insert();
         TestCharge charge = DatabaseFixtures
@@ -552,7 +552,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now())
+                .withCreatedDate(Instant.now())
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
                 .insert();
         DatabaseFixtures
@@ -577,7 +577,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId)
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED)
                 .insert();
 
@@ -610,7 +610,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId)
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(AUTHORISATION_3DS_READY)
                 .insert();
 
@@ -638,7 +638,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED)
                 .insert();
         DatabaseFixtures
@@ -647,7 +647,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeId(nextLong())
                 .withExternalChargeId(RandomIdGenerator.newId())
-                .withCreatedDate(now().minusHours(2))
+                .withCreatedDate(Instant.now().minus(Duration.ofHours(2)))
                 .withChargeStatus(CAPTURE_APPROVED_RETRY)
                 .insert();
 
@@ -749,7 +749,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCreatedDate(now(ZoneId.of("UTC")).minusDays(90))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(90)))
                 .withParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER)
                 .insert();
 
@@ -757,7 +757,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCreatedDate(now(ZoneId.of("UTC")).minusDays(90))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(90)))
                 .withParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER)
                 .withParityCheckDate(now(ZoneId.of("UTC")).minusDays(6))
                 .insert();
@@ -766,7 +766,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCreatedDate(now(ZoneId.of("UTC")).minusDays(4))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(4)))
                 .withParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER)
                 .withParityCheckDate(now(ZoneId.of("UTC")).minusDays(1))
                 .insert();
@@ -786,7 +786,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(defaultTestAccount)
-                .withCreatedDate(now(ZoneId.of("UTC")).minusDays(90))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(90)))
                 .withParityCheckDate(now(ZoneId.of("UTC")))
                 .withParityCheckStatus(ParityCheckStatus.MISSING_IN_LEDGER)
                 .insert();

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -589,11 +589,6 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestCharge withCreatedDate(ZonedDateTime createdDate) {
-            this.createdDate = createdDate.toInstant();
-            return this;
-        }
-
         public TestCharge withCardDetails(TestCardDetails testCardDetails) {
             cardDetails = testCardDetails;
             return this;

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
@@ -13,7 +13,8 @@ import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
 
-import java.time.ZonedDateTime;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 
 import static org.mockito.Mockito.verify;
@@ -48,7 +49,7 @@ public class DiscrepancyServiceTest {
     @Test
     public void aChargeShouldBeCancellable_whenPayAndGatewayStatusesAllowItAndIsOlderThan2Days() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(3))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(EXPIRED)
                 .build();
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, mockGatewayResponse);
@@ -64,7 +65,7 @@ public class DiscrepancyServiceTest {
     @Test
     public void aChargeShouldNotBeCancellable_whenPayAndGatewayStatusesMatch() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(3))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build();
         
@@ -75,7 +76,7 @@ public class DiscrepancyServiceTest {
     @Test
     public void aChargeShouldNotBeCancellable_whenPayStatusIsSuccess() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(3))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(CAPTURED)
                 .build();
         
@@ -86,7 +87,7 @@ public class DiscrepancyServiceTest {
     @Test
     public void aChargeShouldNotBeCancellable_whenPayStatusIsUnfinished() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(3))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(AUTHORISATION_3DS_READY)
                 .build();
 
@@ -97,7 +98,7 @@ public class DiscrepancyServiceTest {
     @Test
     public void aChargeShouldNotBeCancellable_whenGatewayStatusIsFinished() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(3))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(EXPIRED)
                 .build();
         
@@ -108,7 +109,7 @@ public class DiscrepancyServiceTest {
     @Test
     public void aChargeShouldNotBeCancellable_whenChargeIsLessThan2DaysOld() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.now().minusDays(1))
+                .withCreatedDate(Instant.now().minus(Duration.ofDays(1)))
                 .withStatus(EXPIRED)
                 .build();
         

--- a/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/report/dao/PerformanceReportDaoIT.java
@@ -11,6 +11,8 @@ import uk.gov.pay.connector.report.model.domain.GatewayAccountPerformanceReportE
 import uk.gov.pay.connector.report.model.domain.PerformanceReportEntity;
 
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,7 +37,7 @@ public class PerformanceReportDaoIT extends DaoITestBase {
                 .insert();
     }
 
-    private void insertCharge(DatabaseFixtures.TestAccount account, long amount, ZonedDateTime createdDate) {
+    private void insertCharge(DatabaseFixtures.TestAccount account, long amount, Instant createdDate) {
         DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
@@ -49,8 +51,8 @@ public class PerformanceReportDaoIT extends DaoITestBase {
     @Ignore
     @Test
     public void shouldAggregateNumberAndValueOfPayments() {
-        insertCharge(testAccountFixture, 10L, ZonedDateTime.now());
-        insertCharge(testAccountFixture, 2L, ZonedDateTime.now());
+        insertCharge(testAccountFixture, 10L, Instant.now());
+        insertCharge(testAccountFixture, 2L, Instant.now());
         PerformanceReportEntity performanceReportEntity = performanceReportDao.aggregateNumberAndValueOfPayments();
         assertThat(performanceReportEntity.getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
         assertThat(performanceReportEntity.getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
@@ -71,11 +73,11 @@ public class PerformanceReportDaoIT extends DaoITestBase {
                 .withAccountId(174L)
                 .withType(GatewayAccountType.LIVE)
                 .insert();
-        insertCharge(gatewayAccount, 10L, ZonedDateTime.now());
-        insertCharge(gatewayAccount, 2L, ZonedDateTime.now());
-        insertCharge(anotherGatewayAccount, 6L, ZonedDateTime.now());
-        insertCharge(anotherGatewayAccount, 3L, ZonedDateTime.now());
-        insertCharge(anotherGatewayAccount, 6L, ZonedDateTime.now());
+        insertCharge(gatewayAccount, 10L, Instant.now());
+        insertCharge(gatewayAccount, 2L, Instant.now());
+        insertCharge(anotherGatewayAccount, 6L, Instant.now());
+        insertCharge(anotherGatewayAccount, 3L, Instant.now());
+        insertCharge(anotherGatewayAccount, 6L, Instant.now());
 
         List<GatewayAccountPerformanceReportEntity> gatewayAccountPerformanceReportEntities =
                 performanceReportDao.aggregateNumberAndValueOfPaymentsByGatewayAccount().collect(Collectors.toList());
@@ -96,13 +98,14 @@ public class PerformanceReportDaoIT extends DaoITestBase {
 
     @Test
     public void shouldAggregateNumberAndValueOfPaymentsForAGivenDay() {
-        ZonedDateTime oldDate = ZonedDateTime.parse("2017-11-20T10:00:00Z");
-        ZonedDateTime validDate1 = ZonedDateTime.parse("2017-11-21T10:00:00Z");
-        ZonedDateTime validDate2 = ZonedDateTime.parse("2017-11-21T11:00:00Z");
+        Instant oldDate = Instant.parse("2017-11-20T10:00:00Z");
+        Instant validDate1 = Instant.parse("2017-11-21T10:00:00Z");
+        Instant validDate2 = Instant.parse("2017-11-21T11:00:00Z");
         insertCharge(testAccountFixture, 10L, oldDate);
         insertCharge(testAccountFixture, 2L, validDate1);
         insertCharge(testAccountFixture, 10L, validDate2);
-        PerformanceReportEntity performanceReportEntity = performanceReportDao.aggregateNumberAndValueOfPaymentsForAGivenDay(validDate1);
+        PerformanceReportEntity performanceReportEntity = performanceReportDao.aggregateNumberAndValueOfPaymentsForAGivenDay(
+                ZonedDateTime.ofInstant(validDate1, ZoneOffset.UTC));
         assertThat(performanceReportEntity.getAverageAmount(), is(closeTo(new BigDecimal("6"), ZERO)));
         assertThat(performanceReportEntity.getTotalAmount(), is(closeTo(new BigDecimal("12"), ZERO)));
         assertThat(performanceReportEntity.getTotalVolume(), is(2L));

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/UserNotificationServiceTest.java
@@ -16,8 +16,8 @@ import uk.gov.pay.connector.app.NotifyConfiguration;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.usernotification.govuknotify.NotifyClientFactory;
@@ -27,8 +27,8 @@ import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 import uk.gov.service.notify.SendEmailResponse;
 
+import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,7 +79,7 @@ public class UserNotificationServiceTest {
     private final UUID notificationId = randomUUID();
 
     private final ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-            .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneOffset.UTC))
+            .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
             .build();
 
     private final Charge charge = Charge.from(chargeEntity);
@@ -141,7 +141,7 @@ public class UserNotificationServiceTest {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withReference(ServicePaymentReference.of("123$000"))
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .build();
 
         Map<String, String> personalisation = new HashMap<>();
@@ -343,7 +343,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .withCorporateSurcharge(250L)
                 .build();
 
@@ -378,7 +378,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .withNotifySettings(ImmutableMap.of("api_token", "my-api-key", "template_id", "my-template-id"))
                 .build();
 
@@ -397,7 +397,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .withNotifySettings(ImmutableMap.of("api_token", "my-api-key", "refund_issued_template_id", "template_id2"))
                 .build();
         RefundEntity refundEntity = RefundEntityFixture.aValidRefundEntity()
@@ -417,7 +417,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .withNotifySettings(ImmutableMap.of("template_id", "my-template-id"))
                 .build();
  
@@ -433,7 +433,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .withNotifySettings(ImmutableMap.of("api_token", "my-api-key"))
                 .build();
  
@@ -449,7 +449,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
  
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .withNotifySettings(ImmutableMap.of("refund_issued_template_id", "my-template-id"))
                 .build();
 
@@ -467,7 +467,7 @@ public class UserNotificationServiceTest {
         when(mockNotifyClient.sendEmail(any(), any(), any(), any())).thenReturn(mockNotificationCreatedResponse);
 
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
-                .withCreatedDate(ZonedDateTime.of(2016, 1, 1, 10, 23, 12, 0, ZoneId.of("UTC")))
+                .withCreatedDate(Instant.parse("2016-01-01T10:23:12Z"))
                 .withNotifySettings(ImmutableMap.of("api_token", "my-api-key"))
                 .build();
 


### PR DESCRIPTION
In test charge fixtures, use `Instant` rather than `ZonedDateTime` for the created date. This brings it into line with `ChargeEntity`.

There are some small behaviour differences here. If a test created a `ZonedDateTime` using `ZonedDateTime.now()` with a default time zone that uses daylight saving time (such as Europe/London) and then subtracted a certain number of days using `minusDays(…)`, the number of hours subtracted might not be an exact multiple of 24 if the period subtracted included the time when daylight saving time started or finished. With the equivalent subtraction on an `Instant`, the number of hours  is always an exact multiple of 24. The previous behaviour was almost certainly unintended so this is OK.