### PR TITLE
PP-7919: Create table to test concourse DB migration

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1577,4 +1577,12 @@
             <column name="allow_telephone_payment_notifications" value="false"/>
         </update>
     </changeSet>
+
+    <changeSet id="create empty table to test concourse db migration" author="">
+        <createTable tableName="test_concourse_db_migration">
+            <column name="id" type="bigserial" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
Similar to how we tested the DB migration job in Ledger, create a dummy table in Connector so we can try out a 'real' DB migration, rather than just a no-op. 

Once this test has been complete, we'll add a second migration to `dropTable` again.

## How to review

This is my first Connector PR and first Connector DB migration - please shout if I've missed something, or if this PR is a terrible idea.

