### PR TITLE
PP-8198 Fix patch response and add API docs

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -2625,14 +2625,14 @@ HTTP/1.1 404 Not Found
 HTTP/1.1 404 Not Found
 ```
 
-## POST /v1/api/accounts/{accountId}/stripe-setup
+## PATCH /v1/api/accounts/{accountId}/stripe-setup
 
 Updates which Stripe Connect account setup tasks have been completed for a given `accountId`
 
 ### Request example
 
 ```
-POST /v1/api/accounts/123/stripe-setup
+PATCH /v1/api/accounts/123/stripe-setup
 [
     {
         "op": "replace",
@@ -3052,3 +3052,58 @@ Content-Type: application/json
 ```
 
 -----------------------------------------------------------------------------------------------------------
+
+## PATCH /v1/api/accounts/{accountId}/credentials/{credentialsId}
+
+Updates the gateway account credentials with the given `credentials` id for a given `accountId`.
+
+### Request example
+
+```
+PATCH /v1/api/accounts/123/credentials/456
+[
+    {
+        "op": "replace",
+        "path": "credentials",
+        "value": {
+            "username": "foo",
+            "password": "bar",
+            "merchant_id": "baz"
+        }
+    },
+    {
+        "op": "replace",
+        "path": "last_updated_by_user_external_id",
+        "value": "abc123"
+    }
+]
+```
+
+### Request field description
+| Field  | Required | Description                               |
+| ------ |:--------:|------------- |
+| `op`    | X | Must be `"replace"` |
+| `path`  | X | The field to update (`"credentials"` or `"last_updated_by_user_external_id"`) |
+| `value` | X | The value to update the field with |
+
+### Response example
+
+```
+HTTP/1.1 200 OK
+
+{
+  "external_id": "cbb184e7389e4babb52f5628466b226b",
+  "payment_provider": "worldpay",
+  "credentials": {
+    "merchant_id": "baz",
+    "username": "foo"
+  },
+  "state": "ACTIVE",
+  "last_updated_by_user_external_id": "abc123",
+  "created_date": "2021-06-11T13:43:51.464Z",
+  "active_start_date": "2021-06-11T13:43:51.464Z",
+  "active_end_date": null,
+  "gateway_account_id": 1,
+  "gateway_account_credential_id": 1
+}
+```

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountCredentials.java
@@ -45,6 +45,7 @@ public class GatewayAccountCredentials {
         this.paymentProvider = entity.getPaymentProvider();
         this.state = entity.getState();
         this.lastUpdatedByUserExternalId = entity.getLastUpdatedByUserExternalId();
+        this.createdDate = entity.getCreatedDate();
         this.activeStartDate = entity.getActiveStartDate();
         this.activeEndDate = entity.getActiveEndDate();
         this.gatewayAccountId = entity.getGatewayAccountEntity().getId();

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
@@ -69,6 +69,9 @@ public class GatewayAccountCredentialsRequestValidator {
     }
 
     public List<String> getMissingCredentialsFields(Map<String, String> credentials, String paymentProvider) {
+        if (!providerCredentialFields.containsKey(paymentProvider)) {
+            throw new UnsupportedOperationException(format("Cannot perform operation for payment provider [%s]", paymentProvider));
+        }
         return providerCredentialFields.get(paymentProvider).stream()
                 .filter(requiredField -> !credentials.containsKey(requiredField))
                 .collect(Collectors.toList());

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
@@ -60,11 +60,11 @@ public class GatewayAccountCredentialsResourceTest {
             .addProvider(ValidationExceptionMapper.class)
             .build();
 
-    public static final String VALID_ISSUER = "53f0917f101a4428b69d5fb0"; // pragma: allowlist secret`
-    public static final String VALID_ORG_UNIT_ID = "57992a087a0c4849895ab8a2"; // pragma: allowlist secret`
-    public static final String VALID_JWT_MAC_KEY = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9"; // pragma: allowlist secret`
+    private static final String VALID_ISSUER = "53f0917f101a4428b69d5fb0"; // pragma: allowlist secret`
+    private static final String VALID_ORG_UNIT_ID = "57992a087a0c4849895ab8a2"; // pragma: allowlist secret`
+    private static final String VALID_JWT_MAC_KEY = "4cabd5d2-0133-4e82-b0e5-2024dbeddaa9"; // pragma: allowlist secret`
 
-    public static final Map<String, String> valid3dsFlexCredentialsPayload = Map.of(
+    private static final Map<String, String> valid3dsFlexCredentialsPayload = Map.of(
             "issuer", VALID_ISSUER,
             "organisational_unit_id", VALID_ORG_UNIT_ID,
             "jwt_mac_key", VALID_JWT_MAC_KEY);
@@ -81,7 +81,7 @@ public class GatewayAccountCredentialsResourceTest {
             .withGatewayName("worldpay")
             .build();
     private final long smartpayAccountId = 333;
-    public final GatewayAccountEntity smartpayGatewayAccountEntity = aGatewayAccountEntity()
+    private final GatewayAccountEntity smartpayGatewayAccountEntity = aGatewayAccountEntity()
             .withId(smartpayAccountId)
             .withGatewayName("smartpay")
             .build();
@@ -112,7 +112,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void organisationalUnitIdNull_shouldReturn422() throws Exception {
+    void organisationalUnitIdNull_shouldReturn422() throws Exception {
         var payload = new HashMap<String, String>();
         payload.put("issuer", VALID_ISSUER);
         payload.put("organisational_unit_id", null);
@@ -122,7 +122,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void issuerNotInCorrectFormat_shouldReturn422() throws Exception {
+    void issuerNotInCorrectFormat_shouldReturn422() throws Exception {
         var payload = Map.of("issuer", "44992i087n0v4849895al9i3",
                 "organisational_unit_id", VALID_ORG_UNIT_ID,
                 "jwt_mac_key", VALID_JWT_MAC_KEY);
@@ -131,7 +131,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void issuerNull_shouldReturn422() throws Exception {
+    void issuerNull_shouldReturn422() throws Exception {
         var payload = new HashMap<String, String>();
         payload.put("issuer", null);
         payload.put("organisational_unit_id", VALID_ORG_UNIT_ID);
@@ -141,7 +141,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void jwtMacKeyNotInCorrectFormat_shouldReturn422() throws Exception {
+    void jwtMacKeyNotInCorrectFormat_shouldReturn422() throws Exception {
         var payload = Map.of("issuer", VALID_ISSUER,
                 "organisational_unit_id", VALID_ORG_UNIT_ID,
                 "jwt_mac_key", "hihihihi");
@@ -150,7 +150,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void jwtMacKeyNull_shouldReturn422() throws Exception {
+    void jwtMacKeyNull_shouldReturn422() throws Exception {
         var payload = new HashMap<String, String>();
         payload.put("issuer", VALID_ISSUER);
         payload.put("organisational_unit_id", VALID_ORG_UNIT_ID);
@@ -176,7 +176,7 @@ public class GatewayAccountCredentialsResourceTest {
             "issuer, Field [issuer] must be 24 lower-case hexadecimal characters",
             "organisational_unit_id, Field [organisational_unit_id] must be 24 lower-case hexadecimal characters",
     })
-    public void update3dsFlexCredentials_missingFieldsReturnCorrectError(String key, String expectedErrorMessage) throws JsonProcessingException {
+    void update3dsFlexCredentials_missingFieldsReturnCorrectError(String key, String expectedErrorMessage) throws JsonProcessingException {
         Map<String, String> payload = new HashMap<>();
         payload.put("issuer", VALID_ISSUER);
         payload.put("organisational_unit_id", VALID_ORG_UNIT_ID);
@@ -194,7 +194,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void update3dsFlexCredentials_nonExistentGatewayAccountReturns404() {
+    void update3dsFlexCredentials_nonExistentGatewayAccountReturns404() {
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
         Response response = resources
                 .target(format("/v1/api/accounts/%s/3ds-flex-credentials", accountId))
@@ -206,7 +206,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void update3dsFlexCredentials_nonWorldpayGatewayAccountReturns404() {
+    void update3dsFlexCredentials_nonWorldpayGatewayAccountReturns404() {
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(smartpayGatewayAccountEntity));
         Response response = resources
                 .target(format("/v1/api/accounts/%s/3ds-flex-credentials", accountId))
@@ -218,7 +218,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void checkWorldpayCredentials_nonWorldpayGatewayAccountReturns404() {
+    void checkWorldpayCredentials_nonWorldpayGatewayAccountReturns404() {
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(smartpayGatewayAccountEntity));
         Response response = resources
                 .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
@@ -230,7 +230,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void checkWorldpayCredentials_nonExistentGatewayAccountReturns404() {
+    void checkWorldpayCredentials_nonExistentGatewayAccountReturns404() {
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
         Response response = resources
                 .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
@@ -242,7 +242,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void checkWorldpayCredentials_returns422WhenUsernameMissing() {
+    void checkWorldpayCredentials_returns422WhenUsernameMissing() {
         var payload = Map.of(
                 "username", "",
                 "password", "valid-password",
@@ -259,7 +259,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void checkWorldpayCredentials_returns422WhenPasswordMissing() throws JsonProcessingException {
+    void checkWorldpayCredentials_returns422WhenPasswordMissing() throws JsonProcessingException {
         var payload = Map.of(
                 "username", "valid-username",
                 "password", "",
@@ -276,7 +276,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void checkWorldpayCredentials_returns422WhenMerchantIdMissing() throws JsonProcessingException {
+    void checkWorldpayCredentials_returns422WhenMerchantIdMissing() throws JsonProcessingException {
         var payload = Map.of(
                 "username", "valid-username",
                 "password", "valid-password",
@@ -293,7 +293,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void checkWorldpayCredentials_returnsValid() {
+    void checkWorldpayCredentials_returnsValid() {
         WorldpayCredentials worldpayCredentials = new WorldpayCredentials(
                 validCheckWorldpayCredentialsPayload.get("merchant_id"),
                 validCheckWorldpayCredentialsPayload.get("username"),
@@ -316,7 +316,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void checkWorldpayCredentials_returnsInvalid() {
+    void checkWorldpayCredentials_returnsInvalid() {
         WorldpayCredentials worldpayCredentials = new WorldpayCredentials(
                 validCheckWorldpayCredentialsPayload.get("merchant_id"),
                 validCheckWorldpayCredentialsPayload.get("username"),
@@ -352,7 +352,7 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    public void patchGatewayAccountCredentialsGatewayAccountNotFound_shouldReturn404() {
+    void patchGatewayAccountCredentialsGatewayAccountNotFound_shouldReturn404() {
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
 
         var payload = Collections.singletonList(

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.it.dao.DaoITestBase;
+import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 
 import java.util.Map;
 import java.util.Optional;
@@ -15,6 +16,8 @@ import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
@@ -53,12 +56,17 @@ public class GatewayAccountCredentialsDaoIT extends DaoITestBase {
     }
 
     @Test
-    public void hasActiveCredentialsShouldReturnFalseIfGatewayAccountHasNoCredentials() {
+    public void hasActiveCredentialsShouldReturnFalseIfGatewayAccountHasNoActiveCredentials() {
         long gatewayAccountId = nextLong();
+        AddGatewayAccountCredentialsParams credentialsParams = anAddGatewayAccountCredentialsParams()
+                .withState(CREATED)
+                .withPaymentProvider("stripe")
+                .withGatewayAccountId(gatewayAccountId)
+                .build();
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId))
                 .withPaymentGateway("stripe")
-                .withCredentials(null)
+                .withGatewayAccountCredentials(credentialsParams)
                 .withServiceName("a cool service")
                 .build());
 

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountCredentialsParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountCredentialsParams.java
@@ -1,0 +1,149 @@
+package uk.gov.pay.connector.util;
+
+import org.apache.commons.lang3.RandomUtils;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
+import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
+
+public class AddGatewayAccountCredentialsParams {
+    private long id;
+    private Instant createdDate;
+    private Instant activeStartDate;
+    private Instant activeEndDate;
+    private String paymentProvider;
+    private Map<String, String> credentials;
+    private GatewayAccountCredentialState state;
+    private String externalId;
+    private String lastUpdatedByUserExternalId;
+    private long gatewayAccountId;
+
+    public long getId() {
+        return id;
+    }
+
+    public Instant getCreatedDate() {
+        return createdDate;
+    }
+
+    public Instant getActiveStartDate() {
+        return activeStartDate;
+    }
+
+    public Instant getActiveEndDate() {
+        return activeEndDate;
+    }
+
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
+    public Map<String, String> getCredentials() {
+        return credentials;
+    }
+
+    public GatewayAccountCredentialState getState() {
+        return state;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public String getLastUpdatedByUserExternalId() {
+        return lastUpdatedByUserExternalId;
+    }
+
+    public long getGatewayAccountId() {
+        return gatewayAccountId;
+    }
+
+    public static final class AddGatewayAccountCredentialsParamsBuilder {
+        private long id = RandomUtils.nextLong(2, 10000);;
+        private Instant createdDate = Instant.now();
+        private Instant activeStartDate = null;
+        private Instant activeEndDate = null;
+        private String paymentProvider = WORLDPAY.getName();
+        private Map<String, String> credentials = Map.of();
+        private GatewayAccountCredentialState state = CREATED;
+        private String externalId = randomUuid();
+        private String lastUpdatedByUserExternalId;
+        private long gatewayAccountId;
+
+        private AddGatewayAccountCredentialsParamsBuilder() {
+        }
+
+        public static AddGatewayAccountCredentialsParamsBuilder anAddGatewayAccountCredentialsParams() {
+            return new AddGatewayAccountCredentialsParamsBuilder();
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withId(long id) {
+            this.id = id;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withCreatedDate(Instant createdDate) {
+            this.createdDate = createdDate;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withActiveStartDate(Instant activeStartDate) {
+            this.activeStartDate = activeStartDate;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withActiveEndDate(Instant activeEndDate) {
+            this.activeEndDate = activeEndDate;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withPaymentProvider(String paymentProvider) {
+            this.paymentProvider = paymentProvider;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withCredentials(Map<String, String> credentials) {
+            this.credentials = credentials;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withState(GatewayAccountCredentialState state) {
+            this.state = state;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withExternalId(String externalId) {
+            this.externalId = externalId;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withLastUpdatedByUserExternalId(String lastUpdatedByUserExternalId) {
+            this.lastUpdatedByUserExternalId = lastUpdatedByUserExternalId;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParamsBuilder withGatewayAccountId(long gatewayAccountId) {
+            this.gatewayAccountId = gatewayAccountId;
+            return this;
+        }
+
+        public AddGatewayAccountCredentialsParams build() {
+            AddGatewayAccountCredentialsParams addGatewayAccountCredentialsParams = new AddGatewayAccountCredentialsParams();
+            addGatewayAccountCredentialsParams.gatewayAccountId = this.gatewayAccountId;
+            addGatewayAccountCredentialsParams.state = this.state;
+            addGatewayAccountCredentialsParams.lastUpdatedByUserExternalId = this.lastUpdatedByUserExternalId;
+            addGatewayAccountCredentialsParams.credentials = this.credentials;
+            addGatewayAccountCredentialsParams.activeStartDate = this.activeStartDate;
+            addGatewayAccountCredentialsParams.id = this.id;
+            addGatewayAccountCredentialsParams.paymentProvider = this.paymentProvider;
+            addGatewayAccountCredentialsParams.createdDate = this.createdDate;
+            addGatewayAccountCredentialsParams.externalId = this.externalId;
+            addGatewayAccountCredentialsParams.activeEndDate = this.activeEndDate;
+            return addGatewayAccountCredentialsParams;
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -12,6 +12,7 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_SHA_OUT_PASSPHRASE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class AddGatewayAccountParams {
@@ -20,7 +21,7 @@ public class AddGatewayAccountParams {
             CREDENTIALS_USERNAME, "username",
             CREDENTIALS_PASSWORD, "password"
     );
-    
+
     private static final Map<String, String> epdqCredentials = Map.of(
             CREDENTIALS_MERCHANT_ID, "merchant-id",
             CREDENTIALS_USERNAME, "username",
@@ -28,11 +29,11 @@ public class AddGatewayAccountParams {
             CREDENTIALS_SHA_IN_PASSPHRASE, "sha-in",
             CREDENTIALS_SHA_OUT_PASSPHRASE, "sha-out"
     );
-    
+
     private String accountId;
     private String externalId;
     private String paymentGateway;
-    private Map<String, String> credentials;
+    private AddGatewayAccountCredentialsParams credentials;
     private String serviceName;
     private GatewayAccountType type;
     private String description;
@@ -67,7 +68,7 @@ public class AddGatewayAccountParams {
         return paymentGateway;
     }
 
-    public Map<String, String> getCredentials() {
+    public AddGatewayAccountCredentialsParams getCredentials() {
         return credentials;
     }
 
@@ -138,7 +139,8 @@ public class AddGatewayAccountParams {
     public static final class AddGatewayAccountParamsBuilder {
         private String accountId;
         private String paymentGateway = "provider";
-        private Map<String, String> credentials = Map.of();
+        private Map<String, String> credentialsMap = Map.of();
+        private AddGatewayAccountCredentialsParams gatewayAccountCredentialsParams;
         private String serviceName = "service name";
         private GatewayAccountType type = TEST;
         private String description = "description";
@@ -176,19 +178,24 @@ public class AddGatewayAccountParams {
         }
 
         public AddGatewayAccountParamsBuilder withCredentials(Map<String, String> credentials) {
-            this.credentials = credentials;
+            this.credentialsMap = credentials;
             return this;
         }
-        
+
+        public AddGatewayAccountParamsBuilder withGatewayAccountCredentials(AddGatewayAccountCredentialsParams credentials) {
+            this.gatewayAccountCredentialsParams = credentials;
+            return this;
+        }
+
         public AddGatewayAccountParamsBuilder withDefaultCredentials() {
-            this.credentials = defaultCredentials;
+            this.credentialsMap = defaultCredentials;
             return this;
         }
-        
+
         public AddGatewayAccountParamsBuilder withEpdqCredentials() {
-            this.credentials = epdqCredentials;
+            this.credentialsMap = epdqCredentials;
             return this;
-        }        
+        }
 
         public AddGatewayAccountParamsBuilder withServiceName(String serviceName) {
             this.serviceName = serviceName;
@@ -234,7 +241,7 @@ public class AddGatewayAccountParams {
             this.corporatePrepaidDebitCardSurchargeAmount = corporatePrepaidDebitCardSurchargeAmount;
             return this;
         }
-        
+
         public AddGatewayAccountParamsBuilder withAllowMoto(boolean allowMoto) {
             this.allowMoto = allowMoto;
             return this;
@@ -249,17 +256,17 @@ public class AddGatewayAccountParams {
             this.motoMaskCardSecurityCodeInput = motoMaskCardSecurityCodeInput;
             return this;
         }
-        
+
         public AddGatewayAccountParamsBuilder withAllowApplePay(boolean allowApplePay) {
             this.allowApplePay = allowApplePay;
             return this;
         }
-        
+
         public AddGatewayAccountParamsBuilder withAllowGooglePay(boolean allowGooglePay) {
             this.allowGooglePay = allowGooglePay;
             return this;
         }
-        
+
         public AddGatewayAccountParamsBuilder withRequires3ds(boolean requires3ds) {
             this.requires3ds = requires3ds;
             return this;
@@ -271,6 +278,13 @@ public class AddGatewayAccountParams {
         }
 
         public AddGatewayAccountParams build() {
+            if (gatewayAccountCredentialsParams == null) {
+                gatewayAccountCredentialsParams = anAddGatewayAccountCredentialsParams()
+                        .withPaymentProvider(paymentGateway)
+                        .withGatewayAccountId(Long.parseLong(accountId))
+                        .withCredentials(credentialsMap).build();
+            }
+            
             AddGatewayAccountParams addGatewayAccountParams = new AddGatewayAccountParams();
             addGatewayAccountParams.accountId = this.accountId;
             addGatewayAccountParams.externalId = this.externalId;
@@ -279,7 +293,7 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.analyticsId = this.analyticsId;
             addGatewayAccountParams.corporatePrepaidCreditCardSurchargeAmount = this.corporatePrepaidCreditCardSurchargeAmount;
             addGatewayAccountParams.type = this.type;
-            addGatewayAccountParams.credentials = this.credentials;
+            addGatewayAccountParams.credentials = this.gatewayAccountCredentialsParams;
             addGatewayAccountParams.description = this.description;
             addGatewayAccountParams.serviceName = this.serviceName;
             addGatewayAccountParams.corporateCreditCardSurchargeAmount = this.corporateCreditCardSurchargeAmount;


### PR DESCRIPTION
Return the created_date in the response, and modify the test to ensure we are returning all fields.

While modifying the test, created a database fixture for inserting gateway account credentials along with database helper method.

Added basic API docs for endpoint
