### PR TITLE
PP-8130 Add resource to validate worldpay credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -46,7 +46,7 @@ import uk.gov.pay.connector.filters.LoggingMDCResponseFilter;
 import uk.gov.pay.connector.filters.SchemeRewriteFilter;
 import uk.gov.pay.connector.gateway.smartpay.auth.BasicAuthUser;
 import uk.gov.pay.connector.gateway.smartpay.auth.SmartpayAccountSpecificAuthenticator;
-import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccount3dsFlexCredentialsResource;
+import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountCredentialsResource;
 import uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountResource;
 import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountResource;
 import uk.gov.pay.connector.gatewayaccount.resource.StripeAccountSetupResource;
@@ -143,7 +143,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(injector.getInstance(PerformanceReportResource.class));
         environment.jersey().register(injector.getInstance(DiscrepancyResource.class));
         environment.jersey().register(injector.getInstance(EmittedEventResource.class));
-        environment.jersey().register(injector.getInstance(GatewayAccount3dsFlexCredentialsResource.class));
+        environment.jersey().register(injector.getInstance(GatewayAccountCredentialsResource.class));
         environment.jersey().register(injector.getInstance(GatewayCleanupResource.class));
         environment.jersey().register(injector.getInstance(ParityCheckerResource.class));
         environment.jersey().register(injector.getInstance(LoggingMDCRequestFilter.class));

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorModule.java
@@ -49,6 +49,7 @@ import static uk.gov.pay.connector.gateway.GatewayOperation.CANCEL;
 import static uk.gov.pay.connector.gateway.GatewayOperation.CAPTURE;
 import static uk.gov.pay.connector.gateway.GatewayOperation.QUERY;
 import static uk.gov.pay.connector.gateway.GatewayOperation.REFUND;
