### PR TITLE
PP-8282 Get gateway name - return credentials in any state if no ACTIVE credential exist

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountService.java
@@ -223,11 +223,13 @@ public class GatewayAccountService {
                     throwIfNoActiveCredentialExist(gatewayAccountEntity);
                     gatewayAccountEntity.setProviderSwitchEnabled(gatewayAccountRequest.valueAsBoolean());
 
-                    logger.info("Enabled switching payment provider for gateway account [id={}]",
-                            gatewayAccountEntity.getId(),
-                            kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
-                            kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
-                            kv(PROVIDER, gatewayAccountEntity.getGatewayName()));
+                    if(gatewayAccountRequest.valueAsBoolean()) {
+                        logger.info("Enabled switching payment provider for gateway account [id={}]",
+                                gatewayAccountEntity.getId(),
+                                kv(GATEWAY_ACCOUNT_ID, gatewayAccountEntity.getId()),
+                                kv(GATEWAY_ACCOUNT_TYPE, gatewayAccountEntity.getType()),
+                                kv(PROVIDER, gatewayAccountEntity.getGatewayName()));
+                    }
                 }
             )
     );

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -136,6 +136,10 @@ public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
         this.activeStartDate = activeStartDate;
     }
 
+    public void setCreatedDate(Instant createdDate) {
+        this.createdDate = createdDate;
+    }
+
     public void setActiveEndDate(Instant activeEndDate) {
         this.activeEndDate = activeEndDate;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntityFixture.java
@@ -16,12 +16,18 @@ public final class GatewayAccountCredentialsEntityFixture {
     private GatewayAccountCredentialState state = CREATED;
     private GatewayAccountEntity gatewayAccountEntity;
     private String externalId = randomUuid();
+    private Instant createdDate = Instant.now();
 
     private GatewayAccountCredentialsEntityFixture() {
     }
 
     public static GatewayAccountCredentialsEntityFixture aGatewayAccountCredentialsEntity() {
         return new GatewayAccountCredentialsEntityFixture();
+    }
+
+    public GatewayAccountCredentialsEntityFixture withCreatedDate(Instant createdDate) {
+        this.createdDate = createdDate;
+        return this;
     }
 
     public GatewayAccountCredentialsEntityFixture withActiveStartDate(Instant activeStartDate) {
@@ -56,6 +62,7 @@ public final class GatewayAccountCredentialsEntityFixture {
 
     public GatewayAccountCredentialsEntity build() {
         GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = new GatewayAccountCredentialsEntity(gatewayAccountEntity, paymentProvider, credentials, state);
+        gatewayAccountCredentialsEntity.setCreatedDate(createdDate);
         gatewayAccountCredentialsEntity.setActiveStartDate(activeStartDate);
         gatewayAccountCredentialsEntity.setExternalId(externalId);
         return gatewayAccountCredentialsEntity;


### PR DESCRIPTION
## WHAT

- Currently getGatewayName returns payment provider for ACTIVE credential if multiple credentials exists. If for any reason, there are multiple credentials but no ACTIVE credential found, an exception is thrown which results in serialisation errors affecting read operations involving these gateway account(s). This could break admin tool access for services, toolbox functionality and even new payments.
       - So fall back to getting first credential if no ACTIVE credentials found.
- All the logic can be moved to service class once we remove serialising GatewayAccountEntity directly and use DTO object for serialisation.
