### PR TITLE
PP-7589 Restrict use of payment notifications API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.7</eclipselink.version>
         <guice.version>4.2.3</guice.version>
         <jackson.version>2.12.0</jackson.version>
-        <pay-java-commons.version>1.0.20210104125628</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20210107154625</pay-java-commons.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <jooq.version>3.14.4</jooq.version>
         <postgresql.version>42.2.18</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -28,6 +28,7 @@ import uk.gov.pay.commons.utils.xray.Xray;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
+import uk.gov.pay.connector.charge.exception.TelephonePaymentNotificationsNotAllowedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.resource.ChargesFrontendResource;
@@ -124,6 +125,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new ZeroAmountNotAllowedForGatewayAccountExceptionMapper());
         environment.jersey().register(new ConflictWebApplicationExceptionMapper());
         environment.jersey().register(new MotoPaymentNotAllowedForGatewayAccountExceptionMapper());
+        environment.jersey().register(new TelephonePaymentNotificationsNotAllowedExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/TelephonePaymentNotificationsNotAllowedException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/TelephonePaymentNotificationsNotAllowedException.java
@@ -1,0 +1,8 @@
+package uk.gov.pay.connector.charge.exception;
+
+public class TelephonePaymentNotificationsNotAllowedException extends RuntimeException {
+    public TelephonePaymentNotificationsNotAllowedException(Long gatewayAccountId) {
+        super(String.format("Attempt to create telephone payment record for gateway account %s which does not have " +
+                "telephone payment notifications enabled", gatewayAccountId));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/TelephonePaymentNotificationsNotAllowedExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/TelephonePaymentNotificationsNotAllowedExceptionMapper.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.commons.model.ErrorIdentifier;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class TelephonePaymentNotificationsNotAllowedExceptionMapper implements ExceptionMapper<TelephonePaymentNotificationsNotAllowedException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TelephonePaymentNotificationsNotAllowedExceptionMapper.class);
+
+    private static final String RESPONSE_ERROR_MESSAGE = "Telephone payment notifications are not enabled for this gateway account";
+
+    @Override
+    public Response toResponse(TelephonePaymentNotificationsNotAllowedException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED, List.of(RESPONSE_ERROR_MESSAGE));
+
+        return Response.status(403)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesApiResource.java
@@ -3,10 +3,14 @@ package uk.gov.pay.connector.charge.resource;
 import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.exception.TelephonePaymentNotificationsNotAllowedException;
 import uk.gov.pay.connector.charge.model.ChargeCreateRequest;
 import uk.gov.pay.connector.charge.model.telephone.TelephoneChargeCreateRequest;
 import uk.gov.pay.connector.charge.service.ChargeExpiryService;
 import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -47,11 +51,15 @@ public class ChargesApiResource {
     public static final int MAX_AMOUNT = 10_000_000;
     private final ChargeService chargeService;
     private final ChargeExpiryService chargeExpiryService;
+    private final GatewayAccountService gatewayAccountService;
 
     @Inject
-    public ChargesApiResource(ChargeService chargeService, ChargeExpiryService chargeExpiryService) {
+    public ChargesApiResource(ChargeService chargeService,
+                              ChargeExpiryService chargeExpiryService,
+                              GatewayAccountService gatewayAccountService) {
         this.chargeService = chargeService;
         this.chargeExpiryService = chargeExpiryService;
+        this.gatewayAccountService = gatewayAccountService;
     }
 
     @GET
@@ -77,7 +85,7 @@ public class ChargesApiResource {
                 .map(response -> created(response.getLink("self")).entity(response).build())
                 .orElseGet(() -> notFoundResponse("Unknown gateway account: " + accountId));
     }
-    
+
     @POST
     @Path("v1/api/accounts/{accountId}/telephone-charges")
     @Produces(APPLICATION_JSON)
@@ -86,9 +94,16 @@ public class ChargesApiResource {
             @NotNull @Valid TelephoneChargeCreateRequest telephoneChargeCreateRequest,
             @Context UriInfo uriInfo
     ) {
+        GatewayAccountEntity gatewayAccount = gatewayAccountService.getGatewayAccount(accountId)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(accountId));
+
+        if (!gatewayAccount.isAllowTelephonePaymentNotifications()) {
+            throw new TelephonePaymentNotificationsNotAllowedException(gatewayAccount.getId());
+        }
+        
         return chargeService.findCharge(accountId, telephoneChargeCreateRequest)
                 .map(response -> Response.status(200).entity(response).build())
-                .orElseGet(() -> Response.status(201).entity(chargeService.create(telephoneChargeCreateRequest, accountId).get()).build());
+                .orElseGet(() -> Response.status(201).entity(chargeService.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount)).build());
     }
 
     @POST

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -107,7 +107,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         when(mockedChargeDao.findByGatewayTransactionIdAndAccount(gatewayAccount.getId(), "1PROV"))
                 .thenReturn(Optional.of(returnedChargeEntity));
 
-        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+        service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         Optional<ChargeResponse> telephoneChargeResponse = service.findCharge(gatewayAccount.getId(), telephoneChargeCreateRequest);
 
@@ -492,11 +492,10 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .withPaymentOutcome(paymentOutcome)
                 .build();
-
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        
         populateChargeEntity();
 
-        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+        service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -546,11 +545,10 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withPaymentOutcome(paymentOutcome)
                 .withCardExpiry(null)
                 .build();
-
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        
         populateChargeEntity();
 
-        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+        service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -599,11 +597,10 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withPaymentOutcome(paymentOutcome)
                 .withCardExpiry(null)
                 .build();
-
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        
         populateChargeEntity();
 
-        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+        service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -657,11 +654,10 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withAuthCode(stringGreaterThan50)
                 .withTelephoneNumber(stringGreaterThan50)
                 .build();
-
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        
         populateChargeEntity();
 
-        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+        service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -714,11 +710,10 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withAuthCode(stringOf50)
                 .withTelephoneNumber(stringOf50)
                 .build();
-
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
+        
         populateChargeEntity();
 
-        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+        service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -753,9 +748,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withPaymentOutcome(paymentOutcome)
                 .build();
 
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
-
-        service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID);
+        service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -771,10 +764,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
         TelephoneChargeCreateRequest telephoneChargeCreateRequest = telephoneRequestBuilder
                 .withPaymentOutcome(paymentOutcome)
                 .build();
-
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
-
-        ChargeResponse chargeResponse = service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID).get();
+        
+        ChargeResponse chargeResponse = service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 
@@ -809,10 +800,8 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withPaymentOutcome(paymentOutcome)
                 .withCardExpiry(null)
                 .build();
