### PR TITLE
BAU Do not log a InvalidStateTransitionException before trying to force

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -48,16 +48,7 @@ public class ChargeNotificationProcessor {
         try {
             chargeService.transitionChargeState(chargeEntity, newStatus, gatewayEventDate);
         } catch (InvalidStateTransitionException e) {
-            logger.error(format("%s (%s) notification '%s' could not be used to update charge: %s",
-                    gatewayAccount.getGatewayName(), gatewayAccount.getId(), gatewayTransactionId, e.getMessage()),
-                    kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
-                    kv(PROVIDER_PAYMENT_ID, gatewayTransactionId),
-                    kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
-                    kv(PROVIDER, gatewayAccount.getGatewayName()));
-            
-            boolean success = forceTransitionChargeState(gatewayAccount, gatewayTransactionId, chargeEntity, oldStatus, newStatus);
-            
-            if (!success) {
+            if (!forceTransitionChargeState(gatewayAccount, gatewayTransactionId, chargeEntity, oldStatus, newStatus)) {
                 return;
             }
         }


### PR DESCRIPTION
We will try to force the state transition if an
`InvalidStateTransitionException` is thrown. We will log an error if this
forcing of the state transition fails. Therefore do not log an error
before trying.

## WHAT ##
This is to fix https://sentry.io/organizations/govuk-pay/issues/2067568955/?project=5480144&referrer=slack

We also log when we're going to try to force a state transition which is why I think this entire log entry can go rather than just down grade it https://github.com/alphagov/pay-connector/blob/6a96fdec7f3d3bb19c9a6b7622815224eb4b9050/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java#L316
