### PR TITLE
PP-8125 Stripe - Get credentials by payment provider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 
 public abstract class StripeRequest implements GatewayClientRequest {
 
@@ -33,7 +34,7 @@ public abstract class StripeRequest implements GatewayClientRequest {
             throw new IllegalArgumentException("Cannot create StripeRequest without a gateway account");
         }
 
-        String stripeAccountId = gatewayAccount.getCredentials().get("stripe_account_id");
+        String stripeAccountId = gatewayAccount.getCredentials(STRIPE.getName()).get("stripe_account_id");
         if (stripeAccountId == null) {
             throw new IllegalArgumentException("Cannot create StripeRequest with a gateway account with out a stripe account id set");
         }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountService.java
@@ -5,10 +5,12 @@ import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
 
 import java.util.Optional;
 
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+
 public class StripeAccountService {
 
     public Optional<StripeAccountResponse> buildStripeAccountResponse(GatewayAccountEntity gatewayAccountEntity) {
-        return Optional.ofNullable(gatewayAccountEntity.getCredentials())
+        return Optional.ofNullable(gatewayAccountEntity.getCredentials(STRIPE.getName()))
                 .map(credentials -> credentials.get("stripe_account_id"))
                 .map(StripeAccountResponse::new);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCancelHandlerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe;
 
-import com.google.common.collect.ImmutableMap;
 import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
@@ -21,6 +20,8 @@ import uk.gov.pay.connector.gateway.stripe.request.StripeChargeCancelRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripePaymentIntentCancelRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.Map;
+
 import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
 import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,9 +29,10 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
@@ -116,12 +118,12 @@ public class StripeCancelHandlerTest {
     }
 
     private GatewayAccountEntity buildGatewayAccountEntity() {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
-        gatewayAccount.setId(1L);
-        gatewayAccount.setGatewayName("stripe");
-        gatewayAccount.setRequires3ds(false);
-        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
-        gatewayAccount.setType(TEST);
-        return gatewayAccount;
+        return aGatewayAccountEntity()
+        .withId(1L)
+        .withGatewayName("stripe")
+        .withRequires3ds(false)
+        .withType(TEST)
+        .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
+        .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeCaptureHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +20,8 @@ import uk.gov.pay.connector.gateway.stripe.request.StripeTransferOutRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
+import java.util.Map;
+
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
 import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -33,9 +34,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
@@ -248,12 +250,12 @@ public class StripeCaptureHandlerTest {
     }
 
     private GatewayAccountEntity buildGatewayAccountEntity() {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
-        gatewayAccount.setId(1L);
-        gatewayAccount.setGatewayName("stripe");
-        gatewayAccount.setRequires3ds(false);
-        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
-        gatewayAccount.setType(TEST);
-        return gatewayAccount;
+        return aGatewayAccountEntity()
+                .withId(1L)
+                .withGatewayName("stripe")
+                .withRequires3ds(false)
+                .withType(TEST)
+                .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -2,12 +2,10 @@ package uk.gov.pay.connector.gateway.stripe;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.setup.Environment;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
-import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
 import uk.gov.pay.connector.app.LinksConfig;
 import uk.gov.pay.connector.app.StripeAuthTokens;
@@ -33,7 +31,9 @@ import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.JsonObjectMapper;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -51,6 +51,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_CONNECTION_TIMEOUT_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE;
@@ -360,12 +361,12 @@ public class StripePaymentProviderTest {
     }
 
     private GatewayAccountEntity buildTestGatewayAccountEntity() {
-        GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
-        gatewayAccount.setId(1L);
-        gatewayAccount.setGatewayName("stripe");
-        gatewayAccount.setRequires3ds(false);
-        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
-        gatewayAccount.setType(TEST);
-        return gatewayAccount;
+        return aGatewayAccountEntity()
+                .withId(1L)
+                .withGatewayName("stripe")
+                .withRequires3ds(false)
+                .withType(TEST)
+                .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
+                .build();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableMap;
 import org.hamcrest.core.Is;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,10 +19,11 @@ import uk.gov.pay.connector.gateway.stripe.request.StripeRefundRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripeTransferReversalRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.util.Map;
 
 import static org.eclipse.jetty.http.HttpStatus.INTERNAL_SERVER_ERROR_500;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GATEWAY_ERROR;
 import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_REFUND_FULL_CHARGE_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TRANSFER_RESPONSE;
@@ -46,7 +48,7 @@ public class StripeRefundHandlerTest {
     private StripeRefundHandler refundHandler;
     private RefundGatewayRequest refundRequest;
     private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
-    private GatewayAccountEntity gatewayAccount = new GatewayAccountEntity();
+    private GatewayAccountEntity gatewayAccount;
 
     @Mock
     private GatewayClient gatewayClient;
@@ -59,10 +61,13 @@ public class StripeRefundHandlerTest {
     public void setUp() throws Exception {
         refundHandler = new StripeRefundHandler(gatewayClient, gatewayConfig, objectMapper);
 
-        gatewayAccount.setId(123L);
-        gatewayAccount.setCredentials(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
-        gatewayAccount.setType(GatewayAccountType.LIVE);
-        gatewayAccount.setGatewayName("stripe");
+        gatewayAccount =  aGatewayAccountEntity()
+                .withId(123L)
+                .withGatewayName("stripe")
+                .withRequires3ds(false)
+                .withType(LIVE)
+                .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
+                .build();
 
         RefundEntity refundEntity = RefundEntityFixture
                 .aValidRefundEntity()

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeAuthoriseRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -19,10 +18,12 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeAuthoriseRequestTest {
@@ -38,7 +39,7 @@ public class StripeAuthoriseRequestTest {
 
     @Mock
     ChargeEntity charge;
-    @Mock
+
     GatewayAccountEntity gatewayAccount;
     @Mock
     StripeAuthTokens stripeAuthTokens;
@@ -47,7 +48,10 @@ public class StripeAuthoriseRequestTest {
 
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+        gatewayAccount = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", stripeConnectAccountId))
+                .build();
 
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,11 +13,14 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeCaptureRequestTest {
@@ -33,7 +35,7 @@ public class StripeCaptureRequestTest {
 
     @Mock
     ChargeEntity charge;
-    @Mock
+
     GatewayAccountEntity gatewayAccount;
     @Mock
     StripeAuthTokens stripeAuthTokens;
@@ -42,9 +44,12 @@ public class StripeCaptureRequestTest {
 
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
-        when(gatewayAccount.getId()).thenReturn(gatewayAccountId);
-        when(gatewayAccount.isLive()).thenReturn(true);
+        gatewayAccount = aGatewayAccountEntity()
+                .withId(gatewayAccountId)
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
+                .withType(LIVE)
+                .build();
 
         when(charge.getGatewayTransactionId()).thenReturn(stripeChargeId);
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentIntentRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +14,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.net.URI;
 import java.net.URLEncoder;
+import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -22,6 +22,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripePaymentIntentRequestTest {
@@ -29,7 +30,6 @@ public class StripePaymentIntentRequestTest {
     @Mock
     private ChargeEntity charge;
 
-    @Mock
     private GatewayAccountEntity gatewayAccount;
 
     @Mock
@@ -48,7 +48,11 @@ public class StripePaymentIntentRequestTest {
 
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+        gatewayAccount = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", stripeConnectAccountId))
+                .build();
+
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);
         when(charge.getAmount()).thenReturn(amount);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripePaymentMethodRequestTest.java
@@ -1,12 +1,10 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -14,13 +12,16 @@ import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.service.payments.commons.model.CardExpiryDate;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripePaymentMethodRequestTest {
@@ -42,7 +43,7 @@ public class StripePaymentMethodRequestTest {
 
     @Mock
     ChargeEntity charge;
-    @Mock
+
     GatewayAccountEntity gatewayAccount;
     @Mock
     StripeAuthTokens stripeAuthTokens;
@@ -52,7 +53,11 @@ public class StripePaymentMethodRequestTest {
 
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+        gatewayAccount = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", stripeConnectAccountId))
+                .build();
+
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
@@ -65,7 +70,6 @@ public class StripePaymentMethodRequestTest {
         authCardDetails.setEndDate(CardExpiryDate.valueOf(endMonth + "/" + endYear));
 
         CardAuthorisationGatewayRequest authorisationGatewayRequest = new CardAuthorisationGatewayRequest(charge, authCardDetails);
-
 
         stripePaymentMethodRequest = StripePaymentMethodRequest.of(authorisationGatewayRequest, stripeGatewayConfig);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,11 +14,13 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeRefundRequestTest {
@@ -34,7 +35,7 @@ public class StripeRefundRequestTest {
     RefundEntity refundEntity;
     @Mock
     Charge charge;
-    @Mock
+
     GatewayAccountEntity gatewayAccount;
     @Mock
     StripeGatewayConfig stripeGatewayConfig;
@@ -45,7 +46,10 @@ public class StripeRefundRequestTest {
     
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_account_id"));
+        gatewayAccount = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", "stripe_account_id"))
+                .build();
 
         when(refundEntity.getAmount()).thenReturn(refundAmount);
         when(refundEntity.getExternalId()).thenReturn(refundExternalId);

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,14 +9,18 @@ import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
+import java.util.Map;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.LIVE;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeRequestTest {
@@ -28,7 +31,7 @@ public class StripeRequestTest {
     RefundEntity refundEntity;
     @Mock
     Charge charge;
-    @Mock
+
     GatewayAccountEntity gatewayAccount;
     @Mock
     StripeGatewayConfig stripeGatewayConfig;
@@ -39,7 +42,10 @@ public class StripeRequestTest {
 
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", "stripe_connect_account_id"));
+        gatewayAccount = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", "stripe_connect_account_id"))
+                .build();
         when(charge.getGatewayTransactionId()).thenReturn("gatewayTransactionId");
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeAuthTokens.getLive()).thenReturn("live");
@@ -52,13 +58,13 @@ public class StripeRequestTest {
 
     @Test
     public void shouldSetCorrectAuthorizationHeaderForLiveAccount() {
-        when(gatewayAccount.isLive()).thenReturn(true);
+        gatewayAccount.setType(LIVE);
         assertThat(stripeRefundRequest.getHeaders().get("Authorization"), is("Bearer live"));
     }
     
     @Test
     public void shouldSetCorrectAuthorizationHeaderForTestAccount() {
-        when(gatewayAccount.isLive()).thenReturn(false);
+        gatewayAccount.setType(TEST);
         assertThat(stripeRefundRequest.getHeaders().get("Authorization"), is("Bearer test"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,17 +9,18 @@ import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeTransferInRequestTest {
@@ -38,7 +38,7 @@ public class StripeTransferInRequestTest {
     RefundEntity refundEntity;
     @Mock
     Charge charge;
-    @Mock
+
     GatewayAccountEntity gatewayAccount;
     @Mock
     StripeGatewayConfig stripeGatewayConfig;
@@ -50,7 +50,10 @@ public class StripeTransferInRequestTest {
 
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+        gatewayAccount = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", stripeConnectAccountId))
+                .build();
 
         when(charge.getExternalId()).thenReturn(chargeExternalId);
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
@@ -1,6 +1,5 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
-import com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -13,11 +12,13 @@ import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.net.URI;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeTransferOutRequestTest {
@@ -32,7 +33,7 @@ public class StripeTransferOutRequestTest {
 
     @Mock
     ChargeEntity charge;
-    @Mock
+
     GatewayAccountEntity gatewayAccount;
     @Mock
     StripeGatewayConfig stripeGatewayConfig;
@@ -42,7 +43,10 @@ public class StripeTransferOutRequestTest {
 
     @Before
     public void setUp() {
-        when(gatewayAccount.getCredentials()).thenReturn(ImmutableMap.of("stripe_account_id", stripeConnectAccountId));
+        gatewayAccount = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(Map.of("stripe_account_id", stripeConnectAccountId))
+                .build();
 
         when(charge.getGatewayAccount()).thenReturn(gatewayAccount);
         when(charge.getExternalId()).thenReturn(chargeExternalId);

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/service/StripeAccountServiceTest.java
@@ -3,25 +3,24 @@ package uk.gov.pay.connector.gatewayaccount.service;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.StripeAccountResponse;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.BDDMockito.given;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeAccountServiceTest {
 
     private StripeAccountService stripeAccountService;
 
-    @Mock
-    private GatewayAccountEntity mockGatewayAccountEntity;
+    private GatewayAccountEntity gatewayAccountEntity;
 
     @Before
     public void setUp() {
@@ -31,44 +30,40 @@ public class StripeAccountServiceTest {
     @Test
     public void buildStripeAccountResponseShouldReturnStripeAccountResponse() {
         String stripeAccountId = "acct_123example123";
-        given(mockGatewayAccountEntity.getCredentials())
-                .willReturn(Collections.singletonMap("stripe_account_id", stripeAccountId));
+        gatewayAccountEntity = aServiceAccount(Map.of("stripe_account_id", stripeAccountId));
 
         Optional<StripeAccountResponse> stripeAccountResponseOptional =
-                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
+                stripeAccountService.buildStripeAccountResponse(gatewayAccountEntity);
 
         assertThat(stripeAccountResponseOptional.get().getStripeAccountId(), is(stripeAccountId));
     }
 
     @Test
-    public void buildStripeAccountResponseShouldReturnEmptyOptionalWhenCredentialsIsNull() {
-        given(mockGatewayAccountEntity.getCredentials()).willReturn(null);
-
-        Optional<StripeAccountResponse> stripeAccountResponseOptional =
-                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
-
-        assertThat(stripeAccountResponseOptional.isPresent(), is(false));
-    }
-
-    @Test
     public void buildStripeAccountResponseShouldReturnEmptyOptionalWhenCredentialsAreEmpty() {
-        given(mockGatewayAccountEntity.getCredentials()).willReturn(Collections.emptyMap());
+        gatewayAccountEntity = aServiceAccount(Map.of());
 
         Optional<StripeAccountResponse> stripeAccountResponseOptional =
-                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
+                stripeAccountService.buildStripeAccountResponse(gatewayAccountEntity);
 
         assertThat(stripeAccountResponseOptional.isPresent(), is(false));
     }
 
     @Test
     public void buildStripeAccountResponseShouldReturnEmptyOptionalWhenCredentialsPropertyIsNull() {
-        given(mockGatewayAccountEntity.getCredentials())
-                .willReturn(Collections.singletonMap("stripe_account_id", null));
+        gatewayAccountEntity = aServiceAccount(Collections.singletonMap("stripe_account_id", null));
 
         Optional<StripeAccountResponse> stripeAccountResponseOptional =
-                stripeAccountService.buildStripeAccountResponse(mockGatewayAccountEntity);
+                stripeAccountService.buildStripeAccountResponse(gatewayAccountEntity);
 
         assertThat(stripeAccountResponseOptional.isPresent(), is(false));
     }
 
+    private GatewayAccountEntity aServiceAccount(Map credentials) {
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+                .withGatewayName("stripe")
+                .withCredentials(credentials)
+                .build();
+
+        return gatewayAccountEntity;
+    }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Get Stripe credentials based on payment provider name for all operations
- Updated path `/v1/api/accounts/{accountId}/stripe-account` to return stripe_account_id from the credential with payment provider 'Stripe' (only when active/current payment provider is Stripe).
