### PR TITLE
PP-7995 Download Notify client from Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,16 +31,6 @@
         <PACT_CONSUMER_VERSION/>
         <PACT_CONSUMER_TAG/>
     </properties>
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-gov-uk-notify-maven</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/gov-uk-notify/maven</url>
-        </repository>
-    </repositories>
     <dependencies>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>


### PR DESCRIPTION
Remove reference to bintray so that the GOV.UK Notify client is downloaded from Maven Central.
