### PR TITLE
PP-8189 Only allow PATCHing state to VERIFIED_WITH_LIVE_PAYMENT

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -3075,6 +3075,11 @@ PATCH /v1/api/accounts/123/credentials/456
         "op": "replace",
         "path": "last_updated_by_user_external_id",
         "value": "abc123"
+    },
+    {
+        "op": "replace",
+        "path": "state",
+        "value": "VERIFIED_WITH_LIVE_PAYMENT"
     }
 ]
 ```
@@ -3083,8 +3088,13 @@ PATCH /v1/api/accounts/123/credentials/456
 | Field  | Required | Description                               |
 | ------ |:--------:|------------- |
 | `op`    | X | Must be `"replace"` |
-| `path`  | X | The field to update (`"credentials"` or `"last_updated_by_user_external_id"`) |
+| `path`  | X | The field to update (`"credentials"`, `"last_updated_by_user_external_id"` or `"state"`) |
 | `value` | X | The value to update the field with |
+
+### Notes
+
+The only allowed value for `"op": "replace", "path": "state"` is `"VERIFIED_BY_LIVE_USER`". This is because connector
+performs all other state transitions.
 
 ### Response example
 

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsRequestValidatorTest.java
@@ -132,10 +132,10 @@ public class GatewayAccountCredentialsRequestValidatorTest {
                 Collections.singletonList(
                         Map.of("path", "state",
                                 "op", "replace",
-                                "value", "HAPPY")
+                                "value", "ACTIVE")
                 ));
         var thrown = assertThrows(ValidationException.class, () -> validator.validatePatch(request, "worldpay"));
-        assertThat(thrown.getErrors().get(0), is("Value for path [state] must be one of [ACTIVE, CREATED, ENTERED, RETIRED, VERIFIED_WITH_LIVE_PAYMENT]"));
+        assertThat(thrown.getErrors().get(0), is("Operation with path [state] can only be used to update state to [VERIFIED_WITH_LIVE_PAYMENT]"));
     }
 
     @Test


### PR DESCRIPTION
Amend the validation for the patch gateway account credentials endpoint to only allow the value to be "VERIFIED_WITH_LIVE_PAYMENT". All other state transitions are made internally by connector, so this is the only state that a consumer of the API should be able to request to switch to.