### PR TITLE
PP-7590 Use Instant for authorised_date in API responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import uk.gov.pay.commons.api.json.ApiResponseDateTimeSerializer;
 import uk.gov.pay.commons.api.json.ApiResponseInstantSerializer;
 import uk.gov.pay.commons.api.json.ExternalMetadataSerialiser;
 import uk.gov.pay.commons.model.SupportedLanguage;
@@ -82,8 +81,8 @@ public class ChargeResponse {
     private Instant createdDate;
 
     @JsonProperty("authorised_date")
-    @JsonSerialize(using = ApiResponseDateTimeSerializer.class)
-    private ZonedDateTime authorisedDate;
+    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    private Instant authorisedDate;
 
     @JsonProperty("payment_outcome")
     private PaymentOutcome paymentOutcome;
@@ -274,7 +273,7 @@ public class ChargeResponse {
         return createdDate;
     }
 
-    public ZonedDateTime getAuthorisedDate() {
+    public Instant getAuthorisedDate() {
         return authorisedDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -12,7 +12,6 @@ import uk.gov.pay.connector.wallets.WalletType;
 
 import java.net.URI;
 import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +27,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected String description;
     protected String telephoneNumber;
     protected Instant createdDate;
-    protected ZonedDateTime authorisedDate;
+    protected Instant authorisedDate;
     protected List<Map<String, Object>> links = new ArrayList<>();
     protected ServicePaymentReference reference;
     protected String processorId;
@@ -117,7 +116,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return thisObject();
     }
 
-    public T withAuthorisedDate(ZonedDateTime authorisedDate) {
+    public T withAuthorisedDate(Instant authorisedDate) {
         this.authorisedDate = authorisedDate;
         return thisObject();
     }
@@ -324,7 +323,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return telephoneNumber;
     }
 
-    public ZonedDateTime getAuthorisedDate() {
+    public Instant getAuthorisedDate() {
         return authorisedDate;
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -395,7 +395,7 @@ public class ChargeService {
             }
 
             if (externalMetadata.getMetadata().get("authorised_date") != null) {
-                builderOfResponse.withAuthorisedDate(ZonedDateTime.parse(((String) externalMetadata.getMetadata().get("authorised_date"))));
+                builderOfResponse.withAuthorisedDate(ZonedDateTime.parse(((String) externalMetadata.getMetadata().get("authorised_date"))).toInstant());
             }
 
             if (externalMetadata.getMetadata().get("created_date") != null) {


### PR DESCRIPTION
In `ChargeResponse` (the Java model that represents the JSON for a charge sent in API responses), change the Java type of the `authorised_date` property from `ZonedDateTime` to `Instant`, which necessitates switching from `ApiResponseDateTimeSerializer` to `ApiResponseInstantSerializer`.

This will not change how the authorised_date for a charge appears as a JSON string in API responses.