### PR TITLE
PP-7589 Reject Worldpay notifications only for telephone payments accounts

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -11,6 +11,8 @@ import javax.persistence.EntityManager;
 import java.util.List;
 import java.util.Optional;
 
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+
 @Transactional
 public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
 
@@ -43,6 +45,19 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
                 .getResultList().stream().findFirst();
     }
 
+    public boolean isATelephonePaymentNotificationAccount(String merchantId) {
+        String query = "SELECT count(g) FROM gateway_accounts g where g.credentials->>?1 = ?2 " +
+                " and allow_telephone_payment_notifications is true";
+
+        var count = (Number) entityManager.get()
+                .createNativeQuery(query)
+                .setParameter(1, CREDENTIALS_MERCHANT_ID)
+                .setParameter(2, merchantId)
+                .getSingleResult();
+
+        return count.intValue() > 0;
+    }
+
     public List<GatewayAccountEntity> search(GatewayAccountSearchParams params) {
         List<String> filterTemplates = params.getFilterTemplates();
         String whereClause = filterTemplates.isEmpty() ?
@@ -57,9 +72,9 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
         var query = entityManager
                 .get()
                 .createQuery(queryTemplate, GatewayAccountEntity.class);
-        
+
         params.getQueryMap().forEach(query::setParameter);
-        
+
         return query.getResultList();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -145,6 +145,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     )
     private List<CardTypeEntity> cardTypes = newArrayList();
 
+    @Column(name = "allow_telephone_payment_notifications")
+    private boolean allowTelephonePaymentNotifications;
+
     public GatewayAccountEntity() {
     }
 
@@ -309,6 +312,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return integrationVersion3ds;
     }
 
+    @JsonProperty("allow_telephone_payment_notifications")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isAllowTelephonePaymentNotifications() {
+        return allowTelephonePaymentNotifications;
+    }
+
     public void setNotificationCredentials(NotificationCredentials notificationCredentials) {
         this.notificationCredentials = notificationCredentials;
     }
@@ -440,6 +449,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
         this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
