### PR TITLE
PP-7572 Use unique WireMock port per test class

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayStub.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayStub.java
@@ -1,8 +1,13 @@
 package uk.gov.pay.connector.it.gatewayclient;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.lang.String.format;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
@@ -57,11 +62,11 @@ public class GatewayStub {
         );
     }
 
-    public void respondWithStatusCodeAndPayloadWhenCardAuth(int statusCode, String payload) {
-        respondWithStatusCodeAndPayloadWhenCardAuth(statusCode, payload, -1);
+    public void respondWithStatusCodeAndPayloadWhenCardAuth(WireMockServer wireMockServer, int statusCode, String payload) {
+        respondWithStatusCodeAndPayloadWhenCardAuth(wireMockServer,  statusCode, payload, -1);
     }
 
-    public void respondWithStatusCodeAndPayloadWhenCardAuth(int statusCode, String payload, int timeout) {
+    public void respondWithStatusCodeAndPayloadWhenCardAuth(WireMockServer wireMockServer, int statusCode, String payload, int timeout) {
         ResponseDefinitionBuilder responseDefBuilder = aResponse()
                 .withHeader(CONTENT_TYPE, TEXT_XML)
                 .withStatus(statusCode)
@@ -70,7 +75,7 @@ public class GatewayStub {
             responseDefBuilder.withFixedDelay(timeout);
         }
 
-        stubFor(
+        wireMockServer.stubFor(
                 post(urlPathEqualTo("/pal/servlet/soap/Payment"))
                         .withRequestBody(
                                 matching(".*<.*authorise.*>.*</.*authorise>.*")
@@ -89,8 +94,8 @@ public class GatewayStub {
         respondWithStatusCodeAndPayloadWhenCapture(UNKNOWN_STATUS_CODE, CAPTURE_SUCCESS_PAYLOAD);
     }
 
-    public void respondWithUnexpectedResponseCodeWhenCardAuth() {
-        respondWithStatusCodeAndPayloadWhenCardAuth(UNKNOWN_STATUS_CODE, AUTH_SUCCESS_PAYLOAD);
+    public void respondWithUnexpectedResponseCodeWhenCardAuth(WireMockServer wireMockServer) {
+        respondWithStatusCodeAndPayloadWhenCardAuth(wireMockServer, UNKNOWN_STATUS_CODE, AUTH_SUCCESS_PAYLOAD);
     }
 
     public void respondWithMalformedBodyWhenCapture() {

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
@@ -1,46 +1,28 @@
 package uk.gov.pay.connector.it.resources;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.pay.commons.model.ErrorIdentifier;
-import uk.gov.pay.commons.testing.port.PortFactory;
+import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.app.ExecutorServiceConfig;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
-import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
-import uk.gov.pay.connector.util.AddGatewayAccountParams;
-import uk.gov.pay.connector.util.RestAssuredClient;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 
 import java.lang.reflect.Field;
-import java.util.Map;
 
-import static io.dropwizard.testing.ConfigOverride.config;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_IN_PASSPHRASE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
-import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class CardAuthorizeDelayedGatewayResponseIT extends ChargingITestBase {
-    private int port = PortFactory.findFreePort();
 
-    @Rule
-    public DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule(
-            config("worldpay.urls.test", "http://localhost:" + port + "/jsp/merchant/xml/paymentService.jsp"),
-            config("smartpay.urls.test", "http://localhost:" + port + "/pal/servlet/soap/Payment"),
-            config("epdq.urls.test", "http://localhost:" + port + "/epdq")
-    );
-    @Rule
-    public WireMockRule wireMockRule = new WireMockRule(port);
     private String validCardDetails = buildJsonAuthorisationDetailsFor(VALID_SANDBOX_CARD_LIST[0], "visa");
 
     private static final String[] VALID_SANDBOX_CARD_LIST = new String[]{
@@ -58,34 +40,16 @@ public class CardAuthorizeDelayedGatewayResponseIT extends ChargingITestBase {
     public CardAuthorizeDelayedGatewayResponseIT() {
         super("sandbox");
     }
-
-    @Before
-    public void setUp() {
-        databaseTestHelper = app.getDatabaseTestHelper();
-        AddGatewayAccountParams gatewayAccountParams = anAddGatewayAccountParams()
-                .withAccountId(accountId)
-                .withPaymentGateway("sandbox")
-                .withCredentials(Map.of(
-                        CREDENTIALS_MERCHANT_ID, "merchant-id",
-                        CREDENTIALS_USERNAME, "test-user",
-                        CREDENTIALS_PASSWORD, "test-password",
-                        CREDENTIALS_SHA_IN_PASSPHRASE, "test-sha-in-passphrase",
-                        CREDENTIALS_SHA_OUT_PASSPHRASE, "test-sha-out-passphrase"
-                ))
-                .build();
-        databaseTestHelper.addGatewayAccount(gatewayAccountParams);
-        connectorRestApiClient = new RestAssuredClient(app.getLocalPort(), accountId);
-    }
-
+    
     @Test
     public void shouldReturn202_WhenGatewayAuthorisationResponseIsDelayed() throws NoSuchFieldException, IllegalAccessException {
-        ExecutorServiceConfig conf = app.getConf().getExecutorServiceConfig();
+        ExecutorServiceConfig conf = testContext.getExecutorServiceConfig();
         Field timeoutInSeconds = conf.getClass().getDeclaredField("timeoutInSeconds");
         timeoutInSeconds.setAccessible(true);
         timeoutInSeconds.setInt(conf, 0);
 
         String chargeId = createNewChargeWithNoTransactionId(ENTERING_CARD_DETAILS);
-        given().port(app.getLocalPort())
+        given().port(testContext.getPort())
                 .contentType(JSON)
                 .body(validCardDetails)
                 .post(authoriseChargeUrlFor(chargeId))

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargeExpiryResourceEpdqIT.java
@@ -14,7 +14,6 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 import java.time.Instant;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static io.restassured.http.ContentType.JSON;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static javax.ws.rs.core.Response.Status.OK;
@@ -136,7 +135,7 @@ public class ChargeExpiryResourceEpdqIT extends ChargingITestBase {
     }
 
     private void verifyPostToPath(String path) {
-        verify(
+        wireMockServer.verify(
             postRequestedFor(
                 UrlPattern.fromOneOf(
                     null,

--- a/src/test/java/uk/gov/pay/connector/junit/DropwizardTestApplications.java
+++ b/src/test/java/uk/gov/pay/connector/junit/DropwizardTestApplications.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.junit;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.common.collect.Sets;
 import io.dropwizard.Application;
 import io.dropwizard.testing.ConfigOverride;
@@ -11,8 +12,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.InjectorLookup;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -78,11 +77,11 @@ final class DropwizardTestApplications {
         }
     }
 
-    static TestContext getTestContextOf(Class<? extends Application<?>> appClass, String configClasspathLocation) {
+    static TestContext getTestContextOf(Class<? extends Application<?>> appClass, String configClasspathLocation, WireMockServer wireMockServer) {
         Pair<Class<? extends Application>, String> appConfig = Pair.of(appClass, configClasspathLocation);
         DropwizardTestSupport application = apps.get(appConfig);
         return new TestContext(application.getLocalPort(), ((ConnectorConfiguration) application.getConfiguration()),
-                InjectorLookup.getInjector(application.getApplication()).get());
+                InjectorLookup.getInjector(application.getApplication()).get(), wireMockServer);
     }
 
     static void removeConfigOverridesFromSystemProperties() {

--- a/src/test/java/uk/gov/pay/connector/junit/TestContext.java
+++ b/src/test/java/uk/gov/pay/connector/junit/TestContext.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.junit;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.inject.Injector;
 import io.dropwizard.db.DataSourceFactory;
 import org.jdbi.v3.core.Jdbi;
@@ -15,12 +16,14 @@ public class TestContext {
     private DatabaseTestHelper databaseTestHelper;
     private int port;
     private Injector injector;
+    private WireMockServer wireMockServer;
     private String databaseUrl;
     private String databaseUser;
     private String databasePassword;
 
-    TestContext(int port, ConnectorConfiguration connectorConfiguration, Injector injector) {
+    TestContext(int port, ConnectorConfiguration connectorConfiguration, Injector injector, WireMockServer wireMockServer) {
         this.injector = injector;
+        this.wireMockServer = wireMockServer;
         DataSourceFactory dataSourceFactory = connectorConfiguration.getDataSourceFactory();
         databaseUrl = dataSourceFactory.getUrl();
         databaseUser = dataSourceFactory.getUser();
@@ -37,6 +40,10 @@ public class TestContext {
 
     public int getPort() {
         return port;
+    }
+
+    public WireMockServer getWireMockServer() {
+        return wireMockServer;
     }
 
     public ExecutorServiceConfig getExecutorServiceConfig() {

--- a/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/EpdqMockClient.java
@@ -1,18 +1,36 @@
 package uk.gov.pay.connector.rules;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.TEXT_XML;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_MAINTENANCE_ORDER;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_NEW_ORDER;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_QUERY_ORDER;
-import static uk.gov.pay.connector.util.TestTemplateResourceLoader.*;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_FAILED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_OTHER_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_SUCCESS_3D_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_WAITING_EXTERNAL_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_AUTHORISATION_WAITING_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CANCEL_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CAPTURE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_CAPTURE_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_REFUND_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_REFUND_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.EPDQ_UNKNOWN_RESPONSE;
 
 public class EpdqMockClient {
 
-    public EpdqMockClient() {
+    private WireMockServer wireMockServer;
+
+    public EpdqMockClient(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
     }
 
     public void mockAuthorisationSuccess() {
@@ -93,7 +111,7 @@ public class EpdqMockClient {
 
     private void paymentServiceResponse(String route, String responseBody) {
         //FIXME - This mocking approach is very poor. Needs to be revisited. Story PP-900 created.
-        stubFor(
+        wireMockServer.stubFor(
                 post(urlPathEqualTo(String.format("/epdq/%s", route)))
                         .willReturn(
                                 aResponse()

--- a/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/SmartpayMockClient.java
@@ -1,11 +1,11 @@
 package uk.gov.pay.connector.rules;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.http.Fault;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.UUID.randomUUID;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
@@ -23,6 +23,12 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_REFU
 
 public class SmartpayMockClient {
 
+    private WireMockServer wireMockServer;
+
+    public SmartpayMockClient(WireMockServer wireMockServer) {
+        this.wireMockServer = wireMockServer;
+    }
+    
     public void mockAuthorisationWithTransactionId(String transactionId) {
         String authoriseResponse = TestTemplateResourceLoader.load(SMARTPAY_AUTHORISATION_SUCCESS_RESPONSE)
                 .replace("{{pspReference}}", transactionId);
@@ -80,7 +86,7 @@ public class SmartpayMockClient {
     }
 
     public void mockServerFault() {
-        stubFor(
+        wireMockServer.stubFor(
                 post(urlPathEqualTo("/pal/servlet/soap/Payment"))
                         .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
         );
@@ -99,7 +105,7 @@ public class SmartpayMockClient {
     }
 
     private void paymentServiceResponse(String responseBody) {
-        stubFor(
+        wireMockServer.stubFor(
                 post(urlPathEqualTo("/pal/servlet/soap/Payment"))
                         .willReturn(
                                 aResponse()

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -1,15 +1,12 @@
 package uk.gov.pay.connector.rules;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
-import java.util.Optional;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
@@ -27,13 +24,20 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TRANSFER_RESPONSE;
 
 public class StripeMockClient {
+
+    private WireMockServer wireMockServer;
+
+    public StripeMockClient(WireMockServer wireMockServer){
+        this.wireMockServer = wireMockServer;
+    }
+    
     public void mockCreateToken() {
         String payload = TestTemplateResourceLoader.load(STRIPE_CREATE_TOKEN_SUCCESS_RESPONSE);
         setupResponse(payload, "/v1/tokens", 200);
     }
 
     private void setupResponse(String responseBody, String path, int status) {
-        stubFor(post(urlPathEqualTo(path)).withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
+        wireMockServer.stubFor(post(urlPathEqualTo(path)).withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
                 .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON).withStatus(status).withBody(responseBody)));
     }
 
@@ -73,7 +77,7 @@ public class StripeMockClient {
                 .withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
                 .withHeader("Idempotency-Key", matching(".*"));
 
-        stubFor(builder
+        wireMockServer.stubFor(builder
                 .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON).withStatus(200).withBody(payload)));
     }
 


### PR DESCRIPTION
Avoid port conflicts by using a new port number per integration test class. This should mean the tests running in parallel won't interfere with each other.

Achieve this by creating a `WireMockServer` with a unique port per instance of `DropwizardJUnitRunner` that is tied to the lifecycle of the runner. Access this in tests for setting up stubs by adding it to the `DropwizardTestContext`.