### PR TITLE
PP-5706: Include DDC result in contract test

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -132,12 +132,15 @@ public class WorldpayPaymentProviderTest {
     @Test
     public void submitAuthForSoftDecline() {
         validGatewayAccount.setRequires3ds(true);
-        validGatewayAccount.setIntegrationVersion3ds(1);
+        validGatewayAccount.setIntegrationVersion3ds(2);
         validGatewayAccount.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
 
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         // card holder of "EE.REJECTED_ISSUER_REJECTED.SOFT_DECLINED" elicits a soft decline response, see https://developer.worldpay.com/docs/wpg/scaexemptionservices/exemptionengine#testing-exemption-engine
-        var authCardDetails = anAuthCardDetails().withCardHolder("EE.REJECTED_ISSUER_REJECTED.SOFT_DECLINED").build();
+        var authCardDetails = anAuthCardDetails()
+                .withCardHolder("EE.REJECTED_ISSUER_REJECTED.SOFT_DECLINED")
+                .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
+                .build();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
         assertTrue(response.getBaseResponse().isPresent());
@@ -148,12 +151,15 @@ public class WorldpayPaymentProviderTest {
     @Test
     public void submitAuthRequestWithExemptionEngineFlag() {
         validGatewayAccount.setRequires3ds(true);
-        validGatewayAccount.setIntegrationVersion3ds(1);
+        validGatewayAccount.setIntegrationVersion3ds(2);
         validGatewayAccount.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         
         WorldpayPaymentProvider paymentProvider = getValidWorldpayPaymentProvider();
         // card holder of "EE.HONOURED_ISSUER_HONOURED.AUTHORISED" elicits an authorised response, see https://developer.worldpay.com/docs/wpg/scaexemptionservices/exemptionengine#testing-exemption-engine
-        var authCardDetails = anAuthCardDetails().withCardHolder("EE.HONOURED_ISSUER_HONOURED.AUTHORISED").build();
+        var authCardDetails = anAuthCardDetails()
+                .withCardHolder("EE.HONOURED_ISSUER_HONOURED.AUTHORISED")
+                .withWorldpay3dsFlexDdcResult(UUID.randomUUID().toString())
+                .build();
         CardAuthorisationGatewayRequest request = getCardAuthorisationRequest(authCardDetails);
         GatewayResponse<WorldpayOrderStatusResponse> response = paymentProvider.authorise(request);
         assertTrue(response.getBaseResponse().isPresent());


### PR DESCRIPTION
As we're realistically only going to be using exemption engine for gateway
accounts with 3DS Flex, it makes sense to include a 3DS Flex DDC result when
testing the exemption engine.

