### PR TITLE
PP-8255 Add send_payer_email_to_gateway column to gateway_accounts

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1639,4 +1639,12 @@
             </column>
         </addColumn>
     </changeSet>
+
+    <changeSet id="add send_payer_email_to_gateway column to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="send_payer_email_to_gateway" type="boolean" defaultValue="false">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Database migration to add a non-nullable boolean `send_payer_email_to_gateway` column to the `gateway_accounts` table
with a default value of `false`.