### PR TITLE
PP-8125 Add method to get credentials by payment_provider

### DIFF
--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntityFixture.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static com.google.common.collect.Lists.newArrayList;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 
 public final class GatewayAccountEntityFixture {
     private Long id = 1L;
@@ -162,7 +163,7 @@ public final class GatewayAccountEntityFixture {
         this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
         return this;
     }
-    
+
     public GatewayAccountEntityFixture withGatewayAccountCredentials(List<GatewayAccountCredentialsEntity> credentials) {
         this.gatewayAccountCredentialsEntities = credentials;
         return this;
@@ -193,6 +194,14 @@ public final class GatewayAccountEntityFixture {
         gatewayAccountEntity.setCardTypes(cardTypes);
         gatewayAccountEntity.setWorldpay3dsFlexCredentialsEntity(worldpay3dsFlexCredentialsEntity);
         gatewayAccountEntity.setSendPayerIpAddressToGateway(sendPayerIpAddressToGateway);
+
+        if (credentials != null && gatewayAccountCredentialsEntities != null
+                && gatewayAccountCredentialsEntities.isEmpty()) {
+            GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
+                    .withPaymentProvider(gatewayName).build();
+            gatewayAccountCredentialsEntities.add(credentialsEntity);
+        }
+
         gatewayAccountEntity.setGatewayAccountCredentials(gatewayAccountCredentialsEntities);
         return gatewayAccountEntity;
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
@@ -57,6 +57,7 @@ public class GatewayAccountCredentialsDaoIT extends DaoITestBase {
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId))
                 .withPaymentGateway("stripe")
+                .withCredentials(null)
                 .withServiceName("a cool service")
                 .build());
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsServiceTest.java
@@ -147,6 +147,8 @@ public class GatewayAccountCredentialsServiceTest {
     @Test
     void shouldNotUpdateIfNoCredentialsRecordsExist() {
         GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withCredentials(null)
+                .withGatewayAccountCredentials(List.of())
                 .build();
 
         var credentials = Map.of("username", "foo");

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -28,6 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.refund.model.domain.RefundStatus.CREATED;
 import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
@@ -338,6 +341,11 @@ public class DatabaseFixtures {
         private boolean motoMaskCardNumberInput;
         private boolean motoMaskCardSecurityCodeInput;
         private boolean allowTelephonePaymentNotifications;
+        private final Map<String, String> defaultCredentials = Map.of(
+                CREDENTIALS_MERCHANT_ID, "merchant-id",
+                CREDENTIALS_USERNAME, "username",
+                CREDENTIALS_PASSWORD, "password"
+        );
 
         public long getAccountId() {
             return accountId;
@@ -493,6 +501,11 @@ public class DatabaseFixtures {
 
         public TestAccount withAllowTelephonePaymentNotifications(boolean allowTelephonePaymentNotifications) {
             this.allowTelephonePaymentNotifications = allowTelephonePaymentNotifications;
+            return this;
+        }
+
+        public TestAccount withDefaultCredentials() {
+            this.credentials = defaultCredentials; 
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -243,6 +243,7 @@ public class ContractTest {
         dbHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(params.get("gateway_account_id"))
                 .withPaymentGateway("sandbox")
+                .withCredentials(Map.of())
                 .withServiceName("a cool service")
                 .build());
     }
@@ -475,6 +476,7 @@ public class ContractTest {
         worldpayMockClient.mockCredentialsValidationValid();
         dbHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId("333")
+                .withDefaultCredentials()
                 .withPaymentGateway(WORLDPAY.getName())
                 .build());
     }

--- a/src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java
+++ b/src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java
@@ -18,6 +18,7 @@ public class GatewayAccountUtil {
                     .withAnalyticsId("8b02c7e542e74423aa9e6d0f0628fd58")
                     .withServiceName("a cool service")
                     .withCardTypeEntities(Collections.singletonList(dbHelper.getVisaDebitCard()))
+                    .withDefaultCredentials()
                     .insert();
         } else {
             dbHelper.deleteAllChargesOnAccount(accountId);

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -138,7 +138,7 @@ public class AddGatewayAccountParams {
     public static final class AddGatewayAccountParamsBuilder {
         private String accountId;
         private String paymentGateway = "provider";
-        private Map<String, String> credentials;
+        private Map<String, String> credentials = Map.of();
         private String serviceName = "service name";
         private GatewayAccountType type = TEST;
         private String description = "description";
@@ -188,7 +188,7 @@ public class AddGatewayAccountParams {
         public AddGatewayAccountParamsBuilder withEpdqCredentials() {
             this.credentials = epdqCredentials;
             return this;
-        }
+        }        
 
         public AddGatewayAccountParamsBuilder withServiceName(String serviceName) {
             this.serviceName = serviceName;


### PR DESCRIPTION
## WHAT YOU DID
- Added new method to GatewayAccountEntity to get credentials by paymentProvider. This will be used by all operations where creds are required
- Updated test fixtures to add gateway_account_credentials when gateway account is added
