### PR TITLE
PP-8130 Add service for checking Worldpay credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthUtil.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.gateway.util;
 import com.google.common.collect.ImmutableMap;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 
 import java.util.Base64;
 import java.util.Map;
@@ -31,6 +32,11 @@ public class AuthUtil {
 
     public static Map<String, String> getGatewayAccountCredentialsAsAuthHeader(Map<String, String> gatewayCredentials) {
         String value = encode(gatewayCredentials.get(CREDENTIALS_USERNAME), gatewayCredentials.get(CREDENTIALS_PASSWORD));
+        return ImmutableMap.of(AUTHORIZATION, value);
+    }
+    
+    public static Map<String, String> getWorldpayCredentialsCheckAuthHeader(WorldpayCredentials worldpayCredentials) {
+        String value = encode(worldpayCredentials.getUsername(), worldpayCredentials.getPassword());
         return ImmutableMap.of(AUTHORIZATION, value);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
@@ -1,0 +1,85 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import com.google.inject.Inject;
+import io.dropwizard.setup.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.worldpay.exception.NotAWorldpayGatewayAccountException;
+import uk.gov.pay.connector.gateway.worldpay.exception.UnexpectedValidateCredentialsResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+
+import javax.inject.Named;
+import java.net.URI;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayCredentialsCheckAuthHeader;
+import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayInquiryRequestBuilder;
+
+public class WorldpayCredentialsValidationService implements WorldpayGatewayResponseGenerator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorldpayCredentialsValidationService.class);
+
+    private final GatewayClient gatewayClient;
+    private final Map<String, URI> gatewayUrlMap;
+
+    @Inject
+    public WorldpayCredentialsValidationService(@Named("WorldpayGatewayUrlMap") Map<String, URI> gatewayUrlMap,
+                                                GatewayClientFactory gatewayClientFactory,
+                                                Environment environment) {
+        this.gatewayUrlMap = gatewayUrlMap;
+        gatewayClient = gatewayClientFactory.createGatewayClient(WORLDPAY, environment.metrics());
+    }
+
+    public boolean validateCredentials(GatewayAccountEntity gatewayAccountEntity, WorldpayCredentials worldpayCredentials) {
+        if (!gatewayAccountEntity.getGatewayName().equals(WORLDPAY.getName())) {
+            throw new NotAWorldpayGatewayAccountException(gatewayAccountEntity.getId());
+        }
+
+        GatewayOrder order = aWorldpayInquiryRequestBuilder()
+                .withTransactionId("an-order-id-that-will-not-exist")
+                .withMerchantCode(worldpayCredentials.getMerchantId())
+                .build();
+
+        try {
+            GatewayClient.Response response = gatewayClient.postRequestFor(
+                    gatewayUrlMap.get(gatewayAccountEntity.getType()),
+                    gatewayAccountEntity,
+                    order,
+                    getWorldpayCredentialsCheckAuthHeader(worldpayCredentials)
+            );
+
+            // There is no Worldpay endpoint to explicitly check credentials, so we make a query for an non-existent 
+            // transaction and expect:
+            // - a 401 if username/password are incorrect
+            // - a 200 with error code 5 (transaction not found) in the response if all credentials are correct
+            // - a 200 with error code 4 (security violation) if merchant id is incorrect
+            WorldpayQueryResponse worldpayQueryResponse = unmarshallResponse(response, WorldpayQueryResponse.class);
+            switch (worldpayQueryResponse.getErrorCode()) {
+                case "5":
+                    return true;
+                case "4":
+                    return false;
+                default:
+                    LOGGER.error(format("Unexpected error code %s returned by Worldpay when validating credentials", worldpayQueryResponse.getErrorCode()));
+                    throw new UnexpectedValidateCredentialsResponse();
+            }
+        } catch (GatewayException.GatewayErrorException e) {
+            return e.getStatus().map(status -> {
+                if (status == 401) {
+                    return false;
+                }
+                throw new UnexpectedValidateCredentialsResponse();
+            }).orElseThrow(UnexpectedValidateCredentialsResponse::new);
+        } catch (GatewayException e) {
+            throw new UnexpectedValidateCredentialsResponse();
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/exception/UnexpectedValidateCredentialsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/exception/UnexpectedValidateCredentialsResponse.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.gateway.worldpay.exception;
+
+import org.eclipse.jetty.http.HttpStatus;
+
+import javax.ws.rs.WebApplicationException;
+
+public class UnexpectedValidateCredentialsResponse extends WebApplicationException {
+    
+    public UnexpectedValidateCredentialsResponse() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR_500);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -1,0 +1,47 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import java.util.Objects;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class WorldpayCredentials {
+    
+    private String merchantId;
+    private String username;
+    private String password;
+
+    public WorldpayCredentials(String merchantId, String username, String password) {
+        this.merchantId = merchantId;
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getMerchantId() {
+        return merchantId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        WorldpayCredentials that = (WorldpayCredentials) o;
+        return Objects.equals(merchantId, that.merchantId) &&
+                Objects.equals(username, that.username) &&
+                Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(merchantId, username, password);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
@@ -1,0 +1,133 @@
+package uk.gov.pay.connector.gateway.worldpay;
+
+import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.setup.Environment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayClientFactory;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.worldpay.exception.UnexpectedValidateCredentialsResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_UNEXPECTED_ERROR_CODE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_VALID_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+
+@ExtendWith(MockitoExtension.class)
+class WorldpayCredentialsValidationServiceTest {
+
+    private static final URI WORLDPAY_URL = URI.create("http://worldpay.url");
+    private static final Map<String, URI> GATEWAY_URL_MAP = Map.of(TEST.toString(), WORLDPAY_URL);
+
+    @Mock
+    private GatewayClientFactory gatewayClientFactory;
+
+    @Mock
+    private Environment environment;
+
+    @Mock
+    private MetricRegistry metricRegistry;
+
+    @Mock
+    GatewayClient gatewayClient;
+
+    @Mock
+    private GatewayClient.Response response;
+
+    private WorldpayCredentialsValidationService worldpayCredentialsValidationService;
+
+    private GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+            .withGatewayName(WORLDPAY.getName())
+            .withType(TEST)
+            .build();
+
+    private WorldpayCredentials worldpayCredentials = new WorldpayCredentials("A_MERCHANT_ID", "user123", "test");
+
+    @BeforeEach
+    void setUp() {
+        when(environment.metrics()).thenReturn(metricRegistry);
+        when(gatewayClientFactory.createGatewayClient(any(), any())).thenReturn(gatewayClient);
+
+        worldpayCredentialsValidationService = new WorldpayCredentialsValidationService(
+                GATEWAY_URL_MAP,
+                gatewayClientFactory,
+                environment);
+    }
+
+    @Test
+    void shouldReturnTrue_ifWorldpayRespondsWithStatus200AndErrorCode5() throws GatewayException {
+        when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_VALID_RESPONSE));
+
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+                .thenReturn(response);
+
+        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        assertThat(valid, is(true));
+    }
+
+    @Test
+    void shouldReturnFalse_ifWorldpayRespondsWithStatus200AndErrorCode4() throws GatewayException {
+        when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE));
+
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+                .thenReturn(response);
+
+        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        assertThat(valid, is(false));
+    }
+
+    @Test
+    void shouldReturnFalse_ifWorldpayRespondsWithStatus401() throws GatewayException {
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+                .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 401));
+
+        boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
+        assertThat(valid, is(false));
+    }
+
+    @Test
+    void shouldThrowException_whenErrorCodeUnexpected() throws GatewayException {
+        when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_UNEXPECTED_ERROR_CODE));
+
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+                .thenReturn(response);
+
+        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
+    }
+
+    @Test
+    void shouldThrowException_whenErrorStatusCodeNot401() throws GatewayException {
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+                .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 403));
+
+        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
+    }
+
+    @Test
+    void shouldWrapGatewayException() throws GatewayException {
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+                .thenThrow(GatewayException.GenericGatewayException.class);
+
+        assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -60,6 +60,10 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_CAPTURED_INQUIRY_RESPONSE = WORLDPAY_BASE_NAME + "/inquiry/captured.xml";
     public static final String WORLDPAY_CANCELLED_INQUIRY_RESPONSE = WORLDPAY_BASE_NAME + "/inquiry/cancelled.xml";
     public static final String WORLDPAY_REJECTED_INQUIRY_RESPONSE = WORLDPAY_BASE_NAME + "/inquiry/rejected.xml";
+    
+    public static final String WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_VALID_RESPONSE = WORLDPAY_BASE_NAME + "/check-credentials/valid.xml";
+    public static final String WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE = WORLDPAY_BASE_NAME + "/check-credentials/invalid-merchant-id.xml";
+    public static final String WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_UNEXPECTED_ERROR_CODE = WORLDPAY_BASE_NAME + "/check-credentials/unexpected-error-code.xml";
 
     // SMARTPAY
 

--- a/src/test/resources/templates/worldpay/check-credentials/invalid-merchant-id.xml
+++ b/src/test/resources/templates/worldpay/check-credentials/invalid-merchant-id.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the inquiry-->
+    <reply>
+        <orderStatus orderCode="123">
+            <error code="4">
+                <![CDATA[Security violation]]>
+            </error>
+        </orderStatus>
+    </reply>
+</paymentService>

--- a/src/test/resources/templates/worldpay/check-credentials/unexpected-error-code.xml
+++ b/src/test/resources/templates/worldpay/check-credentials/unexpected-error-code.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the inquiry-->
+    <reply>
+        <orderStatus orderCode="123">
+            <error code="2">
+                <![CDATA[Parse error]]>
+            </error>
+        </orderStatus>
+    </reply>
+</paymentService>

--- a/src/test/resources/templates/worldpay/check-credentials/valid.xml
+++ b/src/test/resources/templates/worldpay/check-credentials/valid.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="ExampleCode1"> <!--The merchantCode you supplied in the inquiry-->
+    <reply>
+        <orderStatus orderCode="123">
+            <error code="5">
+                <![CDATA[Could not find payment for order]]>
+            </error>
+        </orderStatus>
+    </reply>
+</paymentService>


### PR DESCRIPTION
- Service sends an inquiry order with an order code that won't be found.
- We know that credentials are valid if a 200 is returned with error code 5, indicating the payment wasn't found.
- If a 401 or a 200 with error code 4 is returned we know that the credentials are invalid.