### PR TITLE
PP-8281 Don't pass gateway account to GatewayClient

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayClientRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayClientRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.gateway.model.request;
 
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
 import java.net.URI;
@@ -10,5 +11,6 @@ public interface GatewayClientRequest {
     URI getUrl();
     GatewayOrder getGatewayOrder();
     Map<String, String> getHeaders();
-    GatewayAccountEntity getGatewayAccount();
+    String getGatewayAccountType();
+    PaymentGatewayName getPaymentProvider();
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeRequest.java
@@ -5,6 +5,7 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.GatewayOrder;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gateway.util.AuthUtil;
@@ -23,11 +24,12 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED_TYPE;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 
 public abstract class StripeRequest implements GatewayClientRequest {
-
-    protected GatewayAccountEntity gatewayAccount;
+    
     private String idempotencyKey;
+    private GatewayAccountEntity gatewayAccount;
     protected StripeGatewayConfig stripeGatewayConfig;
     protected String stripeConnectAccountId;
+    protected String gatewayAccountType;
 
     protected StripeRequest(GatewayAccountEntity gatewayAccount, String idempotencyKey, StripeGatewayConfig stripeGatewayConfig) {
         if (gatewayAccount == null) {
@@ -40,16 +42,22 @@ public abstract class StripeRequest implements GatewayClientRequest {
         }
         
         this.gatewayAccount = gatewayAccount;
+        this.gatewayAccountType = gatewayAccount.getType();
         this.idempotencyKey = idempotencyKey;
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.stripeConnectAccountId = stripeAccountId;
     }
 
-    public final GatewayAccountEntity getGatewayAccount() {
-        return gatewayAccount;
+    @Override
+    public PaymentGatewayName getPaymentProvider() {
+        return STRIPE;
     }
 
-    
+    @Override
+    public String getGatewayAccountType() {
+        return gatewayAccountType;
+    }
+
     public final URI getUrl() {
         return URI.create(stripeGatewayConfig.getUrl() + urlPath());
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationService.java
@@ -45,7 +45,7 @@ public class WorldpayCredentialsValidationService implements WorldpayGatewayResp
         try {
             GatewayClient.Response response = gatewayClient.postRequestFor(
                     gatewayUrlMap.get(gatewayAccountEntity.getType()),
-                    PaymentGatewayName.WORLDPAY.getName(),
+                    PaymentGatewayName.WORLDPAY,
                     gatewayAccountEntity.getType(),
                     order,
                     Collections.emptyList(),

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -253,7 +253,8 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
 
             GatewayClient.Response response = authoriseClient.postRequestFor(
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
-                    request.getGatewayAccount(),
+                    WORLDPAY,
+                    request.getGatewayAccount().getType(),
                     build3dsResponseAuthOrder(request),
                     cookies,
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(WORLDPAY.getName())));

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeCaptureRequestTest.java
@@ -102,10 +102,10 @@ public class StripeCaptureRequestTest {
     }
     
     @Test
-    public void shouldContainCorrectGatewayAccount() {
+    public void shouldHaveCorrectGatewayAccountType() {
         assertThat(
-                stripeCaptureRequest.getGatewayAccount().getId(),
-                is(gatewayAccountId)
+                stripeCaptureRequest.getGatewayAccountType(),
+                is(gatewayAccount.getType())
         );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCredentialsValidationServiceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE;
@@ -63,7 +64,7 @@ class WorldpayCredentialsValidationServiceTest {
     void shouldReturnTrue_ifWorldpayRespondsWithStatus200AndErrorCode5() throws GatewayException {
         when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_VALID_RESPONSE));
 
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
         boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
@@ -74,7 +75,7 @@ class WorldpayCredentialsValidationServiceTest {
     void shouldReturnFalse_ifWorldpayRespondsWithStatus200AndErrorCode4() throws GatewayException {
         when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_INVALID_MERCHANT_ID_RESPONSE));
 
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
         boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
@@ -83,7 +84,7 @@ class WorldpayCredentialsValidationServiceTest {
 
     @Test
     void shouldReturnFalse_ifWorldpayRespondsWithStatus401() throws GatewayException {
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 401));
 
         boolean valid = worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials);
@@ -94,7 +95,7 @@ class WorldpayCredentialsValidationServiceTest {
     void shouldThrowException_whenErrorCodeUnexpected() throws GatewayException {
         when(response.getEntity()).thenReturn(load(WORLDPAY_INQUIRY_CREDENTIAL_VALIDATION_UNEXPECTED_ERROR_CODE));
 
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenReturn(response);
 
         assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
@@ -102,7 +103,7 @@ class WorldpayCredentialsValidationServiceTest {
 
     @Test
     void shouldThrowException_whenErrorStatusCodeNot401() throws GatewayException {
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Error", "Error", 403));
 
         assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));
@@ -110,7 +111,7 @@ class WorldpayCredentialsValidationServiceTest {
 
     @Test
     void shouldWrapGatewayException() throws GatewayException {
-        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq("worldpay"), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
+        when(gatewayClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), eq(emptyList()), anyMap()))
                 .thenThrow(GatewayException.GenericGatewayException.class);
 
         assertThrows(UnexpectedValidateCredentialsResponse.class, () -> worldpayCredentialsValidationService.validateCredentials(gatewayAccountEntity, worldpayCredentials));

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -398,7 +398,7 @@ public class WorldpayPaymentProviderTest {
         ChargeEntity chargeEntity = chargeEntityFixture.build();
 
         when(response.getEntity()).thenReturn(load(WORLDPAY_EXEMPTION_REQUEST_REJECTED_AUTHORISED_RESPONSE));
-        when(authoriseClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
+        when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"),  any(GatewayOrder.class), anyList(), anyMap()))
                 .thenReturn(response);
 
         worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(chargeEntity));
@@ -423,7 +423,7 @@ public class WorldpayPaymentProviderTest {
                 .withTransactionId("MyUniqueTransactionId!")
                 .build();
 
-        when(authoriseClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
+        when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyList(), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 401 from gateway"));
 
         worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(chargeEntity));
@@ -432,7 +432,7 @@ public class WorldpayPaymentProviderTest {
 
         verify(authoriseClient).postRequestFor(
                 eq(WORLDPAY_URL),
-                eq(gatewayAccountEntity),
+                eq(WORLDPAY), eq("test"),
                 gatewayOrderArgumentCaptor.capture(),
                 anyList(),
                 anyMap());
@@ -448,7 +448,7 @@ public class WorldpayPaymentProviderTest {
                 .withTransactionId("MyUniqueTransactionId!")
                 .build();
 
-        when(authoriseClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
+        when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyList(), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 401 from gateway"));
 
         var request = new Auth3dsResponseGatewayRequest(chargeEntity, new Auth3dsResult());
@@ -458,7 +458,7 @@ public class WorldpayPaymentProviderTest {
 
         verify(authoriseClient).postRequestFor(
                 eq(WORLDPAY_URL),
-                eq(gatewayAccountEntity),
+                eq(WORLDPAY), eq("test"),
                 gatewayOrderArgumentCaptor.capture(),
                 anyList(),
                 anyMap());
@@ -476,7 +476,7 @@ public class WorldpayPaymentProviderTest {
                 .withProviderSessionId(providerSessionId)
                 .build();
 
-        when(authoriseClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
+        when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyList(), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(chargeEntity));
@@ -485,7 +485,7 @@ public class WorldpayPaymentProviderTest {
 
         verify(authoriseClient).postRequestFor(
                 eq(WORLDPAY_URL),
-                eq(gatewayAccountEntity),
+                eq(WORLDPAY), eq("test"),
                 ArgumentCaptor.forClass(GatewayOrder.class).capture(),
                 cookies.capture(),
                 ArgumentCaptor.forClass(Map.class).capture());
@@ -504,7 +504,7 @@ public class WorldpayPaymentProviderTest {
                 .withProviderSessionId(providerSessionId)
                 .build();
 
-        when(authoriseClient.postRequestFor(any(URI.class), any(GatewayAccountEntity.class), any(GatewayOrder.class), anyList(), anyMap()))
+        when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyList(), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
         worldpayPaymentProvider.authorise3dsResponse(get3dsResponseGatewayRequest(mockChargeEntity));
@@ -514,7 +514,7 @@ public class WorldpayPaymentProviderTest {
 
         verify(authoriseClient).postRequestFor(
                 eq(WORLDPAY_URL),
-                eq(gatewayAccountEntity),
+                eq(WORLDPAY), eq("test"),
                 gatewayOrderArgumentCaptor.capture(),
                 anyList(),
                 headers.capture());
@@ -545,7 +545,7 @@ public class WorldpayPaymentProviderTest {
         when(response.getEntity()).thenReturn(load(WORLDPAY_3DS_RESPONSE));
         when(response.getResponseCookies()).thenReturn(Map.of(WORLDPAY_MACHINE_COOKIE_NAME, "new-machine-cookie-value"));
 
-        when(authoriseClient.postRequestFor(eq(WORLDPAY_URL), eq(chargeEntity.getGatewayAccount()), any(GatewayOrder.class),
+        when(authoriseClient.postRequestFor(eq(WORLDPAY_URL), eq(WORLDPAY), eq("test"),  any(GatewayOrder.class),
                 eq(List.of(new HttpCookie(WORLDPAY_MACHINE_COOKIE_NAME, "original-machine-cookie"))), anyMap()))
                 .thenReturn(response);
 

--- a/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/GatewayClientTest.java
@@ -52,17 +52,12 @@ public class GatewayClientTest {
     private Response mockResponse;
     @Mock
     private Builder mockBuilder;
-
     @Mock
     private MetricRegistry mockMetricRegistry;
     @Mock
     private Histogram mockResponseTimeHistogram;
     @Mock
     private Counter mockFailureCounter;
-
-    @Mock
-    private GatewayAccountEntity mockGatewayAccountEntity;
-
     @Mock
     private GatewayOrder mockGatewayOrder;
 
@@ -79,10 +74,7 @@ public class GatewayClientTest {
         when(mockClient.target(WORLDPAY_API_ENDPOINT)).thenReturn(mockWebTarget);
         when(mockWebTarget.request()).thenReturn(mockBuilder).thenReturn(mockBuilder);
         when(mockBuilder.post(Entity.entity(orderPayload, mediaType))).thenReturn(mockResponse);
-
-        when(mockGatewayAccountEntity.getGatewayName()).thenReturn("worldpay");
-        when(mockGatewayAccountEntity.getType()).thenReturn("test");
-
+        
         when(mockGatewayOrder.getOrderRequestType()).thenReturn(OrderRequestType.AUTHORISE);
         when(mockGatewayOrder.getPayload()).thenReturn(orderPayload);
         when(mockGatewayOrder.getMediaType()).thenReturn(mediaType);
@@ -107,7 +99,7 @@ public class GatewayClientTest {
     public void shouldIncludeCookieIfSessionIdentifierAvailableInOrder() throws Exception {
         when(mockResponse.getStatus()).thenReturn(200);
 
-        gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, mockGatewayAccountEntity, mockGatewayOrder, 
+        gatewayClient.postRequestFor(WORLDPAY_API_ENDPOINT, WORLDPAY, "test", mockGatewayOrder, 
                 ImmutableList.of(new HttpCookie("machine", "value")), emptyMap());
 
         InOrder inOrder = Mockito.inOrder(mockBuilder);


### PR DESCRIPTION
Don't get the gateway name from the GatewayAccountEntity, as the active payment provider might not be the gateway used for the charge. Instead, use a hardcoded gateway name for Stripe requests and also pass the gateway account type.