### PR TITLE
PP-7554: Add patch for updating an existing account details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Task can be invoked by sending request on admin port.
 |[```/v1/api/accounts```](docs/api_specification.md#post-v1apiaccounts)              | POST    |  Create a new account to associate charges with            |
 |[```/v1/api/accounts```](docs/api_specification.md#get-v1apiaccounts)              | GET    |  Retrieves a collection of all the accounts |
 |[```/v1/api/accounts/{gatewayAccountId}```](docs/api_specification.md#get-v1apiaccountsaccountsid)     | GET    |  Retrieves an existing account without the provider credentials  |
+|[```/v1/api/accounts/{gatewayAccountId}```](docs/api_specification.md#patch-v1apiaccountsaccountid) | PATCH | Updates an existing account's details |
 |[```/v1/api/accounts/{accountId}/charges/{chargeId}```](docs/api_specification.md#get-v1apiaccountsaccountidchargeschargeid)                 | GET    |  Returns the charge with `chargeId`  belongs to account `accountId` |
 |[```/v1/api/accounts/{accountId}/charges```](docs/api_specification.md#post-v1apiaccountsaccountidcharges)                                  | POST    |  Create a new charge for this account `accountId`           |
 |[```/v1/api/notifications/worldpay```](docs/api_specification.md#post-v1apinotificationsworldpay)                                  | POST |  Handle charge update notifications from Worldpay.            |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -971,7 +971,8 @@ Content-Type: application/json
 A generic endpoint that allows the patching of `allow_apple_pay`, `allow_google_pay`, `block_prepaid_cards`, `credentials/gateway_merchant_id`,
 `notify_settings`, `email_collection_mode`, `corporate_credit_card_surcharge_amount`, `corporate_debit_card_surcharge_amount`,
 `corporate_prepaid_credit_card_surcharge_amount`, `corporate_prepaid_debit_card_surcharge_amount`, `allow_zero_amount`, `allow_moto`,
-`moto_mask_card_number_input` or `moto_mask_card_security_code_input` using a JSON Patch-esque message body.
+`moto_mask_card_number_input`, `moto_mask_card_security_code_input`, `allow_telephone_payment_notifications`, `integration_version_3ds` or
+`worldpay_exemption_engine_enabled` using a JSON Patch-esque message body.
 
 ### Request example
 
@@ -994,7 +995,6 @@ Content-Type: application/json
 ```
 200 {}
 ```
-
 
 -----------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This change also adds several new paths to `PATCH /v1/api/accounts/{accountId}` in API Specification documentation.