### PR TITLE
PP-7609 - Emit GATEWAY_3DS_EXEMPTION_RESULT_OBTAINED event

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2021-01-11T11:53:48Z",
+  "generated_at": "2021-01-11T16:11:46Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -180,14 +180,14 @@
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
-      {
-        "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 438,
-        "type": "Base64 High Entropy String"
-      }
-    ],
+       {
+          "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
+          "is_secret": false,
+          "is_verified": false,
+          "line_number": 442,
+          "type": "Base64 High Entropy String"
+       }
+     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
       {
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -12,6 +12,7 @@ import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
@@ -82,6 +83,7 @@ public class WorldpayPaymentProviderTest {
     private Counter mockCounter;
     private Environment mockEnvironment;
     private CardExecutorService mockCardExecutorService = mock(CardExecutorService.class);
+    private EventService mockEventService = mock(EventService.class);
 
     @Before
     public void checkThatWorldpayIsUp() throws IOException {
@@ -390,7 +392,8 @@ public class WorldpayPaymentProviderTest {
                 new WorldpayRefundHandler(gatewayClient, gatewayUrlMap()), 
                 new AuthorisationService(mockCardExecutorService, mockEnvironment), 
                 new AuthorisationLogger(new AuthorisationRequestSummaryStringifier(), new AuthorisationRequestSummaryStructuredLogging()), 
-                mock(ChargeDao.class));
+                mock(ChargeDao.class),
+                mock(EventService.class));
     }
 
     private Map<String, URI> gatewayUrlMap() {


### PR DESCRIPTION
Description:
- This PR modifies WorldpayPaymentProvider to emit the GATEWAY_3DS_EXEMPTION_RESULT_OBTAINED event and modifies the tests to verify whether an event was emitted
- We follow the pattern in ChargeService.updateCharge for UserEmailCollected event as the event is carrying event data so we emit it directly using eventService
- @alexbishop1