### PR TITLE
PP-8255 Send payer email address to Worldpay if enabled

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gateway.worldpay;
 import uk.gov.pay.connector.gateway.GatewayOrder;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 
+import java.util.Optional;
+
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.worldpay.WorldpayOrderRequestBuilder.aWorldpayAuthoriseOrderRequestBuilder;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
@@ -21,7 +23,11 @@ public interface WorldpayOrderBuilder {
         if (request.getGatewayAccount().isSendPayerIpAddressToGateway()) {
             request.getAuthCardDetails().getIpAddress().ifPresent(builder::withPayerIpAddress);
         }
-        
+
+        if (request.getGatewayAccount().isSendPayerEmailToGateway()) {
+            Optional.ofNullable(request.getCharge().getEmail()).ifPresent(builder::withPayerEmail);
+        }
+
         boolean is3dsRequired = request.getAuthCardDetails().getWorldpay3dsFlexDdcResult().isPresent() ||
                 request.getGatewayAccount().isRequires3ds();
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -30,6 +30,7 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         private boolean requires3ds;
         private String paResponse3ds;
         private String payerIpAddress;
+        private String payerEmail;
         private String state;
         private boolean exemptionEngineEnabled;
 
@@ -105,6 +106,14 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
         public void setPayerIpAddress(String payerIpAddress) {
             this.payerIpAddress = payerIpAddress;
+        }
+
+        public String getPayerEmail() {
+            return payerEmail;
+        }
+
+        public void setPayerEmail(String payerEmail) {
+            this.payerEmail = payerEmail;
         }
 
         public String getState() {
@@ -218,6 +227,11 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public WorldpayOrderRequestBuilder withPayerIpAddress(String payerIpAddress) {
         worldpayTemplateData.setPayerIpAddress(payerIpAddress);
+        return this;
+    }
+
+    public WorldpayOrderRequestBuilder withPayerEmail(String payerEmail) {
+        worldpayTemplateData.setPayerEmail(payerEmail);
         return this;
     }
 

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -39,13 +39,20 @@
                 </#if>
                 </#if>
             </paymentDetails>
-            <#if requires3ds>
+            <#if requires3ds || payerEmail??>
             <shopper>
+                <#if payerEmail??>
+                <shopperEmailAddress>${payerEmail?xml}</shopperEmailAddress>
+                </#if>
+                <#if requires3ds>
                 <browser>
                     <acceptHeader>${authCardDetails.acceptHeader?xml}</acceptHeader>
                     <userAgentHeader>${authCardDetails.userAgentHeader?xml}</userAgentHeader>
                 </browser>
+                </#if>
             </shopper>
+            </#if>
+            <#if requires3ds>
             <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>
             <additional3DSData
                 dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()?xml}"

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -23,9 +23,11 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-min-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_3DS_REQUEST_INCLUDING_STATE = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-3ds-request-including-state.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-excluding-3ds.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_EXCLUDING_3DS_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-excluding-3ds-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_FULL_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-full-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds-with-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITHOUT_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds-without-ip-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_3DS_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-3ds-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_INCLUDING_STATE = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-including-state.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_MIN_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-min-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds-with-email.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-excluding-3ds-with-email.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="transaction-id">
+            <description>This is a description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <VISA-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <address2>This road</address2>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </VISA-SSL>
+            </paymentDetails>
+            <shopper>
+                <shopperEmailAddress>test@email.invalid</shopperEmailAddress>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds-with-email.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-including-3ds-with-email.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="transaction-id">
+            <description>This is a description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <VISA-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <address2>This road</address2>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </VISA-SSL>
+                <session id="uniqueSessionId"/>
+            </paymentDetails>
+            <shopper>
+                <shopperEmailAddress>test@email.invalid</shopperEmailAddress>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                </browser>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
If a Worldpay gateway account has the setting to send the payer email address to the gateway enabled, and there is an email address for the payer (either entered directly by the user or passed to us by the service when they created the payment), send it to Worldpay in the authorisation request for a regular card payment.

The email address is sent in the XML authorisation request to Worldpay in an element called `<shopperEmailAddress>`, which is in turn inside an element called `<shopper>` (if 3D Secure is enabled, we already send a `<shopper>` element).

The <shopper> element appears after the `<paymentDetails>` element. If 3D Secure is disabled, the email address is sent like this:

```xml
<shopper>
    <shopperEmailAddress>payer@email.example</shopperEmailAddress>
</shopper>
```

If 3D Secure is enabled, the email address is sent before the `<browser>` element (this matches Worldpay’s examples in their documentation and worked when tested):

```xml
<shopper>
    <shopperEmailAddress>payer@email.example</shopperEmailAddress>
    <browser>
        <acceptHeader>*/*</acceptHeader>
        <userAgentHeader>Mozilla/5.0</userAgentHeader>
    </browser>
</shopper>
```

There are no changes if either the setting to send the payer email to the gateway is not enabled, or if there is no payer email address available.

The email address is only sent for regular card payments. It is not sent for Apple Pay or Google Pay payments.

Worldpay have a setting to send payment confirmation emails to paying users if an email address is supplied. To avoid confusing paying users, this setting should not be enabled.