### PR TITLE
PP-8121 Handle empty POST body on create credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResource.java
@@ -18,6 +18,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCred
 
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
@@ -106,7 +107,7 @@ public class GatewayAccountCredentialsResource {
     @Path("/v1/api/accounts/{accountId}/credentials")
     @Consumes(APPLICATION_JSON)
     @Produces(APPLICATION_JSON)
-    public GatewayAccountCredentials createGatewayAccountCredentials(@PathParam("accountId") Long gatewayAccountId, @Valid GatewayAccountCredentialsRequest gatewayAccountCredentialsRequest) {
+    public GatewayAccountCredentials createGatewayAccountCredentials(@PathParam("accountId") Long gatewayAccountId, @NotNull GatewayAccountCredentialsRequest gatewayAccountCredentialsRequest) {
         gatewayAccountCredentialsRequestValidator.validateCreate(gatewayAccountCredentialsRequest);
 
         return gatewayAccountService.getGatewayAccount(gatewayAccountId)

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceTest.java
@@ -340,6 +340,18 @@ public class GatewayAccountCredentialsResourceTest {
     }
 
     @Test
+    void createGatewayAccountCredentialsMissingBody_shouldReturn422() {
+        when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.of(gatewayAccountEntity));
+
+        Response response = resources
+                .target(format("/v1/api/accounts/%s/credentials", accountId))
+                .request()
+                .post(null);
+
+        assertThat(response.getStatus(), is(422));
+    }
+
+    @Test
     void patchGatewayAccountCredentialsGatewayAccountNotFound_shouldReturn404() {
         when(gatewayAccountService.getGatewayAccount(accountId)).thenReturn(Optional.empty());
 


### PR DESCRIPTION
Specify that the request body for a create gateway account credentials
should not be nullable.

In the case of an empty POST body, respond with `422 Unprocessable Entity`.
