### PR TITLE
PP-8120 Add gateway_account_credentials table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1589,4 +1589,35 @@
     <changeSet id="remove empty table to test concourse db migration" author="">
         <dropTable cascadeConstraints="true" tableName="test_concourse_db_migration" />
     </changeSet>
+
+    <changeSet id="build gateway_account_credentials table" author="">
+        <createTable tableName="gateway_account_credentials">
+            <column name="id" type="bigserial" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="payment_provider" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="credentials" type="json" defaultValue="{}">
+                <constraints nullable="false" unique="false"/>
+            </column>
+            <column name="state" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="active_start_date" type="timestamp without timezone"></column>
+            <column name="active_end_date" type="timestamp without timezone"></column>
+            <column name="created_date" type="timestamp without timezone" defaultValueComputed="(now() at time zone 'utc')">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_updated_by_user_external_id" type="varchar(255)"></column>
+            <column name="version" type="bigint" defaultValue="0">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="gateway_account_id" type="bigserial">
+                <constraints foreignKeyName="fk__gateway_account_credentials_gateway_accounts" referencedTableName="gateway_accounts"
+                             referencedColumnNames="id" nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- Added a new table (`gateway_account_credentials`) which will be used to maintain multiple payment providers and credentials for a given gateway account.


Table from tests

```
connector_tests=# \d gateway_account_credentials
                                        Table "public.gateway_account_credentials"
              Column              |            Type             | Collation | Nullable |             Default
----------------------------------+-----------------------------+-----------+----------+----------------------------------
 id                               | bigint                      |           | not null | generated by default as identity
 payment_provider                 | character varying(255)      |           | not null |
 credentials                      | json                        |           | not null | '{}'::json
 state                            | character varying(255)      |           | not null |
 active_start_date                | timestamp without time zone |           |          |
 active_end_date                  | timestamp without time zone |           |          |
 created_date                     | timestamp without time zone |           | not null | timezone('utc'::text, now())
 last_updated_by_user_external_id | character varying(255)      |           |          |
 version                          | bigint                      |           | not null | 0
 gateway_account_id               | bigint                      |           | not null |
Indexes:
    "gateway_account_credentials_pkey" PRIMARY KEY, btree (id)
Foreign-key constraints:
    "fk__gateway_account_credentials_gateway_accounts" FOREIGN KEY (gateway_account_id) REFERENCES gateway_accounts(id)
```