### PR TITLE
PP-8198 Accept patch operation to update last updated by user

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/jsonpatch/JsonPatchRequest.java
@@ -28,6 +28,10 @@ public class JsonPatchRequest {
         return path;
     }
     
+    public boolean valueIsString() { 
+        return value.isTextual();
+    }
+
     public boolean valueIsBoolean() {
         return value.isBoolean();
     }

--- a/src/main/java/uk/gov/pay/connector/common/validator/JsonPatchRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/common/validator/JsonPatchRequestValidator.java
@@ -73,6 +73,12 @@ public class JsonPatchRequestValidator {
         }
     }
 
+    public static void throwIfValueNotString(JsonPatchRequest request) {
+        if (!request.valueIsString()) {
+            throw new ValidationException(Collections.singletonList(format("Value for path [%s] must be a string", request.getPath())));
+        }
+    }
+
     public static void throwIfValueNotBoolean(JsonPatchRequest request) {
         if (!request.valueIsBoolean()) {
             throw new ValidationException(Collections.singletonList(format("Value for path [%s] must be a boolean", request.getPath())));

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
@@ -33,6 +33,7 @@ public class GatewayAccountCredentialsRequestValidator {
     private final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
 
     public static final String FIELD_CREDENTIALS = "credentials";
+    public static final String FIELD_LAST_UPDATED_BY_USER = "last_updated_by_user_external_id";
 
     @Inject
     public GatewayAccountCredentialsRequestValidator(ConnectorConfiguration configuration) {
@@ -75,7 +76,8 @@ public class GatewayAccountCredentialsRequestValidator {
     
     public void validatePatch(JsonNode patchRequest, String paymentProvider) {
         Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators = Map.of(
-                new PatchPathOperation(FIELD_CREDENTIALS, JsonPatchOp.REPLACE), (operation) -> validateReplaceCredentialsOperation(operation, paymentProvider)
+                new PatchPathOperation(FIELD_CREDENTIALS, JsonPatchOp.REPLACE), (operation) -> validateReplaceCredentialsOperation(operation, paymentProvider),
+                new PatchPathOperation(FIELD_LAST_UPDATED_BY_USER, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString
         );
         var patchRequestValidator = new JsonPatchRequestValidator(operationValidators);
         patchRequestValidator.validate(patchRequest);

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -147,4 +147,8 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
     public void setExternalId(String externalId) {
         this.externalId = externalId;
     }
+
+    public void setLastUpdatedByUserExternalId(String lastUpdatedByUserExternalId) {
+        this.lastUpdatedByUserExternalId = lastUpdatedByUserExternalId;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import static java.lang.String.format;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountCredentialsRequestValidator.FIELD_CREDENTIALS;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountCredentialsRequestValidator.FIELD_LAST_UPDATED_BY_USER;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ENTERED;
@@ -105,6 +106,8 @@ public class GatewayAccountCredentialsService {
                     for (JsonPatchRequest updateRequest : updateRequests) {
                         if (updateRequest.getPath().equals(FIELD_CREDENTIALS) && updateRequest.getOp() == JsonPatchOp.REPLACE) {
                             gatewayAccountCredentialsEntity.setCredentials(updateRequest.valueAsObject());
+                        } else if (updateRequest.getPath().equals(FIELD_LAST_UPDATED_BY_USER) && updateRequest.getOp() == JsonPatchOp.REPLACE) {
+                            gatewayAccountCredentialsEntity.setLastUpdatedByUserExternalId(updateRequest.valueAsString());
                         }
                     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
@@ -103,14 +103,31 @@ public class GatewayAccountCredentialsRequestValidatorTest {
     }
 
     @Test
+    public void shouldThrowWhenLastUpdatedByUserExternalIdIsNotAString() {
+        JsonNode request = objectMapper.valueToTree(
+                Collections.singletonList(
+                        Map.of("path", "last_updated_by_user_external_id",
+                                "op", "replace",
+                                "value", 1)
+                ));
+        var thrown = assertThrows(ValidationException.class, () -> validator.validatePatch(request, "worldpay"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [last_updated_by_user_external_id] must be a string"));
+    }
+
+    @Test
     public void shouldNotThrowWhenValidPatchRequest() {
         Map<String, Object> credentials = Map.of(
                 "merchant_id", "some-merchant-id"
         );
         JsonNode request = objectMapper.valueToTree(
-                Collections.singletonList(Map.of("path", "credentials",
-                        "op", "replace",
-                        "value", credentials)));
+                List.of(
+                        Map.of("path", "credentials",
+                                "op", "replace",
+                                "value", credentials),
+                        Map.of("path", "last_updated_by_user_external_id",
+                                "op", "replace",
+                                "value", "a-user-external-id")
+                ));
         assertDoesNotThrow(() -> validator.validatePatch(request, "worldpay"));
     }
 }


### PR DESCRIPTION
Accept a `replace` operation for path `last_updated_by_user_external_id` for the patch gateway account credentials by id endpoint.