-
-        when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
-
-        ChargeResponse chargeResponse = service.create(telephoneChargeCreateRequest, GATEWAY_ACCOUNT_ID).get();
+        
+        ChargeResponse chargeResponse = service.createFromTelephonePaymentNotification(telephoneChargeCreateRequest, gatewayAccount);
 
         verify(mockedChargeDao).persist(chargeEntityArgumentCaptor.capture());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -70,6 +70,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void createTelephoneChargeForOnlyRequiredFields() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         connectorRestApiClient
                 .postCreateTelephoneCharge(toJson(postBody))
                 .statusCode(201)
@@ -91,6 +92,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
     
     @Test
     public void createTelephoneChargeForStatusOfSuccessForAllFields() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.put("auth_code", "666");
         postBody.put("created_date", "2018-02-21T16:04:25Z");
         postBody.put("authorised_date", "2018-02-21T16:05:33Z");
@@ -139,6 +141,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void createTelephoneChargeForFailedStatusP0010() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome",
                 Map.of(
                         "status", "failed",
@@ -176,6 +179,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void createTelephoneChargeForFailedStatusP0050() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome",
                 Map.of(
                         "status", "failed",
@@ -220,6 +224,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void createTelephoneChargeForFailedStatusP0030() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome",
                 Map.of(
                         "status", "failed",
@@ -257,6 +262,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void createTelephoneChargeWithTruncatedMetaData() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome",
                 Map.of(
                         "status", "failed",
@@ -304,6 +310,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void createTelephoneChargeWithSource() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome", Map.of("status", "success"));
         postBody.replace("processor_id", stringOf51Characters);
 
@@ -320,6 +327,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturnResponseForAlreadyExistingTelephoneCharge() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.put("card_expiry", "02/19");
         postBody.put("card_type", "master-card");
         postBody.put("last_four_digits", "1234");
@@ -355,6 +363,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn400ForInvalidCardExpiryDate() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.put("card_expiry", "99/99");
 
         connectorRestApiClient
@@ -365,7 +374,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForInvalidCardType() {
-        
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.put("card_type", "invalid-card");
         
         connectorRestApiClient
@@ -376,6 +385,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForInvalidPaymentOutcomeStatus() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome",
                 Map.of(
                         "status", "invalid"
@@ -390,6 +400,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForInvalidPaymentOutcomeStatusAndCode() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome",
                 Map.of(
                         "status", "success",
@@ -405,7 +416,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForInvalidPaymentOutcomeErrorCode() {
-        
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.replace("payment_outcome",
                 Map.of(
                         "status", "failed",
@@ -425,6 +436,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForInvalidCreatedDate() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.put("created_date", "invalid");
 
         connectorRestApiClient
@@ -436,6 +448,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForInvalidAuthorisedDate() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.put("authorised_date", "invalid");
 
         connectorRestApiClient
@@ -447,6 +460,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForMissingAmount() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.remove("amount");
         
         connectorRestApiClient
@@ -457,6 +471,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForMissingReference() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.remove("reference");
         
         connectorRestApiClient
@@ -467,6 +482,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForMissingDescription() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.remove("description");
         
         connectorRestApiClient
@@ -477,6 +493,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForMissingProcessorID() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.remove("processor_id");
                 
         connectorRestApiClient
@@ -487,6 +504,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
     
     @Test
     public void shouldReturn422ForMissingProviderID() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.remove("provider_id");
         
         connectorRestApiClient
@@ -497,6 +515,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForMissingPaymentOutcome() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         postBody.remove("payment_outcome");
 
         connectorRestApiClient
@@ -507,6 +526,7 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
 
     @Test
     public void shouldReturn422ForTelephoneChargeCreateRequestNull() {
+        databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
         String payload = toJson(null);
 
         connectorRestApiClient
@@ -514,6 +534,16 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .statusCode(422)
                 .contentType(JSON)
                 .body("message[0]", is("must not be null"));
+    }
+
+    @Test
+    public void shouldReturn403IfTelephoneNotificationsNotAllowedForAccount() {
+        connectorRestApiClient
+                .postCreateTelephoneCharge(toJson(postBody))
+                .statusCode(403)
+                .contentType(JSON)
+                .body("message[0]", is("Telephone payment notifications are not enabled for this gateway account"))
+                .body("error_identifier", is("TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED"));
     }
 
 }

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -23,6 +23,7 @@ import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
 import uk.gov.pay.connector.rules.SQSMockClient;
 import uk.gov.pay.connector.util.AddChargeParams;
+import uk.gov.pay.connector.util.AddGatewayAccountParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 
 import java.time.Duration;


### PR DESCRIPTION
Check if a gateway account has the `allow_telephone_payment_notifications` flag set to `true` for POST requests to the `v1/api/accounts/{accountId}/telephone-charge` endpoint.

If the flag isn't enabled, return a 403 with the error identifier TELEPHONE_PAYMENT_NOTIFICATIONS_NOT_ALLOWED to be handled by public API to return an appropriate error to the end consumer.

Renamed a few methods to make it clear they're for telephone payments while I was here to make things a bit easier.

## Note

Hiding whitespace changes in the diff will make reviewing a tiny bit easier due to some indentation changes.

