### PR TITLE
PP-7589 Discrepancy checker for expunged charges

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-01-08T12:02:04Z",
+  "generated_at": "2021-01-11T11:53:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -184,7 +184,7 @@
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 442,
+        "line_number": 438,
         "type": "Base64 High Entropy String"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseCancelResponse;
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -29,7 +30,7 @@ public interface PaymentProvider {
 
     GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws GatewayException;
 
-    ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) throws GatewayException;
+    ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) throws GatewayException;
 
     Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -42,6 +42,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.EpdqExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -154,13 +155,13 @@ public class EpdqPaymentProvider implements PaymentProvider {
         throw new UnsupportedOperationException("Wallets are not supported for ePDQ");
     }
 
-    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) throws GatewayException {
-        URI url = URI.create(String.format("%s/%s", gatewayUrlMap.get(charge.getGatewayAccount().getType()), ROUTE_FOR_QUERY_ORDER));
+    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccount) throws GatewayException {
+        URI url = URI.create(String.format("%s/%s", gatewayUrlMap.get(gatewayAccount.getType()), ROUTE_FOR_QUERY_ORDER));
         GatewayClient.Response response = authoriseClient.postRequestFor(
-                url, 
-                charge.getGatewayAccount(), 
-                buildQueryOrderRequestFor(charge),
-                getGatewayAccountCredentialsAsAuthHeader(charge.getGatewayAccount().getCredentials()));
+                url,
+                gatewayAccount, 
+                buildQueryOrderRequestFor(charge, gatewayAccount),
+                getGatewayAccountCredentialsAsAuthHeader(gatewayAccount.getCredentials()));
         GatewayResponse<EpdqQueryResponse> epdqGatewayResponse = getUninterpretedEpdqGatewayResponse(response, EpdqQueryResponse.class);
 
         return epdqGatewayResponse.getBaseResponse()
