### PR TITLE
PP-8198 Move integration tests to unit tests

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
-import uk.gov.pay.connector.gateway.worldpay.exception.NotAWorldpayGatewayAccountException;
 import uk.gov.pay.connector.gateway.worldpay.exception.UnexpectedValidateCredentialsResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
@@ -18,7 +17,6 @@ import java.util.Map;
 import static java.lang.String.format;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static uk.gov.pay.connector.gateway.GatewayResponseUnmarshaller.unmarshallResponse;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getWorldpayCredentialsCheckAuthHeader;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayInquiryRequestBuilder;
 
@@ -37,10 +35,6 @@ public class WorldpayCredentialsValidationService implements WorldpayGatewayResp
     }
 
     public boolean validateCredentials(GatewayAccountEntity gatewayAccountEntity, WorldpayCredentials worldpayCredentials) {
-        if (!gatewayAccountEntity.getGatewayName().equals(WORLDPAY.getName())) {
-            throw new NotAWorldpayGatewayAccountException(gatewayAccountEntity.getId());
-        }
-
         GatewayOrder order = aWorldpayInquiryRequestBuilder()
                 .withTransactionId("an-order-id-that-will-not-exist")
                 .withMerchantCode(worldpayCredentials.getMerchantId())

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceIT.java
@@ -3,7 +3,6 @@ package uk.gov.pay.connector.gatewayaccount.resource;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.gson.Gson;
 import io.restassured.specification.RequestSpecification;
-import junitparams.Parameters;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
@@ -20,10 +19,8 @@ import uk.gov.pay.connector.junit.DropwizardTestContext;
 import uk.gov.pay.connector.junit.TestContext;
 import uk.gov.pay.connector.rules.WorldpayMockClient;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -130,85 +127,6 @@ public class GatewayAccountCredentialsResourceIT {
     }
 
     @Test
-    public void should_return_404_when_validating_3ds_flex_credentials_if_gateway_account_does_not_exist() throws Exception {
-        givenSetup()
-                .body(getCheck3dsConfigPayloadForValidCredentials())
-                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, accountId - 1))
-                .then()
-                .statusCode(HttpStatus.SC_NOT_FOUND);
-    }
-
-    @Test
-    public void should_return_422_if_organisation_unit_id_not_in_correct_format() throws Exception {
-        var payload = objectMapper.writeValueAsString(Map.of("issuer", VALID_ISSUER,
-                "organisational_unit_id", "incorrectFormat",
-                "jwt_mac_key", VALID_JWT_MAC_KEY));
-
-        verifyIncorrectFormat(payload, "Field [organisational_unit_id] must be 24 lower-case hexadecimal characters");
-    }
-
-    @Test
-    public void should_return_422_if_organisation_unit_id_is_null() throws Exception {
-        var jsonFields = new HashMap<String, String>();
-        jsonFields.put("issuer", VALID_ISSUER);
-        jsonFields.put("organisational_unit_id", null);
-        jsonFields.put("jwt_mac_key", VALID_JWT_MAC_KEY);
-        var payload = objectMapper.writeValueAsString(jsonFields);
-
-        verifyIncorrectFormat(payload, "Field [organisational_unit_id] must be 24 lower-case hexadecimal characters");
-    }
-
-    @Test
-    public void should_return_422_if_issuer_not_in_correct_format() throws Exception {
-        var payload = objectMapper.writeValueAsString(Map.of("issuer", "44992i087n0v4849895al9i3",
-                "organisational_unit_id", VALID_ORG_UNIT_ID,
-                "jwt_mac_key", VALID_JWT_MAC_KEY));
-
-        verifyIncorrectFormat(payload, "Field [issuer] must be 24 lower-case hexadecimal characters");
-    }
-
-    @Test
-    public void should_return_422_if_issuer_is_null() throws Exception {
-        var jsonFields = new HashMap<String, String>();
-        jsonFields.put("issuer", null);
-        jsonFields.put("organisational_unit_id", VALID_ORG_UNIT_ID);
-        jsonFields.put("jwt_mac_key", VALID_JWT_MAC_KEY);
-        var payload = objectMapper.writeValueAsString(jsonFields);
-
-        verifyIncorrectFormat(payload, "Field [issuer] must be 24 lower-case hexadecimal characters");
-    }
-
-    @Test
-    public void should_return_422_if_jwt_mac_key_not_in_correct_format() throws Exception {
-        var payload = objectMapper.writeValueAsString(Map.of("issuer", VALID_ISSUER,
-                "organisational_unit_id", VALID_ORG_UNIT_ID,
-                "jwt_mac_key", "hihihihi"));
-
-        verifyIncorrectFormat(payload, "Field [jwt_mac_key] must be a UUID in its lowercase canonical representation");
-    }
-
-    @Test
-    public void should_return_422_if_jwt_mac_key_is_null() throws Exception {
-        var jsonFields = new HashMap<String, String>();
-        jsonFields.put("issuer", VALID_ISSUER);
-        jsonFields.put("organisational_unit_id", VALID_ORG_UNIT_ID);
-        jsonFields.put("jwt_mac_key", null);
-        var payload = objectMapper.writeValueAsString(jsonFields);
-
-        verifyIncorrectFormat(payload, "Field [jwt_mac_key] must be a UUID in its lowercase canonical representation");
-    }
-
-    private void verifyIncorrectFormat(String payload, String expectedErrorMessage) {
-        givenSetup()
-                .body(payload)
-                .post(format(VALIDATE_3DS_FLEX_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
-                .body("error_identifier", is(ErrorIdentifier.GENERIC.name()))
-                .body("message[0]", is(expectedErrorMessage));
-    }
-
-    @Test
     public void setWorldpay3dsFlexCredentialsWhenThereAreNonExisting() throws JsonProcessingException {
         String payload = objectMapper.writeValueAsString(Map.of(
                 "issuer", VALID_ISSUER,
@@ -259,152 +177,6 @@ public class GatewayAccountCredentialsResourceIT {
     }
 
     @Test
-    @Parameters({
-            "jwt_mac_key, Field [jwt_mac_key] must be a UUID in its lowercase canonical representation",
-            "issuer, Field [issuer] must be 24 lower-case hexadecimal characters",
-            "organisational_unit_id, Field [organisational_unit_id] must be 24 lower-case hexadecimal characters",
-    })
-    public void update3dsFlexCredentials_missingFieldsReturnCorrectError(String key, String expectedErrorMessage) throws JsonProcessingException {
-        Map<String, String> jsonFields = new HashMap<>();
-        jsonFields.put("issuer", "57992a087a0c4849895ab8a2"); // pragma: allowlist secret`
-        jsonFields.put("organisational_unit_id", "57992a087a0c4849895ab8a2"); // pragma: allowlist secret`
-        jsonFields.put("jwt_mac_key", "512ee2a9-4a3e-46d4-86df-8e2ac3d6a6a8"); // pragma: allowlist secret`
-        jsonFields.remove(key);
-
-        givenSetup()
-                .body(objectMapper.writeValueAsString(jsonFields))
-                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, testAccount.getAccountId()))
-                .then()
-                .statusCode(422)
-                .body("message[0]", is(expectedErrorMessage));
-    }
-
-    @Test
-    public void update3dsFlexCredentials_nonExistentGatewayAccountReturns404() throws JsonProcessingException {
-        Long fakeAccountId = RandomUtils.nextLong();
-        givenSetup()
-                .body(getCheck3dsConfigPayloadForValidCredentials())
-                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, fakeAccountId))
-                .then()
-                .statusCode(404)
-                .body("message[0]", is("Not a Worldpay gateway account"));
-    }
-
-    @Test
-    public void update3dsFlexCredentials_nonWorldpayGatewayAccountReturns404() throws JsonProcessingException {
-        long fakeAccountId = RandomUtils.nextLong();
-        databaseFixtures.aTestAccount().withPaymentProvider("smartpay")
-                .withIntegrationVersion3ds(2)
-                .withAccountId(fakeAccountId)
-                .insert();
-        givenSetup()
-                .body(getCheck3dsConfigPayloadForValidCredentials())
-                .post(format(UPDATE_3DS_FLEX_CREDENTIALS_URL, fakeAccountId))
-                .then()
-                .statusCode(404)
-                .body("message[0]", is("Not a Worldpay gateway account"));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_nonWorldpayGatewayAccountReturns404() throws JsonProcessingException {
-        long accountId = RandomUtils.nextLong();
-        databaseFixtures.aTestAccount().withAccountId(accountId).withPaymentProvider("smartpay").insert();
-        givenSetup()
-                .body(getValidWorldpayCredentials())
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(404)
-                .body("message[0]", is(format("Gateway account with id %s is not a Worldpay account.", accountId)));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_nonExistentGatewayAccountReturns404() throws JsonProcessingException {
-        long accountId = RandomUtils.nextLong();
-        givenSetup()
-                .body(getValidWorldpayCredentials())
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(404)
-                .body("message[0]", is(format("Gateway Account with id [%s] not found.", accountId)));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_returns422WhenUsernameMissing() throws JsonProcessingException {
-        long accountId = RandomUtils.nextLong();
-        String body = objectMapper.writeValueAsString(Map.of(
-                "username", "",
-                "password", "valid-password",
-                "merchant_id", "valid-merchant-id"
-        ));
-        givenSetup()
-                .body(body)
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(422)
-                .body("message[0]", is("Field [username] is required"));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_returns422WhenPasswordMissing() throws JsonProcessingException {
-        long accountId = RandomUtils.nextLong();
-        String body = objectMapper.writeValueAsString(Map.of(
-                "username", "valid-username",
-                "password", "",
-                "merchant_id", "valid-merchant-id"
-        ));
-        givenSetup()
-                .body(body)
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(422)
-                .body("message[0]", is("Field [password] is required"));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_returns422WhenMerchantIdMissing() throws JsonProcessingException {
-        long accountId = RandomUtils.nextLong();
-        String body = objectMapper.writeValueAsString(Map.of(
-                "username", "valid-username",
-                "password", "valid-password",
-                "merchant_id", ""
-        ));
-        givenSetup()
-                .body(body)
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(422)
-                .body("message[0]", is("Field [merchant_id] is required"));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_returnsValid() throws JsonProcessingException {
-        worldpayMockClient.mockCredentialsValidationValid();
-
-        long accountId = RandomUtils.nextLong();
-        databaseFixtures.aTestAccount().withAccountId(accountId).withPaymentProvider("worldpay").insert();
-        givenSetup()
-                .body(getValidWorldpayCredentials())
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(200)
-                .body("result", is("valid"));
-    }
-
-    @Test
-    public void checkWorldpayCredentials_returnsInvalid() throws JsonProcessingException {
-        worldpayMockClient.mockCredentialsValidationInvalid();
-
-        long accountId = RandomUtils.nextLong();
-        databaseFixtures.aTestAccount().withAccountId(accountId).withPaymentProvider("worldpay").insert();
-        givenSetup()
-                .body(getValidWorldpayCredentials())
-                .post(format(VALIDATE_WORLDPAY_CREDENTIALS_URL, accountId))
-                .then()
-                .statusCode(200)
-                .body("result", is("invalid"));
-    }
-
-    @Test
     public void checkWorldpayCredentials_returns500WhenWorldpayReturnsUnexpectedResponse() throws JsonProcessingException {
         worldpayMockClient.mockCredentialsValidationUnexpectedResponse();
 
@@ -435,15 +207,6 @@ public class GatewayAccountCredentialsResourceIT {
                 .body("gateway_account_credentials[1].payment_provider", is("stripe"))
                 .body("gateway_account_credentials[1].credentials.stripe_account_id", is("some-account-id"))
                 .body("gateway_account_credentials[1].external_id", is(notNullValue(String.class)));
-    }
-
-    @Test
-    public void createGatewayAccountsCredentialsMissingAccount_responseShouldBe404() {
-        givenSetup()
-                .body(toJson(Map.of("payment_provider", "worldpay")))
-                .post("/v1/api/accounts/10000/credentials")
-                .then()
-                .statusCode(404);
     }
 
     @Test
@@ -504,28 +267,9 @@ public class GatewayAccountCredentialsResourceIT {
                 .statusCode(400)
                 .body("message[0]", is("Field [value] is required"));
     }
-
-    @Test
-    public void patchGatewayAccountCredentialsGatewayAccountNotFound_shouldReturn404() {
-        Long credentialsId = (Long) databaseTestHelper.getGatewayAccountCredentialsForAccount(accountId).get(0).get("id");
-
-        Map<String, String> newCredentials = Map.of("username", "new-username",
-                "password", "new-password",
-                "merchant_id", "new-merchant-id");
-        givenSetup()
-                .body(toJson(Collections.singletonList(
-                        Map.of("op", "replace",
-                                "path", "credentials",
-                                "value", newCredentials))))
-                .patch(format(PATCH_CREDENTIALS_URL, 10000, credentialsId))
-                .then()
-                .statusCode(404)
-                .body("message[0]", is("Gateway Account with id [10000] not found."));
-    }
-
+    
     @Test
     public void patchGatewayAccountCredentialsGatewayAccountCredentialsNotFound_shouldReturn404() {
-
         Map<String, String> newCredentials = Map.of("username", "new-username",
                 "password", "new-password",
                 "merchant_id", "new-merchant-id");

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
@@ -1,0 +1,377 @@
+package uk.gov.pay.connector.gatewayaccount.resource;
+
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.testcontainers.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
+import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
+import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexCredentialsValidationService;
+import uk.gov.pay.connector.gateway.worldpay.WorldpayCredentialsValidationService;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccount.service.Worldpay3dsFlexCredentialsService;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.util.JsonEncoder.toJson;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class GatewayAccountCredentialsResourceTest {
+
+    private static final GatewayAccountService gatewayAccountService = mock(GatewayAccountService.class);
+    private static final GatewayAccountCredentialsService gatewayAccountCredentialsService = mock(GatewayAccountCredentialsService.class);
+    private static final Worldpay3dsFlexCredentialsService worldpay3dsFlexCredentialsService = mock(Worldpay3dsFlexCredentialsService.class);
+    private static final Worldpay3dsFlexCredentialsValidationService worldpay3dsFlexCredentialsValidationService = mock(Worldpay3dsFlexCredentialsValidationService.class);
+    private static final WorldpayCredentialsValidationService worldpayCredentialsValidationService = mock(WorldpayCredentialsValidationService.class);
+    private static final GatewayAccountCredentialsRequestValidator gatewayAccountCredentialsRequestValidator = mock(GatewayAccountCredentialsRequestValidator.class);
+
+    public static ResourceExtension resources = ResourceExtension.builder()
+            .addResource(new GatewayAccountCredentialsResource(
+                    gatewayAccountService,
+                    gatewayAccountCredentialsService,
+                    worldpay3dsFlexCredentialsService,
+                    worldpay3dsFlexCredentialsValidationService,
+                    worldpayCredentialsValidationService,
+                    gatewayAccountCredentialsRequestValidator
+            ))
+            .setRegisterDefaultExceptionMappers(false)
+            .addProvider(ConstraintViolationExceptionMapper.class)
+            .addProvider(ValidationExceptionMapper.class)
+            .build();
+
+    public static final String VALID_ISSUER = "53f0917f101a4428b69d5fb0"; // pragma: allowlist secret`
+    public static final String VALID_ORG_UNIT_ID = "57992a087a0c4849895ab8a2"; // pragma: allowlist secret`
+    public static final String VALID_JWT_MAC_KEY = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9"; // pragma: allowlist secret`
+
+    public static final Map<String, String> valid3dsFlexCredentialsPayload = Map.of(
+            "issuer", VALID_ISSUER,
+            "organisational_unit_id", VALID_ORG_UNIT_ID,
+            "jwt_mac_key", VALID_JWT_MAC_KEY);
+
+    private static final Map<String, String> validCheckWorldpayCredentialsPayload = Map.of(
+            "username", "valid-user-name",
+            "password", "valid-password",
+            "merchant_id", "valid-merchant-id"
+    );
+
+    private final long accountId = 111;
+    private final GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+            .withId(accountId)
+            .withGatewayName("worldpay")
+            .build();
+    private final long smartpayAccountId = 333;
+    public final GatewayAccountEntity smartpayGatewayAccountEntity = aGatewayAccountEntity()
+            .withId(smartpayAccountId)
+            .withGatewayName("smartpay")
+            .build();
+
+    @Test
+    void validate3dsCredentialsGatewayAccountNotFound_shouldReturn404() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
+
+        var payload = valid3dsFlexCredentialsPayload;
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-3ds-flex-config", accountId))
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Gateway Account with id [111] not found."));
+    }
+
+    @Test
+    void organisationalUnitIdNotInCorrectFormat_shouldReturn422() {
+        var payload = Map.of(
+                "issuer", VALID_ISSUER,
+                "organisational_unit_id", "incorrect format",
+                "jwt_mac_key", VALID_JWT_MAC_KEY);
+
+        verifyCheckWordlapy3dsCredentialsValidationError(payload, "Field [organisational_unit_id] must be 24 lower-case hexadecimal characters");
+    }
+
+    @Test
+    public void organisationalUnitIdNull_shouldReturn422() throws Exception {
+        var payload = new HashMap<String, String>();
+        payload.put("issuer", VALID_ISSUER);
+        payload.put("organisational_unit_id", null);
+        payload.put("jwt_mac_key", VALID_JWT_MAC_KEY);
+
+        verifyCheckWordlapy3dsCredentialsValidationError(payload, "Field [organisational_unit_id] must be 24 lower-case hexadecimal characters");
+    }
+
+    @Test
+    public void issuerNotInCorrectFormat_shouldReturn422() throws Exception {
+        var payload = Map.of("issuer", "44992i087n0v4849895al9i3",
+                "organisational_unit_id", VALID_ORG_UNIT_ID,
+                "jwt_mac_key", VALID_JWT_MAC_KEY);
+
+        verifyCheckWordlapy3dsCredentialsValidationError(payload, "Field [issuer] must be 24 lower-case hexadecimal characters");
+    }
+
+    @Test
+    public void issuerNull_shouldReturn422() throws Exception {
+        var payload = new HashMap<String, String>();
+        payload.put("issuer", null);
+        payload.put("organisational_unit_id", VALID_ORG_UNIT_ID);
+        payload.put("jwt_mac_key", VALID_JWT_MAC_KEY);
+
+        verifyCheckWordlapy3dsCredentialsValidationError(payload, "Field [issuer] must be 24 lower-case hexadecimal characters");
+    }
+
+    @Test
+    public void jwtMacKeyNotInCorrectFormat_shouldReturn422() throws Exception {
+        var payload = Map.of("issuer", VALID_ISSUER,
+                "organisational_unit_id", VALID_ORG_UNIT_ID,
+                "jwt_mac_key", "hihihihi");
+
+        verifyCheckWordlapy3dsCredentialsValidationError(payload, "Field [jwt_mac_key] must be a UUID in its lowercase canonical representation");
+    }
+
+    @Test
+    public void jwtMacKeyNull_shouldReturn422() throws Exception {
+        var payload = new HashMap<String, String>();
+        payload.put("issuer", VALID_ISSUER);
+        payload.put("organisational_unit_id", VALID_ORG_UNIT_ID);
+        payload.put("jwt_mac_key", null);
+
+        verifyCheckWordlapy3dsCredentialsValidationError(payload, "Field [jwt_mac_key] must be a UUID in its lowercase canonical representation");
+    }
+
+    private void verifyCheckWordlapy3dsCredentialsValidationError(Map<String, String> payload, String expectedErrorMessage) {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(gatewayAccountEntity));
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-3ds-flex-config", accountId))
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(422));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is(expectedErrorMessage));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "jwt_mac_key, Field [jwt_mac_key] must be a UUID in its lowercase canonical representation",
+            "issuer, Field [issuer] must be 24 lower-case hexadecimal characters",
+            "organisational_unit_id, Field [organisational_unit_id] must be 24 lower-case hexadecimal characters",
+    })
+    public void update3dsFlexCredentials_missingFieldsReturnCorrectError(String key, String expectedErrorMessage) throws JsonProcessingException {
+        Map<String, String> payload = new HashMap<>();
+        payload.put("issuer", VALID_ISSUER);
+        payload.put("organisational_unit_id", VALID_ORG_UNIT_ID);
+        payload.put("jwt_mac_key", VALID_JWT_MAC_KEY);
+        payload.remove(key);
+
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(gatewayAccountEntity));
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/3ds-flex-credentials", accountId))
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(422));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is(expectedErrorMessage));
+    }
+
+    @Test
+    public void update3dsFlexCredentials_nonExistentGatewayAccountReturns404() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/3ds-flex-credentials", accountId))
+                .request()
+                .post(Entity.json(valid3dsFlexCredentialsPayload));
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Not a Worldpay gateway account"));
+    }
+
+    @Test
+    public void update3dsFlexCredentials_nonWorldpayGatewayAccountReturns404() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(smartpayGatewayAccountEntity));
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/3ds-flex-credentials", accountId))
+                .request()
+                .post(Entity.json(valid3dsFlexCredentialsPayload));
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Not a Worldpay gateway account"));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_nonWorldpayGatewayAccountReturns404() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(smartpayGatewayAccountEntity));
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
+                .request()
+                .post(Entity.json(validCheckWorldpayCredentialsPayload));
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is(format("Gateway account with id %s is not a Worldpay account.", smartpayAccountId)));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_nonExistentGatewayAccountReturns404() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
+                .request()
+                .post(Entity.json(validCheckWorldpayCredentialsPayload));
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is(format("Gateway Account with id [%s] not found.", accountId)));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_returns422WhenUsernameMissing() {
+        var payload = Map.of(
+                "username", "",
+                "password", "valid-password",
+                "merchant_id", "valid-merchant-id"
+        );
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(422));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Field [username] is required"));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_returns422WhenPasswordMissing() throws JsonProcessingException {
+        var payload = Map.of(
+                "username", "valid-username",
+                "password", "",
+                "merchant_id", "valid-merchant-id"
+        );
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(422));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Field [password] is required"));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_returns422WhenMerchantIdMissing() throws JsonProcessingException {
+        var payload = Map.of(
+                "username", "valid-username",
+                "password", "valid-password",
+                "merchant_id", ""
+        );
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(422));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Field [merchant_id] is required"));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_returnsValid() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials(
+                validCheckWorldpayCredentialsPayload.get("merchant_id"),
+                validCheckWorldpayCredentialsPayload.get("username"),
+                validCheckWorldpayCredentialsPayload.get("password"));
+
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(gatewayAccountEntity));
+        when(worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials)).thenReturn(true);
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
+                .request()
+                .post(Entity.json(validCheckWorldpayCredentialsPayload));
+
+        verify(worldpayCredentialsValidationService).validateCredentials(gatewayAccountEntity, worldpayCredentials);
+
+        assertThat(response.getStatus(), is(200));
+        Map<String, Object> responseBody = response.readEntity(new GenericType<HashMap>() {
+        });
+        assertThat(responseBody, hasEntry("result", "valid"));
+    }
+
+    @Test
+    public void checkWorldpayCredentials_returnsInvalid() {
+        WorldpayCredentials worldpayCredentials = new WorldpayCredentials(
+                validCheckWorldpayCredentialsPayload.get("merchant_id"),
+                validCheckWorldpayCredentialsPayload.get("username"),
+                validCheckWorldpayCredentialsPayload.get("password"));
+
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(gatewayAccountEntity));
+        when(worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials)).thenReturn(false);
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
+                .request()
+                .post(Entity.json(validCheckWorldpayCredentialsPayload));
+
+        verify(worldpayCredentialsValidationService).validateCredentials(gatewayAccountEntity, worldpayCredentials);
+
+        assertThat(response.getStatus(), is(200));
+        Map<String, Object> responseBody = response.readEntity(new GenericType<HashMap>() {
+        });
+        assertThat(responseBody, hasEntry("result", "invalid"));
+    }
+    
+    @Test
+    void createGatewayAccountCredentialsGatewayAccountNotFound_shouldReturn404() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/credentials", accountId))
+                .request()
+                .post(Entity.json(Map.of("payment_provider", "worldpay")));
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Gateway Account with id [111] not found."));
+    }
+
+    @Test
+    public void patchGatewayAccountCredentialsGatewayAccountNotFound_shouldReturn404() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
+
+        var payload = Collections.singletonList(
+                Map.of("op", "replace",
+                        "path", "last_updated_by_user_external_id",
+                        "value", "a-user-id")
+        );
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/credentials/222", accountId))
+                .request()
+                .method("PATCH", Entity.json(payload));
+
+        assertThat(response.getStatus(), is(404));
+        assertThat(extractErrorMessagesFromResponse(response).get(0), is("Gateway Account with id [111] not found."));
+    }
+
+    private List extractErrorMessagesFromResponse(Response response) {
+        var responseBody = response.readEntity(new GenericType<HashMap>() {
+        });
+        return (List) responseBody.get("message");
+    }
+}


### PR DESCRIPTION
Move tests from GatewayAccountCredentialsResourceIT to unit tests where they are only testing validation or logic in the resource itself in order to improve test runtime.