### PR TITLE
PP-8208 Allow patching credentials state

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidator.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gatewayaccount.resource;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
@@ -11,11 +10,11 @@ import uk.gov.pay.connector.common.model.api.jsonpatch.JsonPatchRequest;
 import uk.gov.pay.connector.common.validator.JsonPatchRequestValidator;
 import uk.gov.pay.connector.common.validator.PatchPathOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentialsRequest;
-import uk.gov.pay.connector.util.JsonObjectMapper;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -30,10 +29,14 @@ public class GatewayAccountCredentialsRequestValidator {
 
     private final Map<String, List<String>> providerCredentialFields;
     private final Joiner COMMA_JOINER = Joiner.on(", ");
-    private final JsonObjectMapper jsonObjectMapper = new JsonObjectMapper(new ObjectMapper());
+    private static final List<String> allowedStateValues = Arrays.stream(GatewayAccountCredentialState.values())
+            .map(Enum::name)
+            .sorted()
+            .collect(Collectors.toList());
 
     public static final String FIELD_CREDENTIALS = "credentials";
     public static final String FIELD_LAST_UPDATED_BY_USER = "last_updated_by_user_external_id";
+    public static final String FIELD_STATE = "state";
 
     @Inject
     public GatewayAccountCredentialsRequestValidator(ConnectorConfiguration configuration) {
@@ -80,7 +83,8 @@ public class GatewayAccountCredentialsRequestValidator {
     public void validatePatch(JsonNode patchRequest, String paymentProvider) {
         Map<PatchPathOperation, Consumer<JsonPatchRequest>> operationValidators = Map.of(
                 new PatchPathOperation(FIELD_CREDENTIALS, JsonPatchOp.REPLACE), (operation) -> validateReplaceCredentialsOperation(operation, paymentProvider),
-                new PatchPathOperation(FIELD_LAST_UPDATED_BY_USER, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString
+                new PatchPathOperation(FIELD_LAST_UPDATED_BY_USER, JsonPatchOp.REPLACE), JsonPatchRequestValidator::throwIfValueNotString,
+                new PatchPathOperation(FIELD_STATE, JsonPatchOp.REPLACE), this::validateReplaceStateOperation
         );
         var patchRequestValidator = new JsonPatchRequestValidator(operationValidators);
         patchRequestValidator.validate(patchRequest);
@@ -92,6 +96,15 @@ public class GatewayAccountCredentialsRequestValidator {
         if (!missingCredentialsFields.isEmpty()) {
             throw new ValidationException(Collections.singletonList(format("Value for path [%s] is missing field(s): [%s]", 
                     FIELD_CREDENTIALS, COMMA_JOINER.join(missingCredentialsFields))));
+        }
+    }
+    
+    private void validateReplaceStateOperation(JsonPatchRequest request) {
+        JsonPatchRequestValidator.throwIfValueNotString(request);
+        
+        if (!allowedStateValues.contains(request.valueAsString())) {
+            throw new ValidationException(Collections.singletonList(format("Value for path [%s] must be one of [%s]",
+                    request.getPath(), String.join(", ", allowedStateValues))));
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -23,6 +23,7 @@ import static java.lang.String.format;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountCredentialsRequestValidator.FIELD_CREDENTIALS;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountCredentialsRequestValidator.FIELD_LAST_UPDATED_BY_USER;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountCredentialsRequestValidator.FIELD_STATE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ENTERED;
@@ -108,6 +109,8 @@ public class GatewayAccountCredentialsService {
                             gatewayAccountCredentialsEntity.setCredentials(updateRequest.valueAsObject());
                         } else if (updateRequest.getPath().equals(FIELD_LAST_UPDATED_BY_USER) && updateRequest.getOp() == JsonPatchOp.REPLACE) {
                             gatewayAccountCredentialsEntity.setLastUpdatedByUserExternalId(updateRequest.valueAsString());
+                        } else if (updateRequest.getPath().equals(FIELD_STATE) && updateRequest.getOp() == JsonPatchOp.REPLACE) {
+                            gatewayAccountCredentialsEntity.setState(GatewayAccountCredentialState.valueOf(updateRequest.valueAsString()));
                         }
                     }
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
@@ -115,6 +115,30 @@ public class GatewayAccountCredentialsRequestValidatorTest {
     }
 
     @Test
+    public void shouldThrowWhenStateIsNotAString() {
+        JsonNode request = objectMapper.valueToTree(
+                Collections.singletonList(
+                        Map.of("path", "state",
+                                "op", "replace",
+                                "value", 1)
+                ));
+        var thrown = assertThrows(ValidationException.class, () -> validator.validatePatch(request, "worldpay"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [state] must be a string"));
+    }
+
+    @Test
+    public void shouldThrowWhenStateIsNotAllowedValue() {
+        JsonNode request = objectMapper.valueToTree(
+                Collections.singletonList(
+                        Map.of("path", "state",
+                                "op", "replace",
+                                "value", "HAPPY")
+                ));
+        var thrown = assertThrows(ValidationException.class, () -> validator.validatePatch(request, "worldpay"));
+        assertThat(thrown.getErrors().get(0), is("Value for path [state] must be one of [ACTIVE, CREATED, ENTERED, RETIRED, VERIFIED_WITH_LIVE_PAYMENT]"));
+    }
+
+    @Test
     public void shouldNotThrowWhenValidPatchRequest() {
         Map<String, Object> credentials = Map.of(
                 "merchant_id", "some-merchant-id"
@@ -126,7 +150,10 @@ public class GatewayAccountCredentialsRequestValidatorTest {
                                 "value", credentials),
                         Map.of("path", "last_updated_by_user_external_id",
                                 "op", "replace",
-                                "value", "a-user-external-id")
+                                "value", "a-user-external-id"),
+                        Map.of("path", "state",
+                                "op", "replace",
+                                "value", "VERIFIED_WITH_LIVE_PAYMENT")
                 ));
         assertDoesNotThrow(() -> validator.validatePatch(request, "worldpay"));
     }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceIT.java
@@ -260,7 +260,10 @@ public class GatewayAccountCredentialsResourceIT {
                                 "value", newCredentials),
                         Map.of("op", "replace",
                                 "path", "last_updated_by_user_external_id",
-                                "value", "a-new-user-external-id")
+                                "value", "a-new-user-external-id"),
+                        Map.of("op", "replace",
+                                "path", "state",
+                                "value", "VERIFIED_WITH_LIVE_PAYMENT")
                         )))
                 .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
                 .then()
@@ -272,7 +275,7 @@ public class GatewayAccountCredentialsResourceIT {
                 .body("credentials.username", is("new-username"))
                 .body("credentials.merchant_id", is("new-merchant-id"))
                 .body("last_updated_by_user_external_id", is("a-new-user-external-id"))
-                .body("state", is("ACTIVE"))
+                .body("state", is("VERIFIED_WITH_LIVE_PAYMENT"))
                 .body("created_date", is("2021-01-01T00:00:00.000Z"))
                 .body("active_start_date", is("2021-02-01T00:00:00.000Z"))
                 .body("active_end_date", is("2021-03-01T00:00:00.000Z"))


### PR DESCRIPTION
Accept "path": "state" in patch requests to update gateway account credentials.

Allow any valid state.

Add validation for the new update operation.