### PR TITLE
PP-8115 Allow patching send_payer_ip_address_to_gateway

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -43,6 +43,7 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT = "moto_mask_card_security_code_input";
     public static final String FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS = "allow_telephone_payment_notifications";
     public static final String FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED = "worldpay_exemption_engine_enabled";
+    public static final String FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY = "send_payer_ip_address_to_gateway";
 
     private static final List<String> VALID_PATHS = List.of(
             CREDENTIALS_GATEWAY_MERCHANT_ID,
@@ -61,7 +62,8 @@ public class GatewayAccountRequestValidator {
             FIELD_MOTO_MASK_CARD_NUMBER_INPUT,
             FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT,
             FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS,
-            FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED);
+            FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,
+            FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY);
 
     private final RequestValidator requestValidator;
 
@@ -98,6 +100,7 @@ public class GatewayAccountRequestValidator {
             case FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT:
             case FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS:
             case FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED:
+            case FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY:
                 validateReplaceBooleanValue(payload);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -45,6 +45,7 @@ import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequest
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_MOTO_MASK_CARD_NUMBER_INPUT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_NOTIFY_SETTINGS;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED;
 
 public class GatewayAccountService {
@@ -182,6 +183,10 @@ public class GatewayAccountService {
             entry(
                 FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS,
                 (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setAllowTelephonePaymentNotifications(gatewayAccountRequest.valueAsBoolean())
+            ),
+            entry(
+                FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY,
+                (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setSendPayerIpAddressToGateway(gatewayAccountRequest.valueAsBoolean())
             ),
             entry(
                 FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -72,7 +72,9 @@ public class GatewayAccountRequestValidatorTest {
             "replace, allow_telephone_payment_notifications, null, Field [value] is required",
             "replace, allow_telephone_payment_notifications, unfalse, Value [unfalse] must be of type boolean for path [allow_telephone_payment_notifications]",
             "replace, worldpay_exemption_engine_enabled, null, Field [value] is required",
-            "replace, worldpay_exemption_engine_enabled, unfalse, Value [unfalse] must be of type boolean for path [worldpay_exemption_engine_enabled]"
+            "replace, worldpay_exemption_engine_enabled, unfalse, Value [unfalse] must be of type boolean for path [worldpay_exemption_engine_enabled]",
+            "replace, send_payer_ip_address_to_gateway, null, Field [value] is required",
+            "replace, send_payer_ip_address_to_gateway, unfalse, Value [unfalse] must be of type boolean for path [send_payer_ip_address_to_gateway]"
     })
     public void shouldThrowWhenRequestsAreInvalid(String op, String path, @Nullable String value, String expectedErrorMessage) {
         Map<String, String> patch = new HashMap<>() {{

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -391,6 +391,34 @@ public class GatewayAccountServiceTest {
     }
 
     @Test
+    public void shouldUpdateSendPayerIpAddressToGatewayToFalse() {
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
+                "op", "replace",
+                "path", "send_payer_ip_address_to_gateway",
+                "value", false)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setSendPayerIpAddressToGateway(false);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
+    public void shouldUpdateSendPayerIpAddressToGatewayToTrue() {
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
+                "op", "replace",
+                "path", "send_payer_ip_address_to_gateway",
+                "value", true)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setSendPayerIpAddressToGateway(true);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
     public void shouldUpdateIntegrationVersion3ds() {
         JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",


### PR DESCRIPTION
To allow updating this setting from toolbox, allow patching this property of a gateway account.
