### PR TITLE
PP-5641: Generate a new transaction id when re-submitting an auth request

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-01-07T12:31:58Z",
+  "generated_at": "2021-01-08T12:02:04Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -184,7 +184,7 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 437,
+        "line_number": 442,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderStatusResponse.java
@@ -107,6 +107,10 @@ public class WorldpayOrderStatusResponse implements BaseAuthoriseResponse, BaseC
         return Optional.ofNullable(exemptionResponseResult);
     }
 
+    public String getExemptionResponseReason() {
+        return exemptionResponseReason;
+    }
+
     public String getPaRequest() {
         return paRequest;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -181,7 +181,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     response,
                     request.getCharge().getChargeStatus(),
                     request.getCharge().getChargeStatus());
-
+            
+            request.getCharge().setGatewayTransactionId(randomUUID().toString());
             response = worldpayAuthoriseHandler.authoriseWithoutExemption(request);
         } 
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -113,7 +113,11 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
     @Override
     public Optional<String> generateTransactionId() {
-        return Optional.of(randomUUID().toString());
+        return Optional.of(newTransactionId());
+    }
+
+    private String newTransactionId() {
+        return randomUUID().toString();
     }
 
     @Override
@@ -182,7 +186,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     request.getCharge().getChargeStatus(),
                     request.getCharge().getChargeStatus());
             
-            request.getCharge().setGatewayTransactionId(randomUUID().toString());
+            request.getCharge().setGatewayTransactionId(newTransactionId());
             response = worldpayAuthoriseHandler.authoriseWithoutExemption(request);
         } 
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -44,11 +44,13 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static java.util.UUID.randomUUID;
 import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -313,6 +315,8 @@ public class WorldpayPaymentProviderTest {
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         chargeEntityFixture.withGatewayAccountEntity(gatewayAccountEntity);
         chargeEntityFixture.withStatus(ChargeStatus.AUTHORISATION_READY);
+        String gatewayTransactionId = randomUUID().toString();
+        chargeEntityFixture.withGatewayTransactionId(gatewayTransactionId);
         ChargeEntity chargeEntity = chargeEntityFixture.build();
         
         var cardAuthRequest = new CardAuthorisationGatewayRequest(chargeEntity, anAuthCardDetails().build());
@@ -327,6 +331,7 @@ public class WorldpayPaymentProviderTest {
         
         assertTrue(response.getBaseResponse().isPresent());
         assertEquals(secondResponse.getBaseResponse().get(), response.getBaseResponse().get());
+        assertNotEquals(cardAuthRequest.getCharge().getGatewayTransactionId(), gatewayTransactionId);
         
         ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor = ArgumentCaptor.forClass(LoggingEvent.class);
         verify(mockAppender, times(2)).doAppend(loggingEventArgumentCaptor.capture());

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -157,7 +157,8 @@ public class WorldpayPaymentProviderTest {
         assertTrue(response.getBaseResponse().isPresent());
         assertTrue(response.getBaseResponse().get().getLastEvent().isPresent());
         assertEquals(response.getBaseResponse().get().getLastEvent().get(), "AUTHORISED");
-        assertEquals(response.getBaseResponse().get().getExemptionResponseResult(), "HONOURED");
+        assertTrue(response.getBaseResponse().get().getExemptionResponseResult().isPresent());
+        assertEquals(response.getBaseResponse().get().getExemptionResponseResult().get(), "HONOURED");
         assertEquals(response.getBaseResponse().get().getExemptionResponseReason(), "ISSUER_HONOURED");
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -180,7 +180,7 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
 
         assertApiStateIs(chargeId, EXTERNAL_SUCCESS.getStatus());
     }
-
+    
     @Test
     public void shouldAuthoriseCharge_For3dsRequiredCharge() {
         String chargeId = createNewCharge(AUTHORISATION_3DS_REQUIRED);

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -10,10 +10,14 @@ import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import static io.restassured.http.ContentType.JSON;
+import static java.util.UUID.randomUUID;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_REJECTED;
@@ -41,6 +45,24 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
         super("worldpay");
     }
 
+    @Test
+    public void should_set_new_gateway_transaction_id_when_authorisation_with_exemption_engine_results_in_soft_decline() {
+        String gatewayTransactionId = randomUUID().toString();
+        String chargeId = createNewChargeWith(ENTERING_CARD_DETAILS, gatewayTransactionId);
+
+        assertEquals(databaseTestHelper.getChargeByExternalId(chargeId).get("gateway_transaction_id"), gatewayTransactionId);
+
+        worldpayMockClient.mockResponsesForExemptionEngineSoftDecline();
+
+        givenSetup()
+                .body(validAuthorisationDetails)
+                .post(authoriseChargeUrlFor(chargeId))
+                .then()
+                .statusCode(OK.getStatusCode());
+
+        assertNotEquals(databaseTestHelper.getChargeByExternalId(chargeId), gatewayTransactionId);
+    }
+    
     @Test
     public void shouldAuthoriseChargeWithoutCorporateCard_ForValidAuthorisationDetails() {
 


### PR DESCRIPTION
Generate a new transaction id when re-submitting an auth request due to a soft
decline. There's also a manual contract test for this.

Updated the
`contract/WorldpayPaymentProviderTest.submitAuthRequestWithExemptionEngineFlag`
test as we now have the exemption engine enabled on merchant code GBSRECABOFFGDSGBP.