### PR TITLE
PP-7554: Update Gateway Account Resource DTO to include Worldpay 3DS Flex

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Task can be invoked by sending request on admin port.
 
 | Path                          | Supported Methods | Description                        |
 | ----------------------------- | ----------------- | ---------------------------------- |
+|[```/v1/frontend/accounts```](docs/api_specification.md#get-v1frontendaccounts) | GET | Retrieves a collection of all the accounts with the provider credentials.|
 |[```/v1/frontend/accounts/{accountId}```](docs/api_specification.md#get-v1frontendaccountsaccountid)              | GET    |  Retrieves an existing account together with the provider credentials             |
 |[```/v1/frontend/accounts/{accountId}```](docs/api_specification.md#put-v1frontendaccountsaccountid)              | PUT    |  Update gateway credentials associated with this account             |
 |[```/v1/frontend/charges/{chargeId}/status```](docs/api_specification.md#put-v1frontendchargeschargeidstatus)         | PUT    |  Update status of the charge     |

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -247,7 +247,8 @@ Content-Type: application/json
             "enabled": true,
             "template_body": null
         }
-    }
+    },
+    "worldpay_3ds_flex": null
 }
 ```
 
@@ -376,6 +377,11 @@ Content-Type: application/json
               "template_body": null
           }
       },
+      "worldpay_3ds_flex": {
+        "issuer": "44992a087a0c4849895cc9a3",
+        "organisational_unit_id", "57992a087a0c4849895ab8a2",
+        "exemption_engine_enabled": true,
+      },
       "_links": {
         "self": {
           "href": "https://connector.example.com/v1/api/accounts/200"
@@ -412,6 +418,11 @@ Content-Type: application/json
               "enabled": true,
               "template_body": null
           }
+      },
+      "worldpay_3ds_flex": {
+        "issuer": "44992a087a0c4849895cc9a3",
+        "organisational_unit_id", "57992a087a0c4849895ab8a2",
+        "exemption_engine_enabled": true,
       },
       "_links": {
         "self": {
@@ -1143,6 +1154,168 @@ Content-Length: 52
     "message": "Charge with id [123456] not found."
 }
 ```
