### PR TITLE
bau: Java fixes detected by error prone

### DIFF
--- a/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
+++ b/src/main/java/uk/gov/pay/connector/util/DateTimeUtils.java
@@ -14,7 +14,7 @@ import static java.util.Objects.isNull;
 
 public class DateTimeUtils {
 
-    private static final ZoneId UTC = ZoneId.of("Z");
+    private static final ZoneId UTC = ZoneOffset.UTC;
     private static final ZoneId EUROPE_LONDON = ZoneId.of("Europe/London");
     private static DateTimeFormatter dateTimeFormatterAny = DateTimeFormatter.ISO_ZONED_DATE_TIME;
     private static DateTimeFormatter localDateFormatter = DateTimeFormatter.ISO_DATE;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -55,6 +55,7 @@ public class StripeCaptureHandlerTest {
     private CaptureGatewayRequest captureGatewayRequest;
     private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
     private GatewayAccountEntity gatewayAccount;
+    private String transactionId = "ch_1231231123123";
 
     @Before
     public void setup() {
@@ -64,7 +65,6 @@ public class StripeCaptureHandlerTest {
 
         gatewayAccount = buildGatewayAccountEntity();
 
-        final String transactionId = "ch_1231231123123";
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccount)
                 .withTransactionId(transactionId)
@@ -108,7 +108,7 @@ public class StripeCaptureHandlerTest {
                 .withAmount(10001L)
                 .build();
 
-        captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
+        CaptureGatewayRequest captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
         GatewayClient.Response gatewayCaptureResponse = mock(GatewayClient.Response.class);
         when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_CAPTURE_SUCCESS_RESPONSE));
         GatewayClient.Response gatewayTransferResponse = mock(GatewayClient.Response.class);
@@ -132,7 +132,7 @@ public class StripeCaptureHandlerTest {
                 .withAmount(1L)
                 .build();
 
-        captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
+        CaptureGatewayRequest captureGatewayRequest = CaptureGatewayRequest.valueOf(chargeEntity);
         GatewayClient.Response gatewayCaptureResponse = mock(GatewayClient.Response.class);
         when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_CAPTURE_SUCCESS_RESPONSE));
         GatewayClient.Response gatewayTransferResponse = mock(GatewayClient.Response.class);
@@ -147,6 +147,7 @@ public class StripeCaptureHandlerTest {
         assertThat(captureResponse.getFee().get(), is(51L));
     }
     
+    @Test
     public void shouldCaptureWithoutFee_ifCollectFeeSetToFalse() throws Exception {
         GatewayClient.Response gatewayCaptureResponse = mock(GatewayClient.Response.class);
         when(gatewayCaptureResponse.getEntity()).thenReturn(load(STRIPE_CAPTURE_SUCCESS_RESPONSE));
@@ -162,9 +163,8 @@ public class StripeCaptureHandlerTest {
         assertTrue(response.isSuccessful());
         assertThat(response.state(), is(CaptureResponse.ChargeState.COMPLETE));
         assertThat(response.getTransactionId().isPresent(), is(true));
-        assertThat(response.getTransactionId().get(), is("ch_123456"));
-        assertThat(response.getFee().isPresent(), is(true));
-        assertThat(response.getFee().get(), is(0L));
+        assertThat(response.getTransactionId().get(), is(transactionId));
+        assertThat(response.getFee().isPresent(), is(false));
     }
 
     @Test


### PR DESCRIPTION
These were detected by running [error
prone](https://github.com/google/error-prone) against this repo. It detected
that StripeCaptureHandlerTest had a test that had neither `@Ignore` or `@Test`
on it.