### PR TITLE
PP-7919: DB migration to drop the Concourse test table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1585,4 +1585,8 @@
             </column>
         </createTable>
     </changeSet>
+
+    <changeSet id="remove empty table to test concourse db migration" author="">
+        <dropTable cascadeConstraints="true" tableName="test_concourse_db_migration" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
Once we've completed testing the new Concourse DB migration job for Connector, we can remove the empty table created in https://github.com/alphagov/pay-connector/pull/2930.

## How to test

Tested locally by running `mvn clean verify`, and inspecting the postgres container. The `test_concourse_db_migration` table has been removed.