### PR TITLE
PP-7656 Remove old get account by external ID endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -115,18 +115,6 @@ public class GatewayAccountResource {
     }
 
     @GET
-    @Path("/v1/api/accounts/external-id/{externalId}")
-    @Produces(APPLICATION_JSON)
-    public Response getGatewayAccountByExternalId(@PathParam("externalId")  String externalId) {
-        logger.debug("Getting gateway account for account external id {}", externalId);
-        return gatewayAccountService
-                .getGatewayAccountByExternal(externalId)
-                .map(GatewayAccountResourceDTO::new)
-                .map(gatewayAccountDTO -> Response.ok().entity(gatewayAccountDTO).build())
-                .orElseGet(() -> notFoundResponse(format("Account with external id %s not found.", externalId)));
-    }
-
-    @GET
     @Path("/v1/frontend/accounts/external-id/{externalId}")
     @Produces(APPLICATION_JSON)
     public Response getFrontendGatewayAccountByExternalId(@PathParam("externalId")  String externalId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -837,34 +837,4 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .then()
                 .statusCode(NOT_FOUND.getStatusCode());
     }
-
-    @Test
-    public void shouldReturnAccountInformationForGetAccountByExternalId() {
-        this.defaultTestAccount = DatabaseFixtures
-                .withDatabaseTestHelper(databaseTestHelper)
-                .aTestAccount()
-                .insert();
-
-        givenSetup()
-                .get(ACCOUNTS_EXTERNAL_ID_URL + defaultTestAccount.getExternalId())
-                .then()
-                .statusCode(200)
-                .body("payment_provider", is("sandbox"))
-                .body("gateway_account_id", is(Math.toIntExact(defaultTestAccount.getAccountId())))
-                .body("external_id", is(defaultTestAccount.getExternalId()))
-                .body("type", is(TEST.toString()))
-                .body("description", is("a description"))
-                .body("analytics_id", is("an analytics id"))
-                .body("email_collection_mode", is("OPTIONAL"))
-                .body("email_notifications.PAYMENT_CONFIRMED.template_body", is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
-                .body("email_notifications.PAYMENT_CONFIRMED.enabled", is(true))
-                .body("email_notifications.REFUND_ISSUED.template_body", is("Lorem ipsum dolor sit amet, consectetur adipiscing elit."))
-                .body("email_notifications.REFUND_ISSUED.enabled", is(true))
-                .body("service_name", is("service_name"))
-                .body("corporate_credit_card_surcharge_amount", is(0))
-                .body("allow_google_pay", is(false))
-                .body("allow_apple_pay", is(false))
-                .body("allow_zero_amount", is(false))
-                .body("integration_version_3ds", is(2));
-    }
 }


### PR DESCRIPTION
This endpoint has been replaced by an equivalent endpoint that is `/v1/frontend/` rather than `/v1/api/`