### PR TITLE
PP-8195 Add switching provider flag to gateway accounts

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1626,4 +1626,10 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet id="add provider_switch_enabled to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="provider_switch_enabled" type="boolean" defaultValue="false">
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Switching state will be encapsulated with credential status. Add a high
level flag to mark accounts as allowed to switch and as a convenience
attribute for the admin tool.