### PR TITLE
PP-8195 Read and update provider switch enabled flag

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -152,6 +152,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     @OneToMany(mappedBy = "gatewayAccountEntity", cascade = CascadeType.PERSIST)
     private List<GatewayAccountCredentialsEntity> gatewayAccountCredentials = new ArrayList<>();
+    
+    @Column(name = "provider_switch_enabled")
+    private boolean providerSwitchEnabled;
 
     public GatewayAccountEntity() {
     }
@@ -475,6 +478,16 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setGatewayAccountCredentials(List<GatewayAccountCredentialsEntity> gatewayAccountCredentials) {
         this.gatewayAccountCredentials = gatewayAccountCredentials;
+    }
+
+    @JsonProperty("provider_switch_enabled")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isProviderSwitchEnabled() {
+        return providerSwitchEnabled;
+    }
+
+    public void setProviderSwitchEnabled(boolean providerSwitchEnabled) {
+        this.providerSwitchEnabled = providerSwitchEnabled;
     }
 
     public class Views {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -44,6 +44,7 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS = "allow_telephone_payment_notifications";
     public static final String FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED = "worldpay_exemption_engine_enabled";
     public static final String FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY = "send_payer_ip_address_to_gateway";
+    public static final String FIELD_PROVIDER_SWITCH_ENABLED = "provider_switch_enabled";
 
     private static final List<String> VALID_PATHS = List.of(
             CREDENTIALS_GATEWAY_MERCHANT_ID,
@@ -63,7 +64,8 @@ public class GatewayAccountRequestValidator {
             FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT,
             FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS,
             FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,
-            FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY);
+            FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY,
+            FIELD_PROVIDER_SWITCH_ENABLED);
 
     private final RequestValidator requestValidator;
 
@@ -101,6 +103,7 @@ public class GatewayAccountRequestValidator {
             case FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS:
             case FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED:
             case FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY:
+            case FIELD_PROVIDER_SWITCH_ENABLED:
                 validateReplaceBooleanValue(payload);
                 break;
             case FIELD_CORPORATE_CREDIT_CARD_SURCHARGE_AMOUNT:

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -48,6 +48,7 @@ import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequest
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_NOTIFY_SETTINGS;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_PROVIDER_SWITCH_ENABLED;
 
 public class GatewayAccountService {
 
@@ -203,6 +204,10 @@ public class GatewayAccountService {
                         .orElseThrow(() -> new MissingWorldpay3dsFlexCredentialsEntityException(gatewayAccountEntity.getId(), FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED));
                     worldpay3dsFlexCredentialsEntity.setExemptionEngineEnabled(gatewayAccountRequest.valueAsBoolean());
                 }
+            ),
+            entry(
+                FIELD_PROVIDER_SWITCH_ENABLED,
+                (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setProviderSwitchEnabled(gatewayAccountRequest.valueAsBoolean())
             )
     );
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -74,7 +74,9 @@ public class GatewayAccountRequestValidatorTest {
             "replace, worldpay_exemption_engine_enabled, null, Field [value] is required",
             "replace, worldpay_exemption_engine_enabled, unfalse, Value [unfalse] must be of type boolean for path [worldpay_exemption_engine_enabled]",
             "replace, send_payer_ip_address_to_gateway, null, Field [value] is required",
-            "replace, send_payer_ip_address_to_gateway, unfalse, Value [unfalse] must be of type boolean for path [send_payer_ip_address_to_gateway]"
+            "replace, send_payer_ip_address_to_gateway, unfalse, Value [unfalse] must be of type boolean for path [send_payer_ip_address_to_gateway]",
+            "replace, provider_switch_enabled, null, Field [value] is required",
+            "replace, provider_switch_enabled, unfalse, Value [unfalse] must be of type boolean for path [provider_switch_enabled]"
     })
     public void shouldThrowWhenRequestsAreInvalid(String op, String path, @Nullable String value, String expectedErrorMessage) {
         Map<String, String> patch = new HashMap<>() {{

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -81,6 +81,7 @@ public class GatewayAccountDaoIT extends DaoITestBase {
         assertThat(account.getCorporatePrepaidCreditCardSurchargeAmount(), is(0L));
         assertThat(account.getCorporatePrepaidDebitCardSurchargeAmount(), is(0L));
         assertThat(account.isSendPayerIpAddressToGateway(), is(false));
+        assertThat(account.isProviderSwitchEnabled(), is(false));
 
         databaseTestHelper.getAccountCredentials(account.getId());
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -61,6 +61,7 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
         databaseTestHelper.blockPrepaidCards(Long.valueOf(accountId));
         databaseTestHelper.allowMoto(Long.valueOf(accountId));
         databaseTestHelper.allowTelephonePaymentNotifications(Long.valueOf(accountId));
+        databaseTestHelper.enableProviderSwitch(Long.valueOf(accountId));
 
         givenSetup().accept(JSON)
                 .get(ACCOUNTS_FRONTEND_URL + accountId)
@@ -94,7 +95,8 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
                 .body("integration_version_3ds", is(1))
                 .body("block_prepaid_cards", is(true))
                 .body("allow_moto", is(true))
-                .body("allow_telephone_payment_notifications", is(true));
+                .body("allow_telephone_payment_notifications", is(true))
+                .body("provider_switch_enabled", is(true));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -424,6 +424,20 @@ public class GatewayAccountServiceTest {
     }
 
     @Test
+    public void shouldUpdateProviderSwitchEnabledToTrue() {
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
+                "op", "replace",
+                "path", "provider_switch_enabled",
+                "value", true)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setProviderSwitchEnabled(true);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
     public void shouldUpdateIntegrationVersion3ds() {
         JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -661,6 +661,13 @@ public class DatabaseTestHelper {
         );
     }
 
+    public void enableProviderSwitch(long accountId) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("UPDATE gateway_accounts set provider_switch_enabled=true WHERE id=:gatewayAccountId")
+                        .bind("gatewayAccountId", accountId)
+                        .execute()
+        );
+    }
 
     public void addWalletType(long chargeId, WalletType walletType) {
         jdbi.withHandle(handle ->


### PR DESCRIPTION
Depends on database migration in https://github.com/alphagov/pay-connector/pull/2965

Expose `provider_switch_enabled` on gateway account routes. 

Support boolean operations to set value on `@PATCH` routes.