### PR TITLE
PP-8194 Use ChargeEntity paymentProvider for payment gateway name

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -337,7 +337,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         return new StructuredArgument[]{
                 kv(PAYMENT_EXTERNAL_ID, externalId),
                 kv(GATEWAY_ACCOUNT_ID, getGatewayAccount().getId()),
-                kv(PROVIDER, getGatewayAccount().getGatewayName()),
+                kv(PROVIDER, paymentProvider),
                 kv(GATEWAY_ACCOUNT_TYPE, getGatewayAccount().getType())
         };
     }
@@ -400,7 +400,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
     }
 
     public PaymentGatewayName getPaymentGatewayName() {
-        return PaymentGatewayName.valueFrom(gatewayAccount.getGatewayName());
+        return PaymentGatewayName.valueFrom(paymentProvider);
     }
 
     public Auth3dsRequiredEntity get3dsRequiredDetails() {

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -162,6 +162,7 @@ public class ChargesFrontendResource {
                 .withChargeId(chargeId)
                 .withAmount(charge.getAmount())
                 .withDescription(charge.getDescription())
+                .withProviderName(charge.getPaymentProvider())
                 .withGatewayTransactionId(charge.getGatewayTransactionId())
                 .withCreatedDate(charge.getCreatedDate())
                 .withReturnUrl(charge.getReturnUrl())
@@ -190,7 +191,7 @@ public class ChargesFrontendResource {
             auth3dsData.setHtmlOut(charge.get3dsRequiredDetails().getHtmlOut());
             auth3dsData.setMd(charge.get3dsRequiredDetails().getMd());
 
-            if (charge.getGatewayAccount().getGatewayName().equals(WORLDPAY.getName())) {
+            if (WORLDPAY.getName().equals(charge.getPaymentProvider())) {
                 worldpay3dsFlexJwtService.generateChallengeTokenIfAppropriate(charge).ifPresent(
                         auth3dsData::setWorldpayChallengeJwt);
             }

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -56,7 +56,7 @@ public class ChargeEntityFixture {
     private Source source = null;
     private boolean moto;
     private Exemption3ds exemption3ds;
-    private String paymentProvider;
+    private String paymentProvider = "sandbox";
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceWorldpayJwtIT.java
@@ -182,6 +182,7 @@ public class ChargesFrontendResourceWorldpayJwtIT {
                         .withChargeId(chargeId)
                         .withGatewayAccountId(gatewayAccountId)
                         .withExternalChargeId(chargeExternalId)
+                        .withPaymentProvider(paymentProvider.getName())
                         .withStatus(chargeStatus)
                         .build()
         );

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeExpiryServiceTest.java
@@ -126,6 +126,7 @@ public class ChargeExpiryServiceTest {
 
         ChargeEntity expiredCharge = mock(ChargeEntity.class);
         when(expiredCharge.getStatus()).thenReturn(EXPIRED.toString());
+        when(expiredCharge.getPaymentProvider()).thenReturn("worldpay");
         return expiredCharge;
     }
 
@@ -189,6 +190,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now())
                 .withStatus(status)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
@@ -227,6 +229,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now())
                 .withStatus(status)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
@@ -315,6 +318,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now())
                 .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
@@ -337,6 +341,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(AWAITING_CAPTURE_REQUEST)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
@@ -344,6 +349,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(AUTHORISATION_SUCCESS)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
@@ -371,6 +377,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 
@@ -393,6 +400,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
@@ -410,6 +418,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
@@ -427,6 +436,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
         when(mockPaymentProvider.cancel(any())).thenReturn(gatewayResponse);
@@ -444,6 +454,7 @@ public class ChargeExpiryServiceTest {
                 .withAmount(200L)
                 .withCreatedDate(Instant.now().minus(Duration.ofHours(48)).plus(Duration.ofMinutes(1)))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_READY)
+                .withPaymentProvider("worldpay")
                 .withGatewayAccountEntity(gatewayAccount)
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/EpdqAuthorisationErrorGatewayCleanupServiceTest.java
@@ -82,6 +82,7 @@ public class EpdqAuthorisationErrorGatewayCleanupServiceTest {
                 .build();
         charge = aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccountEntity)
+                .withPaymentProvider("epdq")
                 .withStatus(ChargeStatus.AUTHORISATION_ERROR)
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/ChargeExpungeServiceTest.java
@@ -89,6 +89,7 @@ public class ChargeExpungeServiceTest {
     public void expunge_shouldNotExpungeChargeIfInNonTerminalStateAndUpdateParityCheckStatusToSkipped() {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withStatus(CREATED)
+                .withPaymentProvider("epdq")
                 .build();
         when(mockChargeDao.findChargeToExpunge(minimumAgeOfChargeInDays, defaultExcludeChargesParityCheckedWithInDays))
                 .thenReturn(Optional.of(chargeEntity));
@@ -165,6 +166,7 @@ public class ChargeExpungeServiceTest {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(5)))
                 .withStatus(ChargeStatus.valueOf(state))
+                .withPaymentProvider("epdq")
                 .withGatewayAccountEntity(aGatewayAccountEntity().withGatewayName("epdq").build())
                 .build();
 

--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -83,7 +83,7 @@ public class SendRefundEmailIT {
         String payIdSub = "2";
         String refundExternalId = "999999";
 
-        ChargeUtils.ExternalChargeId chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
+        ChargeUtils.ExternalChargeId chargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper, "epdq");
         databaseTestHelper.addRefund(refundExternalId,
                 100,  REFUND_SUBMITTED, transactionId + "/" + payIdSub,
                 ZonedDateTime.now(), chargeId.toString());

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -207,7 +207,7 @@ public class ChargingITestBase {
     }
 
     protected String createNewChargeWithNoTransactionIdOrEmailAddress(ChargeStatus status) {
-        return createNewChargeWithAccountId(status, null, accountId, databaseTestHelper, null).toString();
+        return createNewChargeWithAccountId(status, null, accountId, databaseTestHelper, null, paymentProvider).toString();
     }
 
     protected String createNewChargeWithNoTransactionId(ChargeStatus status) {
@@ -219,7 +219,7 @@ public class ChargingITestBase {
     }
 
     protected String createNewChargeWith(ChargeStatus status, String gatewayTransactionId) {
-        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper).toString();
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper, paymentProvider).toString();
     }
 
     protected RequestSpecification givenSetup() {
@@ -342,7 +342,7 @@ public class ChargingITestBase {
         long chargeId = RandomUtils.nextInt();
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
-        addCharge(chargeId, externalChargeId, status, ServicePaymentReference.of(reference), fromDate, transactionId);
+        addCharge(chargeId, externalChargeId, status, ServicePaymentReference.of(reference), fromDate, transactionId, paymentProvider);
         databaseTestHelper.addToken(chargeId, "tokenId");
         databaseTestHelper.addEvent(chargeId, chargeStatus.getValue());
         databaseTestHelper.updateChargeCardDetails(
@@ -352,12 +352,13 @@ public class ChargingITestBase {
     }
 
     private void addCharge(long chargeId, String externalChargeId, ChargeStatus chargeStatus,
-                           ServicePaymentReference reference, Instant createdDate, String transactionId) {
+                           ServicePaymentReference reference, Instant createdDate, String transactionId, String paymentProvider) {
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId)
                 .withGatewayAccountId(accountId)
                 .withAmount(AMOUNT)
+                .withPaymentProvider(paymentProvider)
                 .withStatus(chargeStatus)
                 .withTransactionId(transactionId)
                 .withReference(reference)
@@ -372,7 +373,7 @@ public class ChargingITestBase {
     protected String addChargeAndCardDetails(Long chargeId, ChargeStatus status, ServicePaymentReference reference, Instant fromDate, String cardBrand) {
         String externalChargeId = "charge" + chargeId;
         ChargeStatus chargeStatus = status != null ? status : AUTHORISATION_SUCCESS;
-        addCharge(chargeId, externalChargeId, chargeStatus, reference, fromDate, null);
+        addCharge(chargeId, externalChargeId, chargeStatus, reference, fromDate, null, paymentProvider);
         databaseTestHelper.addToken(chargeId, "tokenId");
         databaseTestHelper.addEvent(chargeId, chargeStatus.getValue());
         databaseTestHelper.updateChargeCardDetails(chargeId, cardBrand, "1234", "123456", "Mr. McPayment",

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -541,7 +541,7 @@ public class DatabaseFixtures {
         Long corporateCardSurcharge = null;
         Instant createdDate = Instant.now();
         TestAccount testAccount;
-        String paymentProvider;
+        String paymentProvider = "sandbox";
         TestCardDetails cardDetails;
         WalletType walletType;
         ParityCheckStatus parityCheckStatus;

--- a/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/gatewayclient/GatewayAuthFailuresIT.java
@@ -79,6 +79,7 @@ public class GatewayAuthFailuresIT {
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestCharge()
                 .withTestAccount(testAccount)
+                .withPaymentProvider(PAYMENT_PROVIDER)
                 .withChargeStatus(ChargeStatus.ENTERING_CARD_DETAILS)
                 .withTransactionId(TRANSACTION_ID);
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -295,7 +295,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
 
-        String externalChargeId = createNewChargeWithAccountId(ENTERING_CARD_DETAILS, randomId(), accountId, databaseTestHelper).toString();
+        String externalChargeId = createNewChargeWithAccountId(ENTERING_CARD_DETAILS, randomId(), accountId, databaseTestHelper, getPaymentProvider()).toString();
         String cardDetails = buildCorporateJsonAuthorisationDetailsFor(PayersCardType.CREDIT);
 
         givenSetup()

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -12,14 +12,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.postgresql.util.PGobject;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
-import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.charge.util.ExternalMetadataConverter;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.ConfigOverride;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import javax.ws.rs.core.Response.Status;
 import java.sql.Timestamp;
@@ -52,13 +52,13 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.junit.Assert.assertNull;
-import static uk.gov.service.payments.commons.model.Source.CARD_API;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
 import static uk.gov.pay.connector.matcher.ResponseContainsLinkMatcher.containsLink;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
 import static uk.gov.pay.connector.util.JsonEncoder.toJsonWithNulls;
 import static uk.gov.pay.connector.util.NumberMatcher.isNumber;
+import static uk.gov.service.payments.commons.model.Source.CARD_API;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqNotificationResourceIT.java
@@ -172,7 +172,7 @@ public class EpdqNotificationResourceIT extends ChargingITestBase {
         String refundExternalId = "999999";
         int refundAmount = 1000;
 
-        ChargeUtils.ExternalChargeId externalChargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper);
+        ChargeUtils.ExternalChargeId externalChargeId = createNewChargeWithAccountId(CAPTURED, transactionId, accountId, databaseTestHelper, getPaymentProvider());
         databaseTestHelper.addRefund(refundExternalId, 1000,
                 REFUND_SUBMITTED, transactionId + "/" + payIdSub, ZonedDateTime.now(),
                 externalChargeId.toString());

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeNotificationResourceIT.java
@@ -262,6 +262,7 @@ public class StripeNotificationResourceIT {
                 .withExternalChargeId(externalChargeId)
                 .withGatewayAccountId(accountId)
                 .withAmount(1000L)
+                .withPaymentProvider("stripe")
                 .withStatus(status)
                 .withTransactionId(gatewayTransactionId)
                 .build());

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceAuthorizeIT.java
@@ -285,6 +285,7 @@ public class StripeResourceAuthorizeIT {
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId)
+                .withPaymentProvider("stripe")
                 .withGatewayAccountId(accountId)
                 .withAmount(Long.valueOf(AMOUNT))
                 .withStatus(chargeStatus)

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceCancelIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeResourceCancelIT.java
@@ -118,6 +118,7 @@ public class StripeResourceCancelIT {
                 .withExternalChargeId(externalChargeId)
                 .withGatewayAccountId(accountId)
                 .withAmount(Long.valueOf(AMOUNT))
+                .withPaymentProvider("stripe")
                 .withStatus(chargeStatus)
                 .withTransactionId(transactionId)
                 .build());

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -25,13 +25,15 @@ public class ChargeUtils {
                 .put("delayed_capture", true).build());
     }
 
-    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, DatabaseTestHelper databaseTestHelper, String emailAddress) {
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId,
+                                                                DatabaseTestHelper databaseTestHelper, String emailAddress, String paymentProvider) {
         long chargeId = RandomUtils.nextInt();
         ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
         databaseTestHelper.addCharge(anAddChargeParams()
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId.toString())
                 .withGatewayAccountId(accountId)
+                .withPaymentProvider(paymentProvider)
                 .withAmount(6234L)
                 .withStatus(status)
                 .withTransactionId(gatewayTransactionId)
@@ -40,8 +42,11 @@ public class ChargeUtils {
         return externalChargeId;
     }
 
-    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId, String accountId, DatabaseTestHelper databaseTestHelper) {
-        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId, databaseTestHelper, "email@fake.test");
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId,
+                                                                String accountId, DatabaseTestHelper databaseTestHelper,
+                                                                String paymentProvider) {
+        return createNewChargeWithAccountId(status, gatewayTransactionId, accountId,
+                databaseTestHelper, "email@fake.test", paymentProvider);
     }
 
     public static class ExternalChargeId {

--- a/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/FrontendContractTest.java
@@ -128,6 +128,7 @@ public class FrontendContractTest {
                 .withExternalChargeId(chargeExternalId)
                 .withGatewayAccountId(String.valueOf(gatewayAccountId))
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_REQUIRED)
+                .withPaymentProvider("worldpay")
                 .build());
 
         dbHelper.updateCharge3dsFlexChallengeDetails(chargeId,

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -95,6 +95,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
         when(mockMetricRegistry.counter(anyString())).thenReturn(mock(Counter.class));
         
         charge = createNewChargeWith(1L, ENTERING_CARD_DETAILS);
+        charge.setPaymentProvider("worldpay");
         charge.getGatewayAccount().setGatewayName("worldpay");
         charge.getGatewayAccount().setRequires3ds(true);
         when(mockedChargeDao.findByExternalId(charge.getExternalId())).thenReturn(Optional.of(charge));

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -148,7 +148,7 @@ public class AddChargeParams {
         private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
         private String gatewayAccountId;
-        private String paymentProvider;
+        private String paymentProvider = "sandbox";
         private long amount = 1000;
         private ChargeStatus status = ChargeStatus.CAPTURED;
         private String returnUrl = "http://somereturn.gov.uk";


### PR DESCRIPTION
## WHAT

- Current we use gateway account to return payment gateway name for charges. As payment_provider is now available on charges, use the same to return payment gateway name
- Also include payment_provider in Charges frontend response which will be used by frontend application instead of gateway account's payment_provider. This will allow inflight payments to use correct payment provider when switching PSP.
