### PR TITLE
PP-8125 - New charges to use GatewayAccountCredential

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -48,6 +48,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
+
 @Entity
 @Table(name = "gateway_accounts")
 @SequenceGenerator(name = "gateway_accounts_gateway_account_id_seq",
@@ -185,11 +186,6 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @JsonProperty("payment_provider")
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public String getGatewayName() {
-        return gatewayName;
-    }
-
-    @JsonIgnore
-    public String getGatewayNameFromGatewayAccountCredentials() {
         List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = getGatewayAccountCredentials();
         if (gatewayAccountCredentialsEntities.size() == 1) {
             GatewayAccountCredentialsEntity entity = gatewayAccountCredentialsEntities.get(0);

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -1,6 +1,9 @@
 package uk.gov.pay.connector.charge.model.domain;
 
 import com.google.common.collect.ImmutableMap;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -24,9 +27,11 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 
 public class ChargeEntityFixture {
 
@@ -66,10 +71,21 @@ public class ChargeEntityFixture {
         GatewayAccountEntity accountEntity = new GatewayAccountEntity("sandbox", new HashMap<>(), TEST);
         accountEntity.setId(1L);
         accountEntity.setServiceName("MyService");
+
         EmailNotificationEntity emailNotificationEntity = new EmailNotificationEntity(accountEntity);
         emailNotificationEntity.setTemplateBody("template body");
         accountEntity.addNotification(EmailNotificationType.PAYMENT_CONFIRMED, emailNotificationEntity);
         accountEntity.addNotification(EmailNotificationType.REFUND_ISSUED, emailNotificationEntity);
+
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(accountEntity)
+                .withPaymentProvider("sandbox")
+                .withCredentials(Map.of())
+                .withState(CREATED)
+                .build();
+        accountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity));
+
         return accountEntity;
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
-import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.CaptureProcessConfig;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.LinksConfig;
@@ -52,6 +51,9 @@ import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.northamericaregion.UsState;
@@ -59,6 +61,7 @@ import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.token.dao.TokenDao;
 import uk.gov.pay.connector.token.model.domain.TokenEntity;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import javax.ws.rs.core.UriInfo;
 import java.time.ZonedDateTime;
@@ -208,6 +211,18 @@ public class ChargeServiceTest {
 
         gatewayAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), TEST);
         gatewayAccount.setId(GATEWAY_ACCOUNT_ID);
+
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(gatewayAccount)
+                .withPaymentProvider("sandbox")
+                .withCredentials(Map.of())
+                .withState(GatewayAccountCredentialState.CREATED)
+                .build();
+
+        List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntities = new ArrayList<>();
+        gatewayAccountCredentialsEntities.add(gatewayAccountCredentialsEntity);
+        gatewayAccount.setGatewayAccountCredentials(gatewayAccountCredentialsEntities);
 
         when(mockedConfig.getLinks())
                 .thenReturn(mockedLinksConfig);

--- a/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/Worldpay3dsFlexJwtServiceTest.java
@@ -60,6 +60,9 @@ public class Worldpay3dsFlexJwtServiceTest {
     @Mock
     private Worldpay3dsFlexCredentialsEntity worldpay3dsFlexCredentialsEntity;
 
+    private GatewayAccountEntity gatewayAccountEntity;
+    private ChargeEntity chargeEntity;
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
     
@@ -85,7 +88,6 @@ public class Worldpay3dsFlexJwtServiceTest {
         when(mockChargeSweepConfig.getDefaultChargeExpiryThreshold()).thenReturn(TOKEN_EXPIRY_DURATION_SECONDS);
         when(mockConfiguration.getLinks()).thenReturn(mockLinksConfig);
         when(mockConfiguration.getChargeSweepConfig()).thenReturn(mockChargeSweepConfig);
-        
         worldpay3dsFlexJwtService = new Worldpay3dsFlexJwtService(new JwtGenerator(), mockConfiguration);
     }
 
@@ -120,7 +122,7 @@ public class Worldpay3dsFlexJwtServiceTest {
                 .withWorldpayChallengeTransactionId("a-transaction-id")
                 .build();
 
-        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+        chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withStatus(ChargeStatus.AUTHORISATION_SUCCESS)
                 .withAuth3dsDetailsEntity(auth3DsRequiredEntity)
                 .build();
@@ -134,7 +136,7 @@ public class Worldpay3dsFlexJwtServiceTest {
     public void shouldNotReturnChallengeTokenIfChallengeDataNotPresent() {
         Auth3dsRequiredEntity auth3DsRequiredEntity = anAuth3dsRequiredEntity().build();
 
-        ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+        chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withStatus(ChargeStatus.AUTHORISATION_3DS_REQUIRED)
                 .withAuth3dsDetailsEntity(auth3DsRequiredEntity)
                 .build();
@@ -150,11 +152,11 @@ public class Worldpay3dsFlexJwtServiceTest {
         when(worldpay3dsFlexCredentialsEntity.getOrganisationalUnitId()).thenReturn("myOrg");
         when(worldpay3dsFlexCredentialsEntity.getJwtMacKey()).thenReturn("fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
 
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+        gatewayAccountEntity = aGatewayAccountEntity()
                 .withGatewayName(WORLDPAY.getName())
                 .withWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity)
                 .build();
-        ChargeEntity chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
+        chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
 
         Optional<String> maybeToken = worldpay3dsFlexJwtService.generateChallengeTokenIfAppropriate(chargeEntity);
         
@@ -233,12 +235,13 @@ public class Worldpay3dsFlexJwtServiceTest {
         when(worldpay3dsFlexCredentialsEntity.getIssuer()).thenReturn(null);
         when(worldpay3dsFlexCredentialsEntity.getOrganisationalUnitId()).thenReturn("myOrg");
         when(worldpay3dsFlexCredentialsEntity.getJwtMacKey()).thenReturn("fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+
+        gatewayAccountEntity = aGatewayAccountEntity()
                 .withId(1L)
                 .withGatewayName(WORLDPAY.getName())
                 .withWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity)
                 .build();
-        ChargeEntity chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
+        chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex JWT for account 1 because the " +
@@ -252,12 +255,12 @@ public class Worldpay3dsFlexJwtServiceTest {
         when(worldpay3dsFlexCredentialsEntity.getIssuer()).thenReturn("me");
         when(worldpay3dsFlexCredentialsEntity.getOrganisationalUnitId()).thenReturn(null);
         when(worldpay3dsFlexCredentialsEntity.getJwtMacKey()).thenReturn("fa2daee2-1fbb-45ff-4444-52805d5cd9e0");
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+        gatewayAccountEntity = aGatewayAccountEntity()
                 .withId(1L)
                 .withGatewayName(WORLDPAY.getName())
                 .withWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity)
                 .build();
-        ChargeEntity chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
+        chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
         expectedException.expectMessage(
@@ -272,12 +275,12 @@ public class Worldpay3dsFlexJwtServiceTest {
         when(worldpay3dsFlexCredentialsEntity.getIssuer()).thenReturn("me");
         when(worldpay3dsFlexCredentialsEntity.getOrganisationalUnitId()).thenReturn("myOrg");
         when(worldpay3dsFlexCredentialsEntity.getJwtMacKey()).thenReturn(null);
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+        gatewayAccountEntity = aGatewayAccountEntity()
                 .withId(1L)
                 .withGatewayName(WORLDPAY.getName())
                 .withWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity)
                 .build();
-        ChargeEntity chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
+        chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
 
         expectedException.expect(Worldpay3dsFlexJwtCredentialsException.class);
         expectedException.expectMessage("Cannot generate Worldpay 3ds Flex JWT for account 1 because the " +
@@ -288,13 +291,13 @@ public class Worldpay3dsFlexJwtServiceTest {
 
     @Test
     public void generateChallengeToken_shouldThrowExceptionForNonWorldpayAccount() {
-        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+        gatewayAccountEntity = aGatewayAccountEntity()
                 .withId(1L)
                 .withGatewayName(SMARTPAY.getName())
-                .withCredentials(VALID_CREDENTIALS)
                 .withWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity)
                 .build();
-        ChargeEntity chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
+
+        chargeEntity = createValidChargeEntityForChallengeToken(gatewayAccountEntity);
 
         expectedException.expect(Worldpay3dsFlexJwtPaymentProviderException.class);
         expectedException.expectMessage("Cannot provide a Worldpay 3ds flex JWT for account 1 because the " +

--- a/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessorTest.java
@@ -17,19 +17,17 @@ import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.model.Event;
 import uk.gov.pay.connector.events.model.ResourceType;
-import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.verify;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 @RunWith(JUnitParamsRunner.class)
 public class ChargeNotificationProcessorTest {
@@ -43,9 +41,6 @@ public class ChargeNotificationProcessorTest {
     protected GatewayAccountEntity gatewayAccount;
 
     @Mock
-    protected GatewayAccountDao mockedGatewayAccountDao;
-
-    @Mock
     protected ChargeService chargeService;
     
     @Mock
@@ -53,7 +48,9 @@ public class ChargeNotificationProcessorTest {
     
     @Before
     public void setUp() {
-        gatewayAccount = new GatewayAccountEntity("sandbox", new HashMap<>(), TEST);
+        gatewayAccount = GatewayAccountEntityFixture
+                .aGatewayAccountEntity()
+                .build();
         gatewayAccount.setId(GATEWAY_ACCOUNT_ID);
         chargeNotificationProcessor = new ChargeNotificationProcessor(chargeService, eventService);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/BaseSmartpayPaymentProviderTest.java
@@ -12,13 +12,13 @@ import uk.gov.pay.connector.gateway.ClientFactory;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
-
 import java.net.URI;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 public abstract class BaseSmartpayPaymentProviderTest {
@@ -60,15 +61,17 @@ public abstract class BaseSmartpayPaymentProviderTest {
     }
 
     GatewayAccountEntity aServiceAccount() {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
-        gatewayAccount.setId(1L);
-        gatewayAccount.setGatewayName("smartpay");
-        gatewayAccount.setCredentials(ImmutableMap.of(
-                "username", "theUsername",
-                "password", "thePassword",
-                "merchant_id", "theMerchantCode"
-        ));
-        gatewayAccount.setType(TEST);
+        GatewayAccountEntity gatewayAccount = GatewayAccountEntityFixture
+                .aGatewayAccountEntity()
+                .withId(1L)
+                .withGatewayName(SMARTPAY.getName())
+                .withCredentials(ImmutableMap.of(
+                        "username", "theUsername",
+                        "password", "thePassword",
+                        "merchant_id", "theMerchantCode"
+                ))
+                .withType(TEST)
+                .build();
 
         return gatewayAccount;
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -10,7 +10,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.w3c.dom.Document;
-import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.common.model.domain.Address;
@@ -26,8 +25,10 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.XPathUtils;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
@@ -365,16 +366,18 @@ class WorldpayAuthoriseHandlerTest {
     }
     
     private GatewayAccountEntity aServiceAccount() {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
-        gatewayAccount.setId(1L);
-        gatewayAccount.setGatewayName("worldpay");
-        gatewayAccount.setRequires3ds(false);
-        gatewayAccount.setCredentials(Map.of(
-                CREDENTIALS_MERCHANT_ID, "worlpay-merchant",
-                CREDENTIALS_USERNAME, "worldpay-password",
-                CREDENTIALS_PASSWORD, "password"
-        ));
-        gatewayAccount.setType(TEST);
+        GatewayAccountEntity gatewayAccount = GatewayAccountEntityFixture
+                .aGatewayAccountEntity()
+                .withId(1L)
+                .withGatewayName(WORLDPAY.getName())
+                .withRequires3ds(false)
+                .withCredentials(Map.of(
+                        CREDENTIALS_MERCHANT_ID, "worlpay-merchant",
+                        CREDENTIALS_USERNAME, "worldpay-password",
+                        CREDENTIALS_PASSWORD, "password"
+                ))
+                .build();
+
         return gatewayAccount;
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
@@ -1,7 +1,5 @@
 package uk.gov.pay.connector.gateway.worldpay;
 
-import com.codahale.metrics.MetricRegistry;
-import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityTest.java
@@ -38,8 +38,7 @@ class GatewayAccountEntityTest {
                 .withPaymentProvider("sandbox")
                 .build();
         gatewayAccountCredentialsEntities.add(gatewayAccountCredentialsEntity);
-        gatewayAccountEntity.setGatewayAccountCredentials(gatewayAccountCredentialsEntities);
-        assertThat(gatewayAccountEntity.getGatewayNameFromGatewayAccountCredentials(), is("sandbox"));
+        assertThat(gatewayAccountEntity.getGatewayName(), is("sandbox"));
     }
 
     @Test
@@ -65,16 +64,15 @@ class GatewayAccountEntityTest {
         gatewayAccountCredentialsEntities.add(latestActiveGatewayAccountCredential);
         gatewayAccountCredentialsEntities.add(earlierActiveGatewayAccountCredential);
         gatewayAccountCredentialsEntities.add(latestRetiredGatewayAccountCredential);
-
         gatewayAccountEntity.setGatewayAccountCredentials(gatewayAccountCredentialsEntities);
 
-        assertThat(gatewayAccountEntity.getGatewayNameFromGatewayAccountCredentials(), is("stripe"));
+        assertThat(gatewayAccountEntity.getGatewayName(), is("stripe"));
     }
 
     @Test
     void shouldThrowWebApplicationExceptionWhenGatewayAccountCredentialsIsEmpty() {
-        gatewayAccountEntity.setGatewayAccountCredentials(List.of());
-        assertThrows(WebApplicationException.class, () -> gatewayAccountEntity.getGatewayNameFromGatewayAccountCredentials());
+        gatewayAccountEntity.setGatewayAccountCredentials(new ArrayList<>());
+        assertThrows(WebApplicationException.class, () -> gatewayAccountEntity.getGatewayName());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -1,11 +1,14 @@
 package uk.gov.pay.connector.gatewayaccount.model;
 
 import org.junit.Test;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntity;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,6 +45,13 @@ public class GatewayAccountResourceDTOTest {
         entity.setMotoMaskCardSecurityCodeInput(true);
         entity.setAllowTelephonePaymentNotifications(true);
         entity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
+        entity.setGatewayAccountCredentials(List.of(
+                GatewayAccountCredentialsEntityFixture.
+                        aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("testGatewayName")
+                        .withState(GatewayAccountCredentialState.ACTIVE)
+                        .build()
+        ));
 
         Map<EmailNotificationType, EmailNotificationEntity> emailNotifications = new HashMap<>();
         emailNotifications.put(EmailNotificationType.PAYMENT_CONFIRMED, new EmailNotificationEntity(new GatewayAccountEntity(), "testTemplate", true));

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -27,6 +27,9 @@ import uk.gov.pay.connector.gateway.smartpay.SmartpayRefundResponse;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundResponse;
 import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.exception.RefundException;
@@ -39,7 +42,9 @@ import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -101,6 +106,9 @@ public class RefundServiceTest {
     private StateTransitionService mockStateTransitionService;
     @Mock
     private LedgerService mockLedgerService;
+    private GatewayAccountEntity account;
+    private ChargeEntity chargeEntity;
+    private List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntityList = new ArrayList<>();
 
     @Before
     public void setUp() {
@@ -117,11 +125,17 @@ public class RefundServiceTest {
         String externalChargeId = "chargeId";
         Long refundAmount = 100L;
         Long accountId = 2L;
-        String providerName = "worldpay";
+        String providerName = WORLDPAY.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
+        chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
@@ -166,10 +180,16 @@ public class RefundServiceTest {
         String externalChargeId = "chargeId";
         Long refundAmount = 100L;
         Long accountId = 2L;
-        String providerName = "worldpay";
+        String providerName = WORLDPAY.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
 
         ChargeResponse.RefundSummary refundSummary = new ChargeResponse.RefundSummary();
         refundSummary.setStatus("available");
@@ -232,11 +252,17 @@ public class RefundServiceTest {
         String externalChargeId = "chargeId";
         Long refundAmount = 100L;
         Long accountId = 2L;
-        String providerName = "worldpay";
+        String providerName = WORLDPAY.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
+        chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
@@ -260,11 +286,18 @@ public class RefundServiceTest {
         String externalChargeId = "chargeId";
         Long amount = 100L;
         Long accountId = 2L;
-        String providerName = "smartpay";
+        String providerName = SMARTPAY.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withPaymentProvider(SMARTPAY.getName())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
+        chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
@@ -310,14 +343,20 @@ public class RefundServiceTest {
         String externalChargeId = "chargeId";
         Long amount = 100L;
         Long accountId = 2L;
-        String providerName = "worldpay";
+        String providerName = WORLDPAY.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
         String generatedReference = "generated-reference";
 
         String providerReference = "worldpay-reference";
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
@@ -352,12 +391,18 @@ public class RefundServiceTest {
         String externalChargeId = "chargeId";
         Long amount = 100L;
         Long accountId = 2L;
-        String providerName = "worldpay";
+        String providerName = WORLDPAY.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
         String generatedReference = "generated-reference";
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
@@ -389,13 +434,20 @@ public class RefundServiceTest {
     public void shouldRefundAndSendEmail_whenGatewayRefundStateIsComplete_forChargeWithNoCorporateSurcharge() {
         String externalChargeId = "chargeId";
         Long accountId = 2L;
-        String providerName = "sandbox";
+        String providerName = SANDBOX.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withPaymentProvider(SANDBOX.getName())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
         String reference = "reference";
 
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId(reference)
                 .withExternalId(externalChargeId)
@@ -410,14 +462,21 @@ public class RefundServiceTest {
     public void shouldRefundAndSendEmail_whenGatewayRefundStatusIsComplete_forChargeWithCorporateSurcharge() {
         String externalChargeId = "chargeId";
         Long accountId = 2L;
-        String providerName = "sandbox";
+        String providerName = SANDBOX.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withPaymentProvider(SANDBOX.getName())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
         String reference = "reference";
 
         long corporateSurcharge = 50L;
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        chargeEntity = aValidChargeEntity()
                 .withCorporateSurcharge(corporateSurcharge)
                 .withGatewayAccountEntity(account)
                 .withTransactionId(reference)
@@ -469,9 +528,16 @@ public class RefundServiceTest {
     public void shouldFailWhenChargeRefundIsNotAvailable() {
         String externalChargeId = "chargeId";
         Long accountId = 2L;
-        GatewayAccountEntity account = new GatewayAccountEntity("sandbox", newHashMap(), TEST);
+        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
         account.setId(accountId);
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withPaymentProvider(SANDBOX.getName())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
+        chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withExternalId(externalChargeId)
                 .withTransactionId("transactionId")
@@ -494,9 +560,16 @@ public class RefundServiceTest {
         Long amount = 1000L;
         String externalChargeId = "chargeId";
         Long accountId = 2L;
-        GatewayAccountEntity account = new GatewayAccountEntity("sandbox", newHashMap(), TEST);
+        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
         account.setId(accountId);
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withPaymentProvider(SANDBOX.getName())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
+        chargeEntity = aValidChargeEntity()
                 .withAmount(amount)
                 .withExternalId(externalChargeId)
                 .withGatewayAccountEntity(account)
@@ -522,9 +595,16 @@ public class RefundServiceTest {
         Long corporateSurcharge = 250L;
         String externalChargeId = "chargeId";
         Long accountId = 2L;
-        GatewayAccountEntity account = new GatewayAccountEntity("sandbox", newHashMap(), TEST);
+        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
         account.setId(accountId);
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withPaymentProvider(SANDBOX.getName())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
+        chargeEntity = aValidChargeEntity()
                 .withAmount(amount)
                 .withExternalId(externalChargeId)
                 .withCorporateSurcharge(corporateSurcharge)
@@ -551,9 +631,16 @@ public class RefundServiceTest {
     public void shouldFailWhenANewRefundHasBeenCreatedSincePreviouslyQueried() {
         String externalChargeId = "chargeId";
         Long accountId = 2L;
-        GatewayAccountEntity account = new GatewayAccountEntity("sandbox", newHashMap(), TEST);
+        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
         account.setId(accountId);
-        ChargeEntity chargeEntity = aValidChargeEntity()
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withPaymentProvider(SANDBOX.getName())
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
+        chargeEntity = aValidChargeEntity()
                 .withAmount(1000L)
                 .withExternalId(externalChargeId)
                 .withGatewayAccountEntity(account)
@@ -612,10 +699,16 @@ public class RefundServiceTest {
         String externalChargeId = "chargeId";
         Long amount = 100L;
         Long accountId = 2L;
-        String providerName = "worldpay";
+        String providerName = WORLDPAY.getName();
 
-        GatewayAccountEntity account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
+        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
         account.setId(accountId);
+        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
+                .aGatewayAccountCredentialsEntity()
+                .withGatewayAccountEntity(account)
+                .withState(GatewayAccountCredentialState.ACTIVE)
+                .build());
         ChargeEntity capturedCharge = aValidChargeEntity()
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transaction-id")


### PR DESCRIPTION
Description:
- New charges will use the payment_provider name from GatewayAccountCredential rather than GatewayAccount
- If there is only 1 GatewayAccountCredential then use that regardless of status otherwise get the latest ACTIVE GatewayAccountCredential
- Since there isn't a test for GatewayAccountEntity the logic had to be tested in ChargeServiceCreateTest. Since the logic of getGatewayName() is tested using charges only 1 new test
for telephone charges was added to verify that it correctly returned the right payment_provider name