### PR TITLE
PP-8125 Worldpay notifications - query gateway_account_credentials for merchant_id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/dao/GatewayAccountDao.java
@@ -46,8 +46,10 @@ public class GatewayAccountDao extends JpaDao<GatewayAccountEntity> {
     }
 
     public boolean isATelephonePaymentNotificationAccount(String merchantId) {
-        String query = "SELECT count(g) FROM gateway_accounts g where g.credentials->>?1 = ?2 " +
-                " and allow_telephone_payment_notifications is true";
+        String query = "SELECT count(g) FROM gateway_accounts g, gateway_account_credentials gac " +
+                " where g.id = gac.gateway_account_id " +
+                " AND gac.credentials->>?1 = ?2 " +
+                " and g.allow_telephone_payment_notifications is true";
 
         var count = (Number) entityManager.get()
                 .createNativeQuery(query)


### PR DESCRIPTION
## WHAT YOU DID

- Queries `gateway_account_credentials` for matching merchant_id for worldpay notifications and uses flag `allow_telephone_payment_notifications` on gateway account to determine whether the gateway account is configured to accept telephone payment notifications.
