### PR TITLE
PP-8198 Add patch gateway account credentials endpoint

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountCredentialsNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountCredentialsNotFoundException.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
+
+public class GatewayAccountCredentialsNotFoundException extends WebApplicationException {
+    
+    public GatewayAccountCredentialsNotFoundException(Long id) {
+        super(notFoundResponse(format("Gateway account credentials with id [%s] not found.", id)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -1,0 +1,96 @@
+package uk.gov.pay.connector.gatewayaccount.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class GatewayAccountCredentials {
+
+    @JsonProperty("gateway_account_credential_id")
+    private Long id;
+    
+    private String externalId;
+    
+    private String paymentProvider;
+            
+    private Map<String, String> credentials;
+    
+    private GatewayAccountCredentialState state;
+    
+    private String lastUpdatedByUserExternalId;
+
+    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    private Instant createdDate;
+
+    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    private Instant activeStartDate;
+
+    @JsonSerialize(using = ApiResponseInstantSerializer.class)
+    private Instant activeEndDate;
+    
+    private Long gatewayAccountId;
+
+    public GatewayAccountCredentials(GatewayAccountCredentialsEntity entity) {
+        this.id = entity.getId();
+        this.externalId = entity.getExternalId();
+        this.paymentProvider = entity.getPaymentProvider();
+        this.state = entity.getState();
+        this.lastUpdatedByUserExternalId = entity.getLastUpdatedByUserExternalId();
+        this.activeStartDate = entity.getActiveStartDate();
+        this.activeEndDate = entity.getActiveEndDate();
+        this.gatewayAccountId = entity.getGatewayAccountEntity().getId();
+
+        var clonedCredentials = new HashMap<>(entity.getCredentials());
+        clonedCredentials.remove("password");
+        this.credentials = clonedCredentials;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public Map<String, String> getCredentials() {
+        return credentials;
+    }
+
+    public GatewayAccountCredentialState getState() {
+        return state;
+    }
+
+    public String getLastUpdatedByUserExternalId() {
+        return lastUpdatedByUserExternalId;
+    }
+
+    public Instant getCreatedDate() {
+        return createdDate;
+    }
+
+    public Instant getActiveStartDate() {
+        return activeStartDate;
+    }
+
+    public Instant getActiveEndDate() {
+        return activeEndDate;
+    }
+
+    public Long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
@@ -3,10 +3,13 @@ package uk.gov.pay.connector.gatewayaccountcredentials.dao;
 import com.google.inject.Provider;
 import com.google.inject.persist.Transactional;
 import uk.gov.pay.connector.common.dao.JpaDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentials;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+
+import java.util.Optional;
 
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 
@@ -21,6 +24,10 @@ public class GatewayAccountCredentialsDao extends JpaDao<GatewayAccountCredentia
     @Override
     public void persist(GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
         super.persist(gatewayAccountCredentialsEntity);
+    }
+    
+    public Optional<GatewayAccountCredentialsEntity> findById(Long id) {
+        return super.findById(GatewayAccountCredentialsEntity.class, id);
     }
 
     public boolean hasActiveCredentials(Long gatewayAccountId) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -317,7 +317,7 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
         Map<String, String> currentCredentials = databaseTestHelper.getAccountCredentials(Long.valueOf(accountId));
         assertThat(currentCredentials, is(gatewayAccountPayload.getCredentials()));
 
-        List<Map<String, Object>> gatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentials(Long.parseLong(accountId));
+        List<Map<String, Object>> gatewayAccountCredentials = databaseTestHelper.getGatewayAccountCredentialsForAccount(Long.parseLong(accountId));
         assertThat(gatewayAccountCredentials, hasSize(1));
         Map<String, Object> updatedGatewayAccountCredentials = gatewayAccountCredentials.get(0);
         assertThat(updatedGatewayAccountCredentials, hasEntry("state", ACTIVE.toString()));

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -947,11 +947,19 @@ public class DatabaseTestHelper {
                         .first());
     }
 
-    public List<Map<String, Object>> getGatewayAccountCredentials(long accountId) {
+    public List<Map<String, Object>> getGatewayAccountCredentialsForAccount(long accountId) {
         return jdbi.withHandle(handle ->
                 handle.createQuery("SELECT * FROM gateway_account_credentials where gateway_account_id = :accountId")
                         .bind("accountId", accountId)
                         .mapToMap()
                         .list());
+    }
+
+    public Map<String, Object> getGatewayAccountCredentialsById(long credentialsId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * FROM gateway_account_credentials where id = :id")
+                        .bind("id", credentialsId)
+                        .mapToMap()
+                        .first());
     }
 }


### PR DESCRIPTION
Add patch endpoint to update gateway account credentials by id.

Add service that allows for updating the credentials column on the entity when a replace operation is included in the patch request.