### PR TITLE
PP-8255 Add send payer email to gateway flag on gateway account

### DIFF
--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -983,7 +983,8 @@ Content-Type: application/json
 A generic endpoint that allows the patching of `allow_apple_pay`, `allow_google_pay`, `block_prepaid_cards`, `credentials/gateway_merchant_id`,
 `notify_settings`, `email_collection_mode`, `corporate_credit_card_surcharge_amount`, `corporate_debit_card_surcharge_amount`,
 `corporate_prepaid_credit_card_surcharge_amount`, `corporate_prepaid_debit_card_surcharge_amount`, `allow_zero_amount`, `allow_moto`,
-`moto_mask_card_number_input`, `moto_mask_card_security_code_input`, `allow_telephone_payment_notifications`, `integration_version_3ds` or
+`moto_mask_card_number_input`, `moto_mask_card_security_code_input`, `allow_telephone_payment_notifications`, 
+`send_payer_ip_address_to_gateway`, `send_payer_email_to_gateway`, `integration_version_3ds` or
 `worldpay_exemption_engine_enabled` using a JSON Patch-esque message body.
 
 ### Request example

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -145,6 +145,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Column(name = "send_payer_ip_address_to_gateway")
     private boolean sendPayerIpAddressToGateway;
 
+    @Column(name = "send_payer_email_to_gateway")
+    private boolean sendPayerEmailToGateway;
+
     @ManyToMany
     @JoinTable(
             name = "accepted_card_types",
@@ -374,6 +377,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         return sendPayerIpAddressToGateway;
     }
 
+    @JsonProperty("send_payer_email_to_gateway")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public boolean isSendPayerEmailToGateway() {
+        return sendPayerEmailToGateway;
+    }
+
     public void setNotificationCredentials(NotificationCredentials notificationCredentials) {
         this.notificationCredentials = notificationCredentials;
     }
