### PR TITLE
PP-8255 Send payer email to Worldpay for Apple Pay and Google Pay

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.wallets.WalletAuthorisationHandler;
 import javax.inject.Inject;
 import java.net.URI;
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gateway.util.AuthUtil.getGatewayAccountCredentialsAsAuthHeader;
@@ -48,11 +49,16 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
 
         boolean is3dsRequired = request.getGatewayAccount().isRequires3ds();
         boolean isSendIpAddress = request.getGatewayAccount().isSendPayerIpAddressToGateway();
+        boolean isSendPayerEmailToGateway = request.getGatewayAccount().isSendPayerEmailToGateway();
 
         var builder = aWorldpayAuthoriseWalletOrderRequestBuilder(request.getWalletAuthorisationData().getWalletType());
 
         if (is3dsRequired && isSendIpAddress) {
             builder.withPayerIpAddress(request.getWalletAuthorisationData().getPaymentInfo().getIpAddress());
+        }
+
+        if (isSendPayerEmailToGateway) {
+            Optional.ofNullable(request.getWalletAuthorisationData().getPaymentInfo().getEmail()).ifPresent(builder::withPayerEmail);
         }
 
         return builder

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseApplePayOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseApplePayOrderTemplate.xml
@@ -19,6 +19,11 @@
                     </#if>
                 </EMVCO_TOKEN-SSL>
             </paymentDetails>
+            <#if payerEmail??>
+            <shopper>
+                <shopperEmailAddress>${payerEmail?xml}</shopperEmailAddress>
+            </shopper>
+            </#if>
         </order>
     </submit>
 </paymentService>

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseGooglePayOrderTemplate.xml
@@ -20,12 +20,17 @@
                 </#if>
                 </#if>
             </paymentDetails>
-            <#if requires3ds>
+            <#if requires3ds || payerEmail??>
             <shopper>
+                <#if payerEmail??>
+                <shopperEmailAddress>${payerEmail?xml}</shopperEmailAddress>
+                </#if>
+                <#if requires3ds>
                 <browser>
                     <acceptHeader>${walletAuthorisationData.paymentInfo.acceptHeader?xml}</acceptHeader>
                     <userAgentHeader>${walletAuthorisationData.paymentInfo.userAgentHeader?xml}</userAgentHeader>
                 </browser>
+                </#if>
             </shopper>
             </#if>
         </order>

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -42,9 +42,12 @@ import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIA
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL;
 
 @RunWith(MockitoJUnitRunner.class)
 public class WorldpayWalletAuthorisationHandlerTest {
@@ -88,10 +91,53 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Test
     public void shouldSendApplePayRequestWhenApplePayDetailsArePresent() throws Exception {
         try {
-            worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest());
+            worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(false));
         } catch (GatewayErrorException e) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendApplePayRequestWithPayerEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(true);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(true));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendApplePayRequestWithoutPayerEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(false);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(true));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendApplePayRequestWithoutPayerEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(true);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getApplePayAuthorisationRequest(false));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
             assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
         }
@@ -100,10 +146,53 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Test
     public void shouldSendGooglePayRequestWhenGooglePayDetailsArePresent() throws Exception {
         try {
-            worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest());
+            worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(false));
         } catch (GatewayErrorException e) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendGooglePayRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(true);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(true));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendGooglePayRequestWithoutEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(false);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(true));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendGooglePayRequestWithoutEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(true);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getGooglePayAuthorisationRequest(false));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
             assertThat(headers.getValue(), is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
         }
@@ -112,10 +201,11 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Test
     public void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithoutIpAddressArePresent() throws Exception {
         try {
-            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false));
+            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, false));
         } catch (GatewayErrorException e) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
-            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
             assertThat(headers.getValue().size(), is(1));
             assertThat(headers.getValue(),
                     is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
@@ -125,7 +215,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Test
     public void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithIpAddressArePresent() throws Exception {
         try {
-            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, true));
+            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, true, false));
         } catch (GatewayErrorException e) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS), gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -137,7 +227,7 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Test
     public void shouldSendGooglePay3dsRequestWhenGooglePayDetailsWithout3dsEnabledArePresent() throws Exception {
         try {
-            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(false, true));
+            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(false, true, false));
         } catch (GatewayErrorException e) {
             verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
             assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST), gatewayOrderArgumentCaptor.getValue().getPayload());
@@ -146,29 +236,76 @@ public class WorldpayWalletAuthorisationHandlerTest {
         }
     }
 