@@ -287,13 +288,13 @@ public class EpdqPaymentProvider implements PaymentProvider {
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
-    private GatewayOrder buildQueryOrderRequestFor(ChargeEntity charge) {
+    private GatewayOrder buildQueryOrderRequestFor(Charge charge, GatewayAccountEntity gatewayAccount) {
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
         epdqPayloadDefinitionForQueryOrder.setOrderId(charge.getExternalId());
-        epdqPayloadDefinitionForQueryOrder.setPassword(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForQueryOrder.setUserId(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForQueryOrder.setPspId(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID));
-        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForQueryOrder.setPassword(gatewayAccount.getCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinitionForQueryOrder.setUserId(gatewayAccount.getCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinitionForQueryOrder.setPspId(gatewayAccount.getCredentials().get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(gatewayAccount.getCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse.GatewayRespon
 import uk.gov.pay.connector.gateway.sandbox.applepay.SandboxWalletAuthorisationHandler;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -59,7 +60,7 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
+    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
         throw new UnsupportedOperationException("Querying payment status not currently supported by Sandbox");
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
 
@@ -152,7 +153,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
+    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
         throw new UnsupportedOperationException("Querying payment status not currently supported by Smartpay");
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -37,6 +37,7 @@ import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeAuthoriseRequest;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
@@ -96,7 +97,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) {
+    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
         throw new UnsupportedOperationException("Querying payment status not currently supported by Stripe");
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -121,12 +121,12 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(ChargeEntity charge) throws GatewayException {
+    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) throws GatewayException {
         GatewayClient.Response response = inquiryClient.postRequestFor(
-                gatewayUrlMap.get(charge.getGatewayAccount().getType()),
-                charge.getGatewayAccount(),
-                buildQuery(charge),
-                getGatewayAccountCredentialsAsAuthHeader(charge.getGatewayAccount().getCredentials())
+                gatewayUrlMap.get(gatewayAccountEntity.getType()),
+                gatewayAccountEntity,
+                buildQuery(charge, gatewayAccountEntity),
+                getGatewayAccountCredentialsAsAuthHeader(gatewayAccountEntity.getCredentials())
         );
         GatewayResponse<WorldpayQueryResponse> worldpayGatewayResponse = getWorldpayGatewayResponse(response, WorldpayQueryResponse.class);
 
@@ -151,10 +151,10 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
         return true;
     }
 
-    private GatewayOrder buildQuery(ChargeEntity charge) {
+    private GatewayOrder buildQuery(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
         return aWorldpayInquiryRequestBuilder()
                 .withTransactionId(charge.getGatewayTransactionId())
-                .withMerchantCode(charge.getGatewayAccount().getCredentials().get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(gatewayAccountEntity.getCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/DiscrepancyResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/DiscrepancyResource.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.connector.paymentprocessor.resource;
 
 import com.google.inject.Inject;
-import org.hibernate.validator.constraints.NotEmpty;
 import uk.gov.pay.connector.paymentprocessor.service.DiscrepancyService;
 import uk.gov.pay.connector.report.model.GatewayStatusComparison;
 
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -2,13 +2,14 @@ package uk.gov.pay.connector.paymentprocessor.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProviders;
-import uk.gov.pay.connector.gateway.ChargeQueryResponse;
-import uk.gov.pay.logging.LoggingKeys;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
@@ -27,8 +28,13 @@ public class QueryService {
         this.providers = providers;
     }
     
+    public ChargeQueryResponse getChargeGatewayStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) throws GatewayException {
+        return providers.byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
+                .queryPaymentStatus(charge, gatewayAccountEntity);
+    }   
     public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) throws GatewayException {
-        return providers.byName(charge.getPaymentGatewayName()).queryPaymentStatus(charge);
+        return providers.byName(PaymentGatewayName.valueFrom(charge.getGatewayAccount().getGatewayName()))
+                .queryPaymentStatus(Charge.from(charge), charge.getGatewayAccount());
     }
 
     public boolean canQueryChargeGatewayStatus(PaymentGatewayName paymentGatewayName) {

--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -142,6 +142,18 @@ public class LedgerStub {
         );
     }
 
+    public void returnTransactionNotFound(String externalId) {
+        ResponseDefinitionBuilder responseDefBuilder = aResponse()
+                .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                .withStatus(404);
+
+        stubFor(
+                get(urlPathEqualTo(format("/v1/transaction/%s", externalId)))
+                        .withQueryParam("override_account_id_restriction", equalTo("true"))
+                        .willReturn(responseDefBuilder)
+        );
+    }
+
     private static Map<String, Object> testChargeToLedgerTransactionJson(DatabaseFixtures.TestCharge testCharge, DatabaseFixtures.TestFee fee) {
         var map = new HashMap<String, Object>();
         Optional.ofNullable(testCharge.getExternalChargeId()).ifPresent(value -> map.put("id", value));

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderIT.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gateway.epdq;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.ErrorType;
@@ -129,7 +131,8 @@ public class EpdqPaymentProviderIT extends BaseEpdqPaymentProviderIT {
     @Test
     public void shouldSuccessfullyQueryChargeStatus() throws Exception {
         mockPaymentProviderResponse(200, successQueryAuthorisedResponse());
-        ChargeQueryResponse response = provider.queryPaymentStatus(buildChargeEntity());
+        ChargeEntity chargeEntity = buildChargeEntity();
+        ChargeQueryResponse response = provider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
         assertThat(response.getMappedStatus(), is(Optional.of(AUTHORISATION_SUCCESS)));
         assertThat(response.foundCharge(), is(true));
     }
@@ -137,7 +140,8 @@ public class EpdqPaymentProviderIT extends BaseEpdqPaymentProviderIT {
     @Test
     public void shouldReturnQueryResponseWhenChargeNotFound() throws Exception {
         mockPaymentProviderResponse(200, errorQueryResponse());
-        ChargeQueryResponse response = provider.queryPaymentStatus(buildChargeEntity());
+        ChargeEntity chargeEntity = buildChargeEntity();
+        ChargeQueryResponse response = provider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
         assertThat(response.getMappedStatus(), is(Optional.empty()));
         assertThat(response.foundCharge(), is(false));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
@@ -483,7 +484,7 @@ public class WorldpayPaymentProviderTest {
         when(inquiryClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyMap()))
                 .thenReturn(response);
         
-        ChargeQueryResponse chargeQueryResponse = worldpayPaymentProvider.queryPaymentStatus(chargeEntity);
+        ChargeQueryResponse chargeQueryResponse = worldpayPaymentProvider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
         
         assertThat(chargeQueryResponse.getMappedStatus(), is(Optional.of(ChargeStatus.AUTHORISATION_SUCCESS)));
         assertThat(chargeQueryResponse.foundCharge(), is(true));

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -302,7 +302,7 @@ public class EpdqPaymentProviderTest {
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
 
-        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(chargeEntity);
+        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
         assertThat(chargeQueryResponse.getMappedStatus(), is(Optional.of(ChargeStatus.AUTHORISATION_SUCCESS)));
         assertThat(chargeQueryResponse.foundCharge(), is(true));
     }
@@ -310,7 +310,7 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldReturnQueryResponseWhenChargeNotFound() throws Exception {
         setUpAndCheckThatEpdqIsUp();
-        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(chargeEntity);
+        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
         assertThat(chargeQueryResponse.getMappedStatus(), is(Optional.empty()));
         assertThat(chargeQueryResponse.foundCharge(), is(false));
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
@@ -1,20 +1,22 @@
 package uk.gov.pay.connector.it.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -42,19 +44,47 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
         assertEquals(2, results.size());
 
 
-        assertEquals( "AUTHORISATION SUCCESS", results.get(0).get("gatewayStatus").asText());
-        assertEquals( "EXPIRED", results.get(0).get("payStatus").asText());
-        assertEquals( chargeId, results.get(0).get("chargeId").asText());
-        assertEquals( "ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(0).get("rawGatewayResponse").asText());
-        assertEquals( "EXTERNAL_SUBMITTED", results.get(0).get("gatewayExternalStatus").asText());
-        assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
+        assertEquals("AUTHORISATION SUCCESS", results.get(0).get("gatewayStatus").asText());
+        assertEquals("EXPIRED", results.get(0).get("payStatus").asText());
+        assertEquals(chargeId, results.get(0).get("chargeId").asText());
+        assertEquals("ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(0).get("rawGatewayResponse").asText());
+        assertEquals("EXTERNAL_SUBMITTED", results.get(0).get("gatewayExternalStatus").asText());
+        assertEquals("EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
 
-        assertEquals( "AUTHORISATION SUCCESS", results.get(1).get("gatewayStatus").asText());
-        assertEquals( "AUTHORISATION SUCCESS", results.get(1).get("payStatus").asText());
-        assertEquals( chargeId2, results.get(1).get("chargeId").asText());
-        assertEquals( "ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(1).get("rawGatewayResponse").asText());
-        assertEquals( "EXTERNAL_SUBMITTED", results.get(1).get("gatewayExternalStatus").asText());
-        assertEquals( "EXTERNAL_SUBMITTED", results.get(1).get("payExternalStatus").asText());
+        assertEquals("AUTHORISATION SUCCESS", results.get(1).get("gatewayStatus").asText());
+        assertEquals("AUTHORISATION SUCCESS", results.get(1).get("payStatus").asText());
+        assertEquals(chargeId2, results.get(1).get("chargeId").asText());
+        assertEquals("ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(1).get("rawGatewayResponse").asText());
+        assertEquals("EXTERNAL_SUBMITTED", results.get(1).get("gatewayExternalStatus").asText());
+        assertEquals("EXTERNAL_SUBMITTED", results.get(1).get("payExternalStatus").asText());
+    }
+
+    @Test
+    public void shouldReturnDiscrepencyReportForExpungedCharges() throws JsonProcessingException {
+        DatabaseFixtures.TestCharge charge = DatabaseFixtures.withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(getTestAccount())
+                .withExternalChargeId("external_charge_id_10")
+                .withTransactionId("gateway_transaction_id_")
+                .withChargeStatus(ChargeStatus.AUTHORISATION_SUCCESS);
+
+        ledgerStub.returnLedgerTransaction(charge.getExternalChargeId(), charge, null);
+        epdqMockClient.mockAuthorisationQuerySuccess();
+
+        List<JsonNode> results = connectorRestApiClient
+                .getDiscrepancyReport(toJson(singletonList(charge.getExternalChargeId())))
+                .statusCode(200)
+                .contentType(JSON)
+                .extract().body().jsonPath().getList(".", JsonNode.class);
+
+        assertEquals(1, results.size());
+
+        assertEquals("AUTHORISATION SUCCESS", results.get(0).get("gatewayStatus").asText());
+        assertNull(results.get(0).get("payStatus"));
+        assertEquals(charge.getExternalChargeId(), results.get(0).get("chargeId").asText());
+        assertEquals("ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(0).get("rawGatewayResponse").asText());
+        assertEquals("EXTERNAL_SUBMITTED", results.get(0).get("gatewayExternalStatus").asText());
+        assertEquals("submitted", results.get(0).get("payExternalStatus").asText());
     }
 
     @Test
@@ -69,14 +99,14 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
                 .contentType(JSON)
                 .extract().body().jsonPath().getList(".", JsonNode.class);
 
-                assertEquals(1, results.size());
+        assertEquals(1, results.size());
 
-        assertEquals( "AUTHORISATION REJECTED", results.get(0).get("gatewayStatus").asText());
-        assertEquals( "EXPIRED", results.get(0).get("payStatus").asText());
-        assertEquals( chargeId, results.get(0).get("chargeId").asText());
-        assertEquals( "ePDQ query response (PAYID: 3014644340, STATUS: 2, NCERROR: CARD REFUSED, NCERRORPLUS: CARD REFUSED)", results.get(0).get("rawGatewayResponse").asText());
-        assertEquals( "EXTERNAL_FAILED_REJECTED", results.get(0).get("gatewayExternalStatus").asText());
-        assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
+        assertEquals("AUTHORISATION REJECTED", results.get(0).get("gatewayStatus").asText());
+        assertEquals("EXPIRED", results.get(0).get("payStatus").asText());
+        assertEquals(chargeId, results.get(0).get("chargeId").asText());
+        assertEquals("ePDQ query response (PAYID: 3014644340, STATUS: 2, NCERROR: CARD REFUSED, NCERRORPLUS: CARD REFUSED)", results.get(0).get("rawGatewayResponse").asText());
+        assertEquals("EXTERNAL_FAILED_REJECTED", results.get(0).get("gatewayExternalStatus").asText());
+        assertEquals("EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
     }
 
     @Test
@@ -93,18 +123,19 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
         assertEquals(1, results.size());
 
         assertNull(results.get(0).get("gatewayStatus"));
-        assertEquals( "EXPIRED", results.get(0).get("payStatus").asText());
-        assertEquals( chargeId, results.get(0).get("chargeId").asText());
-        assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
+        assertEquals("EXPIRED", results.get(0).get("payStatus").asText());
+        assertEquals(chargeId, results.get(0).get("chargeId").asText());
+        assertEquals("EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
     }
-    
+
 
     @Test
     public void should404_whenAChargeIdDoesntExist() {
         epdqMockClient.mockAuthorisationQuerySuccess();
 
+        ledgerStub.returnTransactionNotFound("nonExistentId");
         connectorRestApiClient
-                .getDiscrepancyReport(toJson(Collections.singletonList("nonExistentId")))
+                .getDiscrepancyReport(toJson(singletonList("nonExistentId")))
                 .statusCode(404);
     }
 
@@ -124,14 +155,14 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
         assertEquals(2, results.size());
 
 
-        assertEquals( "AUTHORISATION SUCCESS", results.get(0).get("gatewayStatus").asText());
-        assertEquals( "EXPIRED", results.get(0).get("payStatus").asText());
-        assertEquals( chargeId, results.get(0).get("chargeId").asText());
-        assertEquals( "ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(0).get("rawGatewayResponse").asText());
-        assertEquals( "EXTERNAL_SUBMITTED", results.get(0).get("gatewayExternalStatus").asText());
-        assertEquals( "EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
+        assertEquals("AUTHORISATION SUCCESS", results.get(0).get("gatewayStatus").asText());
+        assertEquals("EXPIRED", results.get(0).get("payStatus").asText());
+        assertEquals(chargeId, results.get(0).get("chargeId").asText());
+        assertEquals("ePDQ query response (PAYID: 3014644340, STATUS: 5)", results.get(0).get("rawGatewayResponse").asText());
+        assertEquals("EXTERNAL_SUBMITTED", results.get(0).get("gatewayExternalStatus").asText());
+        assertEquals("EXTERNAL_FAILED_EXPIRED", results.get(0).get("payExternalStatus").asText());
         assertTrue(results.get(0).get("processed").asBoolean());
     }
-    
+
 
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.service.ChargeExpiryService;
@@ -12,10 +13,12 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -39,27 +42,33 @@ public class DiscrepancyServiceTest {
     private ChargeExpiryService expiryService;
 
     @Mock
+    private GatewayAccountService gatewayAccountService;
+
+    @Mock
     private BaseInquiryResponse mockGatewayResponse;
-    
+
     @Before
     public void beforeTest() {
-        discrepancyService = new DiscrepancyService(chargeService, queryService, expiryService);
+        discrepancyService = new DiscrepancyService(chargeService, queryService, expiryService, gatewayAccountService);
     }
-    
+
     @Test
     public void aChargeShouldBeCancellable_whenPayAndGatewayStatusesAllowItAndIsOlderThan2Days() throws GatewayException {
-        ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(EXPIRED)
                 .build();
+        Charge charge = Charge.from(chargeEntity);
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, mockGatewayResponse);
-        when(chargeService.findChargeByExternalId(charge.getExternalId())).thenReturn(charge);
-        when(queryService.getChargeGatewayStatus(charge)).thenReturn(chargeQueryResponse);
-        when(expiryService.forceCancelWithGateway(charge)).thenReturn(true);
+        when(chargeService.findCharge(chargeEntity.getExternalId())).thenReturn(Optional.of(charge));
+        when(chargeService.findChargeByExternalId(chargeEntity.getExternalId())).thenReturn(chargeEntity);
+        when(queryService.getChargeGatewayStatus(charge, chargeEntity.getGatewayAccount())).thenReturn(chargeQueryResponse);
+        when(gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId())).thenReturn(Optional.of(chargeEntity.getGatewayAccount()));
+        when(expiryService.forceCancelWithGateway(chargeEntity)).thenReturn(true);
 
-        discrepancyService.resolveDiscrepancies(Collections.singletonList(charge.getExternalId()));
-        
-        verify(expiryService).forceCancelWithGateway(charge);
+        discrepancyService.resolveDiscrepancies(Collections.singletonList(chargeEntity.getExternalId()));
+
+        verify(expiryService).forceCancelWithGateway(chargeEntity);
     }
 
     @Test
@@ -68,7 +77,7 @@ public class DiscrepancyServiceTest {
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build();
-        
+
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, mockGatewayResponse);
         assertChargeIsNotCancelled(charge, chargeQueryResponse);
     }
@@ -79,7 +88,7 @@ public class DiscrepancyServiceTest {
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(CAPTURED)
                 .build();
-        
+
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, mockGatewayResponse);
         assertChargeIsNotCancelled(charge, chargeQueryResponse);
     }
@@ -101,7 +110,7 @@ public class DiscrepancyServiceTest {
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(EXPIRED)
                 .build();
-        
+
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(CAPTURED, mockGatewayResponse);
         assertChargeIsNotCancelled(charge, chargeQueryResponse);
     }
@@ -112,16 +121,18 @@ public class DiscrepancyServiceTest {
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(1)))
                 .withStatus(EXPIRED)
                 .build();
-        
+
         ChargeQueryResponse chargeQueryResponse = new ChargeQueryResponse(AUTHORISATION_SUCCESS, mockGatewayResponse);
         assertChargeIsNotCancelled(charge, chargeQueryResponse);
     }
 
-    private void assertChargeIsNotCancelled(ChargeEntity charge, ChargeQueryResponse chargeQueryResponse) throws GatewayException {
-        when(chargeService.findChargeByExternalId(charge.getExternalId())).thenReturn(charge);
-        when(queryService.getChargeGatewayStatus(charge)).thenReturn(chargeQueryResponse);
+    private void assertChargeIsNotCancelled(ChargeEntity chargeEntity, ChargeQueryResponse chargeQueryResponse) throws GatewayException {
+        Charge charge = Charge.from(chargeEntity);
+        when(chargeService.findCharge(chargeEntity.getExternalId())).thenReturn(Optional.of(charge));
+        when(gatewayAccountService.getGatewayAccount(chargeEntity.getGatewayAccount().getId())).thenReturn(Optional.of(chargeEntity.getGatewayAccount()));
+        when(queryService.getChargeGatewayStatus(charge, chargeEntity.getGatewayAccount())).thenReturn(chargeQueryResponse);
 
-        discrepancyService.resolveDiscrepancies(Collections.singletonList(charge.getExternalId()));
+        discrepancyService.resolveDiscrepancies(Collections.singletonList(chargeEntity.getExternalId()));
         verifyNoMoreInteractions(expiryService);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -43,9 +44,10 @@ public class QueryServiceTest {
     @Test
     public void isTerminableWithGateway_returnsTrueForNotFinishedExternalStatus() throws Exception {
         ChargeEntity chargeEntity = aValidChargeEntity().build();
+        Charge charge = Charge.from(chargeEntity);
 
         ChargeQueryResponse response = new ChargeQueryResponse(AUTHORISATION_3DS_REQUIRED, mockGatewayResponse);
-        when(paymentProvider.queryPaymentStatus(chargeEntity)).thenReturn(response);
+        when(paymentProvider.queryPaymentStatus(charge, chargeEntity.getGatewayAccount())).thenReturn(response);
 
         assertThat(queryService.isTerminableWithGateway(chargeEntity), is(true));
     }
@@ -53,9 +55,10 @@ public class QueryServiceTest {
     @Test
     public void isTerminableWithGateway_returnsFalseForFinishedExternalStatus() throws Exception {
         ChargeEntity chargeEntity = aValidChargeEntity().build();
+        Charge charge = Charge.from(chargeEntity);
 
         ChargeQueryResponse response = new ChargeQueryResponse(CAPTURED, mockGatewayResponse);
-        when(paymentProvider.queryPaymentStatus(chargeEntity)).thenReturn(response);
+        when(paymentProvider.queryPaymentStatus(charge, chargeEntity.getGatewayAccount())).thenReturn(response);
 
         assertThat(queryService.isTerminableWithGateway(chargeEntity), is(false));
     }


### PR DESCRIPTION
## WHAT YOU DID
- Updated discrepancy checker to work for expunged charges.
- So far we have passed `ChargeEntity` to PaymentProvider methods. As `ChargeEntity` won't be available for expunged payments, `queryPaymentStatus` signature has been updated to take `Charge` object created from either ChargeEntity or LedgerTransaction as available. 