### PR TITLE
PP-7656 Add frontend get account by external ID endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -127,6 +127,20 @@ public class GatewayAccountResource {
     }
 
     @GET
+    @Path("/v1/frontend/accounts/external-id/{externalId}")
+    @Produces(APPLICATION_JSON)
+    public Response getFrontendGatewayAccountByExternalId(@PathParam("externalId")  String externalId) {
+        return gatewayAccountService
+                .getGatewayAccountByExternal(externalId)
+                .map(gatewayAccount ->
+                {
+                    gatewayAccount.getCredentials().remove("password");
+                    return Response.ok(gatewayAccount).build();
+                })
+                .orElseGet(() -> notFoundResponse(format("Account with external id %s not found.", externalId)));
+    }
+
+    @GET
     @Path("/v1/frontend/accounts")
     @Produces(APPLICATION_JSON)
     public Response getFrontendGatewayAccounts(

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -473,33 +473,6 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     }
 
     @Test
-    public void shouldNotReturn3dsFlexCredentials_whenGatewayAccountHasNoCreds() {
-        String gatewayAccountId = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
-        givenSetup()
-                .get("/v1/frontend/accounts/" + gatewayAccountId)
-                .then()
-                .statusCode(200)
-                .body("worldpay_3ds_flex", nullValue());
-    }
-
-    @Test
-    public void shouldReturn3dsFlexCredentials_whenGatewayAccountHasCreds() {
-        String gatewayAccountId = createAGatewayAccountFor("worldpay", "a-description", "analytics-id");
-        databaseTestHelper.insertWorldpay3dsFlexCredential(Long.valueOf(gatewayAccountId), "macKey", "issuer", "org_unit_id", 2L);
-        givenSetup()
-                .get("/v1/frontend/accounts/" + gatewayAccountId)
-                .then()
-                .statusCode(200)
-                .body("$", hasKey("worldpay_3ds_flex"))
-                .body("worldpay_3ds_flex.issuer", is("issuer"))
-                .body("worldpay_3ds_flex.organisational_unit_id", is("org_unit_id"))
-                .body("worldpay_3ds_flex", not(hasKey("jwt_mac_key")))
-                .body("worldpay_3ds_flex", not(hasKey("version")))
-                .body("worldpay_3ds_flex", not(hasKey("gateway_account_id")))
-                .body("worldpay_3ds_flex.exemption_engine_enabled", is(false));
-    }
-
-    @Test
     public void shouldReturn200WhenWorldpayExemptionEngineEnabledIsUpdated() throws JsonProcessingException {
         String gatewayAccountId = createAGatewayAccountFor(WORLDPAY.getName(), "a-description", "analytics-id");
         databaseTestHelper.insertWorldpay3dsFlexCredential(

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -28,6 +28,7 @@ public class GatewayAccountResourceTestBase {
     public static final String ACCOUNTS_API_URL = "/v1/api/accounts/";
     public static final String ACCOUNTS_FRONTEND_URL = "/v1/frontend/accounts/";
     public static final String ACCOUNTS_EXTERNAL_ID_URL = ACCOUNTS_API_URL + "external-id/";
+    public static final String ACCOUNT_FRONTEND_EXTERNAL_ID_URL = "/v1/frontend/accounts/external-id/";
 
     @DropwizardTestContext
     protected TestContext testContext;


### PR DESCRIPTION
For get account by internal ID, we have 2 endpoints:
- /v1/api/accounts/<id>
- /v1/frontend/accounts/<id>

The /v1/api endpoint is used by public api and the `/v1/frontend`
endpoint is used by selfservice and toolbox. The `/v1/frontend` endpoint
includes the gateway credentials but the `/v1/api` endpoint does not.

For get account by external ID we added the endpoint
`/v1/api/accounts/external-id/<externalId>`

This returns the gateway account without the gateway credentials and
is used by selfservice.

However, to be consistent with the get account endpoint, and as
selfservice needs to get the gateway credentials we should have instead
added a `/v1/frontend/accounts/external-id/<externalId>` endpoint.

This commit adds the new endpoint. The `/v1/api` endpoint will be removed
when it is no longer used by selfservice.
