### PR TITLE
Update gateway_account_credentials when credentials patched

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -472,6 +472,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
     }
 
+    public void setGatewayAccountCredentials(List<GatewayAccountCredentialsEntity> gatewayAccountCredentials) {
+        this.gatewayAccountCredentials = gatewayAccountCredentials;
+    }
+
     public class Views {
         public class ApiView {
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -21,6 +21,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountSearchParams;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountServicesFactory;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.usernotification.service.GatewayAccountNotificationCredentialsService;
 
 import javax.inject.Inject;
@@ -74,16 +75,23 @@ public class GatewayAccountResource {
     private final CardTypeDao cardTypeDao;
     private final Map<String, List<String>> providerCredentialFields;
     private final GatewayAccountNotificationCredentialsService gatewayAccountNotificationCredentialsService;
+    private final GatewayAccountCredentialsService gatewayAccountCredentialsService;
     private final GatewayAccountRequestValidator validator;
     private final GatewayAccountServicesFactory gatewayAccountServicesFactory;
 
     @Inject
-    public GatewayAccountResource(GatewayAccountService gatewayAccountService, GatewayAccountDao gatewayDao, CardTypeDao cardTypeDao, ConnectorConfiguration conf,
+    public GatewayAccountResource(GatewayAccountService gatewayAccountService,
+                                  GatewayAccountDao gatewayDao,
+                                  CardTypeDao cardTypeDao,
+                                  ConnectorConfiguration conf,
                                   GatewayAccountNotificationCredentialsService gatewayAccountNotificationCredentialsService,
-                                  GatewayAccountRequestValidator validator, GatewayAccountServicesFactory gatewayAccountServicesFactory) {
+                                  GatewayAccountCredentialsService gatewayAccountCredentialsService,
+                                  GatewayAccountRequestValidator validator, 
+                                  GatewayAccountServicesFactory gatewayAccountServicesFactory) {
         this.gatewayAccountService = gatewayAccountService;
         this.cardTypeDao = cardTypeDao;
         this.gatewayAccountNotificationCredentialsService = gatewayAccountNotificationCredentialsService;
+        this.gatewayAccountCredentialsService = gatewayAccountCredentialsService;
         this.validator = validator;
         this.gatewayAccountServicesFactory = gatewayAccountServicesFactory;
         providerCredentialFields = newHashMap();
@@ -234,6 +242,7 @@ public class GatewayAccountResource {
                             }
 
                             gatewayAccount.setCredentials(credentialsPayload);
+                            gatewayAccountCredentialsService.updateGatewayAccountCredentialsForLegacyEndpoint(gatewayAccount, credentialsPayload);
                             return Response.ok().build();
                         }
                 )

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -114,4 +114,12 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     public void setActiveStartDate(Instant activeStartDate) {
         this.activeStartDate = activeStartDate;
     }
+
+    public void setCredentials(Map<String, String> credentials) {
+        this.credentials = credentials;
+    }
+
+    public void setState(GatewayAccountCredentialState state) {
+        this.state = state;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.model;
+
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+
+public final class GatewayAccountCredentialsEntityFixture {
+    private Instant activeStartDate = Instant.now();
+    private String paymentProvider = WORLDPAY.getName();
+    private Map<String, String> credentials = Map.of();
+    private GatewayAccountCredentialState state = CREATED;
+    private GatewayAccountEntity gatewayAccountEntity;
+
+    private GatewayAccountCredentialsEntityFixture() {
+    }
+
+    public static GatewayAccountCredentialsEntityFixture aGatewayAccountCredentialsEntity() {
+        return new GatewayAccountCredentialsEntityFixture();
+    }
+
+    public GatewayAccountCredentialsEntityFixture withActiveStartDate(Instant activeStartDate) {
+        this.activeStartDate = activeStartDate;
+        return this;
+    }
+
+    public GatewayAccountCredentialsEntityFixture withPaymentProvider(String paymentProvider) {
+        this.paymentProvider = paymentProvider;
+        return this;
+    }
+
+    public GatewayAccountCredentialsEntityFixture withCredentials(Map<String, String> credentials) {
+        this.credentials = credentials;
+        return this;
+    }
+
+    public GatewayAccountCredentialsEntityFixture withState(GatewayAccountCredentialState state) {
+        this.state = state;
+        return this;
+    }
+
+    public GatewayAccountCredentialsEntityFixture withGatewayAccountEntity(GatewayAccountEntity gatewayAccountEntity) {
+        this.gatewayAccountEntity = gatewayAccountEntity;
+        return this;
+    }
+
+    public GatewayAccountCredentialsEntity build() {
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials, state);
+        gatewayAccountCredentialsEntity.setActiveStartDate(activeStartDate);
+        return gatewayAccountCredentialsEntity;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -1,10 +1,12 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +39,7 @@ public final class GatewayAccountEntityFixture {
     private List<CardTypeEntity> cardTypes = newArrayList();
     private Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity;
     private boolean sendPayerIpAddressToGateway;
+    private List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = new ArrayList<>();
 
     private GatewayAccountEntityFixture() {
     }
@@ -159,6 +162,11 @@ public final class GatewayAccountEntityFixture {
         this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
         return this;
     }
+    
+    public GatewayAccountEntityFixture withGatewayAccountCredentials(List<GatewayAccountCredentialsEntity> credentials) {
+        this.gatewayAccountCredentialsEntities = credentials;
+        return this;
+    }
 
     public GatewayAccountEntity build() {
         GatewayAccountEntity gatewayAccountEntity = new GatewayAccountEntity();
@@ -185,6 +193,7 @@ public final class GatewayAccountEntityFixture {
         gatewayAccountEntity.setCardTypes(cardTypes);
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
         gatewayAccountEntity.setSendPayerIpAddressToGateway(sendPayerIpAddressToGateway);
+        gatewayAccountEntity.setGatewayAccountCredentials(gatewayAccountCredentialsEntities);
         return gatewayAccountEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResourceValidationTest.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.testing.junit.ResourceTestRule;
 import org.junit.ClassRule;
 import org.junit.Test;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.GatewayConfig;
 import uk.gov.pay.connector.app.WorldpayConfig;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.rules.ResourceTestRuleWithCustomExceptionMappersBuilder;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
@@ -42,7 +42,7 @@ public class GatewayAccountResourceValidationTest {
     @ClassRule
     public static ResourceTestRule resources = ResourceTestRuleWithCustomExceptionMappersBuilder.getBuilder()
             .addResource(new GatewayAccountResource(null, null, null, mockConnectorConfiguration,
-                    null, new GatewayAccountRequestValidator(new RequestValidator()), null))
+                    null, null, new GatewayAccountRequestValidator(new RequestValidator()), null))
             .build();
 
     @Test
@@ -105,7 +105,7 @@ public class GatewayAccountResourceValidationTest {
     @Test
     public void shouldReturn400_whenCorporatePrepaidCreditCardSurchargeOperationIsMissing() {
         JsonNode jsonNode = objectMapper.valueToTree(
-                Map.of("path", "corporate_prepaid_credit_card_surcharge_amount","value", 250));
+                Map.of("path", "corporate_prepaid_credit_card_surcharge_amount", "value", 250));
         Response response = resources.client()
                 .target("/v1/api/accounts/12")
                 .request()
@@ -150,7 +150,7 @@ public class GatewayAccountResourceValidationTest {
     @Test
     public void shouldReturn400_whenCorporatePrepaidCreditCardSurchargeAmountValueIsMissing() {
         JsonNode jsonNode = objectMapper.valueToTree(
-                Map.of("op", "replace","path", "corporate_prepaid_credit_card_surcharge_amount"));
+                Map.of("op", "replace", "path", "corporate_prepaid_credit_card_surcharge_amount"));
         Response response = resources.client()
                 .target("/v1/api/accounts/12")
                 .request()

--- a/src/test/java/uk/gov/pay/connector/usernotification/service/GatewayAccountNotificationCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/usernotification/service/GatewayAccountNotificationCredentialsServiceTest.java
@@ -14,9 +14,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.common.exception.CredentialsException;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.usernotification.model.domain.NotificationCredentials;
 import uk.gov.pay.connector.util.HashUtil;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -25,6 +27,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 
 
 @RunWith(MockitoJUnitRunner.class)
@@ -40,6 +44,9 @@ public class GatewayAccountNotificationCredentialsServiceTest {
 
     @Mock
     HashUtil hashUtil;
+    
+    @Mock
+    GatewayAccountEntity gatewayAccount;
 
     @Before
     public void setup() {
@@ -48,7 +55,6 @@ public class GatewayAccountNotificationCredentialsServiceTest {
 
     @Test
     public void shouldCreateNotificationCredentialsIfNotPresentAndEncryptPassword() throws CredentialsException {
-        GatewayAccountEntity gatewayAccount = mock(GatewayAccountEntity.class);
         Map<String, String> credentials = ImmutableMap.of("username", "bob", "password", "bobssecret");
 
         when(gatewayAccount.getNotificationCredentials()).thenReturn(null);
@@ -71,7 +77,6 @@ public class GatewayAccountNotificationCredentialsServiceTest {
 
     @Test
     public void shouldUpdateExistingNotificationCredentialIfPresent() throws CredentialsException {
-        GatewayAccountEntity gatewayAccount = mock(GatewayAccountEntity.class);
         NotificationCredentials notificationCredentials = mock(NotificationCredentials.class);
         Map<String, String> credentials = ImmutableMap.of("username", "bob", "password", "bobssecret");
 
@@ -92,7 +97,6 @@ public class GatewayAccountNotificationCredentialsServiceTest {
         expectedException.expect(CredentialsException.class);
         expectedException.expectMessage("Invalid password length");
 
-        GatewayAccountEntity gatewayAccount = mock(GatewayAccountEntity.class);
         Map<String, String> credentials = ImmutableMap.of("username", "bob", "password", "bobsecret");
 
         gatewayAccountNotificationCredentialsService.setCredentialsForAccount(credentials, gatewayAccount);

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -5,8 +5,6 @@ import org.apache.commons.lang.math.RandomUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.Jdbi;
 import org.postgresql.util.PGobject;
-import uk.gov.service.payments.commons.model.CardExpiryDate;
-import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.exception.ExternalMetadataConverterException;
@@ -17,6 +15,8 @@ import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
@@ -60,8 +60,8 @@ public class DatabaseTestHelper {
                             ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                             ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
                             ":corporate_prepaid_credit_card_surcharge_amount, " +
-                            ":corporate_prepaid_debit_card_surcharge_amount, "+
-                            ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, "+
+                            ":corporate_prepaid_debit_card_surcharge_amount, " +
+                            ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, " +
                             ":allow_apple_pay, :allow_google_pay, :requires_3ds, :allow_telephone_payment_notifications)")
                             .bind("id", Long.valueOf(params.getAccountId()))
                             .bind("external_id", params.getExternalId())
@@ -151,6 +151,7 @@ public class DatabaseTestHelper {
                          String userEmail, String chargeExternalId) {
         return addRefund(externalId, amount, status, gatewayTransactionId, createdDate, submittedByUserExternalId, userEmail, chargeExternalId, null, null);
     }
+
     public int addRefund(String externalId, long amount, RefundStatus status,
                          String gatewayTransactionId, ZonedDateTime createdDate, String submittedByUserExternalId,
                          String userEmail, String chargeExternalId, ParityCheckStatus parityCheckStatus, ZonedDateTime parityCheckDate) {
@@ -552,7 +553,7 @@ public class DatabaseTestHelper {
                         .first()
         );
     }
-    
+
     public String getExemption3ds(Long chargeId) {
         return jdbi.withHandle(h ->
                 h.createQuery("SELECT exemption_3ds from charges WHERE id = :charge_id")
@@ -880,12 +881,12 @@ public class DatabaseTestHelper {
                                                 String organisationalUnitId,
                                                 Long version) {
         insertWorldpay3dsFlexCredential(
-            gatewayAccountId,
-            jwtMacKey,
-            issuer,
-            organisationalUnitId,
-            version,
-            false);
+                gatewayAccountId,
+                jwtMacKey,
+                issuer,
+                organisationalUnitId,
+                version,
+                false);
     }
 
     public void insertWorldpay3dsFlexCredential(Long gatewayAccountId,
@@ -895,15 +896,15 @@ public class DatabaseTestHelper {
                                                 Long version,
                                                 boolean isExemptionEngineEnabled) {
         jdbi.withHandle(handle ->
-            handle.createUpdate("INSERT INTO worldpay_3ds_flex_credentials(gateway_account_id, jwt_mac_key, issuer, organisational_unit_id, version, exemption_engine) " +
-                    "VALUES (:gatewayAccountId, :jwtMacKey, :issuer, :organisationalUnitId, :version, :exemption_engine)")
-                .bind("gatewayAccountId", gatewayAccountId)
-                .bind("jwtMacKey", jwtMacKey)
-                .bind("issuer", issuer)
-                .bind("organisationalUnitId", organisationalUnitId)
-                .bind("version", version)
-                .bind("exemption_engine", isExemptionEngineEnabled)
-                .execute()
+                handle.createUpdate("INSERT INTO worldpay_3ds_flex_credentials(gateway_account_id, jwt_mac_key, issuer, organisational_unit_id, version, exemption_engine) " +
+                        "VALUES (:gatewayAccountId, :jwtMacKey, :issuer, :organisationalUnitId, :version, :exemption_engine)")
+                        .bind("gatewayAccountId", gatewayAccountId)
+                        .bind("jwtMacKey", jwtMacKey)
+                        .bind("issuer", issuer)
+                        .bind("organisationalUnitId", organisationalUnitId)
+                        .bind("version", version)
+                        .bind("exemption_engine", isExemptionEngineEnabled)
+                        .execute()
         );
     }
 
@@ -921,5 +922,13 @@ public class DatabaseTestHelper {
                         .bind("accountId", accountId)
                         .mapToMap()
                         .first());
+    }
+
+    public List<Map<String, Object>> getGatewayAccountCredentials(long accountId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * FROM gateway_account_credentials where gateway_account_id = :accountId")
+                        .bind("accountId", accountId)
+                        .mapToMap()
+                        .list());
     }
 }


### PR DESCRIPTION
This is to ensure that after back-filling the gateway_account_credentials table, any updates to credentials made by users in the admin tool are propagated to the new table.

Once we have switched over to fully using the new table to get credentials and the new endpoint to update credentials has been added, this code will be discarded.