### PR TITLE
PP-7672 Send IP address to Smartpay during authorisation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilder.java
@@ -1,17 +1,14 @@
 package uk.gov.pay.connector.gateway.smartpay;
 
+import uk.gov.pay.connector.gateway.OrderRequestBuilder;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.templates.PayloadBuilder;
 import uk.gov.pay.connector.gateway.templates.TemplateBuilder;
-import uk.gov.pay.connector.gateway.OrderRequestBuilder;
-import uk.gov.pay.connector.northamericaregion.CanadaPostalcodeToProvinceOrTerritoryMapper;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
-import uk.gov.pay.connector.northamericaregion.UsZipCodeToStateMapper;
 
 import javax.ws.rs.core.MediaType;
-import java.util.Locale;
 
 public class SmartpayOrderRequestBuilder extends OrderRequestBuilder {
     static public class SmartpayTemplateData extends TemplateData {
@@ -19,6 +16,7 @@ public class SmartpayOrderRequestBuilder extends OrderRequestBuilder {
         private String paResponse;
         private String md;
         private String stateOrProvince;
+        private String payerIpAddress;
 
         public String getReference() {
             return reference;
@@ -50,6 +48,14 @@ public class SmartpayOrderRequestBuilder extends OrderRequestBuilder {
 
         public void setStateOrProvince(String stateOrProvince) {
             this.stateOrProvince = stateOrProvince;
+        }
+
+        public void setPayerIpAddress(String payerIpAddress) {
+            this.payerIpAddress = payerIpAddress;
+        }
+
+        public String getPayerIpAddress() {
+            return payerIpAddress;
         }
     }
 
@@ -105,6 +111,11 @@ public class SmartpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public SmartpayOrderRequestBuilder withMd(String md) {
         smartpayTemplateData.setMd(md);
+        return this;
+    }
+
+    public SmartpayOrderRequestBuilder withPayerIpAddress(String payerIpAddress) {
+        smartpayTemplateData.setPayerIpAddress(payerIpAddress);
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -171,6 +171,10 @@ public class SmartpayPaymentProvider implements PaymentProvider {
         SmartpayOrderRequestBuilder smartpayOrderRequestBuilder = request.getGatewayAccount().isRequires3ds() ?
                 SmartpayOrderRequestBuilder.aSmartpay3dsRequiredOrderRequestBuilder() : SmartpayOrderRequestBuilder.aSmartpayAuthoriseOrderRequestBuilder();
 
+        if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
+            request.getAuthCardDetails().getIpAddress().ifPresent(smartpayOrderRequestBuilder::withPayerIpAddress);
+        }
+
         return smartpayOrderRequestBuilder
                 .withMerchantCode(getMerchantCode(request))
                 .withPaymentPlatformReference(request.getChargeExternalId())

--- a/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/smartpay/SmartpayAuthoriseOrderTemplate.xml
@@ -29,6 +29,9 @@
                   </ns1:card>
                 <ns1:merchantAccount>${merchantCode}</ns1:merchantAccount>
                 <ns1:reference>${paymentPlatformReference?xml}</ns1:reference>
+                <#if payerIpAddress??>
+                  <ns1:shopperIP>${payerIpAddress?xml}</ns1:shopperIP>
+                </#if>
                 <ns1:shopperReference>${description?xml}</ns1:shopperReference>
             </ns1:paymentRequest>
         </ns1:authorise>

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayOrderRequestBuilderTest.java
@@ -30,6 +30,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALI
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_INCLUDING_STATE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITHOUT_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITH_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_CANCEL_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_CAPTURE_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_REFUND_SMARTPAY_REQUEST;
@@ -136,6 +137,23 @@ public class SmartpayOrderRequestBuilderTest {
                 .build();
 
         assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_INCLUDING_STATE), actualRequest.getPayload());
+        assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
+    }
+
+    @Test
+    public void shouldGenerateValidAuthoriseOrderWithIpAddress() throws Exception {
+        AuthCardDetails authCardDetails = getValidTestCard(null);
+
+        GatewayOrder actualRequest = aSmartpayAuthoriseOrderRequestBuilder()
+                .withPayerIpAddress("8.8.8.8")
+                .withMerchantCode("MerchantAccount")
+                .withDescription("MyDescription")
+                .withPaymentPlatformReference("MyPlatformReference")
+                .withAmount("2000")
+                .withAuthorisationDetails(authCardDetails)
+                .build();
+
+        assertXMLEqual(TestTemplateResourceLoader.load(SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITH_IP_ADDRESS), actualRequest.getPayload());
         assertEquals(OrderRequestType.AUTHORISE, actualRequest.getOrderRequestType());
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -76,6 +76,7 @@ public class TestTemplateResourceLoader {
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_MINIMAL = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-minimal.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_INCLUDING_STATE = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-including-state.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITHOUT_ADDRESS = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-without-address.xml";
+    public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_REQUEST_WITH_IP_ADDRESS = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-request-with-ip-address.xml";
     public static final String SMARTPAY_SPECIAL_CHAR_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST = SMARTPAY_BASE_NAME + "/special-char-valid-authorise-smartpay-3ds-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request.xml";
     public static final String SMARTPAY_VALID_AUTHORISE_SMARTPAY_3DS_REQUEST_MINIMAL = SMARTPAY_BASE_NAME + "/valid-authorise-smartpay-3ds-request-minimal.xml";

--- a/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-with-ip-address.xml
+++ b/src/test/resources/templates/smartpay/valid-authorise-smartpay-request-with-ip-address.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<soap:Envelope
+        xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+        xmlns:ns1="http://payment.services.adyen.com"
+        xmlns:ns2="http://common.services.adyen.com">
+    <soap:Body>
+        <ns1:authorise>
+            <ns1:paymentRequest>
+                <ns1:amount>
+                    <ns2:currency>GBP</ns2:currency>
+                    <ns2:value>2000</ns2:value>
+                </ns1:amount>
+                <ns1:card>
+                    <ns1:cvc>737</ns1:cvc>
+                    <ns1:expiryMonth>08</ns1:expiryMonth>
+                    <ns1:expiryYear>2018</ns1:expiryYear>
+                    <ns1:holderName>Mr. Payment</ns1:holderName>
+                    <ns1:number>5555444433331111</ns1:number>
+                </ns1:card>
+                <ns1:merchantAccount>MerchantAccount</ns1:merchantAccount>
+                <ns1:reference>MyPlatformReference</ns1:reference>
+                <ns1:shopperReference>MyDescription</ns1:shopperReference>
+                <ns1:shopperIP>8.8.8.8</ns1:shopperIP>
+            </ns1:paymentRequest>
+        </ns1:authorise>
+    </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
## WHAT YOU DID
- Sends payer IP address, if available, to Smartpay when the flag (send_payer_ip_address_to_gateway) on gateway account is enabled.