+    }
+
+    public void setAllowTelephonePaymentNotifications(boolean allowTelephonePaymentNotifications) {
+        this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
     }
 
     public class Views {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -95,6 +95,10 @@ public class GatewayAccountService {
         return gatewayAccountDao.findByExternalId(gatewayAccountExternalId);
     }
 
+    public boolean isATelephonePaymentNotificationAccount(String merchantCode) {
+        return gatewayAccountDao.isATelephonePaymentNotificationAccount(merchantCode);
+    }
+
     private final Map<String, BiConsumer<JsonPatchRequest, GatewayAccountEntity>> attributeUpdater = Map.ofEntries(
             entry(
                 CREDENTIALS_GATEWAY_MERCHANT_ID,

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -337,6 +337,7 @@ public class DatabaseFixtures {
         private boolean allowMoto;
         private boolean motoMaskCardNumberInput;
         private boolean motoMaskCardSecurityCodeInput;
+        private boolean allowTelephonePaymentNotifications;
 
         public long getAccountId() {
             return accountId;
@@ -388,6 +389,10 @@ public class DatabaseFixtures {
 
         public Map<EmailNotificationType, TestEmailNotification> getEmailNotifications() {
             return emailNotifications;
+        }
+
+        public boolean isAllowTelephonePaymentNotifications() {
+            return allowTelephonePaymentNotifications;
         }
 
         public TestAccount withAccountId(long accountId) {
@@ -486,6 +491,11 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestAccount withAllowTelephonePaymentNotifications(boolean allowTelephonePaymentNotifications) {
+            this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
+            return this;
+        }
+
         public TestAccount insert() {
             databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(accountId))
@@ -505,6 +515,7 @@ public class DatabaseFixtures {
                     .withAllowMoto(allowMoto)
                     .withMotoMaskCardNumberInput(motoMaskCardNumberInput)
                     .withMotoMaskCardSecurityCodeInput(motoMaskCardSecurityCodeInput)
+                    .withAllowTelephonePaymentNotifications(allowTelephonePaymentNotifications)
                     .build());
             for (TestCardType cardType : cardTypes) {
                 databaseTestHelper.addAcceptedCardType(this.getAccountId(), cardType.getId());
@@ -513,6 +524,7 @@ public class DatabaseFixtures {
 
             return this;
         }
+
     }
 
     public class TestCharge {

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayNotificationResourceIT.java
@@ -162,11 +162,11 @@ public class WorldpayNotificationResourceIT extends ChargingITestBase {
     }
 
     @Test
-    public void shouldReturnNon2xxStatusIfChargeIsNotFoundForTransaction() throws Exception {
+    public void shouldReturn2xxStatusIfChargeIsNotFoundForTransaction() throws Exception {
         ledgerStub.returnNotFoundForFindByProviderAndGatewayTransactionId("worldpay",
                 "unknown-transaction-id");
         notifyConnector("unknown-transaction-id", "GARBAGE")
-                .statusCode(403)
+                .statusCode(200)
                 .extract().body()
                 .asString();
     }

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -30,6 +30,7 @@ public class AddGatewayAccountParams {
     private boolean allowApplePay;
     private boolean allowGooglePay;
     private boolean requires3ds;
+    private boolean allowTelephonePaymentNotifications;
 
     public int getIntegrationVersion3ds() {
         return integrationVersion3ds;
@@ -111,6 +112,10 @@ public class AddGatewayAccountParams {
         return requires3ds;
     }
 
+    public boolean isAllowTelephonePaymentNotifications() {
+        return allowTelephonePaymentNotifications;
+    }
+
     public static final class AddGatewayAccountParamsBuilder {
         private String accountId;
         private String paymentGateway = "provider";
@@ -132,6 +137,7 @@ public class AddGatewayAccountParams {
         private boolean allowGooglePay;
         private boolean requires3ds;
         private String externalId = randomUuid();
+        private boolean allowTelephonePaymentNotifications;
 
         private AddGatewayAccountParamsBuilder() {
         }
@@ -230,6 +236,11 @@ public class AddGatewayAccountParams {
             return this;
         }
 
+        public AddGatewayAccountParamsBuilder withAllowTelephonePaymentNotifications(boolean allowTelephonePaymentNotifications) {
+            this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
+            return this;
+        }
+
         public AddGatewayAccountParams build() {
             AddGatewayAccountParams addGatewayAccountParams = new AddGatewayAccountParams();
             addGatewayAccountParams.accountId = this.accountId;
@@ -252,6 +263,7 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.allowApplePay = this.allowApplePay;
             addGatewayAccountParams.allowGooglePay = this.allowGooglePay;
             addGatewayAccountParams.requires3ds = this.requires3ds;
+            addGatewayAccountParams.allowTelephonePaymentNotifications = this.allowTelephonePaymentNotifications;
             return addGatewayAccountParams;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -55,14 +55,14 @@ public class DatabaseTestHelper {
                             "integration_version_3ds, corporate_credit_card_surcharge_amount, " +
                             "corporate_debit_card_surcharge_amount, corporate_prepaid_credit_card_surcharge_amount, " +
                             "corporate_prepaid_debit_card_surcharge_amount, allow_moto, moto_mask_card_number_input, " +
-                            "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds) " +
+                            "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds, allow_telephone_payment_notifications) " +
                             "VALUES (:id, :external_id, :payment_provider, :credentials, :service_name, :type, " +
                             ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                             ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
                             ":corporate_prepaid_credit_card_surcharge_amount, " +
                             ":corporate_prepaid_debit_card_surcharge_amount, "+
                             ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, "+
-                            ":allow_apple_pay, :allow_google_pay, :requires_3ds)")
+                            ":allow_apple_pay, :allow_google_pay, :requires_3ds, :allow_telephone_payment_notifications)")
                             .bind("id", Long.valueOf(params.getAccountId()))
                             .bind("external_id", params.getExternalId())
                             .bind("payment_provider", params.getPaymentGateway())
@@ -83,6 +83,7 @@ public class DatabaseTestHelper {
                             .bind("allow_apple_pay", params.isAllowApplePay())
                             .bind("allow_google_pay", params.isAllowGooglePay())
                             .bind("requires_3ds", params.isRequires3ds())
+                            .bind("allow_telephone_payment_notifications", params.isAllowTelephonePaymentNotifications())
                             .execute());
         } catch (SQLException e) {
             throw new RuntimeException(e);
@@ -630,6 +631,14 @@ public class DatabaseTestHelper {
     public void allowMoto(long accountId) {
         jdbi.withHandle(handle ->
                 handle.createUpdate("UPDATE gateway_accounts set allow_moto=true WHERE id=:gatewayAccountId")
+                        .bind("gatewayAccountId", accountId)
+                        .execute()
+        );
+    }
+
+    public void allowTelephonePaymentNotifications(long accountId) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("UPDATE gateway_accounts set allow_telephone_payment_notifications=true WHERE id=:gatewayAccountId")
                         .bind("gatewayAccountId", accountId)
                         .execute()
         );


### PR DESCRIPTION
## WHAT YOU DID
- Rejects Worldpay notifications for accounts used for telephone payment reporting and when an associated charge is not found. This is to handle cases where we receive notification from Worldpay before the payment is reported to us.
- For any other accounts, simply ignore notification as notifications could be related to payments outside Pay.

Should set `allow_telephone_payment_notifications` flag for existing accounts before this goes out https://github.com/alphagov/pay-scripts/pull/1051