### PR TITLE
PP-8123 Set active_start_date for new & active credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
@@ -8,6 +8,8 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+
 @Transactional
 public class GatewayAccountCredentialsDao extends JpaDao<GatewayAccountCredentialsEntity> {
 
@@ -19,5 +21,19 @@ public class GatewayAccountCredentialsDao extends JpaDao<GatewayAccountCredentia
     @Override
     public void persist(GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
         super.persist(gatewayAccountCredentialsEntity);
+    }
+
+    public boolean hasActiveCredentials(Long gatewayAccountId) {
+        String query = "SELECT COUNT(gace) FROM GatewayAccountCredentialsEntity gace " +
+                " WHERE gace.gatewayAccountEntity.id = :gatewayAccountId AND gace.state = :state";
+
+        long count = (long) entityManager
+                .get()
+                .createQuery(query)
+                .setParameter("gatewayAccountId", gatewayAccountId)
+                .setParameter("state", ACTIVE)
+                .getSingleResult();
+
+        return count > 0;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -67,12 +67,19 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     }
 
     public GatewayAccountCredentialsEntity(GatewayAccountEntity gatewayAccountEntity, String paymentProvider,
-                                           Map<String,String> credentials, GatewayAccountCredentialState state) {
+                                           Map<String, String> credentials, GatewayAccountCredentialState state) {
         this.paymentProvider = paymentProvider;
         this.gatewayAccountEntity = gatewayAccountEntity;
         this.credentials = credentials;
         this.state = state;
         this.createdDate = Instant.now();
+    }
+
+    public GatewayAccountCredentialsEntity(GatewayAccountEntity gatewayAccountEntity, String paymentProvider,
+                                           Map<String, String> credentials, GatewayAccountCredentialState state,
+                                           Instant activeStartDate) {
+        this(gatewayAccountEntity, paymentProvider, credentials, state);
+        this.activeStartDate = activeStartDate;
     }
 
     public Long getId() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -8,12 +8,14 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
 import javax.inject.Inject;
+import java.time.Instant;
 import java.util.Map;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ENTERED;
 
 public class GatewayAccountCredentialsService {
 
@@ -27,20 +29,33 @@ public class GatewayAccountCredentialsService {
     @Transactional
     public void createGatewayAccountCredentials(GatewayAccountEntity gatewayAccountEntity, String paymentProvider,
                                                 Map<String, String> credentials) {
-        GatewayAccountCredentialState state = calculateState(paymentProvider, credentials);
-        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity
-                = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials, state);
+        GatewayAccountCredentialState state = calculateState(gatewayAccountEntity, paymentProvider, credentials);
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
+
+        if (state == ACTIVE) {
+            gatewayAccountCredentialsEntity
+                    = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials,
+                    state, Instant.now());
+        } else {
+            gatewayAccountCredentialsEntity
+                    = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials, state);
+        }
 
         gatewayAccountCredentialsDao.persist(gatewayAccountCredentialsEntity);
     }
 
-    private GatewayAccountCredentialState calculateState(String paymentProvider, Map<String, String> credentials) {
+    private GatewayAccountCredentialState calculateState(GatewayAccountEntity gatewayAccountEntity,
+                                                         String paymentProvider, Map<String, String> credentials) {
         PaymentGatewayName paymentGatewayName = PaymentGatewayName.valueFrom(paymentProvider);
         if (paymentGatewayName == SANDBOX) {
             return ACTIVE;
         }
-        // todo: state should be ENTERED if another active credentials record exists (when switching PSP)
         if (paymentGatewayName == STRIPE && !credentials.isEmpty()) {
+            boolean hasActiveCredentials =
+                    gatewayAccountCredentialsDao.hasActiveCredentials(gatewayAccountEntity.getId());
+            if (hasActiveCredentials){
+                return ENTERED;
+            }
             return ACTIVE;
         }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
@@ -1,0 +1,65 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.dao;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.it.dao.DaoITestBase;
+
+import java.util.Map;
+
+import static org.apache.commons.lang3.RandomUtils.nextLong;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
+
+public class GatewayAccountCredentialsDaoIT extends DaoITestBase {
+    private GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
+    private GatewayAccountDao gatewayAccountDao;
+
+    @Before
+    public void setUp() {
+        gatewayAccountCredentialsDao = env.getInstance(GatewayAccountCredentialsDao.class);
+        gatewayAccountDao = env.getInstance(GatewayAccountDao.class);
+    }
+
+    @After
+    public void truncate() {
+        databaseTestHelper.truncateAllData();
+    }
+
+    @Test
+    public void hasActiveCredentialsShouldReturnTrueIfGatewayAccountHasActiveCredentials() {
+        long gatewayAccountId = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId))
+                .withPaymentGateway("stripe")
+                .withServiceName("a cool service")
+                .build());
+        GatewayAccountEntity gatewayAccountEntity = gatewayAccountDao.findById(gatewayAccountId).get();
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity
+                = new GatewayAccountCredentialsEntity(gatewayAccountEntity, "stripe", Map.of(), ACTIVE);
+        gatewayAccountCredentialsDao.persist(gatewayAccountCredentialsEntity);
+
+        boolean result = gatewayAccountCredentialsDao.hasActiveCredentials(gatewayAccountId);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void hasActiveCredentialsShouldReturnFalseIfGatewayAccountHasNoCredentials() {
+        long gatewayAccountId = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId))
+                .withPaymentGateway("stripe")
+                .withServiceName("a cool service")
+                .build());
+
+        boolean result = gatewayAccountCredentialsDao.hasActiveCredentials(gatewayAccountId);
+
+        assertThat(result, is(false));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
@@ -22,6 +22,7 @@ import static io.restassured.http.ContentType.JSON;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.text.IsEmptyString.isEmptyString;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
@@ -103,6 +104,7 @@ public class CreateGatewayAccountResourceIT extends GatewayAccountResourceTestBa
         assertThat(gatewayAccountCredentialsList.get(0).getCredentials().get("stripe_account_id"), is("abc"));
         assertThat(gatewayAccountCredentialsList.get(0).getState(), is(ACTIVE));
         assertThat(gatewayAccountCredentialsList.get(0).getPaymentProvider(), is("stripe"));
+        assertThat(gatewayAccountCredentialsList.get(0).getActiveStartDate(), is(notNullValue()));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- For sandbox or stripe accounts credentials set to ACTIVE state, set `active_start_date` immediately.
- For stripe credentials, if an active credentials record exists, set state to ENTERED - this is specific to switching PSP and the state to be set to ACTIVE when service switches PSP