+-----------------------------------------------------------------------------------------------------------
+
+## GET /v1/frontend/accounts
+
+Retrieves a collection of accounts with the provider credentials, optionally filtering by the provided query parameters
+
+| Field                | Always present | Description                                                                                                                                      |
+|:---------------------|:--------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `accountIds`         |                | The account IDs that the results should be filtered by. A comma separated list of IDs.                                                           |
+| `moto_enabled`       |                | The accounts will be filtered by whether or not MOTO payment are enabled for the account if this parameter is provided. "true" or "false".       |
+| `apple_pay_enabled`  |                | The accounts will be filtered by whether or not Apple pay is enabled for the account if this parameter is provided. "true" or "false".           |
+| `google_pay_enabled` |                | The accounts will be filtered by whether or not Google pay is enabled for the account if this parameter is provided. "true" or "false".          |
+| `requires_3ds`       |                | The accounts will be filtered by whether or not 3DS is required for the account if this parameter is provided. "true" or "false".                |
+| `type`               |                | The accounts will be filtered by type if this parameter is provided. "test" or "live".                                                           |
+| `payment_provider`   |                | The accounts will be filtered by payment provider if this parameter is provided. One of "sandbox" or "worldpay", "smartpay", "epdq" or "stripe". |
+
+### Request example
+
+```
+GET /v1/frontend/accounts?accountIds=1,2&payment_provider=worldpay
+```
+
+### Response example
+
+```
+200 OK
+Content-Type: application/json
+{
+  "accounts": [
+    {
+      "type": "test",
+      "description": "a description",
+      "gateway_account_id": 100,
+      "payment_provider": "sandbox",
+      "service_name": "service_name",
+      "analytics_id": "an analytics id",
+      "corporate_credit_card_surcharge_amount": 0,
+      "corporate_debit_card_surcharge_amount": 0,
+      "corporate_prepaid_credit_card_surcharge_amount": 0,
+      "corporate_prepaid_debit_card_surcharge_amount": 0,
+      "credentials: {
+        "username:" "Username"
+      },
+      "allow_apple_pay": false,
+      "allow_google_pay": false,
+      "block_prepaid_cards": false,
+      "allow_zero_amount": false,
+      "email_collection_mode": "MANDATORY",
+      "requires3ds": false,
+      "allow_moto": false,
+      "allow_telephone_payment_notifications": false,
+      "moto_mask_card_number_input": false,
+      "moto_mask_card_security_code_input": false,
+      "email_notifications": {
+          "REFUND_ISSUED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          },
+          "PAYMENT_CONFIRMED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          }
+      },
+      "_links": {
+        "self": {
+          "href": "https://connector.example.com/v1/api/accounts/100"
+        }
+      }
+    },
+    {
+      "type": "live",
+      "description": "a description",
+      "gateway_account_id": 200,
+      "payment_provider": "sandbox",
+      "service_name": "service_name",
+      "analytics_id": "an analytics id",
+      "corporate_credit_card_surcharge_amount": 250,
+      "corporate_debit_card_surcharge_amount": 0,
+      "corporate_prepaid_credit_card_surcharge_amount": 250,
+      "corporate_prepaid_debit_card_surcharge_amount": 0,
+      "credentials: {
+        "username:" "Username"
+      },
+      "allow_apple_pay": false,
+      "allow_google_pay": false,
+      "block_prepaid_cards": false,
+      "allow_zero_amount": false,
+      "email_collection_mode": "MANDATORY",
+      "requires3ds": false,
+      "allow_moto": false,
+      "moto_mask_card_number_input": false,
+      "moto_mask_card_security_code_input": false,
+      "email_notifications": {
+          "REFUND_ISSUED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          },
+          "PAYMENT_CONFIRMED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          }
+      },
+      "worldpay_3ds_flex": {
+        "issuer": "44992a087a0c4849895cc9a3",
+        "organisational_unit_id", "57992a087a0c4849895ab8a2",
+        "exemption_engine_enabled": true,
+      },
+      "_links": {
+        "self": {
+          "href": "https://connector.example.com/v1/api/accounts/200"
+        }
+      }
+    },
+    {
+      "type": "test",
+      "description": "a description",
+      "gateway_account_id": 400,
+      "payment_provider": "worldpay",
+      "analytics_id": "an analytics id",
+      "corporate_credit_card_surcharge_amount": 0,
+      "corporate_debit_card_surcharge_amount": 0,
+      "corporate_prepaid_credit_card_surcharge_amount": 0,
+      "corporate_prepaid_debit_card_surcharge_amount": 0,
+      "allow_apple_pay": false,
+      "allow_google_pay": false,
+      "block_prepaid_cards": false,
+      "allow_zero_amount": false,
+      "email_collection_mode": "MANDATORY",
+      "requires3ds": false,
+      "allow_moto": false,
+      "moto_mask_card_number_input": false,
+      "moto_mask_card_security_code_input": false,
+      "email_notifications": {
+          "REFUND_ISSUED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          },
+          "PAYMENT_CONFIRMED": {
+              "version": 1,
+              "enabled": true,
+              "template_body": null
+          }
+      },
+      "worldpay_3ds_flex": {
+        "issuer": "44992a087a0c4849895cc9a3",
+        "organisational_unit_id", "57992a087a0c4849895ab8a2",
+        "exemption_engine_enabled": true,
+      },
+      "_links": {
+        "self": {
+          "href": "https://connector.example.com/v1/api/accounts/400"
+        }
+      }
+    }
+  ]
+}
+```
 
 -----------------------------------------------------------------------------------------------------------
 
@@ -1195,7 +1368,8 @@ Content-Type: application/json
           "enabled": true,
           "template_body": null
       }
