### PR TITLE
PP-8198 Improve JSON patch request validator

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
 import java.util.Map;
+import java.util.Objects;
 
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION;
 import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_OPERATION_PATH;
@@ -12,12 +13,12 @@ import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIEL
 
 public class JsonPatchRequest {
 
-    private static ObjectMapper objectMapper = new ObjectMapper();
-    private static JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(objectMapper);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(objectMapper);
     
-    private JsonPatchOp op;
-    private String path;
-    private JsonNode value;
+    private final JsonPatchOp op;
+    private final String path;
+    private final JsonNode value;
 
     public JsonPatchOp getOp() {
         return op;
@@ -25,6 +26,10 @@ public class JsonPatchRequest {
 
     public String getPath() {
         return path;
+    }
+    
+    public boolean valueIsBoolean() {
+        return value.isBoolean();
     }
 
     public String valueAsString() {
@@ -70,7 +75,20 @@ public class JsonPatchRequest {
                 payload.get(FIELD_VALUE));
 
     }
-    
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JsonPatchRequest that = (JsonPatchRequest) o;
+        return op == that.op && Objects.equals(path, that.path) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(op, path, value);
+    }
+
     public class JsonNodeNotCorrectTypeException extends RuntimeException {
         public JsonNodeNotCorrectTypeException(String message) {
             super(message);

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidator.java
@@ -1,47 +1,35 @@
 package uk.gov.pay.connector.gatewayaccount.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import uk.gov.pay.connector.common.exception.ValidationException;
 import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchOp;
+import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchRequest;
+import uk.gov.pay.connector.common.validator.JsonPatchRequestValidator;
 import uk.gov.pay.connector.common.validator.PatchPathOperation;
-import uk.gov.pay.connector.common.validator.PatchRequestValidator;
-import uk.gov.pay.connector.common.validator.RequestValidator;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountSetupTask;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchKeys.FIELD_VALUE;
-
 public class StripeAccountSetupRequestValidator {
 
-    private static final Map<PatchPathOperation, Consumer<JsonNode>> operationValidators;
+    private static final Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators;
 
     static {
-        Map<PatchPathOperation, Consumer<JsonNode>> map = new HashMap<>();
+        Map<PatchPathOperation, Consumer<JsonPatchRequest>> map = new HashMap<>();
         Arrays.stream(StripeAccountSetupTask.values()).forEach(stripeAccountSetupTask ->
                 map.put(
                         new PatchPathOperation(stripeAccountSetupTask.name().toLowerCase(), JsonPatchOp.REPLACE),
-                        StripeAccountSetupRequestValidator::validateReplaceTaskOperation)
+                        JsonPatchRequestValidator::throwIfValueNotBoolean)
         );
         operationValidators = Collections.unmodifiableMap(map);
     }
     
-    private final PatchRequestValidator validator = new PatchRequestValidator(operationValidators);
+    private final JsonPatchRequestValidator validator = new JsonPatchRequestValidator(operationValidators);
 
     public void validatePatchRequest(JsonNode payload) {
         validator.validate(payload);
     }
-
-    private static void validateReplaceTaskOperation(JsonNode operation) {
-        List<String> valueErrors = RequestValidator.checkIsBoolean(operation, FIELD_VALUE);
-        if (!valueErrors.isEmpty()) {
-            throw new ValidationException(valueErrors);
-        }
-    }
-
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
@@ -99,7 +99,7 @@ public class GatewayAccountCredentialsRequestValidatorTest {
                         "op", "replace",
                         "value", credentials)));
         var thrown = assertThrows(ValidationException.class, () -> validator.validatePatch(request, "worldpay"));
-        assertThat(thrown.getErrors().get(0), is("Value for path [credentials] op [replace] is missing field(s): [merchant_id]"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [credentials] is missing field(s): [merchant_id]"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupRequestValidatorTest.java
@@ -64,7 +64,7 @@ public class StripeAccountSetupRequestValidatorTest {
 
                 Map.of("expectedErrorMessage", "Field [value] is required", "operation", "replace", "path", "bank_account"),
                 Map.of("expectedErrorMessage", "Field [value] is required", "operation", "replace", "path", "bank_account", "value", ""),
-                Map.of("expectedErrorMessage", "Field [value] must be a boolean", "operation", "replace", "path", "bank_account", "value", "true"),
+                Map.of("expectedErrorMessage", "Value for path [bank_account] must be a boolean", "operation", "replace", "path", "bank_account", "value", "true"),
                 new HashMap<String, Object>() {{put("expectedErrorMessage", "Field [value] is required"); put("operation", "replace"); put("path", "bank_account"); put("value", null);}},
         };
     }


### PR DESCRIPTION
Rename to JsonPatchRequestValidator to make it clearer we're validating patch request that follow the JSON Patch spec.

Refactor validator so that consumers for validating individual operations accept a `JsonPatchRequest` rather than a `JsonNode`, so its clearer what the consumer should be expecting to validate. By doing this improve the error message given when a value is invalid by including the `path` validation failed for.