### PR TITLE
PP-7572 Use unique WireMock port when using app rule

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardAuthorizeDelayedGatewayResponseIT.java
@@ -22,7 +22,6 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDe
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
 public class CardAuthorizeDelayedGatewayResponseIT extends ChargingITestBase {
-
     private String validCardDetails = buildJsonAuthorisationDetailsFor(VALID_SANDBOX_CARD_LIST[0], "visa");
 
     private static final String[] VALID_SANDBOX_CARD_LIST = new String[]{

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -13,7 +13,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import uk.gov.pay.commons.model.CardExpiryDate;
 import uk.gov.pay.commons.model.charge.ExternalMetadata;
-import uk.gov.pay.commons.testing.port.PortFactory;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -44,7 +43,6 @@ import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUNDED;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.REFUND_ERROR;
-import static uk.gov.pay.connector.rules.AppWithPostgresRule.WIREMOCK_PORT;
 import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.PAYMENT_CONFIRMED;
 import static uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType.REFUND_ISSUED;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
@@ -52,16 +50,13 @@ import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccoun
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 
 public class ContractTest {
-    public static final int WORLDPAY_DDC_PORT_NUMBER = PortFactory.findFreePort();
-
+    
     @ClassRule
     public static DropwizardAppWithPostgresRule app = new DropwizardAppWithPostgresRule(
-            ConfigOverride.config("captureProcessConfig.backgroundProcessingEnabled", "false"),
-            ConfigOverride.config("worldpay.threeDsFlexDdcUrls.test", String.format("http://localhost:%s/shopper/3ds/ddc.html", WORLDPAY_DDC_PORT_NUMBER)),
-            ConfigOverride.config("worldpay.threeDsFlexDdcUrls.live", String.format("http://localhost:%s/shopper/3ds/ddc.html", WORLDPAY_DDC_PORT_NUMBER)));
+            ConfigOverride.config("captureProcessConfig.backgroundProcessingEnabled", "false"));
 
     @ClassRule
-    public static WireMockRule wireMockRule = new WireMockRule(WIREMOCK_PORT);
+    public static WireMockRule wireMockRule = new WireMockRule(app.getWireMockPort());
 
     private SQSMockClient sqsMockClient = new SQSMockClient();
 

--- a/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
@@ -4,9 +4,7 @@ import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
 import au.com.dius.pact.provider.junit.loader.PactBrokerAuth;
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -19,11 +17,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
 public class SelfServiceContractTest extends ContractTest {
-    @ClassRule
-    public static WireMockClassRule worldpayDeviceDataCollectionRule = new WireMockClassRule(WORLDPAY_DDC_PORT_NUMBER);
 
     @BeforeClass
     public static void setUpBeforeClass() {
-        worldpayDeviceDataCollectionRule.stubFor(post(urlPathEqualTo("/shopper/3ds/ddc.html")).willReturn(aResponse().withStatus(200)));
+        wireMockRule.stubFor(post(urlPathEqualTo("/shopper/3ds/ddc.html")).willReturn(aResponse().withStatus(200)));
     }
 }


### PR DESCRIPTION
Have a unique WireMock port per instance of AppWithPostgresRule and use this port when initialising the WireMockRule in test classes.

Move the standard url config overrides which need to be set up to use the WireMock port into the AppWithPostgresRule setup so these don't need to be set up per test instance.
