### PR TITLE
PP-8198 Add validation for credentials patch request

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
@@ -1,13 +1,11 @@
 package uk.gov.pay.connector.common.model.api.jsonpatch;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.pay.connector.util.JsonObjectMapper;
 
-import java.io.IOException;
 import java.util.Map;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_VALUE;
@@ -15,6 +13,7 @@ import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIEL
 public class JsonPatchRequest {
 
     private static ObjectMapper objectMapper = new ObjectMapper();
+    private static JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(objectMapper);
     
     private JsonPatchOp op;
     private String path;
@@ -54,16 +53,7 @@ public class JsonPatchRequest {
     }
 
     public Map<String, String> valueAsObject() {
-        if (value != null) {
-            if ((value.isTextual() && !isEmpty(value.asText())) || (!value.isNull() && value.isObject())) {
-                try {
-                    return objectMapper.readValue(value.traverse(), new TypeReference<Map<String, String>>() {});
-                } catch (IOException e) {
-                    throw new RuntimeException("Malformed JSON object in value", e);
-                }
-            }
-        }
-        return null;
+        return jsonObjectMapper.getAsMap(value);
     }
 
 

--- a/src/main/java/uk/gov/pay/connector/common/validator/RequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/RequestValidator.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.common.validator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.util.List;
 import java.util.Set;
@@ -24,7 +25,7 @@ public class RequestValidator {
         return applyCheck(payload, isNotBoolean(), fieldNames, "Field [%s] must be a boolean");
     }
 
-    public static  List<String> checkIsString(JsonNode payload, String... fieldNames) {
+    public static List<String> checkIsString(JsonNode payload, String... fieldNames) {
         return applyCheck(payload, isNotString(), fieldNames, "Field [%s] must be a string");
     }
 
@@ -61,6 +62,8 @@ public class RequestValidator {
                 return isNullValue().apply(jsonElement);
             } else if (jsonElement instanceof ArrayNode) {
                 return notExistOrEmptyArray().apply(jsonElement);
+            } else if (jsonElement instanceof ObjectNode) {
+                return notExistOrEmptyObject().apply(jsonElement);
             } else {
                 return notExistOrBlankText().apply(jsonElement);
             }
@@ -71,6 +74,13 @@ public class RequestValidator {
         return jsonElement -> (
                 jsonElement == null ||
                         ((jsonElement instanceof ArrayNode) && (jsonElement.size() == 0))
+        );
+    }
+
+    private static Function<JsonNode, Boolean> notExistOrEmptyObject() {
+        return jsonElement -> (
+                jsonElement == null ||
+                        ((jsonElement instanceof ObjectNode) && jsonElement.isEmpty())
         );
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
@@ -1,18 +1,27 @@
 package uk.gov.pay.connector.gatewayaccount.resource;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.common.exception.ValidationException;
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchOp;
+import uk.gov.pay.connector.common.validator.PatchPathOperation;
+import uk.gov.pay.connector.common.validator.PatchRequestValidator;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest;
+import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.Maps.newHashMap;
 import static java.lang.String.format;
+import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_VALUE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest.PAYMENT_PROVIDER_FIELD_NAME;
@@ -21,6 +30,9 @@ public class GatewayAccountCredentialsRequestValidator {
 
     private final Map<String, List<String>> providerCredentialFields;
     private final Joiner COMMA_JOINER = Joiner.on(", ");
+    private final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+
+    public static final String FIELD_CREDENTIALS = "credentials";
 
     @Inject
     public GatewayAccountCredentialsRequestValidator(ConnectorConfiguration configuration) {
@@ -59,5 +71,22 @@ public class GatewayAccountCredentialsRequestValidator {
         return providerCredentialFields.get(paymentProvider).stream()
                 .filter(requiredField -> !credentials.containsKey(requiredField))
                 .collect(Collectors.toList());
+    }
+    
+    public void validatePatch(JsonNode patchRequest, String paymentProvider) {
+        Map<PatchPathOperation, Consumer<JsonNode>> operationValidators = Map.of(
+                new PatchPathOperation(FIELD_CREDENTIALS, JsonPatchOp.REPLACE), (operation) -> validateReplaceCredentialsOperation(operation, paymentProvider)
+        );
+        var patchRequestValidator = new PatchRequestValidator(operationValidators);
+        patchRequestValidator.validate(patchRequest);
+    }
+    
+    private void validateReplaceCredentialsOperation(JsonNode operation, String paymentProvider) {
+        Map<String, String> credentialsMap = jsonObjectMapper.getAsMap(operation.get(FIELD_VALUE));
+        List<String> missingCredentialsFields = getMissingCredentialsFields(credentialsMap, paymentProvider);
+        if (!missingCredentialsFields.isEmpty()) {
+            throw new ValidationException(Collections.singletonList(format("Value for path [%s] op [%s] is missing field(s): [%s]", 
+                    FIELD_CREDENTIALS, JsonPatchOp.REPLACE.name().toLowerCase(Locale.ROOT), COMMA_JOINER.join(missingCredentialsFields))));
+        }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/util/JsonObjectMapper.java
+++ b/src/main/java/uk/gov/pay/connector/util/JsonObjectMapper.java
@@ -1,5 +1,7 @@
 package uk.gov.pay.connector.util;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -7,8 +9,10 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
+import java.util.Map;
 
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
 public class JsonObjectMapper {
@@ -29,5 +33,18 @@ public class JsonObjectMapper {
                     format("There was an exception parsing the payload [%s] into an [%s], e=[%s]",
                     jsonResponse, targetType, e.getMessage())));
         }
+    }
+
+    public Map<String, String> getAsMap(JsonNode jsonNode) {
+        if (jsonNode != null) {
+            if ((jsonNode.isTextual() && !isEmpty(jsonNode.asText())) || (!jsonNode.isNull() && jsonNode.isObject())) {
+                try {
+                    return objectMapper.readValue(jsonNode.traverse(), new TypeReference<Map<String, String>>() {});
+                } catch (IOException e) {
+                    throw new RuntimeException("Malformed JSON object in value", e);
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/common/validator/PatchRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/common/validator/PatchRequestValidatorTest.java
@@ -61,6 +61,11 @@ class PatchRequestValidatorTest {
                         put("path", "foo");
                         put("value", null);
                     }})),
+                    Arguments.of("Field [value] is required", buildPatchRequest(new HashMap<>() {{
+                        put("operation", "add");
+                        put("path", "foo");
+                        put("value", Map.of());
+                    }})),
 
                     Arguments.of("Field [path] must be one of [bar, foo]", buildPatchRequest(Map.of("operation", "add", "path", "baz", "value", true))),
                     Arguments.of("Operation [replace] not supported for path [foo]", buildPatchRequest(Map.of("operation", "replace", "path", "foo", "value", true)))

--- a/src/test/java/uk/gov/pay/connector/util/JsonObjectMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/JsonObjectMapperTest.java
@@ -1,31 +1,43 @@
 package uk.gov.pay.connector.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
 import javax.ws.rs.WebApplicationException;
+import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 public class JsonObjectMapperTest {
-    private JsonObjectMapper mapper = new JsonObjectMapper(new ObjectMapper());
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(objectMapper);
 
     @Test
     public void shouldMapToObject() {
         String jsonString = "{\"id\":1}";
-        LocalTestObject fromJson = mapper.getObject(jsonString, LocalTestObject.class);
+        LocalTestObject fromJson = jsonObjectMapper.getObject(jsonString, LocalTestObject.class);
         assertNotNull(fromJson);
         assertEquals(1, fromJson.getId());
     }
 
-    @Test(expected = WebApplicationException.class)
+    @Test()
     public void shouldThrowException() {
         String jsonString = "{\"id\":\"abc\"}";
-        LocalTestObject fromJson = mapper.getObject(jsonString, LocalTestObject.class);
-        assertNotNull(fromJson);
-        assertEquals(1, fromJson.getId());
+        assertThrows(WebApplicationException.class, () -> jsonObjectMapper.getObject(jsonString, LocalTestObject.class));
+    }
+    
+    @Test
+    public void shouldMapToMap() throws JsonProcessingException {
+        JsonNode jsonNode = objectMapper.readTree("{\"foo\":\"bar\"}");
+        Map<String, String> fromJson = jsonObjectMapper.getAsMap(jsonNode);
+        assertThat(fromJson, hasEntry("foo", "bar"));
     }
 }
 


### PR DESCRIPTION
Add validation to be used by the new PATCH endpoint for updating a gateway_account_credentials record. This expects a request with body following the structure of the JSON Patch specification http://jsonpatch.com/

As part of validation, validate that the mandatory credentials are present, depending on the payment provider.