-    private WalletAuthorisationGatewayRequest getGooglePayAuthorisationRequest() throws IOException {
-        GooglePayAuthRequest googlePayAuthRequest =
-                Jackson.getObjectMapper().readValue(fixture("googlepay/example-auth-request.json"), GooglePayAuthRequest.class);
+    @Test
+    public void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(true);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, true));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(),
+                    is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayDisabledAndPayerEmailPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(false);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, true));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(),
+                    is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    @Test
+    public void shouldSendGooglePay3dsRequestWithEmailWhenSendingPayerEmailToGatewayEnabledAndPayerEmailNotPresent() throws Exception {
+        gatewayAccountEntity.setSendPayerEmailToGateway(true);
+        try {
+            worldpayWalletAuthorisationHandler.authorise(getGooglePay3dsAuthorisationRequest(true, false, false));
+        } catch (GatewayErrorException e) {
+            verify(mockGatewayClient).postRequestFor(eq(WORLDPAY_URL), eq(gatewayAccountEntity), gatewayOrderArgumentCaptor.capture(), headers.capture());
+            assertXMLEqual(TestTemplateResourceLoader.load(WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS),
+                    gatewayOrderArgumentCaptor.getValue().getPayload());
+            assertThat(headers.getValue().size(), is(1));
+            assertThat(headers.getValue(),
+                    is(AuthUtil.getGatewayAccountCredentialsAsAuthHeader(gatewayAccountCredentials)));
+        }
+    }
+
+    private WalletAuthorisationGatewayRequest getGooglePayAuthorisationRequest(boolean withPayerEmail) throws IOException {
+        String fixturePath = withPayerEmail ? "googlepay/example-auth-request.json" : "googlepay/example-auth-request-without-email.json";
+        GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture(fixturePath), GooglePayAuthRequest.class);
         return new WalletAuthorisationGatewayRequest(chargeEntity, googlePayAuthRequest);
     }
 
