### PR TITLE
PP-8229 refactor patching credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -146,7 +146,11 @@ public class GatewayAccountCredentialsService {
     public GatewayAccountCredentials updateGatewayAccountCredentials(GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity, List<JsonPatchRequest> updateRequests) {
         for (JsonPatchRequest updateRequest : updateRequests) {
             if (updateRequest.getPath().equals(FIELD_CREDENTIALS) && updateRequest.getOp() == JsonPatchOp.REPLACE) {
-                gatewayAccountCredentialsEntity.setCredentials(updateRequest.valueAsObject());
+                HashMap<String, String> updatableMap = new HashMap<>(gatewayAccountCredentialsEntity.getCredentials());
+                updateRequest.valueAsObject().forEach((key, value) -> {
+                    updatableMap.put(key, value);
+                });
+                gatewayAccountCredentialsEntity.setCredentials(updatableMap);
                 if (gatewayAccountCredentialsEntity.getState() == CREATED) {
                     updateStateForEnteredCredentials(gatewayAccountCredentialsEntity);
                 }


### PR DESCRIPTION
## WHAT YOU DID
- refactor patch replace `credentials` to not replace all of credentials but to keep existing ones that are not on the top level patch request
- add test
