### PR TITLE
PP-7554: Add a new path for enabling/disabling Worldpay 3DS Exemption Engine

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MissingWorldpay3dsFlexCredentialsEntityException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/MissingWorldpay3dsFlexCredentialsEntityException.java
@@ -1,0 +1,14 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import uk.gov.pay.connector.util.ResponseUtil;
+
+import javax.ws.rs.BadRequestException;
+
+public class MissingWorldpay3dsFlexCredentialsEntityException extends BadRequestException {
+    public MissingWorldpay3dsFlexCredentialsEntityException(Long accountId,
+                                                            String path){
+        super(ResponseUtil.badRequestResponse(
+                String.format("Worldpay gateway account %s has no Worldpay 3DS flex credentials entity for path [%s].",
+                        accountId, path)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/NotSupportedGatewayAccountException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/NotSupportedGatewayAccountException.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import uk.gov.pay.connector.util.ResponseUtil;
+
+import javax.ws.rs.BadRequestException;
+
+public class NotSupportedGatewayAccountException extends BadRequestException {
+    public NotSupportedGatewayAccountException(Long accountId,
+                                               String gatewayName,
+                                               String path) {
+        super(ResponseUtil.badRequestResponse(
+                String.format("Gateway account %s is not %s gateway account for path [%s].",
+                    accountId, gatewayName, path)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -230,6 +230,11 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return notificationCredentials;
     }
 
+    @JsonIgnore
+    public Optional<Worldpay3dsFlexCredentialsEntity> getWorldpay3dsFlexCredentialsEntity() {
+        return Optional.ofNullable(worldpay3dsFlexCredentialsEntity);
+    }
+
     @JsonInclude(NON_NULL)
     @JsonProperty("worldpay_3ds_flex")
     public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/Worldpay3dsFlexCredentialsEntity.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 
 import javax.persistence.Column;
@@ -20,12 +21,15 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
     @Id
     @GeneratedValue(generator = "worldpay_3ds_flex_credentials_id_seq", strategy = GenerationType.SEQUENCE)
     @Column(name = "id")
+    @JsonIgnore
     private Long id;
 
     @JoinColumn(name = "gateway_account_id", updatable = false, insertable = false)
+    @JsonIgnore
     private GatewayAccountEntity gatewayAccountEntity;
 
     @Column(name = "gateway_account_id")
+    @JsonIgnore
     private Long gatewayAccountId;
 
     @Column
@@ -35,6 +39,7 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
     private String organisationalUnitId;
 
     @Column(name = "jwt_mac_key")
+    @JsonIgnore
     private String jwtMacKey;
 
     @Column(name = "exemption_engine")
@@ -64,6 +69,10 @@ public class Worldpay3dsFlexCredentialsEntity extends AbstractVersionedEntity {
 
     public String getJwtMacKey() {
         return jwtMacKey;
+    }
+
+    public void setExemptionEngineEnabled(boolean isExemptionEngineEnabled) {
+        this.exemptionEngineEnabled = isExemptionEngineEnabled;
     }
 
     public void setGatewayAccountId(Long gatewayAccountId) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -42,7 +42,7 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_MOTO_MASK_CARD_NUMBER_INPUT = "moto_mask_card_number_input";
     public static final String FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT = "moto_mask_card_security_code_input";
     public static final String FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS = "allow_telephone_payment_notifications";
-
+    public static final String FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED = "worldpay_exemption_engine_enabled";
 
     private static final List<String> VALID_PATHS = List.of(
             CREDENTIALS_GATEWAY_MERCHANT_ID,
@@ -60,7 +60,8 @@ public class GatewayAccountRequestValidator {
             FIELD_ALLOW_MOTO,
             FIELD_MOTO_MASK_CARD_NUMBER_INPUT,
             FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT,
-            FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS);
+            FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS,
+            FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED);
 
     private final RequestValidator requestValidator;
 
@@ -96,6 +97,7 @@ public class GatewayAccountRequestValidator {
             case FIELD_MOTO_MASK_CARD_NUMBER_INPUT:
             case FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT:
             case FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS:
+            case FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED:
                 validateReplaceBooleanValue(payload);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT:

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -70,10 +70,12 @@ public class GatewayAccountRequestValidatorTest {
             "replace, moto_mask_card_security_code_input, null, Field [value] is required",
             "replace, moto_mask_card_security_code_input, unfalse, Value [unfalse] must be of type boolean for path [moto_mask_card_security_code_input]",
             "replace, allow_telephone_payment_notifications, null, Field [value] is required",
-            "replace, allow_telephone_payment_notifications, unfalse, Value [unfalse] must be of type boolean for path [allow_telephone_payment_notifications]"
+            "replace, allow_telephone_payment_notifications, unfalse, Value [unfalse] must be of type boolean for path [allow_telephone_payment_notifications]",
+            "replace, worldpay_exemption_engine_enabled, null, Field [value] is required",
+            "replace, worldpay_exemption_engine_enabled, unfalse, Value [unfalse] must be of type boolean for path [worldpay_exemption_engine_enabled]"
     })
     public void shouldThrowWhenRequestsAreInvalid(String op, String path, @Nullable String value, String expectedErrorMessage) {
-        Map<String, String> patch = new HashMap<String, String>() {{
+        Map<String, String> patch = new HashMap<>() {{
             put(FIELD_OPERATION, op);
             put(FIELD_OPERATION_PATH, path);
         }};


### PR DESCRIPTION
This pull request
- updates GatewayAccountRequestValidator to include a new path `worldpay_exemption_engine_enabled` to validate that the value in the request is boolean.
- updates the existing integration test to ensure that `exemption_engine_enabled` is present after calling the endpoint `/v1/frontend/accounts/`.
- updates GatewayAccountService to support the new path `worldpay_exemption_engine_enabled` for enabling or disabling Worldpay 3DS Exemption Engine and to throw exception if the gateway account is not Worldpay or the Worldpay gateway account has no 3DS flex credentials entity.
- updates Worldpay3dsFlexCredentialsEntity to include the annotation `@JsonIgnore` on `id`, `gatewayAccountEntity`, `gatewayAccountId` and `jwtMacKey`. `gatewayAccountEntity` should be ignored to avoid throwing StackOverflow exception. `id` and `gatewayAccountId` are not required because they are used for database purposes (e.g. primary key). `jwtMacKey` should be ignored because it is a secret field.
- adds getWorldpay3dsFlexCredentialsEntity() method to GatewayAccountEntity because this method provides an instance of Worldpay3dsFlexCredentialsEntity which is needed for toggling `exemption_engine` in the database. This method is annotated with `@JsonIgnore` because getWorldpay3dsFlexCredentials() method already has `@JsonProperty("worldpay_3ds_flex")` and is used in Responses.
- updates Worldpay3dsFlexCredentialsEntity to allow us to set exemption_engine to true or false in the database.
- adds an integration test to GatewayAccountResource to ensure that Worldpay exemption engine can be enabled for Worldpay gateway account.