-    private WalletAuthorisationGatewayRequest getGooglePay3dsAuthorisationRequest(boolean isRequires3ds, boolean withIpAddress) throws IOException {
-        GooglePayAuthRequest googlePayAuthRequest =
-                Jackson.getObjectMapper().readValue(fixture("googlepay/example-3ds-auth-request.json"), GooglePayAuthRequest.class);
+    private WalletAuthorisationGatewayRequest getGooglePay3dsAuthorisationRequest(boolean isRequires3ds, boolean withIpAddress, boolean withPayerEmail)
+            throws IOException {
+        String fixturePath = withPayerEmail ? "googlepay/example-3ds-auth-request.json" : "googlepay/example-3ds-auth-request-without-email.json";
+        GooglePayAuthRequest googlePayAuthRequest = Jackson.getObjectMapper().readValue(fixture(fixturePath), GooglePayAuthRequest.class);
         chargeEntity.getGatewayAccount().setRequires3ds(isRequires3ds);
         chargeEntity.getGatewayAccount().setSendPayerIpAddressToGateway(withIpAddress);
         chargeEntity.setExternalId(GOOGLE_PAY_3DS_WITHOUT_IP_ADDRESS);
         return new WalletAuthorisationGatewayRequest(chargeEntity, googlePayAuthRequest);
     }
 
-    private WalletAuthorisationGatewayRequest getApplePayAuthorisationRequest() {
+    private WalletAuthorisationGatewayRequest getApplePayAuthorisationRequest(boolean withPayerEmail) {
+        String payerEmail = withPayerEmail ? "aaa@bbb.test" : null;
         AppleDecryptedPaymentData data = new AppleDecryptedPaymentData(
                 new WalletPaymentInfo(
                         "4242",
                         "visa",
                         PayersCardType.DEBIT,
                         "Mr. Payment",
-                        "aaa@bbb.test"
+                        payerEmail
                 ),
                 "4818528840010767",
                 LocalDate.of(2023, 12, 1),

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -33,9 +33,12 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_REQUEST_WITHOUT_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-without-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_MIN_DATA = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-min-data.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_APPLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-apple-pay-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-with-email.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-without-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-ip-address.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-email.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";

--- a/src/test/resources/googlepay/example-3ds-auth-request-without-email.json
+++ b/src/test/resources/googlepay/example-3ds-auth-request-without-email.json
@@ -1,0 +1,15 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "4242",
+    "brand": "visa",
+    "cardholder_name": "Example Name",
+    "accept_header": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8",
+    "user_agent_header": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36",
+    "ip_address": "8.8.8.8"
+  },
+  "encrypted_payment_data": {
+    "signature": "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl",
+    "protocol_version": "ECv1",
+    "signed_message": "aSignedMessage"
+  }
+}

--- a/src/test/resources/googlepay/example-auth-request-without-email.json
+++ b/src/test/resources/googlepay/example-auth-request-without-email.json
@@ -1,0 +1,12 @@
+{
+  "payment_info": {
+    "last_digits_card_number": "4242",
+    "brand": "visa",
+    "cardholder_name": "Example Name"
+  },
+  "encrypted_payment_data": {
+    "signature": "MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl",
+    "protocol_version": "ECv1",
+    "signed_message": "aSignedMessage"
+  }
+}

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-apple-pay-with-email.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-apple-pay-with-email.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <EMVCO_TOKEN-SSL type="APPLEPAY">
+                    <tokenNumber>4818528840010767</tokenNumber>
+                    <expiryDate><date month="12" year="2023"/></expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cryptogram>Ao/fzpIAFvp1eB9y8WVDMAACAAA=</cryptogram>
+                    <eciIndicator>07</eciIndicator>
+                </EMVCO_TOKEN-SSL>
+            </paymentDetails>
+            <shopper>
+                <shopperEmailAddress>aaa@bbb.test</shopperEmailAddress>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-with-email.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-3ds-with-email.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <PAYWITHGOOGLE-SSL>
+                    <protocolVersion>ECv1</protocolVersion>
+                    <signature>MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl</signature>
+                    <signedMessage>aSignedMessage</signedMessage>
+                </PAYWITHGOOGLE-SSL>
+                <session id="uniqueSessionId"/>
+            </paymentDetails>
+            <shopper>
+                <shopperEmailAddress>example@test.example</shopperEmailAddress>
+                <browser>
+                    <acceptHeader>text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,/;q=0.8</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36</userAgentHeader>
+                </browser>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-with-email.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-google-pay-with-email.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="MyUniqueTransactionId!" shopperLanguageCode="en">
+            <description>This is the description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <PAYWITHGOOGLE-SSL>
+                    <protocolVersion>ECv1</protocolVersion>
+                    <signature>MEYCIQC+a+AzSpQGr42UR1uTNX91DQM2r7SeKwzNs0UPoeSrrQIhAPpSzHjYTvvJGGzWwli8NRyHYE/diQMLL8aXqm9VIrwl</signature>
+                    <signedMessage>aSignedMessage</signedMessage>
+                </PAYWITHGOOGLE-SSL>
+            </paymentDetails>
+            <shopper>
+                <shopperEmailAddress>example@test.example</shopperEmailAddress>
+            </shopper>
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
When authorising an Apple Pay or Google Pay payment, if the gateway account has the setting to send the payer email address to the gateway enabled, and an email address was supplied for the payer (for Apple Pay, it’s technically the email address of the shipping contact), send it to Worldpay in the authorisation request.

The email address is sent in the XML authorisation request to Worldpay in an element called `<shopperEmailAddress>`, which is in turn inside an element called <shopper> (if 3D Secure is enabled, we already send a `<shopper>` element).

The `<shopper>` element appears after the `<paymentDetails>` element. If it’s an Apple Pay payment, or a Google Pay payment and 3D Secure is disabled, the email address is sent like this:

```xml
<shopper>
    <shopperEmailAddress>name@email.example</shopperEmailAddress>
</shopper>
```

If it’s a Google Pay payment and 3D Secure is enabled, the email address is sent before the `<browser>` element:

```xml
<shopper>
    <shopperEmailAddress>name@email.example</shopperEmailAddress>
    <browser>
        <acceptHeader>*/*</acceptHeader>
        <userAgentHeader>Mozilla/5.0</userAgentHeader>
    </browser>
</shopper>
```

There are no changes if either the setting to send the payer email to the gateway is not enabled, or if there is no email address available.

At the point where we send the authorisation request, we have not yet stored the email address on the charge, so we get it from the `WalletPaymentInfo` (the normalised Apple Pay or Google Pay payload). Although the template has direct access to the `WalletPaymentInfo` object, getting the email from there would bypass the check that the setting to send the payer email address to the gateway is enabled (and we’re not able to check that setting from within the template). Instead, we check if the setting is enabled earlier and if it is we add the email address (if there is one) to the template data and retrieve it from there within the template.

Sending the email address for regular card payments was added in commit 15815a2ce4f1c3a01a7f291b554065b61fcc2788.

Worldpay have a setting to send payment confirmation emails to paying users if an email address is supplied. To avoid confusing paying users, this setting should not be enabled.