### PR TITLE
PP-7589 Add new flag `allow_telephone_payment_notifications` to gateway_accounts

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1561,4 +1561,20 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add allow_telephone_payment_notifications to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="allow_telephone_payment_notifications" type="boolean">
+            </column>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="add default to allow_telephone_payment_notifications" author="">
+        <addDefaultValue tableName="gateway_accounts" columnName="allow_telephone_payment_notifications" defaultValue="false"/>
+    </changeSet>
+
+    <changeSet id="update allow_telephone_payment_notifications with default value" author="">
+        <update tableName="gateway_accounts">
+            <column name="allow_telephone_payment_notifications" value="false"/>
+        </update>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- Adds flag `allow_telephone_payment_notifications` to gateway account which indicates if the account is used for telephone payments reporting.
- This flag will also be used to handle Worldpay notifications differently for telephone payments i.e., if the flag is enabled and we receive notifications for charges we are not aware of, worldpay notifications will be rejected (as external service might not have reported payment to us yet). If flag is disabled, we simply ignore worldpay notification (cases where services using same merchant account outside pay and we are receiving notifications about unknown payments).

