### PR TITLE
bau: Use proper xml escaping

### DIFF
--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -48,7 +48,7 @@
             </shopper>
             <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>
             <additional3DSData
-                dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()}"
+                dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()?xml}"
                 challengeWindowSize="390x400" challengePreference="noPreference"
             />
             </#if>


### PR DESCRIPTION
Prevent a malicious paying user potentially injecting XML into the auth request to Worldpay.