### PR TITLE
PP-8125 - Ledger payment created events use ChargeEntity.getPaymentProvider() method

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentCreatedEventDetails.java
@@ -71,7 +71,7 @@ public class PaymentCreatedEventDetails extends EventDetails {
                 .withReference(charge.getReference().toString())
                 .withReturnUrl(charge.getReturnUrl())
                 .withGatewayAccountId(charge.getGatewayAccount().getId())
-                .withPaymentProvider(charge.getGatewayAccount().getGatewayName())
+                .withPaymentProvider(charge.getPaymentProvider())
                 .withLanguage(charge.getLanguage().toString())
                 .withDelayedCapture(charge.isDelayedCapture())
                 .withLive(charge.getGatewayAccount().isLive())

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/PaymentNotificationCreatedEventDetails.java
@@ -75,7 +75,7 @@ public class PaymentNotificationCreatedEventDetails extends EventDetails {
                 cardDetails.map(CardDetailsEntity::getCardBrand).orElse(null),
                 cardDetails.flatMap(CardDetailsEntity::getCardTypeDetails).map(CardBrandLabelEntity::getLabel).orElse(null),
                 charge.getGatewayAccount().isLive(),
-                charge.getGatewayAccount().getGatewayName(),
+                charge.getPaymentProvider(),
                 charge.getExternalMetadata().map(ExternalMetadata::getMetadata).orElse(null),
                 charge.getSource(),
                 charge.getLanguage().toString());

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentNotificationCreatedTest.java
@@ -1,14 +1,14 @@
 package uk.gov.pay.connector.events.model.charge;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.junit.Before;
-import org.junit.Test;
-import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.CardDetailsEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import java.time.Instant;
 import java.util.Map;
@@ -19,8 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 import static uk.gov.pay.connector.model.domain.AuthCardDetailsFixture.anAuthCardDetails;
+import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHONE;
 
 public class PaymentNotificationCreatedTest {
 
@@ -30,8 +30,8 @@ public class PaymentNotificationCreatedTest {
 
     private ChargeEntityFixture chargeEntityFixture;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         chargeEntityFixture = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.parse(time))
                 .withStatus(ChargeStatus.PAYMENT_NOTIFICATION_CREATED)
@@ -43,7 +43,7 @@ public class PaymentNotificationCreatedTest {
     }
 
     @Test
-    public void whenAllTheDataIsAvailable() throws JsonProcessingException {
+    void whenAllTheDataIsAvailable() throws JsonProcessingException {
         ExternalMetadata externalMetadata = new ExternalMetadata(Map.of(
                 "processor_id", "processorID",
                 "auth_code", "012345",
@@ -81,7 +81,7 @@ public class PaymentNotificationCreatedTest {
     }
 
     @Test
-    public void whenCardDetailsAndMetadataAreNotAvailable() throws JsonProcessingException {
+    void whenCardDetailsAndMetadataAreNotAvailable() throws JsonProcessingException {
         chargeEntityFixture
                 .withCardDetails(null)
                 .withExternalMetadata(null);
@@ -114,7 +114,7 @@ public class PaymentNotificationCreatedTest {
     }
 
     @Test
-    public void whenCardDetailsIsAvailableButNotAllItsFieldsAre() throws JsonProcessingException {
+    void whenCardDetailsIsAvailableButNotAllItsFieldsAre() throws JsonProcessingException {
         CardDetailsEntity cardDetailsEntity = new CardDetailsEntity();
         cardDetailsEntity.setCardHolderName("Mr Test");
 


### PR DESCRIPTION
Description:
- Refactors tests to use JUnit 5 and method sources transformed to static methods to use @ParameterizedTest annotation
- Both PaymentCreatedEventDetails and PaymentNotificationCreatedEventDetails use ChargeEntity.getPaymentProvider()