### PR TITLE
PP-8123 Add credentials entry for new gateway account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.gatewayaccount.util.CredentialsConverter;
 import uk.gov.pay.connector.gatewayaccount.util.JsonToMapConverter;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
@@ -31,6 +32,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +150,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Column(name = "allow_telephone_payment_notifications")
     private boolean allowTelephonePaymentNotifications;
 
+    @OneToMany(mappedBy = "gatewayAccountEntity", cascade = CascadeType.PERSIST)
+    @JsonIgnore
+    private List<GatewayAccountCredentialsEntity> gatewayAccountCredentials = new ArrayList<>();
+
     public GatewayAccountEntity() {
     }
 
@@ -184,6 +190,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @JsonView(Views.ApiView.class)
     public Map<String, String> getCredentials() {
         return credentials;
+    }
+
+    public List<GatewayAccountCredentialsEntity> getGatewayAccountCredentials() {
+        return gatewayAccountCredentials;
     }
 
     @JsonView(Views.ApiView.class)

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.dao;
+
+import com.google.inject.Provider;
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.common.dao.JpaDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+@Transactional
+public class GatewayAccountCredentialsDao extends JpaDao<GatewayAccountCredentialsEntity> {
+
+    @Inject
+    public GatewayAccountCredentialsDao(final Provider<EntityManager> entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public void persist(GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
+        super.persist(gatewayAccountCredentialsEntity);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialState.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialState.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.model;
+
+public enum GatewayAccountCredentialState {
+    CREATED,
+    ENTERED,
+    VERIFIED_WITH_LIVE_PAYMENT,
+    ACTIVE,
+    RETIRED;
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -1,0 +1,113 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.util.CredentialsConverter;
+import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import java.time.Instant;
+import java.util.Map;
+
+@Entity
+@Table(name = "gateway_account_credentials")
+@SequenceGenerator(name = "gateway_account_credentials_id_seq",
+        sequenceName = "gateway_account_credentials_id_seq", allocationSize = 1)
+public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "gateway_account_credentials_id_seq")
+    @JsonIgnore
+    private Long id;
+
+    @Column(name = "payment_provider")
+    private String paymentProvider;
+
+    @Column(name = "credentials", columnDefinition = "json")
+    @Convert(converter = CredentialsConverter.class)
+    private Map<String, String> credentials;
+
+    @Column(name = "state", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private GatewayAccountCredentialState state;
+
+    @Column(name = "last_updated_by_user_external_id")
+    private String lastUpdatedByUserExternalId;
+
+    @Column(name = "created_date")
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    private Instant createdDate;
+
+    @Column(name = "active_start_date")
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    private Instant activeStartDate;
+
+    @Column(name = "active_end_date")
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    private Instant activeEndDate;
+
+    @ManyToOne
+    @JoinColumn(name = "gateway_account_id", nullable = false)
+    @JsonIgnore
+    private GatewayAccountEntity gatewayAccountEntity;
+
+    public GatewayAccountCredentialsEntity() {
+    }
+
+    public GatewayAccountCredentialsEntity(GatewayAccountEntity gatewayAccountEntity, String paymentProvider,
+                                           Map<String,String> credentials, GatewayAccountCredentialState state) {
+        this.paymentProvider = paymentProvider;
+        this.gatewayAccountEntity = gatewayAccountEntity;
+        this.credentials = credentials;
+        this.state = state;
+        this.createdDate = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public Map<String, String> getCredentials() {
+        return credentials;
+    }
+
+    public GatewayAccountCredentialState getState() {
+        return state;
+    }
+
+    public String getLastUpdatedByUserExternalId() {
+        return lastUpdatedByUserExternalId;
+    }
+
+    public Instant getCreatedDate() {
+        return createdDate;
+    }
+
+    public Instant getActiveStartDate() {
+        return activeStartDate;
+    }
+
+    public Instant getActiveEndDate() {
+        return activeEndDate;
+    }
+
+    public GatewayAccountEntity getGatewayAccountEntity() {
+        return gatewayAccountEntity;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -1,0 +1,49 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.service;
+
+import com.google.inject.persist.Transactional;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+
+import javax.inject.Inject;
+import java.util.Map;
+
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+
+public class GatewayAccountCredentialsService {
+
+    private final GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
+
+    @Inject
+    public GatewayAccountCredentialsService(GatewayAccountCredentialsDao gatewayAccountCredentialsDao) {
+        this.gatewayAccountCredentialsDao = gatewayAccountCredentialsDao;
+    }
+
+    @Transactional
+    public void createGatewayAccountCredentials(GatewayAccountEntity gatewayAccountEntity, String paymentProvider,
+                                                Map<String, String> credentials) {
+        GatewayAccountCredentialState state = calculateState(paymentProvider, credentials);
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity
+                = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials, state);
+
+        gatewayAccountCredentialsDao.persist(gatewayAccountCredentialsEntity);
+    }
+
+    private GatewayAccountCredentialState calculateState(String paymentProvider, Map<String, String> credentials) {
+        PaymentGatewayName paymentGatewayName = PaymentGatewayName.valueFrom(paymentProvider);
+        if (paymentGatewayName == SANDBOX) {
+            return ACTIVE;
+        }
+        // todo: state should be ENTERED if another active credentials record exists (when switching PSP)
+        if (paymentGatewayName == STRIPE && !credentials.isEmpty()) {
+            return ACTIVE;
+        }
+
+        return CREATED;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
@@ -1,0 +1,101 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.dao.GatewayAccountCredentialsDao;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+
+@ExtendWith(MockitoExtension.class)
+public class GatewayAccountCredentialsServiceTest {
+
+    @Mock
+    GatewayAccountCredentialsDao mockGatewayAccountCredentialsDao;
+
+    GatewayAccountCredentialsService gatewayAccountCredentialsService;
+
+    @BeforeEach
+    void setup() {
+        gatewayAccountCredentialsService = new GatewayAccountCredentialsService(mockGatewayAccountCredentialsDao);
+    }
+
+    @Test
+    public void createCredentialsForSandboxShouldCreateRecordWithActiveState() {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().build();
+
+        ArgumentCaptor<GatewayAccountCredentialsEntity> argumentCaptor = ArgumentCaptor.forClass(GatewayAccountCredentialsEntity.class);
+        gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccountEntity, "sandbox", Map.of());
+
+        verify(mockGatewayAccountCredentialsDao).persist(argumentCaptor.capture());
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = argumentCaptor.getValue();
+
+        assertThat(gatewayAccountCredentialsEntity.getPaymentProvider(), is("sandbox"));
+        assertThat(gatewayAccountCredentialsEntity.getGatewayAccountEntity(), is(gatewayAccountEntity));
+        assertThat(gatewayAccountCredentialsEntity.getState(), is(ACTIVE));
+        assertThat(gatewayAccountCredentialsEntity.getCredentials().isEmpty(), is(true));
+    }
+
+    @Test
+    public void createCredentialsForStripeAndWithCredentialsShouldCreateRecordWithActiveState() {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().build();
+
+        ArgumentCaptor<GatewayAccountCredentialsEntity> argumentCaptor = ArgumentCaptor.forClass(GatewayAccountCredentialsEntity.class);
+        gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccountEntity, "stripe", Map.of("stripe_account_id", "abc"));
+
+        verify(mockGatewayAccountCredentialsDao).persist(argumentCaptor.capture());
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = argumentCaptor.getValue();
+
+        assertThat(gatewayAccountCredentialsEntity.getPaymentProvider(), is("stripe"));
+        assertThat(gatewayAccountCredentialsEntity.getGatewayAccountEntity(), is(gatewayAccountEntity));
+        assertThat(gatewayAccountCredentialsEntity.getState(), is(ACTIVE));
+        assertThat(gatewayAccountCredentialsEntity.getCredentials().get("stripe_account_id"), is("abc"));
+    }
+
+    @Test
+    public void createCredentialsForStripeAndWithOutCredentialsShouldCreateRecordWithCreatedState() {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().build();
+
+        ArgumentCaptor<GatewayAccountCredentialsEntity> argumentCaptor = ArgumentCaptor.forClass(GatewayAccountCredentialsEntity.class);
+        gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccountEntity, "stripe", Map.of());
+
+        verify(mockGatewayAccountCredentialsDao).persist(argumentCaptor.capture());
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = argumentCaptor.getValue();
+
+        assertThat(gatewayAccountCredentialsEntity.getPaymentProvider(), is("stripe"));
+        assertThat(gatewayAccountCredentialsEntity.getGatewayAccountEntity(), is(gatewayAccountEntity));
+        assertThat(gatewayAccountCredentialsEntity.getState(), is(CREATED));
+        assertThat(gatewayAccountCredentialsEntity.getCredentials().isEmpty(), is(true));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"worldpay", "epdq", "smartpay"})
+    public void createCredentialsForProvidersShouldCreateRecordWithCreatedState(String paymentProvider) {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity().build();
+
+        ArgumentCaptor<GatewayAccountCredentialsEntity> argumentCaptor = ArgumentCaptor.forClass(GatewayAccountCredentialsEntity.class);
+        gatewayAccountCredentialsService.createGatewayAccountCredentials(gatewayAccountEntity, paymentProvider, Map.of());
+
+        verify(mockGatewayAccountCredentialsDao).persist(argumentCaptor.capture());
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = argumentCaptor.getValue();
+
+        assertThat(gatewayAccountCredentialsEntity.getPaymentProvider(), is(paymentProvider));
+        assertThat(gatewayAccountCredentialsEntity.getGatewayAccountEntity(), is(gatewayAccountEntity));
+        assertThat(gatewayAccountCredentialsEntity.getState(), is(CREATED));
+        assertThat(gatewayAccountCredentialsEntity.getCredentials().isEmpty(), is(true));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResourceDTO;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 
 import java.util.Arrays;
 import java.util.List;
@@ -61,6 +62,9 @@ public class GatewayAccountServiceTest {
     @Mock
     private Worldpay3dsFlexCredentialsEntity mockWorldpay3dsFlexCredentialsEntity;
 
+    @Mock
+    private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
+
     private GatewayAccountService gatewayAccountService;
     
     private static final Long GATEWAY_ACCOUNT_ID = 100L;
@@ -71,7 +75,8 @@ public class GatewayAccountServiceTest {
 
     @Before
     public void setUp() {
-        gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao);
+        gatewayAccountService = new GatewayAccountService(mockGatewayAccountDao, mockCardTypeDao,
+                mockGatewayAccountCredentialsService);
         when(mockGatewayAccountEntity.getType()).thenReturn("test");
         when(getMockGatewayAccountEntity1.getType()).thenReturn("test");
         when(getMockGatewayAccountEntity1.getServiceName()).thenReturn("service one");


### PR DESCRIPTION
## WHAT YOU DID
- Adds new `gateway_account_credentials` entry when a new gateway account is created. This enables us to support multiple payment providers for a gateway accounts and support switching PSP
- Following are the credentials states
> CREATED - when account is created by support (go live process or switching PSP)
ENTERED - credentials entered by service or provided when creating account (ex: stripe) - used when switching psp
VERIFIED_WITH_LIVE_PAYMENT - a live payment has passed
ACTIVE  - “switched” by the service to the new payment provider or the only credential for gateway account
RETIRED - previously active payment provider

