### PR TITLE
PP-8125 - Update Stripe notifications to search gateway_account_credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -35,16 +35,6 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
                 .getResultList().stream().findFirst();
     }
 
-    public Optional<GatewayAccountEntity> findByCredentialsKeyValue(String key, String value) {
-        String query = "SELECT * FROM gateway_accounts where credentials->>?1 = ?2";
-
-        return entityManager.get()
-                .createNativeQuery(query, GatewayAccountEntity.class)
-                .setParameter(1, key)
-                .setParameter(2, value)
-                .getResultList().stream().findFirst();
-    }
-
     public boolean isATelephonePaymentNotificationAccount(String merchantId) {
         String query = "SELECT count(g) FROM gateway_accounts g, gateway_account_credentials gac " +
                 " where g.id = gac.gateway_account_id " +

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountCredentialsNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountCredentialsNotFoundException.java
@@ -10,4 +10,8 @@ public class GatewayAccountCredentialsNotFoundException extends WebApplicationEx
     public GatewayAccountCredentialsNotFoundException(Long id) {
         super(notFoundResponse(format("Gateway account credentials with id [%s] not found.", id)));
     }
+
+    public GatewayAccountCredentialsNotFoundException(String message) {
+        super(notFoundResponse(message));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDao.java
@@ -51,4 +51,14 @@ public class GatewayAccountCredentialsDao extends JpaDao<GatewayAccountCredentia
                 .setParameter("externalId", externalId)
                 .getResultList().stream().findFirst();
     }
+
+    public Optional<GatewayAccountCredentialsEntity> findByCredentialsKeyValue(String key, String value) {
+        String query = "SELECT * FROM gateway_account_credentials where credentials->>?1 = ?2";
+
+        return entityManager.get()
+                .createNativeQuery(query, GatewayAccountCredentialsEntity.class)
+                .setParameter(1, key)
+                .setParameter(2, value)
+                .getResultList().stream().findFirst();
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -147,22 +147,6 @@ public class GatewayAccountDaoIT extends DaoITestBase {
     }
 
     @Test
-    public void findByCredentialsKeyValue_shouldFindGatewayAccount() {
-        var credMap = Map.of("some_payment_provider_account_id", "accountid");
-        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
-                .withAccountId(String.valueOf(gatewayAccountId))
-                .withPaymentGateway("test provider")
-                .withServiceName("service name")
-                .withCredentials(credMap)
-                .build());
-
-        Optional<GatewayAccountEntity> maybeGatewayAccount = gatewayAccountDao.findByCredentialsKeyValue("some_payment_provider_account_id", "accountid");
-        assertThat(maybeGatewayAccount.isPresent(), is(true));
-        Map<String, String> credentialsMap = maybeGatewayAccount.get().getCredentials();
-        assertThat(credentialsMap, hasEntry("some_payment_provider_account_id", "accountid"));
-    }
-
-    @Test
     public void findById_shouldFindGatewayAccountWithCorporateSurcharges() {
         DatabaseFixtures.TestAccount accountRecord = createAccountRecordWithCorporateSurcharges();
 


### PR DESCRIPTION
Description:
- When a Stripe payout notification is processed we want to search the gateway_account_credentials table for the credentials before proceeding
- An additional check is added to PayoutEmitterService and PayoutReconcileProcess to verify whether the GatewayAccountCredentialsEntity exists then checking if the GatewayAccountEntity exists before proceeding