### PR TITLE
BAU — Ignore Worldpay SETTLED notifications

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -37,6 +37,7 @@ public class WorldpayNotificationService {
             "EXPIRED",
             "REFUSED",
             "REFUSED_BY_BANK",
+            "SETTLED",
             "SETTLED_BY_MERCHANT",
             "SENT_FOR_REFUND"
     );

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -229,6 +229,7 @@ class WorldpayNotificationServiceTest {
                 "EXPIRED",
                 "REFUSED",
                 "REFUSED_BY_BANK",
+                "SETTLED",
                 "SETTLED_BY_MERCHANT",
                 "SENT_FOR_REFUND"
         );


### PR DESCRIPTION
Explicitly ignore `SETTLED` notifications from Worldpay. If we do not do this, we will respond with a non-200 HTTP status to Worldpay’s request, which can cause them to hold off sending us further notifications for the same gateway account because they think our endpoint is down.