### PR TITLE
PP-8288 Stripe - Delay transferring to connect account

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-06-22T14:31:45Z",
+  "generated_at": "2021-06-28T11:41:45Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -339,7 +339,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 136,
         "type": "Secret Keyword"
       }
     ],
@@ -376,7 +376,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
+        "line_number": 136,
         "type": "Secret Keyword"
       }
     ],
@@ -413,7 +413,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 124,
+        "line_number": 126,
         "type": "Secret Keyword"
       }
     ],
@@ -450,7 +450,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 130,
+        "line_number": 132,
         "type": "Secret Keyword"
       }
     ],
@@ -487,7 +487,7 @@
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 129,
+        "line_number": 131,
         "type": "Secret Keyword"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/StripeGatewayConfig.java
@@ -40,6 +40,11 @@ public class StripeGatewayConfig extends Configuration {
 
     @Valid
     @NotNull
+    @Min(1)
+    private int transferDelay;
+
+    @Valid
+    @NotNull
     private List<String> allowedCidrs;
 
     @NotNull
@@ -79,5 +84,9 @@ public class StripeGatewayConfig extends Configuration {
 
     public List<String> getCredentials() {
         return credentials;
+    }
+
+    public int getTransferDelay() {
+        return transferDelay;
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -112,6 +112,7 @@ stripe:
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-false}
   notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-1000}
+  transferDelay: ${STRIPE_TRANSFER_DELAY:-2000}
   credentials: ['stripe_account_id']
 
 executorServiceConfig:

--- a/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml
@@ -78,6 +78,7 @@ stripe:
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
+  transferDelay: ${STRIPE_TRANSFER_DELAY:-100}
   credentials: ['stripe_account_id']
 
 jerseyClient:

--- a/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
+++ b/src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml
@@ -78,6 +78,7 @@ stripe:
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
+  transferDelay: ${STRIPE_TRANSFER_DELAY:-100}
   credentials: ['stripe_account_id']
 
 jerseyClient:

--- a/src/test/resources/config/client-factory-test-config.yaml
+++ b/src/test/resources/config/client-factory-test-config.yaml
@@ -68,6 +68,7 @@ stripe:
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
+  transferDelay: ${STRIPE_TRANSFER_DELAY:-100}
   credentials: ['stripe_account_id']
 
 jerseyClient:

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -74,6 +74,7 @@ stripe:
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE:-0.08}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-100}
+  transferDelay: ${STRIPE_TRANSFER_DELAY:-100}
   credentials: ['stripe_account_id']
 
 executorServiceConfig:

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -73,6 +73,7 @@ stripe:
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-true}
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID:-stripe_platform_account_id}
   notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-1000}
+  transferDelay: ${STRIPE_TRANSFER_DELAY:-1000}
   credentials: ['stripe_account_id']
 
 executorServiceConfig:


### PR DESCRIPTION
# WHAT YOU DID
- Delay transferring the net amount to connect account so we can rule out `lock_timeout` errors we are seeing when transferring net amount to connect account.
   - `lock_timeout` from Stripe happens when two requests modify same object concurrently. Although we have not seen multiple requests to Stripe, it could be Stripe holding lock on object for longer (when captured) and rejecting subsequent transfer request
