### PR TITLE
BAU Replace YYYY with yyyy in DateTimeFormatter

### DIFF
--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/AppleDecryptedPaymentData.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/AppleDecryptedPaymentData.java
@@ -58,7 +58,7 @@ public class AppleDecryptedPaymentData implements AuthorisationDetails, WalletAu
     }
 
     public String getExpiryDateYear() {
-        return applicationExpirationDate.format(DateTimeFormatter.ofPattern("YYYY"));
+        return applicationExpirationDate.format(DateTimeFormatter.ofPattern("yyyy"));
     }
     
     @Override


### PR DESCRIPTION
`YYYY` will return the year based upon the week year based on the locale
setting. This can give surprising results near year end and in
circumstances when the locale is not as expected, eg. `en_US`
rather than `en_GB`.

`yyyy` will return the calendar year and is what we most likely want.

Intelij highlights this method and others in the
`AppleDecryptedPaymentData` as unused but they are magically called by
the template builder as part of
`WorldpayWalletAuthorisationHandler.buildWalletAuthoriseOrder` method.

## WHAT YOU DID
Listened to @alexbishop1 presentation on why dates are so hard and spotted this similar occurrence.