### PR TITLE
PP-8216 Allow checking credentials for non Worldpay account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
@@ -6,12 +6,14 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.worldpay.exception.UnexpectedValidateCredentialsResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 
 import javax.inject.Named;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Map;
 
 import static java.lang.String.format;
@@ -43,8 +45,10 @@ public class WorldpayCredentialsValidationService implements WorldpayGatewayResp
         try {
             GatewayClient.Response response = gatewayClient.postRequestFor(
                     gatewayUrlMap.get(gatewayAccountEntity.getType()),
-                    gatewayAccountEntity,
+                    PaymentGatewayName.WORLDPAY.getName(),
+                    gatewayAccountEntity.getType(),
                     order,
+                    Collections.emptyList(),
                     getWorldpayCredentialsCheckAuthHeader(worldpayCredentials)
             );
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResource.java
@@ -97,12 +97,7 @@ public class GatewayAccountCredentialsResource {
     public ValidationResult validateWorldpayCredentials(@PathParam("accountId") Long gatewayAccountId,
                                                         @Valid WorldpayCredentials worldpayCredentials) {
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)
-                .map(gatewayAccountEntity -> {
-                    if (!gatewayAccountEntity.getGatewayName().equals(WORLDPAY.getName())) {
-                        throw new NotAWorldpayGatewayAccountException(gatewayAccountEntity.getId());
-                    }
-                    return worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
-                })
+                .map(gatewayAccountEntity -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials))
                 .map(ValidationResult::new)
                 .orElseThrow(() -> new GatewayAccountNotFoundException(gatewayAccountId));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.gatewayaccount.model.WorldpayCredentials;
 import java.net.URI;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,7 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE;
@@ -44,12 +45,12 @@ class WorldpayCredentialsValidationServiceTest {
 
     private WorldpayCredentialsValidationService worldpayCredentialsValidationService;
 
-    private GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
-            .withGatewayName(WORLDPAY.getName())
+    private final GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+            .withGatewayName(SMARTPAY.getName())
             .withType(TEST)
             .build();
 
-    private WorldpayCredentials worldpayCredentials = new WorldpayCredentials("A_MERCHANT_ID", "user123", "test");
+    private final WorldpayCredentials worldpayCredentials = new WorldpayCredentials("A_MERCHANT_ID", "user123", "test");
 
     @BeforeEach
     void setUp() {
@@ -62,7 +63,7 @@ class WorldpayCredentialsValidationServiceTest {
     void shouldReturnTrue_ifWorldpayRespondsWithStatus200AndErrorCode5() throws GatewayException {
         when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_VALID_RESPONSE));
 
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
         boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
@@ -73,7 +74,7 @@ class WorldpayCredentialsValidationServiceTest {
     void shouldReturnFalse_ifWorldpayRespondsWithStatus200AndErrorCode4() throws GatewayException {
         when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE));
 
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
         boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
@@ -82,7 +83,7 @@ class WorldpayCredentialsValidationServiceTest {
 
     @Test
     void shouldReturnFalse_ifWorldpayRespondsWithStatus401() throws GatewayException {
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 401));
 
         boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
@@ -93,7 +94,7 @@ class WorldpayCredentialsValidationServiceTest {
     void shouldThrowException_whenErrorCodeUnexpected() throws GatewayException {
         when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_UNEXPECTED_ERROR_CODE));
 
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
         assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
@@ -101,7 +102,7 @@ class WorldpayCredentialsValidationServiceTest {
 
     @Test
     void shouldThrowException_whenErrorStatusCodeNot401() throws GatewayException {
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 403));
 
         assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
@@ -109,7 +110,7 @@ class WorldpayCredentialsValidationServiceTest {
 
     @Test
     void shouldWrapGatewayException() throws GatewayException {
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), any(GatewayOrder.class), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(GatewayException.GenericGatewayException.class);
 
         assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
@@ -218,18 +218,6 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
-    void checkWorldpayCredentials_nonWorldpayGatewayAccountReturns404() {
-        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(smartpayGatewayAccountEntity));
-        Response response = resources
-                .target(format("/v1/api/accounts/%s/worldpay/check-credentials", accountId))
-                .request()
-                .post(Entity.json(validCheckWorldpayCredentialsPayload));
-
-        assertThat(response.getStatus(), is(404));
-        assertThat(extractErrorMessagesFromResponse(response).get(0), is(format("Gateway account with id %s is not a Worldpay account.", smartpayAccountId)));
-    }
-
-    @Test
     void checkWorldpayCredentials_nonExistentGatewayAccountReturns404() {
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
         Response response = resources


### PR DESCRIPTION
- Remove restriction that Worldpay credentials can only be checked for a gateway account that already has Worldpay as the payment provider, as we want to be able to call this endpoint when in the process of switching from another provider to Worldpay
- Refactor GatewayClient to allow passing in the gateway name and account type as strings rather than a GatewayAccountEntity, so we log with the correct gateway name when checking Worldpay credentials when the current active provider for the account isn't Worldpay.
