### PR TITLE
PP-8282 Enable switching PSP only if account as active creds

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountWithoutAnActiveCredentialException.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/exception/GatewayAccountWithoutAnActiveCredentialException.java
@@ -1,0 +1,12 @@
+package uk.gov.pay.connector.gatewayaccount.exception;
+
+import javax.ws.rs.BadRequestException;
+
+import static java.lang.String.format;
+import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
+
+public class GatewayAccountWithoutAnActiveCredentialException extends BadRequestException {
+    public GatewayAccountWithoutAnActiveCredentialException(Long id) {
+        super(badRequestResponse(format("Gateway account with id [%s] does not have an active credential", id)));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/service/GatewayAccountCredentialsService.java
@@ -44,7 +44,7 @@ public class GatewayAccountCredentialsService {
 
     private static final String GATEWAY_MERCHANT_ID = "gateway_merchant_id";
     private final GatewayAccountCredentialsDao gatewayAccountCredentialsDao;
-    
+
     private final Set<GatewayAccountCredentialState> USABLE_STATES = Set.of(ENTERED, VERIFIED_WITH_LIVE_PAYMENT, ACTIVE);
 
     @Inject
@@ -180,7 +180,7 @@ public class GatewayAccountCredentialsService {
             credentialsEntity.setState(ENTERED);
         }
     }
-    
+
     public GatewayAccountCredentialsEntity getUsableCredentialsForProvider(GatewayAccountEntity gatewayAccountEntity, String paymentProvider) {
         List<GatewayAccountCredentialsEntity> credentialsForProvider = gatewayAccountEntity.getGatewayAccountCredentials()
                 .stream()
@@ -194,7 +194,7 @@ public class GatewayAccountCredentialsService {
         List<GatewayAccountCredentialsEntity> credentialsInState = credentialsForProvider.stream().filter(gatewayAccountCredentialsEntity ->
                 USABLE_STATES.contains(gatewayAccountCredentialsEntity.getState()))
                 .collect(Collectors.toList());
-        
+
         if (credentialsInState.isEmpty()) {
             throw new NoCredentialsInUsableStateException(paymentProvider);
         }
@@ -202,5 +202,9 @@ public class GatewayAccountCredentialsService {
             throw new WebApplicationException(badRequestResponse(Collections.singletonList("Multiple usable credentials exist for payment provider [%s], unable to determine which to use.")));
         }
         return credentialsInState.get(0);
+    }
+
+    public boolean hasActiveCredentials(Long gatewayAccountId) {
+        return gatewayAccountCredentialsDao.hasActiveCredentials(gatewayAccountId);
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
- Allow enabling PSP switching only if the current credential (payment provider) is fully ACTIVE. There should be ac active payment provider to continue taking payments with when adding a new provider to switch to.

- Also added logging when provider switch is enabled and gateway account is switched to new PSP

