### PR TITLE
PP-8245: Reduce number of hosted graphite metrics

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
@@ -63,10 +63,9 @@ public class AuthorisationService {
     }
 
     void emitAuthorisationMetric(ChargeEntity charge, String operation) {
-        metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.%s.result.%s",
+        metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.result.%s",
                 charge.getGatewayAccount().getGatewayName(),
                 charge.getGatewayAccount().getType(),
-                charge.getGatewayAccount().getId(),
                 operation,
                 charge.getStatus())
         ).inc();

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -104,10 +104,9 @@ public class CardAuthoriseService {
             );
             
             metricRegistry.counter(String.format(
-                    "gateway-operations.%s.%s.%s.authorise.%s.result.%s",
+                    "gateway-operations.%s.%s.authorise.%s.result.%s",
                     updatedCharge.getGatewayAccount().getGatewayName(),
                     updatedCharge.getGatewayAccount().getType(),
-                    updatedCharge.getGatewayAccount().getId(),
                     authorisationRequestSummary.billingAddress() == PRESENT ? "with-billing-address" : "without-billing-address",
                     newStatus.toString())).inc();
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -122,10 +122,10 @@ public class CardCaptureService {
                 charge.getGatewayAccount().getAnalyticsId(), charge.getGatewayAccount().getId(),
                 captureResponse, oldStatus, nextStatus);
 
-        metricRegistry.counter(format("gateway-operations.%s.%s.%s.capture.result.%s",
+        metricRegistry.counter(format("gateway-operations.%s.%s.capture.result.%s",
                 charge.getGatewayAccount().getGatewayName(),
                 charge.getGatewayAccount().getType(),
-                charge.getGatewayAccount().getId(), nextStatus.toString())).inc();
+                nextStatus.toString())).inc();
 
         if (captureResponse.isSuccessful() && charge.isDelayedCapture()) {
             userNotificationService.sendPaymentConfirmedEmail(charge, charge.getGatewayAccount());

--- a/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
@@ -93,10 +93,9 @@ public class StateTransitionService {
 
     private void incrementPerGatewayAccountStateTransitionCounter(ChargeStatus targetChargeState, ChargeEventEntity chargeEventEntity) {
         metricRegistry.counter(String.format(
-                "state-transition.%s.%s.%s.to.%s",
+                "state-transition.%s.%s.to.%s",
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getType(),
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getGatewayName(),
-                chargeEventEntity.getChargeEntity().getGatewayAccount().getId(),
                 targetChargeState)).inc();
     }
     

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -117,10 +117,9 @@ public class WalletAuthoriseService {
 
         LOGGER.info("{} authorisation {} - charge_external_id={}, payment provider response={}",
                 walletType.toString(), successOrFailure, chargeEntity.getExternalId(), operationResponse.toString());
-        metricRegistry.counter(format("gateway-operations.%s.%s.%s.authorise.%s.result.%s",
+        metricRegistry.counter(format("gateway-operations.%s.%s.authorise.%s.result.%s",
                 chargeEntity.getGatewayAccount().getGatewayName(),
                 chargeEntity.getGatewayAccount().getType(),
-                chargeEntity.getGatewayAccount().getId(),
                 walletType.equals(WalletType.GOOGLE_PAY) ? "google-pay" : "apple-pay",
                 successOrFailure)).inc();
     }


### PR DESCRIPTION
We are frequently exceeding our hosted graphite metric limit. We can probably
drop the metrics at the gateway account id level, which is what this commit
does. If we do need granular metrics by gateway account ids this would normally
be done by splunk anyway.

