### PR TITLE
PP-8221 Allow for payment provider to be specified when creating charge

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -22,6 +22,9 @@ import io.dropwizard.migrations.MigrationsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
+import uk.gov.pay.connector.gatewayaccountcredentials.exception.NoCredentialsExistForProviderException;
+import uk.gov.pay.connector.gatewayaccountcredentials.exception.NoCredentialsExistForProviderExceptionMapper;
+import uk.gov.pay.connector.gatewayaccountcredentials.exception.NoCredentialsInUsableStateExceptionMapper;
 import uk.gov.pay.connector.report.resource.ParityCheckerResource;
 import uk.gov.service.payments.commons.utils.healthchecks.DatabaseHealthCheck;
 import uk.gov.service.payments.commons.utils.metrics.DatabaseMetricsService;
@@ -124,6 +127,8 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new ConflictWebApplicationExceptionMapper());
         environment.jersey().register(new MotoPaymentNotAllowedForGatewayAccountExceptionMapper());
         environment.jersey().register(new TelephonePaymentNotificationsNotAllowedExceptionMapper());
+        environment.jersey().register(new NoCredentialsExistForProviderExceptionMapper());
+        environment.jersey().register(new NoCredentialsInUsableStateExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.hibernate.validator.constraints.Length;
+import uk.gov.pay.connector.charge.validation.ValidPaymentProvider;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataDeserialiser;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -65,6 +66,10 @@ public class ChargeCreateRequest {
     
     @JsonProperty("moto")
     private boolean moto;
+    
+    @JsonProperty("payment_provider")
+    @ValidPaymentProvider
+    private String paymentProvider;
 
     public ChargeCreateRequest() {
         // for Jackson
@@ -80,7 +85,8 @@ public class ChargeCreateRequest {
                         PrefilledCardHolderDetails prefilledCardHolderDetails,
                         ExternalMetadata externalMetadata,
                         Source source,
-                        boolean moto) {
+                        boolean moto,
+                        String paymentProvider) {
         this.amount = amount;
         this.description = description;
         this.reference = reference;
@@ -92,6 +98,7 @@ public class ChargeCreateRequest {
         this.externalMetadata = externalMetadata;
         this.source = source;
         this.moto = moto;
+        this.paymentProvider = paymentProvider;
     }
 
     public long getAmount() {
@@ -138,6 +145,10 @@ public class ChargeCreateRequest {
         return moto;
     }
 
+    public String getPaymentProvider() {
+        return paymentProvider;
+    }
+
     public String toStringWithoutPersonalIdentifiableInformation() {
         return "ChargeCreateRequest{" +
                 "amount=" + amount +
@@ -147,6 +158,7 @@ public class ChargeCreateRequest {
                 ", source=" + source +
                 ", moto=" + moto +
                 (language != null ? ", language=" + language.toString() : "") +
+                (paymentProvider != null ? ", payment_provider=" + paymentProvider : "") +
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/validation/PaymentProviderValidator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/validation/PaymentProviderValidator.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.charge.validation;
+
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class PaymentProviderValidator implements ConstraintValidator<ValidPaymentProvider, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        
+        return PaymentGatewayName.isValidPaymentGateway(value);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/validation/ValidPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/charge/validation/ValidPaymentProvider.java
@@ -1,0 +1,26 @@
+package uk.gov.pay.connector.charge.validation;
+
+import uk.gov.pay.connector.charge.validation.telephone.CardBrandValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({ FIELD})
+@Retention(RUNTIME)
+@Constraint(validatedBy = PaymentProviderValidator.class)
+@Documented
+public @interface ValidPaymentProvider {
+
+    String message() default "Field [payment_provider] must be one of [epdq, sandbox, smartpay, stripe, worldpay]";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+    
+}

--- a/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/api/ErrorResponse.java
@@ -12,13 +12,17 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 public class ErrorResponse {
     
     @JsonProperty("error_identifier")
-    private final ErrorIdentifier identifier;
+    private ErrorIdentifier identifier;
     
     @JsonProperty("message")
-    private final List<String> messages;
+    private List<String> messages;
     
     @JsonProperty("reason")
-    private final String reason;
+    private String reason;
+    
+    public ErrorResponse() {
+        // for Jackson deserialization
+    }
     
     public ErrorResponse(ErrorIdentifier identifier, List<String> messages, String reason) {
         this.identifier = identifier;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsExistForProviderException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsExistForProviderException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.exception;
+
+import static java.lang.String.format;
+
+public class NoCredentialsExistForProviderException extends RuntimeException {
+    public NoCredentialsExistForProviderException(String paymentProvider) {
+        super(format("Account does not support payment provider [%s]", paymentProvider));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsExistForProviderExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsExistForProviderExceptionMapper.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class NoCredentialsExistForProviderExceptionMapper implements ExceptionMapper<NoCredentialsExistForProviderException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoCredentialsExistForProviderExceptionMapper.class);
+    
+    @Override
+    public Response toResponse(NoCredentialsExistForProviderException exception) {
+        LOGGER.info(exception.getMessage());
+        
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(400)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsInUsableStateException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsInUsableStateException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.exception;
+
+import static java.lang.String.format;
+
+public class NoCredentialsInUsableStateException extends RuntimeException {
+    public NoCredentialsInUsableStateException(String paymentProvider) {
+        super(format("Account does not have credentials in a usable state for payment provider [%s]", paymentProvider));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsInUsableStateExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/exception/NoCredentialsInUsableStateExceptionMapper.java
@@ -1,0 +1,27 @@
+package uk.gov.pay.connector.gatewayaccountcredentials.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+public class NoCredentialsInUsableStateExceptionMapper implements ExceptionMapper<NoCredentialsInUsableStateException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoCredentialsInUsableStateExceptionMapper.class);
+    
+    @Override
+    public Response toResponse(NoCredentialsInUsableStateException exception) {
+        LOGGER.info(exception.getMessage());
+        
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        return Response.status(400)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/ChargeCreateRequestBuilder.java
@@ -16,6 +16,7 @@ public final class ChargeCreateRequestBuilder {
     private ExternalMetadata externalMetadata;
     private Source source;
     private boolean moto;
+    private String paymentProvider;
 
     private ChargeCreateRequestBuilder() {
     }
@@ -79,8 +80,13 @@ public final class ChargeCreateRequestBuilder {
         return this;   
     }
 
+    public ChargeCreateRequestBuilder withPaymentProvider(String paymentProvider) {
+        this.paymentProvider = paymentProvider;
+        return this;
+    }
+
     public ChargeCreateRequest build() {
         return new ChargeCreateRequest(amount, description, reference, returnUrl, email, delayedCapture, language,
-                prefilledCardHolderDetails, externalMetadata, source, moto);
+                prefilledCardHolderDetails, externalMetadata, source, moto, paymentProvider);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -54,6 +54,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.northamericaregion.NorthAmericaRegion;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.northamericaregion.UsState;
@@ -168,6 +169,9 @@ public class ChargeServiceTest {
 
     @Mock
     protected RefundService mockedRefundService;
+    
+    @Mock
+    protected GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
 
     @Mock
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
@@ -232,7 +236,8 @@ public class ChargeServiceTest {
 
         service = new ChargeService(mockedTokenDao, mockedChargeDao, mockedChargeEventDao,
                 mockedCardTypeDao, mockedGatewayAccountDao, mockedConfig, mockedProviders,
-                mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockNorthAmericanRegionMapper);
+                mockStateTransitionService, ledgerService, mockedRefundService, mockEventService,
+                mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper);
     }
 
     @After

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountCredentialsResourceIT.java
@@ -35,6 +35,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomUtils.nextLong;
 import static org.hamcrest.CoreMatchers.is;
@@ -104,7 +105,7 @@ public class GatewayAccountCredentialsResourceIT {
         testAccount = databaseFixtures.aTestAccount().withPaymentProvider("worldpay")
                 .withIntegrationVersion3ds(2)
                 .withAccountId(accountId)
-                .withGatewayAccountCredentials(credentialsParams)
+                .withGatewayAccountCredentials(singletonList(credentialsParams))
                 .insert();
     }
 
@@ -295,7 +296,7 @@ public class GatewayAccountCredentialsResourceIT {
         Long credentialsId = (Long) databaseTestHelper.getGatewayAccountCredentialsForAccount(accountId).get(0).get("id");
 
         givenSetup()
-                .body(toJson(Collections.singletonList(
+                .body(toJson(singletonList(
                         Map.of("op", "replace",
                                 "path", "credentials"))))
                 .patch(format(PATCH_CREDENTIALS_URL, accountId, credentialsId))
@@ -310,7 +311,7 @@ public class GatewayAccountCredentialsResourceIT {
                 "password", "new-password",
                 "merchant_id", "new-merchant-id");
         givenSetup()
-                .body(toJson(Collections.singletonList(
+                .body(toJson(singletonList(
                         Map.of("op", "replace",
                                 "path", "credentials",
                                 "value", newCredentials))))

--- a/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/dao/GatewayAccountCredentialsDaoIT.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.it.dao.DaoITestBase;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -66,7 +67,7 @@ public class GatewayAccountCredentialsDaoIT extends DaoITestBase {
         databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId(String.valueOf(gatewayAccountId))
                 .withPaymentGateway("stripe")
-                .withGatewayAccountCredentials(credentialsParams)
+                .withGatewayAccountCredentials(Collections.singletonList(credentialsParams))
                 .withServiceName("a cool service")
                 .build());
 

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -2,9 +2,6 @@ package uk.gov.pay.connector.it.dao;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.RandomUtils;
-import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
-import uk.gov.service.payments.commons.model.CardExpiryDate;
-import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
@@ -16,14 +13,18 @@ import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
+import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
 
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -322,7 +323,7 @@ public class DatabaseFixtures {
         String externalId = randomUuid();
         private String paymentProvider = "sandbox";
         private Map<String, String> credentialsMap = Map.of();
-        private AddGatewayAccountCredentialsParams gatewayAccountCredentialsParams;
+        private List<AddGatewayAccountCredentialsParams> gatewayAccountCredentialsParams;
         private String serviceName = "service_name";
         private String description = "a description";
         private String analyticsId = "an analytics id";
@@ -361,7 +362,7 @@ public class DatabaseFixtures {
             return paymentProvider;
         }
 
-        public AddGatewayAccountCredentialsParams getCredentials() {
+        public List<AddGatewayAccountCredentialsParams> getCredentials() {
             return gatewayAccountCredentialsParams;
         }
 
@@ -429,8 +430,8 @@ public class DatabaseFixtures {
             this.credentialsMap = credentials;
             return this;
         }
-        
-        public TestAccount withGatewayAccountCredentials(AddGatewayAccountCredentialsParams gatewayAccountCredentialsParams) {
+
+        public TestAccount withGatewayAccountCredentials(List<AddGatewayAccountCredentialsParams> gatewayAccountCredentialsParams) {
             this.gatewayAccountCredentialsParams = gatewayAccountCredentialsParams;
             return this;
         }
@@ -518,13 +519,14 @@ public class DatabaseFixtures {
 
         public TestAccount insert() {
             if (gatewayAccountCredentialsParams == null) {
-                gatewayAccountCredentialsParams = anAddGatewayAccountCredentialsParams()
-                        .withGatewayAccountId(accountId)
-                        .withPaymentProvider(paymentProvider)
-                        .withCredentials(credentialsMap)
-                        .build();
+                gatewayAccountCredentialsParams = Collections.singletonList(
+                        anAddGatewayAccountCredentialsParams()
+                                .withGatewayAccountId(accountId)
+                                .withPaymentProvider(paymentProvider)
+                                .withCredentials(credentialsMap)
+                                .build());
             }
-            
+
             databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
                     .withAccountId(String.valueOf(accountId))
                     .withExternalId(externalId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTest.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.connector.it.resources;
+
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import io.dropwizard.testing.junit5.ResourceExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.pay.connector.charge.resource.ChargesApiResource;
+import uk.gov.pay.connector.charge.service.ChargeExpiryService;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(DropwizardExtensionsSupport.class)
+public class ChargesApiResourceTest {
+
+    private static final ChargeService chargeService = mock(ChargeService.class);
+    private static final ChargeExpiryService chargeExpiryService = mock(ChargeExpiryService.class);
+    private static final GatewayAccountService gatewayAccountService = mock(GatewayAccountService.class);
+
+    public static ResourceExtension resources = ResourceExtension.builder()
+            .addResource(new ChargesApiResource(chargeService, chargeExpiryService, gatewayAccountService))
+            .setRegisterDefaultExceptionMappers(false)
+            .addProvider(ConstraintViolationExceptionMapper.class)
+            .build();
+
+    @Test
+    void createCharge_invalidPaymentProvider_shouldReturn422() {
+        var payload = Map.of(
+                "amount", 100,
+                "reference", "ref",
+                "description", "desc",
+                "return_url", "http://service.url/success-page/",
+                "payment_provider", "simon"
+        );
+
+        Response response = resources
+                .target("/v1/api/accounts/1/charges")
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(422));
+        ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+        assertThat(errorResponse.getMessages(), hasItem("Field [payment_provider] must be one of [epdq, sandbox, smartpay, stripe, worldpay]"));
+        assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
+    }
+    
+}

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.JSON;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 import static uk.gov.pay.connector.cardtype.model.domain.CardType.DEBIT;
@@ -495,7 +496,7 @@ public class ContractTest {
                 .build();
         dbHelper.addGatewayAccount(anAddGatewayAccountParams()
                 .withAccountId("333")
-                .withGatewayAccountCredentials(gatewayAccountCredentialsParams)
+                .withGatewayAccountCredentials(singletonList(gatewayAccountCredentialsParams))
                 .withPaymentGateway(WORLDPAY.getName())
                 .build());
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -28,6 +28,7 @@ import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.Authori
 import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationResponse;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsFlexRequiredParams;
 import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
 import uk.gov.pay.connector.refund.service.RefundService;
@@ -72,6 +73,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private NorthAmericanRegionMapper northAmericanRegionMapper;
     @Mock
     private RefundService mockedRefundService;
+    @Mock
+    private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
@@ -98,7 +101,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         when(mockConfiguration.getAuthorisation3dsConfig()).thenReturn(mockAuthorisation3dsConfig);
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
-                null, mockConfiguration, null, mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, northAmericanRegionMapper);
+                null, mockConfiguration, null, mockStateTransitionService, ledgerService,
+                mockedRefundService, mockEventService, mockGatewayAccountCredentialsService, northAmericanRegionMapper);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationService, mockConfiguration);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -44,6 +44,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.model.domain.AddressFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -123,6 +124,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private RefundService mockRefundService;
+    
+    @Mock
+    private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
 
     @Mock
     private NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
@@ -146,7 +150,8 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ConnectorConfiguration mockConfiguration = mock(ConnectorConfiguration.class);
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                stateTransitionService, ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper);
+                stateTransitionService, ledgerService, mockRefundService, mockEventService, 
+                mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper);
 
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
@@ -114,6 +115,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     @Mock 
     private RefundService mockedRefundService;
     @Mock
+    private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
+    @Mock
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
 
     @Before
@@ -124,7 +127,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
-                mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, mockNorthAmericanRegionMapper);
+                mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, 
+                mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/WorldpayCardAuthoriseServiceTest.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayAuthorisationRequestSummary;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
@@ -102,7 +103,7 @@ class WorldpayCardAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mock(ConnectorConfiguration.class), null,
                 mock(StateTransitionService.class), mock(LedgerService.class), mock(RefundService.class), 
-                mock(EventService.class), mock(NorthAmericanRegionMapper.class));
+                mock(EventService.class), mock(GatewayAccountCredentialsService.class), mock(NorthAmericanRegionMapper.class));
         
         cardAuthorisationService = new CardAuthoriseService(
                 mockedCardTypeDao,

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.util;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode.MANDATORY;
@@ -33,7 +35,7 @@ public class AddGatewayAccountParams {
     private String accountId;
     private String externalId;
     private String paymentGateway;
-    private AddGatewayAccountCredentialsParams credentials;
+    private List<AddGatewayAccountCredentialsParams> credentials;
     private String serviceName;
     private GatewayAccountType type;
     private String description;
@@ -69,7 +71,7 @@ public class AddGatewayAccountParams {
         return paymentGateway;
     }
 
-    public AddGatewayAccountCredentialsParams getCredentials() {
+    public List<AddGatewayAccountCredentialsParams> getCredentials() {
         return credentials;
     }
 
@@ -145,7 +147,7 @@ public class AddGatewayAccountParams {
         private String accountId;
         private String paymentGateway = "provider";
         private Map<String, String> credentialsMap = Map.of();
-        private AddGatewayAccountCredentialsParams gatewayAccountCredentialsParams;
+        private List<AddGatewayAccountCredentialsParams> gatewayAccountCredentialsParams;
         private String serviceName = "service name";
         private GatewayAccountType type = TEST;
         private String description = "description";
@@ -188,7 +190,7 @@ public class AddGatewayAccountParams {
             return this;
         }
 
-        public AddGatewayAccountParamsBuilder withGatewayAccountCredentials(AddGatewayAccountCredentialsParams credentials) {
+        public AddGatewayAccountParamsBuilder withGatewayAccountCredentials(List<AddGatewayAccountCredentialsParams> credentials) {
             this.gatewayAccountCredentialsParams = credentials;
             return this;
         }
@@ -290,12 +292,13 @@ public class AddGatewayAccountParams {
 
         public AddGatewayAccountParams build() {
             if (gatewayAccountCredentialsParams == null) {
-                gatewayAccountCredentialsParams = anAddGatewayAccountCredentialsParams()
-                        .withPaymentProvider(paymentGateway)
-                        .withGatewayAccountId(Long.parseLong(accountId))
-                        .withCredentials(credentialsMap).build();
+                gatewayAccountCredentialsParams = Collections.singletonList(
+                        anAddGatewayAccountCredentialsParams()
+                                .withPaymentProvider(paymentGateway)
+                                .withGatewayAccountId(Long.parseLong(accountId))
+                                .withCredentials(credentialsMap).build());
             }
-            
+
             AddGatewayAccountParams addGatewayAccountParams = new AddGatewayAccountParams();
             addGatewayAccountParams.accountId = this.accountId;
             addGatewayAccountParams.externalId = this.externalId;

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -62,7 +62,7 @@ public class DatabaseTestHelper {
                         .bind("id", Long.valueOf(params.getAccountId()))
                         .bind("external_id", params.getExternalId())
                         .bind("payment_provider", params.getPaymentGateway())
-                        .bindBySqlType("credentials", buildCredentialsJson(params.getCredentials()), OTHER)
+                        .bindBySqlType("credentials", buildCredentialsJson(params.getCredentials().get(0)), OTHER)
                         .bind("service_name", params.getServiceName())
                         .bind("type", params.getType())
                         .bind("description", params.getDescription())
@@ -83,7 +83,7 @@ public class DatabaseTestHelper {
                         .bind("provider_switch_enabled", params.isProviderSwitchEnabled())
                         .execute());
         if (params.getCredentials() != null) {
-            insertGatewayAccountCredentials(params.getCredentials());
+            params.getCredentials().forEach(this::insertGatewayAccountCredentials);
         }
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
+++ b/src/test/java/uk/gov/pay/connector/util/RestAssuredClient.java
@@ -73,6 +73,10 @@ public class RestAssuredClient {
     }
 
     public ValidatableResponse postCreateCharge(String postBody) {
+        return postCreateCharge(postBody, accountId);
+    }
+
+    public ValidatableResponse postCreateCharge(String postBody, String accountId) {
         String requestPath = "/v1/api/accounts/{accountId}/charges"
                 .replace("{accountId}", accountId);
 

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -41,6 +41,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStringifier;
 import uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayOrderStatusResponse;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
@@ -123,6 +124,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     
     @Mock
     private RefundService mockRefundService;
+    
+    @Mock
+    private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
 
     private WalletAuthoriseService walletAuthoriseService;
 
@@ -154,7 +158,8 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null, mockStateTransitionService,
-                ledgerService, mockRefundService, mockEventService, mockNorthAmericanRegionMapper));
+                ledgerService, mockRefundService, mockEventService, mockGatewayAccountCredentialsService,
+                mockNorthAmericanRegionMapper));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
- Optional `payment_provider` field on create charge request accepted.
- If field is present, verify there are credentials with payment provider for gateway account that have state `ENTERED`,
`VERIFIED_WITH_LIVE_PAYMENT` or `ACTIVE`.
- Set provided payment provider on charge to be used for gateway requests for this charge.