### PR TITLE
BAU — Use Instant in tests that extend ChargingITestBase

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -28,7 +28,7 @@ import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.util.RestAssuredClient;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -321,20 +321,20 @@ public class ChargingITestBase {
         return chargeId;
     }
 
-    protected String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, ZonedDateTime fromDate) {
+    protected String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, Instant fromDate) {
         return addChargeAndCardDetails(status, reference, fromDate, "");
 
     }
 
-    protected String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, ZonedDateTime fromDate, String cardBrand) {
+    protected String addChargeAndCardDetails(ChargeStatus status, ServicePaymentReference reference, Instant fromDate, String cardBrand) {
         return addChargeAndCardDetails(nextLong(), status, reference, fromDate, cardBrand);
     }
 
     protected String addCharge(ChargeStatus status) {
-        return addCharge(status, "ref", ZonedDateTime.now(), RandomIdGenerator.newId());
+        return addCharge(status, "ref", Instant.now(), RandomIdGenerator.newId());
     }
     
-    protected String addCharge(ChargeStatus status, String reference, ZonedDateTime fromDate, String transactionId) {
+    protected String addCharge(ChargeStatus status, String reference, Instant fromDate, String transactionId) {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
@@ -348,7 +348,7 @@ public class ChargingITestBase {
     }
 
     private void addCharge(long chargeId, String externalChargeId, ChargeStatus chargeStatus,
-                             ServicePaymentReference reference, ZonedDateTime createdDate, String transactionId) {
+                           ServicePaymentReference reference, Instant createdDate, String transactionId) {
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId)
@@ -357,7 +357,7 @@ public class ChargingITestBase {
                 .withStatus(chargeStatus)
                 .withTransactionId(transactionId)
                 .withReference(reference)
-                .withCreatedDate(createdDate.toInstant())
+                .withCreatedDate(createdDate)
                 .withVersion(1)
                 .withLanguage(SupportedLanguage.ENGLISH)
                 .withDelayedCapture(false)
@@ -365,7 +365,7 @@ public class ChargingITestBase {
                 .build());
     }
 
-    protected String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, ZonedDateTime fromDate, String cardBrand) {
+    protected String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, Instant fromDate, String cardBrand) {
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
         addCharge(chargeId, externalChargeId, chargeStatus, reference, fromDate, null);

--- a/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
@@ -20,10 +20,12 @@ import uk.gov.pay.connector.junit.ConfigOverride;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static java.time.temporal.ChronoUnit.HOURS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -56,7 +58,7 @@ public class StateTransitionsIT extends ChargingITestBase {
 
     @Test
     public void shouldPutPaymentStateTransitionMessageOntoQueueGivenAuthCancel() throws InterruptedException {
-        String chargeId = addCharge(AUTHORISATION_SUCCESS, "ref", ZonedDateTime.now().minusHours(1), "transaction-id-transition-it");
+        String chargeId = addCharge(AUTHORISATION_SUCCESS, "ref", Instant.now().minus(1, HOURS), "transaction-id-transition-it");
 
         cancelChargeAndCheckApiStatus(chargeId, SYSTEM_CANCELLED, 204);
 
@@ -84,7 +86,7 @@ public class StateTransitionsIT extends ChargingITestBase {
 
     @Test
     public void shouldEmitCorrectRefundEvents() throws Exception{
-        String chargeId = addCharge(CAPTURED, "ref", ZonedDateTime.now().minusHours(1), "transaction-id-transition-it");
+        String chargeId = addCharge(CAPTURED, "ref", Instant.now().minus(1, HOURS), "transaction-id-transition-it");
         Long refundAmount = 50L;
         Long refundAmountAvailable = AMOUNT;
         ImmutableMap<String, Long> refundData = ImmutableMap.of("amount", refundAmount, "refund_amount_available", refundAmountAvailable);

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureWithSqsQueueIT.java
@@ -18,9 +18,11 @@ import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -73,7 +75,7 @@ public class CardResourceCaptureWithSqsQueueIT extends ChargingITestBase {
 
     @Test
     public void shouldAddChargeToQueueAndSubmitForCapture_IfChargeWasAwaitingCapture() {
-        String chargeId = addCharge(AWAITING_CAPTURE_REQUEST, "ref", ZonedDateTime.now().minusHours(48L).plusMinutes(1L), RandomIdGenerator.newId());
+        String chargeId = addCharge(AWAITING_CAPTURE_REQUEST, "ref", Instant.now().minus(48, HOURS).plus(1, MINUTES), RandomIdGenerator.newId());
 
         captureApproveUrl = captureUrlForAwaitingCaptureCharge(accountId, chargeId);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeCancelResourceIT.java
@@ -11,12 +11,13 @@ import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.HOURS;
 import static javax.ws.rs.core.Response.Status.ACCEPTED;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -42,7 +43,7 @@ public class ChargeCancelResourceIT extends ChargingITestBase {
     @Test
     @Parameters({"CREATED", "ENTERING_CARD_DETAILS"})
     public void shouldRespond204WithNoLockingEvent_IfCancelledBeforeAuth(ChargeStatus status) {
-        String chargeId = addCharge(status, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
+        String chargeId = addCharge(status, "ref", Instant.now().minus(1, HOURS), "irrelevant");
         cancelChargeAndCheckApiStatus(chargeId, SYSTEM_CANCELLED, 204);
 
         List<String> events = databaseTestHelper.getInternalEvents(chargeId);
@@ -52,7 +53,7 @@ public class ChargeCancelResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldPreserveCardDetailsIfCancelled() {
-        String externalChargeId = addCharge(ChargeStatus.AUTHORISATION_SUCCESS, "ref", ZonedDateTime.now().minusHours(1), "irrelavant");
+        String externalChargeId = addCharge(ChargeStatus.AUTHORISATION_SUCCESS, "ref", Instant.now().minus(1, HOURS), "irrelavant");
         Long chargeId = Long.valueOf(StringUtils.removeStart(externalChargeId, "charge"));
 
         worldpayMockClient.mockCancelSuccess();
@@ -78,7 +79,7 @@ public class ChargeCancelResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldRespondWith204WithLockingStatus_IfCancelledAfterAuth() {
-        String chargeId = addCharge(AUTHORISATION_SUCCESS, "ref", ZonedDateTime.now().minusHours(1), "transaction-id");
+        String chargeId = addCharge(AUTHORISATION_SUCCESS, "ref", Instant.now().minus(1, HOURS), "transaction-id");
         worldpayMockClient.mockCancelSuccess();
 
         cancelChargeAndCheckApiStatus(chargeId, SYSTEM_CANCELLED, 204);
@@ -93,7 +94,7 @@ public class ChargeCancelResourceIT extends ChargingITestBase {
     @Test
     public void shouldRespondWith204WithLockingStatus_IfCancelFailedAfterAuth() {
 
-        String chargeId = addCharge(AUTHORISATION_SUCCESS, "ref", ZonedDateTime.now().minusHours(1), "irrelavant");
+        String chargeId = addCharge(AUTHORISATION_SUCCESS, "ref", Instant.now().minus(1, HOURS), "irrelavant");
         worldpayMockClient.mockCancelError();
 
         cancelChargeAndCheckApiStatus(chargeId, SYSTEM_CANCEL_ERROR, 204);
@@ -208,6 +209,6 @@ public class ChargeCancelResourceIT extends ChargingITestBase {
     }
 
     private String createNewInPastChargeWithStatus(ChargeStatus status) {
-        return addCharge(status, "ref", ZonedDateTime.now().minusHours(1), "irrelavant");
+        return addCharge(status, "ref", Instant.now().minus(1, HOURS), "irrelavant");
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
@@ -11,11 +11,12 @@ import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.restassured.http.ContentType.JSON;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_READY;
@@ -35,7 +36,7 @@ public class ChargeExpiryResourceEpdqIT extends ChargingITestBase {
     
     @Test
     public void shouldExpireWithGatewayIfExistsInCancellableStateWithGatewayEvenIfChargeIsPreAuthorisation() {
-        String chargeId = addCharge(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+        String chargeId = addCharge(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", Instant.now().minus(90, MINUTES), RandomIdGenerator.newId());
 
         epdqMockClient.mockAuthorisationQuerySuccess();
         epdqMockClient.mockCancelSuccess();
@@ -62,7 +63,7 @@ public class ChargeExpiryResourceEpdqIT extends ChargingITestBase {
 
     @Test
     public void shouldHandleCaseWhereEpdqRespondsWithUnknownStatus() {
-        String chargeId = addCharge(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+        String chargeId = addCharge(ChargeStatus.AUTHORISATION_3DS_REQUIRED, "ref", Instant.now().minus(90, MINUTES), RandomIdGenerator.newId());
         epdqMockClient.mockUnknown();
 
         connectorRestApiClient
@@ -86,7 +87,7 @@ public class ChargeExpiryResourceEpdqIT extends ChargingITestBase {
 
     @Test
     public void shouldUpdateChargeStatusToMatchTerminalStateOnGateway() {
-        String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+        String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", Instant.now().minus(90, MINUTES), RandomIdGenerator.newId());
         
         epdqMockClient.mockAuthorisationQuerySuccessCaptured();
 
@@ -111,7 +112,7 @@ public class ChargeExpiryResourceEpdqIT extends ChargingITestBase {
 
     @Test
     public void shouldUpdateChargeStatusToMatchTerminalStateOnGatewayWhenNotAForceTransition() {
-        String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", ZonedDateTime.now().minusMinutes(90), RandomIdGenerator.newId());
+        String chargeId = addCharge(AUTHORISATION_3DS_READY, "ref", Instant.now().minus(90, MINUTES), RandomIdGenerator.newId());
 
         epdqMockClient.mockAuthorisationQuerySuccessAuthFailed();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -20,12 +20,15 @@ import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import javax.ws.rs.core.HttpHeaders;
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -344,7 +347,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
     @Test
     public void shouldGetSuccessAndFailedResponseForExpiryChargeTask() {
         //create charge
-        String extChargeId = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
+        String extChargeId = addChargeAndCardDetails(CREATED, ServicePaymentReference.of("ref"), Instant.now().minus(90, MINUTES));
 
         // run expiry task
         connectorRestApiClient
@@ -369,7 +372,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
     @Test
     public void shouldGetSuccessResponseForExpiryChargeTaskFor3dsRequiredPayments() {
         String extChargeId = addChargeAndCardDetails(ChargeStatus.AUTHORISATION_3DS_REQUIRED, ServicePaymentReference.of("ref"),
-                ZonedDateTime.now().minusMinutes(90));
+                Instant.now().minus(90, MINUTES));
 
         connectorRestApiClient
                 .postChargeExpiryTask()
@@ -393,7 +396,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
     public void shouldGetSuccessForExpiryChargeTask_withStatus_awaitingCaptureRequest() {
         //create charge
         String extChargeId = addChargeAndCardDetails(AWAITING_CAPTURE_REQUEST,
-                ServicePaymentReference.of("ref"), ZonedDateTime.now().minusHours(120L));
+                ServicePaymentReference.of("ref"), Instant.now().minus(120, HOURS));
 
         // run expiry task
         connectorRestApiClient
@@ -419,7 +422,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
     public void shouldGetNoContentForMarkChargeAsCaptureApproved_withStatus_awaitingCaptureRequest() {
         //create charge
         String extChargeId = addChargeAndCardDetails(AWAITING_CAPTURE_REQUEST,
-                ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
+                ServicePaymentReference.of("ref"), Instant.now().minus(90, MINUTES));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -443,7 +446,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
     public void shouldGetNoContentForMarkChargeAsCaptureApproved_withStatus_captureApproved() {
         //create charge
         String extChargeId = addChargeAndCardDetails(CAPTURE_APPROVED,
-                ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
+                ServicePaymentReference.of("ref"), Instant.now().minus(90, MINUTES));
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -479,7 +482,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
     public void shouldGetConflictExceptionFor_markChargeAsCaptureApproved_whenNoChargeExists() {
         //create charge
         String extChargeId = addChargeAndCardDetails(EXPIRED,
-                ServicePaymentReference.of("ref"), ZonedDateTime.now().minusMinutes(90));
+                ServicePaymentReference.of("ref"), Instant.now().minus(90, MINUTES));
 
         final String expectedErrorMessage = format("Operation for charge conflicting, %s, attempt to perform delayed capture on charge not in AWAITING CAPTURE REQUEST state.", extChargeId);
         connectorRestApiClient

--- a/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/DiscrepancyResourceIT.java
@@ -11,11 +11,13 @@ import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
 import static io.restassured.http.ContentType.JSON;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -31,8 +33,8 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReturnAllCharges_whenRequestDiscrepancyReport() {
-        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
-        String chargeId2 = addCharge(ChargeStatus.AUTHORISATION_SUCCESS, "ref", ZonedDateTime.now().minusHours(1), "irrelevant");
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(1, HOURS), "irrelevant");
+        String chargeId2 = addCharge(ChargeStatus.AUTHORISATION_SUCCESS, "ref", Instant.now().minus(1, HOURS), "irrelevant");
         epdqMockClient.mockAuthorisationQuerySuccess();
 
         List<JsonNode> results = connectorRestApiClient
@@ -89,7 +91,7 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldReportOnChargesThatAreInErrorStatesInGatewayAccount() {
-        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusDays(8), "irrelevant");
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(8, DAYS), "irrelevant");
         epdqMockClient.mockAuthorisationQuerySuccessAuthFailed();
         epdqMockClient.mockCancelSuccess();
 
@@ -111,7 +113,7 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldHandleCaseWhereChargeIsInUnknownState() {
-        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusDays(8), "irrelevant");
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(8, DAYS), "irrelevant");
         epdqMockClient.mockUnknown();
 
         List<JsonNode> results = connectorRestApiClient
@@ -141,8 +143,8 @@ public class DiscrepancyResourceIT extends ChargingITestBase {
 
     @Test
     public void shouldProcessDiscrepanciesWherePayStateIsExpiredAndGatewayStateIsAuthorised() {
-        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusDays(8), "irrelevant");
-        String chargeId2 = addCharge(ChargeStatus.EXPIRED, "ref", ZonedDateTime.now().minusDays(8), "irrelevant");
+        String chargeId = addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(8, DAYS), "irrelevant");
+        String chargeId2 = addCharge(ChargeStatus.EXPIRED, "ref", Instant.now().minus(8, DAYS), "irrelevant");
         epdqMockClient.mockAuthorisationQuerySuccess();
         epdqMockClient.mockCancelSuccess();
 


### PR DESCRIPTION
Use `Instant` instead of `ZonedDateTime` for charge created dates in `ChargingITestBase` and tests that extend `ChargingITestBase`.