### PR TITLE
PP-8115 Rename send_payer_ip_address_to_gateway field in responses

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -323,6 +323,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return allowTelephonePaymentNotifications;
     }
 
+    @JsonProperty("send_payer_ip_address_to_gateway")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isSendPayerIpAddressToGateway() {
+        return sendPayerIpAddressToGateway;
+    }
+
     public void setNotificationCredentials(NotificationCredentials notificationCredentials) {
         this.notificationCredentials = notificationCredentials;
     }
@@ -446,10 +452,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setWorldpay3dsFlexCredentialsEntity(Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity) {
         this.worldpay3dsFlexCredentialsEntity = worldpay3dsFlexCredentialsEntity;
-    }
-
-    public boolean isSendPayerIpAddressToGateway() {
-        return sendPayerIpAddressToGateway;
     }
 
     public void setSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {


### PR DESCRIPTION
The GatewayAccountEntity class doesn't use snake case by default so add annotation so that property is returned with name `send_payer_ip_address_to_gateway` rather than `sendPayerIpAddressToGateway`.

This field currently isn't consumed by any other microservices, so this is fine to change.