@@ -501,6 +510,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
 
     public void setSendPayerIpAddressToGateway(boolean sendPayerIpAddressToGateway) {
         this.sendPayerIpAddressToGateway = sendPayerIpAddressToGateway;
+    }
+
+    public void setSendPayerEmailToGateway(boolean sendPayerEmailToGateway) {
+        this.sendPayerEmailToGateway = sendPayerEmailToGateway;
     }
 
     public void setAllowTelephonePaymentNotifications(boolean allowTelephonePaymentNotifications) {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidator.java
@@ -44,6 +44,7 @@ public class GatewayAccountRequestValidator {
     public static final String FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS = "allow_telephone_payment_notifications";
     public static final String FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED = "worldpay_exemption_engine_enabled";
     public static final String FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY = "send_payer_ip_address_to_gateway";
+    public static final String FIELD_SEND_PAYER_EMAIL_TO_GATEWAY = "send_payer_email_to_gateway";
     public static final String FIELD_PROVIDER_SWITCH_ENABLED = "provider_switch_enabled";
 
     private static final List<String> VALID_PATHS = List.of(
@@ -65,6 +66,7 @@ public class GatewayAccountRequestValidator {
             FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS,
             FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,
             FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY,
+            FIELD_SEND_PAYER_EMAIL_TO_GATEWAY,
             FIELD_PROVIDER_SWITCH_ENABLED);
 
     private final RequestValidator requestValidator;
@@ -103,6 +105,7 @@ public class GatewayAccountRequestValidator {
             case FIELD_ALLOW_TELEPHONE_PAYMENT_NOTIFICATIONS:
             case FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED:
             case FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY:
+            case FIELD_SEND_PAYER_EMAIL_TO_GATEWAY:
             case FIELD_PROVIDER_SWITCH_ENABLED:
                 validateReplaceBooleanValue(payload);
                 break;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -46,6 +46,7 @@ import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequest
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_MOTO_MASK_CARD_NUMBER_INPUT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_MOTO_MASK_CARD_SECURITY_CODE_INPUT;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_NOTIFY_SETTINGS;
+import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_EMAIL_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED;
 import static uk.gov.pay.connector.gatewayaccount.resource.GatewayAccountRequestValidator.FIELD_PROVIDER_SWITCH_ENABLED;
@@ -197,6 +198,10 @@ public class GatewayAccountService {
             entry(
                 FIELD_SEND_PAYER_IP_ADDRESS_TO_GATEWAY,
                 (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setSendPayerIpAddressToGateway(gatewayAccountRequest.valueAsBoolean())
+            ),
+            entry(
+                FIELD_SEND_PAYER_EMAIL_TO_GATEWAY,
+                (gatewayAccountRequest, gatewayAccountEntity) -> gatewayAccountEntity.setSendPayerEmailToGateway(gatewayAccountRequest.valueAsBoolean())
             ),
             entry(
                 FIELD_WORLDPAY_EXEMPTION_ENGINE_ENABLED,

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1643,6 +1643,7 @@
     <changeSet id="add send_payer_email_to_gateway column to gateway_accounts table" author="">
         <addColumn tableName="gateway_accounts">
             <column name="send_payer_email_to_gateway" type="boolean" defaultValue="false">
+                <constraints nullable="false"/>
             </column>
         </addColumn>
     </changeSet>

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountRequestValidatorTest.java
@@ -75,6 +75,8 @@ public class GatewayAccountRequestValidatorTest {
             "replace, worldpay_exemption_engine_enabled, unfalse, Value [unfalse] must be of type boolean for path [worldpay_exemption_engine_enabled]",
             "replace, send_payer_ip_address_to_gateway, null, Field [value] is required",
             "replace, send_payer_ip_address_to_gateway, unfalse, Value [unfalse] must be of type boolean for path [send_payer_ip_address_to_gateway]",
+            "replace, send_payer_email_to_gateway, null, Field [value] is required",
+            "replace, send_payer_email_to_gateway, unfalse, Value [unfalse] must be of type boolean for path [send_payer_email_to_gateway]",
             "replace, provider_switch_enabled, null, Field [value] is required",
             "replace, provider_switch_enabled, unfalse, Value [unfalse] must be of type boolean for path [provider_switch_enabled]"
     })

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -81,6 +81,7 @@ public class GatewayAccountDaoIT extends DaoITestBase {
         assertThat(account.getCorporatePrepaidCreditCardSurchargeAmount(), is(0L));
         assertThat(account.getCorporatePrepaidDebitCardSurchargeAmount(), is(0L));
         assertThat(account.isSendPayerIpAddressToGateway(), is(false));
+        assertThat(account.isSendPayerEmailToGateway(), is(false));
         assertThat(account.isProviderSwitchEnabled(), is(false));
 
         databaseTestHelper.getAccountCredentials(account.getId());

--- a/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayAccountServiceTest.java
@@ -425,6 +425,34 @@ public class GatewayAccountServiceTest {
     }
 
     @Test
+    public void shouldUpdateSendPayerEmailToGatewayToFalse() {
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
+                "op", "replace",
+                "path", "send_payer_email_to_gateway",
+                "value", false)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setSendPayerEmailToGateway(false);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
+    public void shouldUpdateSendPayerEmailToGatewayToTrue() {
+        JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
+                "op", "replace",
+                "path", "send_payer_email_to_gateway",
+                "value", true)));
+
+        when(mockGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(mockGatewayAccountEntity));
+        Optional<GatewayAccount> optionalGatewayAccount = gatewayAccountService.doPatch(GATEWAY_ACCOUNT_ID, request);
+        assertThat(optionalGatewayAccount.isPresent(), is(true));
+        verify(mockGatewayAccountEntity).setSendPayerEmailToGateway(true);
+        verify(mockGatewayAccountDao).merge(mockGatewayAccountEntity);
+    }
+
+    @Test
     public void shouldUpdateProviderSwitchEnabledToTrue() {
         JsonPatchRequest request = JsonPatchRequest.from(objectMapper.valueToTree(Map.of(
                 "op", "replace",


### PR DESCRIPTION
Add a `sendPayerEmailToGateway` boolean to `GatewayAccountEntity`, mapped to the existing `send_payer_email_to_gateway` column in the `gateway_accounts` table of the database (defaults to `false`).

Include an appropriate `"send_payer_email_to_gateway"` JSON property in responses to requests made to `/v1/frontend/accounts/ACCOUNT_ID`.

Make it so that the flag can be toggled by sending a `PATCH` request to `/v1/api/accounts/ACCOUNT_ID` with a JSON payload like the following:

```json
{
  "op": "replace",
  "path": "send_payer_email_to_gateway",
  "value": true
}
```

While the flag is exposed and can be toggled, it has no effect on the business logic yet.