### PR TITLE
PP-7696 Update API docs to document internal.source

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": null,
+    "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-01-29T14:10:01Z",
+  "generated_at": "2021-01-29T17:43:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,10 +90,16 @@
     ],
     "docs/api_specification.md": [
       {
+        "hashed_secret": "fa1ab503d57a889458acec40b9bd9e3a8af00ff4",
+        "is_verified": false,
+        "line_number": 1307,
+        "type": "Hex High Entropy String"
+      },
+      {
         "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1236,
+        "line_number": 1417,
         "type": "Secret Keyword"
       }
     ],
@@ -168,14 +174,14 @@
         "hashed_secret": "c2baab12724c0f29014dc172042a17ebbd9b60d4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 108,
+        "line_number": 109,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "4991aba1cb28cabc042aa415f2689cf359bb4af2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 109,
+        "line_number": 110,
         "type": "Secret Keyword"
       }
     ],
@@ -232,7 +238,7 @@
         "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 131,
+        "line_number": 132,
         "type": "Hex High Entropy String"
       }
     ],

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -606,6 +606,7 @@ Content-Type: application/json
 | `prefilled_cardholder_details.billing_addess.postcode` | | Postcode of the billing address to be prefilled on frontend card details page |
 | `prefilled_cardholder_details.billing_addess.city` | | City of the billing address to be prefilled on frontend card details page |
 | `prefilled_cardholder_details.billing_addess.country` | | Country code of the billing address to be prefilled on frontend card details page |
+| `internal.source`        |           | Source of payment (e.g. CARD_PAYMENT_LINK) - defaults to CARD_API (which cannot be specified explicitly) |
 
 ### Response example
 


### PR DESCRIPTION
Update the API docs to document the `internal.source` property that can be optionally included in a request to create a card payment.