### PR TITLE
PP-7696 Accept CARD_AGENT_INITIATED_MOTO as created payment source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.7</eclipselink.version>
         <guice.version>4.2.3</guice.version>
         <jackson.version>2.12.1</jackson.version>
-        <pay-java-commons.version>1.0.20210119122436</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20210129092323</pay-java-commons.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <jooq.version>3.14.6</jooq.version>
         <postgresql.version>42.2.18</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/charge/model/SourceDeserialiser.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/SourceDeserialiser.java
@@ -7,12 +7,18 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import uk.gov.pay.commons.model.Source;
 
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.commons.model.Source.CARD_AGENT_INITIATED_MOTO;
 import static uk.gov.pay.commons.model.Source.CARD_API;
 import static uk.gov.pay.commons.model.Source.CARD_PAYMENT_LINK;
 
 public class SourceDeserialiser extends JsonDeserializer<Source> {
+
+    private static final Set<Source> ALLOWED_SOURCES = EnumSet.of(CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO);
+
     public SourceDeserialiser() {
     }
 
@@ -23,16 +29,9 @@ public class SourceDeserialiser extends JsonDeserializer<Source> {
             return null;
         }
 
-        try {
-            Source source = Source.valueOf(valueAsString);
-
-            if (CARD_API.equals(source) || CARD_PAYMENT_LINK.equals(source)) {
-                return source;
-            }
-
-            throw new JsonMappingException(null, "Field [source] must be one of CARD_API, CARD_PAYMENT_LINK");
-        } catch (IllegalArgumentException e) {
-            throw new JsonMappingException(null, "Field [source] must be one of CARD_API, CARD_PAYMENT_LINK");
-        }
+        return Source.from(valueAsString)
+                .filter(ALLOWED_SOURCES::contains)
+                .orElseThrow(() -> new JsonMappingException(null, "Field [source] must be one of CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO"));
     }
+
 }

--- a/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/util/JsonMappingExceptionMapper.java
@@ -30,8 +30,8 @@ public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingEx
             return "Field [metadata] must be an object of JSON key-value pairs";
         }
 
-        if (message.contains("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK")) {
-            return "Field [source] must be one of CARD_API, CARD_PAYMENT_LINK";
+        if (message.contains("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO")) {
+            return "Field [source] must be one of CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO";
         }
 
         return message;

--- a/src/test/java/uk/gov/pay/connector/charge/model/SourceDeserialiserTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/SourceDeserialiserTest.java
@@ -1,0 +1,63 @@
+package uk.gov.pay.connector.charge.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.commons.model.Source;
+
+import java.io.IOException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class SourceDeserialiserTest {
+
+    @Mock private JsonParser mockJsonParser;
+    @Mock private DeserializationContext mockDeserializationContext;
+
+    private final SourceDeserialiser sourceDeserialiser = new SourceDeserialiser();
+
+    @Test
+    void shouldDeserialiseNullToNull() throws IOException {
+        given(mockJsonParser.getValueAsString()).willReturn(null);
+        Source result = sourceDeserialiser.deserialize(mockJsonParser, mockDeserializationContext);
+        assertThat(result, is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Source.class, names = {"CARD_API", "CARD_PAYMENT_LINK", "CARD_AGENT_INITIATED_MOTO"})
+    void shouldDeserialiseAcceptedSources(Source source) throws IOException {
+        given(mockJsonParser.getValueAsString()).willReturn(source.name());
+        Source result = sourceDeserialiser.deserialize(mockJsonParser, mockDeserializationContext);
+        assertThat(result, is(source));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Source.class, names = {"CARD_API", "CARD_PAYMENT_LINK", "CARD_AGENT_INITIATED_MOTO"}, mode = EXCLUDE)
+    void shouldThrowExceptionForSourcesNotExplicitlyAllowed(Source source) throws IOException {
+        given(mockJsonParser.getValueAsString()).willReturn(source.name());
+        var thrown = assertThrows(JsonMappingException.class,
+                () -> sourceDeserialiser.deserialize(mockJsonParser, mockDeserializationContext));
+        assertThat(thrown.getMessage(), is("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO"));
+    }
+
+    @Test
+    void shouldThrowExceptionForUnrecognisedSource() throws IOException {
+        given(mockJsonParser.getValueAsString()).willReturn("CAKE_BASED_BARTERING_SYSTEM");
+        var thrown = assertThrows(JsonMappingException.class,
+                () -> sourceDeserialiser.deserialize(mockJsonParser, mockDeserializationContext));
+        assertThat(thrown.getMessage(), is("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -756,7 +756,7 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
                 .postCreateCharge(postBody)
                 .statusCode(400)
                 .contentType(JSON)
-                .body(JSON_MESSAGE_KEY, contains("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK"));
+                .body(JSON_MESSAGE_KEY, contains("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO"));
     }
 
     @Test
@@ -775,7 +775,7 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
                 .postCreateCharge(postBody)
                 .statusCode(400)
                 .contentType(JSON)
-                .body(JSON_MESSAGE_KEY, contains("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK"));
+                .body(JSON_MESSAGE_KEY, contains("Field [source] must be one of CARD_API, CARD_PAYMENT_LINK, CARD_AGENT_INITIATED_MOTO"));
     }
 
     @Test


### PR DESCRIPTION
When processing a request to create a new payment via the standard API, accept `CARD_AGENT_INITIATED_MOTO` as a valid source.