-    }
+    },
+    "worldpay_3ds_flex": null
 }
 ```
 
@@ -1362,6 +1536,7 @@ Content-Type: application/json
         "corporate_debit_card_surcharge_amount": 0,
         "corporate_prepaid_credit_card_surcharge_amount": 0,
         "corporate_prepaid_debit_card_surcharge_amount": 0,
+        "worldpay_3ds_flex": null,
         "card_types": [
             {
                 "id": "79404bb9-31fb-4ad6-xxxx-789c3b044059",

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -85,6 +86,10 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("moto_mask_card_security_code_input")
     private boolean motoMaskCardSecurityCodeInput;
 
+    @JsonInclude(NON_NULL)
+    @JsonProperty("worldpay_3ds_flex")
+    private Worldpay3dsFlexCredentials worldpay3dsFlexCredentials;
+
     public GatewayAccountResourceDTO() {
     }
 
@@ -110,7 +115,8 @@ public class GatewayAccountResourceDTO {
                                      boolean allowMoto,
                                      boolean motoMaskCardNumberInput,
                                      boolean motoMaskCardSecurityCodeInput,
-                                     boolean allowTelephonePaymentNotifications) {
+                                     boolean allowTelephonePaymentNotifications,
+                                     Worldpay3dsFlexCredentials worldpay3dsFlexCredentials) {
         this.accountId = accountId;
         this.externalId = externalId;
         this.paymentProvider = paymentProvider;
@@ -134,6 +140,7 @@ public class GatewayAccountResourceDTO {
         this.motoMaskCardNumberInput = motoMaskCardNumberInput;
         this.motoMaskCardSecurityCodeInput = motoMaskCardSecurityCodeInput;
         this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
+        this.worldpay3dsFlexCredentials = worldpay3dsFlexCredentials;
     }
 
     public static GatewayAccountResourceDTO fromEntity(GatewayAccountEntity gatewayAccountEntity) {
@@ -160,7 +167,8 @@ public class GatewayAccountResourceDTO {
                 gatewayAccountEntity.isAllowMoto(),
                 gatewayAccountEntity.isMotoMaskCardNumberInput(),
                 gatewayAccountEntity.isMotoMaskCardSecurityCodeInput(),
-                gatewayAccountEntity.isAllowTelephonePaymentNotifications()
+                gatewayAccountEntity.isAllowTelephonePaymentNotifications(),
+                gatewayAccountEntity.getWorldpay3dsFlexCredentials().orElse(null)
         );
     }
 
@@ -262,5 +270,9 @@ public class GatewayAccountResourceDTO {
 
     public boolean isAllowTelephonePaymentNotifications() {
         return allowTelephonePaymentNotifications;
+    }
+
+    public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {
+        return Optional.ofNullable(worldpay3dsFlexCredentials);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
 
 
 public class GatewayAccountResourceDTOTest {
@@ -40,6 +41,7 @@ public class GatewayAccountResourceDTOTest {
         entity.setMotoMaskCardNumberInput(true);
         entity.setMotoMaskCardSecurityCodeInput(true);
         entity.setAllowTelephonePaymentNotifications(true);
+        entity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
 
         Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));
@@ -70,5 +72,6 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.isMotoMaskCardNumberInput(), is(entity.isMotoMaskCardNumberInput()));
         assertThat(dto.isMotoMaskCardSecurityCodeInput(), is(entity.isMotoMaskCardSecurityCodeInput()));
         assertThat(dto.isAllowTelephonePaymentNotifications(), is(entity.isAllowTelephonePaymentNotifications()));
+        assertThat(dto.getWorldpay3dsFlexCredentials(), is(entity.getWorldpay3dsFlexCredentials()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -193,13 +193,27 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     public void shouldGetAllGatewayAccountsWhenSearchWithNoParams() {
         String gatewayAccountId1 = createAGatewayAccountFor("sandbox");
         updateGatewayAccount(gatewayAccountId1, "allow_moto", true);
-        createAGatewayAccountFor("sandbox");
+        String gatewayAccountId2 = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
+        databaseTestHelper.insertWorldpay3dsFlexCredential(
+            Long.valueOf(gatewayAccountId2),
+                "macKey",
+                "issuer",
+                "org_unit_id",
+                2L,
+                true);
 
         givenSetup()
                 .get("/v1/api/accounts")
                 .then()
                 .statusCode(OK.getStatusCode())
-                .body("accounts", hasSize(2));
+                .body("accounts", hasSize(2))
+                .body("accounts[0].gateway_account_id", is(Integer.valueOf(gatewayAccountId1)))
+                .body("accounts[0].worldpay_3ds_flex", nullValue())
+                .body("accounts[1].gateway_account_id", is(Integer.valueOf(gatewayAccountId2)))
+                .body("accounts[1].worldpay_3ds_flex.issuer", is("issuer"))
+                .body("accounts[1].worldpay_3ds_flex.organisational_unit_id", is("org_unit_id"))
+                .body("accounts[1].worldpay_3ds_flex.exemption_engine_enabled", is(true))
+                .body("accounts[1].worldpay_3ds_flex", not(hasKey("jwt_mac_key")));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -873,16 +873,36 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void insertWorldpay3dsFlexCredential(Long gatewayAccountId, String jwtMacKey, String issuer, String organisationalUnitId, Long version) {
+    public void insertWorldpay3dsFlexCredential(Long gatewayAccountId,
+                                                String jwtMacKey,
+                                                String issuer,
+                                                String organisationalUnitId,
+                                                Long version) {
+        insertWorldpay3dsFlexCredential(
+            gatewayAccountId,
+            jwtMacKey,
+            issuer,
+            organisationalUnitId,
+            version,
+            false);
+    }
+
+    public void insertWorldpay3dsFlexCredential(Long gatewayAccountId,
+                                                String jwtMacKey,
+                                                String issuer,
+                                                String organisationalUnitId,
+                                                Long version,
+                                                boolean isExemptionEngineEnabled) {
         jdbi.withHandle(handle ->
-                handle
-                        .createUpdate("INSERT INTO worldpay_3ds_flex_credentials(gateway_account_id, jwt_mac_key, issuer, organisational_unit_id, version) VALUES (:gatewayAccountId, :jwtMacKey, :issuer, :organisationalUnitId, :version)")
-                        .bind("gatewayAccountId", gatewayAccountId)
-                        .bind("jwtMacKey", jwtMacKey)
-                        .bind("issuer", issuer)
-                        .bind("organisationalUnitId", organisationalUnitId)
-                        .bind("version", version)
-                        .execute()
+            handle.createUpdate("INSERT INTO worldpay_3ds_flex_credentials(gateway_account_id, jwt_mac_key, issuer, organisational_unit_id, version, exemption_engine) " +
+                    "VALUES (:gatewayAccountId, :jwtMacKey, :issuer, :organisationalUnitId, :version, :exemption_engine)")
+                .bind("gatewayAccountId", gatewayAccountId)
+                .bind("jwtMacKey", jwtMacKey)
+                .bind("issuer", issuer)
+                .bind("organisationalUnitId", organisationalUnitId)
+                .bind("version", version)
+                .bind("exemption_engine", isExemptionEngineEnabled)
+                .execute()
         );
     }
 


### PR DESCRIPTION
This pull request has two commits.

1. The first commit adds `worldpay_3ds_flex` JSON field to GatewayAccountResourceDTO. This will enable both GET endpoints `/v1/api/accounts` and `/v1/frontend/accounts` to return GatewayAccountResourceDTO object containing `worldpay_3ds_flex` JSON field. It updates the existing integration test to ensure that the new field is present.
2. The second commit adds `worldpay_3ds_flex` JSON field to an account object returned by calling GET `/v1/api/accounts` endpoint in API specification documentation.

This change is needed for scenario 6 taken from the story.