+import static uk.gov.pay.connector.gateway.GatewayOperation.VALIDATE_CREDENTIALS;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 
 public class ConnectorModule extends AbstractModule {
@@ -176,6 +177,13 @@ public class ConnectorModule extends AbstractModule {
     @Named("WorldpayInquiryGatewayClient")
     public GatewayClient worldpayInquiryGatewayClient(GatewayClientFactory gatewayClientFactory) {
         return gatewayClientFactory.createGatewayClient(WORLDPAY, QUERY, environment.metrics());
+    }
+
+    @Provides
+    @Singleton
+    @Named("WorldpayValidateCredentialsGatewayClient")
+    public GatewayClient worldpayValidateCredentialsGatewayClient(GatewayClientFactory gatewayClientFactory) {
+        return gatewayClientFactory.createGatewayClient(WORLDPAY, VALIDATE_CREDENTIALS, environment.metrics());
     }
 
     @Provides

--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayOperation.java
@@ -5,7 +5,8 @@ public enum GatewayOperation {
     CAPTURE("capture"),
     REFUND("refund"),
     QUERY("query"),
-    CANCEL("cancel");
+    CANCEL("cancel"),
+    VALIDATE_CREDENTIALS("validate_credentials");
 
     private final String description;
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/exception/NotAWorldpayGatewayAccountException.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/exception/NotAWorldpayGatewayAccountException.java
@@ -1,16 +1,15 @@
 package uk.gov.pay.connector.gateway.worldpay.exception;
 
-import org.apache.http.HttpStatus;
-
 import javax.ws.rs.WebApplicationException;
 
 import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 
 public class NotAWorldpayGatewayAccountException extends WebApplicationException {
 
     private static final String ERROR_MESSAGE = "Gateway account with id %s is not a Worldpay account.";
 
     public NotAWorldpayGatewayAccountException(Long gatewayAccountId) {
-        super(format(ERROR_MESSAGE, gatewayAccountId), HttpStatus.SC_NOT_FOUND);
+        super(notFoundResponse(format(ERROR_MESSAGE, gatewayAccountId)));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/exception/UnexpectedValidateCredentialsResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/exception/UnexpectedValidateCredentialsResponse.java
@@ -4,9 +4,11 @@ import org.eclipse.jetty.http.HttpStatus;
 
 import javax.ws.rs.WebApplicationException;
 
+import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
+
 public class UnexpectedValidateCredentialsResponse extends WebApplicationException {
     
     public UnexpectedValidateCredentialsResponse() {
-        super(HttpStatus.INTERNAL_SERVER_ERROR_500);
+        super(serviceErrorResponse("Worldpay returned an unexpected response when validating credentials"));
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/WorldpayCredentials.java
@@ -3,14 +3,25 @@ package uk.gov.pay.connector.gatewayaccount.model;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class WorldpayCredentials {
     
+    @NotEmpty(message = "Field [merchant_id] is required")
     private String merchantId;
+
+    @NotEmpty(message = "Field [username] is required")
     private String username;
+
+    @NotEmpty(message = "Field [password] is required")
     private String password;
+    
+    public WorldpayCredentials() {
+        // Blank constructor needed for deserialization
+    }
 
     public WorldpayCredentials(String merchantId, String username, String password) {
         this.merchantId = merchantId;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResource.java
@@ -2,9 +2,11 @@ package uk.gov.pay.connector.gatewayaccount.resource;
 
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexCredentialsValidationService;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayCredentialsValidationService;
 import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsRequest;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.Worldpay3dsFlexCredentialsService;
 
@@ -21,19 +23,22 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 
 @Path("/")
-public class GatewayAccount3dsFlexCredentialsResource {
+public class GatewayAccountCredentialsResource {
 
     private final GatewayAccountService gatewayAccountService;
     private final Worldpay3dsFlexCredentialsService worldpay3dsFlexCredentialsService;
     private final Worldpay3dsFlexCredentialsValidationService worldpay3dsFlexCredentialsValidationService;
+    private final WorldpayCredentialsValidationService worldpayCredentialsValidationService;
 
     @Inject
-    public GatewayAccount3dsFlexCredentialsResource(GatewayAccountService gatewayAccountService,
-                                                    Worldpay3dsFlexCredentialsService worldpay3dsFlexCredentialsService, 
-                                                    Worldpay3dsFlexCredentialsValidationService worldpay3dsFlexCredentialsValidationService) {
+    public GatewayAccountCredentialsResource(GatewayAccountService gatewayAccountService,
+                                             Worldpay3dsFlexCredentialsService worldpay3dsFlexCredentialsService,
+                                             Worldpay3dsFlexCredentialsValidationService worldpay3dsFlexCredentialsValidationService,
+                                             WorldpayCredentialsValidationService worldpayCredentialsValidationService) {
         this.gatewayAccountService = gatewayAccountService;
         this.worldpay3dsFlexCredentialsService = worldpay3dsFlexCredentialsService;
         this.worldpay3dsFlexCredentialsValidationService = worldpay3dsFlexCredentialsValidationService;
+        this.worldpayCredentialsValidationService = worldpayCredentialsValidationService;
     }
 
     @POST
@@ -62,8 +67,20 @@ public class GatewayAccount3dsFlexCredentialsResource {
     public ValidationResult validateWorldpay3dsCredentials(@PathParam("accountId") Long gatewayAccountId,
                                                            @Valid Worldpay3dsFlexCredentialsRequest worldpay3dsCredentials) {
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
-                .map(gatewayAccountEntity -> 
+                .map(gatewayAccountEntity ->
                         worldpay3dsFlexCredentialsValidationService.validateCredentials(gatewayAccountEntity, Worldpay3dsFlexCredentials.from(worldpay3dsCredentials)))
+                .map(ValidationResult::new)
+                .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
+    }
+
+    @POST
+    @Path("/v1/api/accounts/{accountId}/worldpay/check-credentials")
+    @Produces(APPLICATION_JSON)
+    @Consumes(APPLICATION_JSON)
+    public ValidationResult validateWorldpayCredentials(@PathParam("accountId") Long gatewayAccountId,
+                                                        @Valid WorldpayCredentials worldpayCredentials) {
+        return gatewayAccountService.getGatewayAccount(gatewayAccountId)
+                .map(gatewayAccountEntity -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials))
                 .map(ValidationResult::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/Worldpay3dsFlexCredentialsValidationServiceTest.java
@@ -175,9 +175,6 @@ class Worldpay3dsFlexCredentialsValidationServiceTest {
         
         var exception = assertThrows(NotAWorldpayGatewayAccountException.class,
                 () -> service.validateCredentials(gatewayAccount, getValid3dsFlexCredentials()));
-        assertEquals(exception.getResponse().getStatus(), HttpStatus.SC_NOT_FOUND);
-        assertEquals(exception.getMessage(), format("Gateway account with id %s is not a Worldpay account.", gatewayAccount.getId()));
-        assertThat(exception, is(instanceOf(WebApplicationException.class)));
     }
 
     private Worldpay3dsFlexCredentials getValid3dsFlexCredentials() {

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.gateway.GatewayClient;
-import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.worldpay.exception.UnexpectedValidateCredentialsResponse;
@@ -40,15 +39,6 @@ class WorldpayCredentialsValidationServiceTest {
     private static final Map<String, URI> GATEWAY_URL_MAP = Map.of(TEST.toString(), WORLDPAY_URL);
 
     @Mock
-    private GatewayClientFactory gatewayClientFactory;
-
-    @Mock
-    private Environment environment;
-
-    @Mock
-    private MetricRegistry metricRegistry;
-
-    @Mock
     GatewayClient gatewayClient;
 
     @Mock
@@ -65,13 +55,9 @@ class WorldpayCredentialsValidationServiceTest {
 
     @BeforeEach
     void setUp() {
-        when(environment.metrics()).thenReturn(metricRegistry);
-        when(gatewayClientFactory.createGatewayClient(any(), any())).thenReturn(gatewayClient);
-
         worldpayCredentialsValidationService = new WorldpayCredentialsValidationService(
                 GATEWAY_URL_MAP,
-                gatewayClientFactory,
-                environment);
+                gatewayClient);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -20,6 +20,9 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CANC
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CAPTURE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESULT_REJECTED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_UNEXPECTED_ERROR_CODE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_VALID_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_REFUND_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
@@ -87,6 +90,21 @@ public class WorldpayMockClient {
     public void mockRefundError() {
         String refundResponse = load(WORLDPAY_REFUND_ERROR_RESPONSE);
         paymentServiceResponse(refundResponse);
+    }
+    
+    public void mockCredentialsValidationValid() {
+        String credentialsValidResponse = load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_VALID_RESPONSE);
+        paymentServiceResponse(credentialsValidResponse);
+    }
+
+    public void mockCredentialsValidationInvalid() {
+        String credentialsValidResponse = load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE);
+        paymentServiceResponse(credentialsValidResponse);
+    }
+
+    public void mockCredentialsValidationUnexpectedResponse() {
+        String credentialsValidResponse = load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_UNEXPECTED_ERROR_CODE);
+        paymentServiceResponse(credentialsValidResponse);
     }
 
     public void mockAuthorisationGatewayError() {


### PR DESCRIPTION
Rename and use existing GatewayAccount3dsFlexCredentialsResource to add Worldpay credentials validation endpoint.

Register an additional singleton GatewayClient for validating credentials as a unique key is required for the metrics registry.
