### PR TITLE
PP-8214 Add provider_switch_enabled field to response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -86,6 +86,9 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("moto_mask_card_security_code_input")
     private boolean motoMaskCardSecurityCodeInput;
 
+    @JsonProperty("provider_switch_enabled")
+    private boolean providerSwitchEnabled;
+
     @JsonInclude(NON_NULL)
     @JsonProperty("worldpay_3ds_flex")
     private Worldpay3dsFlexCredentials worldpay3dsFlexCredentials;
@@ -118,6 +121,7 @@ public class GatewayAccountResourceDTO {
         this.motoMaskCardSecurityCodeInput = gatewayAccountEntity.isMotoMaskCardSecurityCodeInput();
         this.allowTelephonePaymentNotifications = gatewayAccountEntity.isAllowTelephonePaymentNotifications();
         this.worldpay3dsFlexCredentials = gatewayAccountEntity.getWorldpay3dsFlexCredentials().orElse(null);
+        this.providerSwitchEnabled = gatewayAccountEntity.isProviderSwitchEnabled();
     }
 
     public long getAccountId() {
@@ -218,6 +222,10 @@ public class GatewayAccountResourceDTO {
 
     public boolean isAllowTelephonePaymentNotifications() {
         return allowTelephonePaymentNotifications;
+    }
+
+    public boolean isProviderSwitchEnabled() {
+        return providerSwitchEnabled;
     }
 
     public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -15,7 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.gatewayaccount.model.Worldpay3dsFlexCredentialsEntity.Worldpay3dsFlexCredentialsEntityBuilder.aWorldpay3dsFlexCredentialsEntity;
 
-
 public class GatewayAccountResourceDTOTest {
 
     @Test
@@ -44,6 +43,7 @@ public class GatewayAccountResourceDTOTest {
         entity.setMotoMaskCardNumberInput(true);
         entity.setMotoMaskCardSecurityCodeInput(true);
         entity.setAllowTelephonePaymentNotifications(true);
+        entity.setProviderSwitchEnabled(true);
         entity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         entity.setGatewayAccountCredentials(List.of(
                 GatewayAccountCredentialsEntityFixture.
@@ -83,5 +83,6 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.isMotoMaskCardSecurityCodeInput(), is(entity.isMotoMaskCardSecurityCodeInput()));
         assertThat(dto.isAllowTelephonePaymentNotifications(), is(entity.isAllowTelephonePaymentNotifications()));
         assertThat(dto.getWorldpay3dsFlexCredentials(), is(entity.getWorldpay3dsFlexCredentials()));
+        assertThat(dto.isProviderSwitchEnabled(), is(entity.isProviderSwitchEnabled()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -185,7 +185,8 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .body("allow_apple_pay", is(false))
                 .body("allow_zero_amount", is(false))
                 .body("integration_version_3ds", is(2))
-                .body("allow_telephone_payment_notifications", is(true));
+                .body("allow_telephone_payment_notifications", is(true))
+                .body("provider_switch_enabled", is(false));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
- Currently `provider_switch_enabled` is only available on `/v1/frontend/accounts/` response. Added provider_switch_enabled to GatewayAccountResourceDTO which ensures field is available on all other account endpoints (/v1/api/accounts/*)

