### PR TITLE
PP-8198 Add common validator for patch requests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/validator/PatchPathOperation.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/PatchPathOperation.java
@@ -1,0 +1,36 @@
+package uk.gov.pay.connector.common.validator;
+
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchOp;
+
+import java.util.Objects;
+
+public class PatchPathOperation {
+    private final String path;
+    private final JsonPatchOp operation;
+
+    public PatchPathOperation(String path, JsonPatchOp operation) {
+        this.path = path;
+        this.operation = operation;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public JsonPatchOp getOperation() {
+        return operation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PatchPathOperation that = (PatchPathOperation) o;
+        return Objects.equals(path, that.path) && Objects.equals(operation, that.operation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path, operation);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/common/validator/PatchRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/PatchRequestValidator.java
@@ -1,0 +1,73 @@
+package uk.gov.pay.connector.common.validator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import uk.gov.pay.connector.common.exception.ValidationException;
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchOp;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_VALUE;
+
+public class PatchRequestValidator {
+
+    private static final Set<String> allowedOps = Arrays.stream(JsonPatchOp.values())
+            .map(jsonPatchOp -> jsonPatchOp.name().toLowerCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+    
+    private final Map<PatchPathOperation, Consumer<JsonNode>> operationValidators;
+
+    public PatchRequestValidator(Map<PatchPathOperation, Consumer<JsonNode>> operationValidators) {
+        this.operationValidators = operationValidators;
+    }
+
+    public void validate(JsonNode payload) {
+        if (!payload.isArray()) {
+            throw new ValidationException(Collections.singletonList("JSON is not an array"));
+        }
+
+        for (JsonNode jsonNode : payload) {
+            List<String> fieldErrors = RequestValidator.checkIfExistsOrEmpty(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH, FIELD_VALUE);
+            if (!fieldErrors.isEmpty()) {
+                throw new ValidationException(fieldErrors);
+            }
+
+            List<String> opPathTypeErrors = RequestValidator.checkIsString(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH);
+            if (!opPathTypeErrors.isEmpty()) {
+                throw new ValidationException(opPathTypeErrors);
+            }
+
+            String op = jsonNode.get(FIELD_OPERATION).asText();
+            List<String> opErrors = RequestValidator.checkIsAllowedValue(jsonNode, allowedOps, FIELD_OPERATION);
+            if (!opErrors.isEmpty()) {
+                throw new ValidationException(opErrors);
+            }
+
+            JsonPatchOp jsonPatchOp = JsonPatchOp.valueOf(op.toUpperCase());
+
+            String path = jsonNode.get(FIELD_OPERATION_PATH).asText();
+            Set<String> allowedPaths = operationValidators.keySet().stream().map(PatchPathOperation::getPath).collect(Collectors.toSet());
+
+            List<String> pathErrors = RequestValidator.checkIsAllowedValue(jsonNode, allowedPaths, FIELD_OPERATION_PATH);
+            if (!pathErrors.isEmpty()) {
+                throw new ValidationException(pathErrors);
+            }
+
+            PatchPathOperation pathOperation = new PatchPathOperation(path, jsonPatchOp);
+            if (!operationValidators.containsKey(pathOperation)) {
+                throw new ValidationException(Collections.singletonList(format("Operation [%s] not supported for path [%s]", op, path)));
+            }
+
+            operationValidators.get(pathOperation).accept(jsonNode);
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/common/validator/RequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/RequestValidator.java
@@ -16,32 +16,32 @@ import static org.apache.commons.lang3.math.NumberUtils.isDigits;
 
 public class RequestValidator {
 
-    public List<String> checkIsNumeric(JsonNode payload, String... fieldNames) {
+    public static List<String> checkIsNumeric(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotNumeric(), fieldNames, "Field [%s] must be a number");
     }
 
-    public List<String> checkIsBoolean(JsonNode payload, String... fieldNames) {
+    public static List<String> checkIsBoolean(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotBoolean(), fieldNames, "Field [%s] must be a boolean");
     }
 
-    public List<String> checkIsString(JsonNode payload, String... fieldNames) {
+    public static  List<String> checkIsString(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotString(), fieldNames, "Field [%s] must be a string");
     }
 
-    public List<String> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
+    public static List<String> checkIfExistsOrEmpty(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, notExistOrEmpty(), fieldNames, "Field [%s] is required");
     }
 
-    public List<String> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {
+    public static List<String> checkMaxLength(JsonNode payload, int maxLength, String... fieldNames) {
         return applyCheck(payload, exceedsMaxLength(maxLength), fieldNames, "Field [%s] must have a maximum length of " + maxLength + " characters");
     }
 
-    public List<String> checkIsAllowedValue(JsonNode payload, Set<String> allowedValues, String... fieldNames) {
+    public static List<String> checkIsAllowedValue(JsonNode payload, Set<String> allowedValues, String... fieldNames) {
         return applyCheck(payload, isNotAllowedValue(allowedValues), fieldNames, "Field [%s] must be one of "
                 + allowedValues.stream().sorted().collect(Collectors.joining(", ", "[", "]")));
     }
 
-    private List<String> applyCheck(JsonNode payload, Function<JsonNode, Boolean> check, String[] fieldNames, String errorMessage) {
+    private static List<String> applyCheck(JsonNode payload, Function<JsonNode, Boolean> check, String[] fieldNames, String errorMessage) {
         List<String> errors = newArrayList();
         for (String fieldName : fieldNames) {
             if (check.apply(payload.get(fieldName))) {
@@ -51,11 +51,11 @@ public class RequestValidator {
         return errors;
     }
 
-    private Function<JsonNode, Boolean> exceedsMaxLength(int maxLength) {
+    private static Function<JsonNode, Boolean> exceedsMaxLength(int maxLength) {
         return jsonNode -> jsonNode.asText().length() > maxLength;
     }
 
-    private Function<JsonNode, Boolean> notExistOrEmpty() {
+    private static Function<JsonNode, Boolean> notExistOrEmpty() {
         return (jsonElement) -> {
             if (jsonElement instanceof NullNode) {
                 return isNullValue().apply(jsonElement);
@@ -67,7 +67,7 @@ public class RequestValidator {
         };
     }
 
-    private Function<JsonNode, Boolean> notExistOrEmptyArray() {
+    private static Function<JsonNode, Boolean> notExistOrEmptyArray() {
         return jsonElement -> (
                 jsonElement == null ||
                         ((jsonElement instanceof ArrayNode) && (jsonElement.size() == 0))

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidator.java
@@ -1,69 +1,46 @@
 package uk.gov.pay.connector.gatewayaccount.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.inject.Inject;
 import uk.gov.pay.connector.common.exception.ValidationException;
 import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchOp;
+import uk.gov.pay.connector.common.validator.PatchPathOperation;
+import uk.gov.pay.connector.common.validator.PatchRequestValidator;
 import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.function.Consumer;
 
-import static java.lang.String.format;
-import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
-import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_VALUE;
 
 public class StripeAccountSetupRequestValidator {
 
-    private final RequestValidator requestValidator;
+    private static final Map<PatchPathOperation, Consumer<JsonNode>> operationValidators;
 
-    @Inject
-    public StripeAccountSetupRequestValidator(RequestValidator requestValidator) {
-        this.requestValidator = requestValidator;
+    static {
+        Map<PatchPathOperation, Consumer<JsonNode>> map = new HashMap<>();
+        Arrays.stream(StripeAccountSetupTask.values()).forEach(stripeAccountSetupTask ->
+                map.put(
+                        new PatchPathOperation(stripeAccountSetupTask.name().toLowerCase(), JsonPatchOp.REPLACE),
+                        StripeAccountSetupRequestValidator::validateReplaceTaskOperation)
+        );
+        operationValidators = Collections.unmodifiableMap(map);
     }
+    
+    private final PatchRequestValidator validator = new PatchRequestValidator(operationValidators);
 
     public void validatePatchRequest(JsonNode payload) {
-        if (!payload.isArray()) {
-            throw new ValidationException(Collections.singletonList("JSON is not an array"));
-        }
-        
-        for (JsonNode jsonNode : payload) {
-            List<String> fieldErrors = requestValidator.checkIfExistsOrEmpty(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH, FIELD_VALUE);
-            if (!fieldErrors.isEmpty()) {
-                throw new ValidationException(fieldErrors);
-            }
+        validator.validate(payload);
+    }
 
-            List<String> opPathTypeErrors = requestValidator.checkIsString(jsonNode, FIELD_OPERATION, FIELD_OPERATION_PATH);
-            if (!opPathTypeErrors.isEmpty()) {
-                throw new ValidationException(opPathTypeErrors);
-            }
-
-            Set<String> allowedPaths = Arrays.stream(StripeAccountSetupTask.values())
-                    .map(stripeAccountSetupTask -> stripeAccountSetupTask.name().toLowerCase())
-                    .collect(Collectors.toSet());
-
-            String op = jsonNode.get(FIELD_OPERATION).asText();
-            String path = jsonNode.get(FIELD_OPERATION_PATH).asText();
-
-            List<String> pathErrors = requestValidator.checkIsAllowedValue(jsonNode, allowedPaths, FIELD_OPERATION_PATH);
-
-            if (!pathErrors.isEmpty()) {
-                throw new ValidationException(pathErrors);
-            }
-
-            List<String> valueErrors = requestValidator.checkIsBoolean(jsonNode, FIELD_VALUE);
-            if (!valueErrors.isEmpty()) {
-                throw new ValidationException(valueErrors);
-            }
-
-            if (!op.equals(JsonPatchOp.REPLACE.name().toLowerCase())) {
-                throw new ValidationException(Collections.singletonList(format("Operation [%s] not supported for path [%s]", op, path)));
-            }
+    private static void validateReplaceTaskOperation(JsonNode operation) {
+        List<String> valueErrors = RequestValidator.checkIsBoolean(operation, FIELD_VALUE);
+        if (!valueErrors.isEmpty()) {
+            throw new ValidationException(valueErrors);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/common/validator/PatchRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/validator/PatchRequestValidatorTest.java
@@ -1,0 +1,128 @@
+package uk.gov.pay.connector.common.validator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import uk.gov.pay.connector.common.exception.ValidationException;
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchOp;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class PatchRequestValidatorTest {
+    
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    static class InvalidValuesTestProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext) throws Exception {
+            return Stream.of(
+                    Arguments.of("Field [path] is required", buildPatchRequest(Map.of("operation", "add", "value", true))),
+                    Arguments.of("Field [path] is required", buildPatchRequest(Map.of("operation", "add", "path", "", "value", true))),
+                    Arguments.of("Field [path] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", "add");
+                        put("path", null);
+                        put("value", true);
+                    }})),
+                    Arguments.of("Field [path] must be a string", buildPatchRequest(Map.of("operation", "add", "path", 1234, "value", true))),
+
+                    Arguments.of("Field [op] is required", buildPatchRequest(Map.of("path", "foo", "value", true))),
+                    Arguments.of("Field [op] is required", buildPatchRequest(Map.of("operation", "", "path", "foo", "value", true))),
+                    Arguments.of("Field [op] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", null);
+                        put("path", "foo");
+                        put("value", true);
+                    }})),
+                    Arguments.of("Field [op] must be a string", buildPatchRequest(Map.of("operation", 1234, "path", "foo", "value", true))),
+                    Arguments.of("Field [op] must be one of [add, remove, replace]", buildPatchRequest(Map.of("operation", "cook", "path", "foo", "value", true))),
+
+                    Arguments.of("Field [value] is required", buildPatchRequest(Map.of("operation", "add", "path", "foo"))),
+                    Arguments.of("Field [value] is required", buildPatchRequest(Map.of("operation", "add", "path", "foo", "value", ""))),
+                    Arguments.of("Field [value] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", "add");
+                        put("path", "foo");
+                        put("value", null);
+                    }})),
+
+                    Arguments.of("Field [path] must be one of [bar, foo]", buildPatchRequest(Map.of("operation", "add", "path", "baz", "value", true))),
+                    Arguments.of("Operation [replace] not supported for path [foo]", buildPatchRequest(Map.of("operation", "replace", "path", "foo", "value", true)))
+            );
+        }
+    }
+    
+    @ParameterizedTest
+    @ArgumentsSource(InvalidValuesTestProvider.class)
+    void shouldThrowExceptionWhenValidationFails(String expectedErrorMessage, JsonNode request) {
+        Map<PatchPathOperation, Consumer<JsonNode>> operationValidators = Map.of(
+                new PatchPathOperation("foo", JsonPatchOp.ADD), (node) -> {},
+                new PatchPathOperation("bar", JsonPatchOp.REPLACE), (node) -> {}
+        );
+        
+        var patchRequestValidator = new PatchRequestValidator(operationValidators);
+        ValidationException validationException = assertThrows(ValidationException.class,
+                () -> patchRequestValidator.validate(request));
+
+        assertThat(validationException, hasProperty("errors", contains(expectedErrorMessage)));
+    }
+
+    @Test
+    void shouldSucceedForValidRequestAndCallOperationValidator() {
+        JsonNode fooOperation = objectMapper.valueToTree(Map.of("path", "foo",
+                "op", "add",
+                "value", 1));
+        JsonNode barOperation = objectMapper.valueToTree(Map.of("path", "bar",
+                "op", "replace",
+                "value", 1));
+        JsonNode request = objectMapper.valueToTree(List.of(fooOperation, barOperation));
+        
+        Consumer<JsonNode> addFooValidator = mock(Consumer.class);
+        doAnswer((node) -> null).when(addFooValidator).accept(eq(fooOperation));
+
+        Consumer<JsonNode> replaceBarValidator = mock(Consumer.class);
+        doAnswer((node) -> null).when(replaceBarValidator).accept(eq(barOperation));
+        
+        Map<PatchPathOperation, Consumer<JsonNode>> operationValidators = Map.of(
+                new PatchPathOperation("foo", JsonPatchOp.ADD), addFooValidator,
+                new PatchPathOperation("bar", JsonPatchOp.REPLACE), replaceBarValidator
+        );
+        
+        var patchRequestValidator = new PatchRequestValidator(operationValidators);
+
+        patchRequestValidator.validate(request);
+        verify(addFooValidator).accept(eq(fooOperation));
+        verify(replaceBarValidator).accept(eq(barOperation));
+    }
+
+    private static JsonNode buildPatchRequest(Map<Object, Object> data) {
+        Map<Object, Object> params = new HashMap<>();
+        if (data.containsKey("operation")) {
+            params.put("op", data.get("operation"));
+        }
+        if (data.containsKey("path")) {
+            params.put("path", data.get("path"));
+        }
+        if (data.containsKey("value")) {
+            params.put("value", data.get("value"));
+        }
+
+        return objectMapper.valueToTree(Collections.singletonList(params));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
@@ -8,7 +8,6 @@ import junitparams.converters.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.pay.connector.common.exception.ValidationException;
-import uk.gov.pay.connector.common.validator.RequestValidator;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -23,7 +22,7 @@ import static org.junit.Assert.assertThrows;
 @RunWith(JUnitParamsRunner.class)
 public class StripeAccountSetupRequestValidatorTest {
 
-    private final StripeAccountSetupRequestValidator validator = new StripeAccountSetupRequestValidator(new RequestValidator());
+    private final StripeAccountSetupRequestValidator validator = new StripeAccountSetupRequestValidator();
     private static ObjectMapper objectMapper = new ObjectMapper();
 
     @Parameters({

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -138,13 +138,13 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
         long gatewayAccountId = Long.valueOf(createAGatewayAccountFor("stripe"));
         givenSetup()
                 .body(toJson(Collections.singletonList(ImmutableMap.of(
-                        "op", "not_replace",
+                        "op", "remove",
                         "path", "bank_account",
                         "value", true))))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
                 .then()
                 .statusCode(400)
-                .body("message", contains("Operation [not_replace] not supported for path [bank_account]"))
+                .body("message", contains("Operation [remove] not supported for path [bank_account]"))
                 .body("error_identifier", is(ErrorIdentifier.GENERIC.toString()));
     }
 


### PR DESCRIPTION
Validation of JSON patch request body following the JSON patch spec http://jsonpatch.com/:
- Checks the JSON is an array
- Checks that "op", "path" and "value" are present
- Checks that "op" and "path" are strings
- Checks that "op" is one of the allowed values.

Validator takes a map of validators to apply to each allowed op/path combination.
It will check that the op/path combination in the request is one of the allowed combinations and then apply the Consumer provided for the validation of the operation.
