### PR TITLE
PP-8281 Use charge payment provider for metrics/logging

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeCancelService.java
@@ -145,7 +145,7 @@ public class ChargeCancelService {
                 chargeEntity.getGatewayTransactionId(),
                 chargeEntity.getAmount(),
                 OperationType.CANCELLATION.getValue(),
-                chargeEntity.getGatewayAccount().getGatewayName(),
+                chargeEntity.getPaymentProvider(),
                 chargeEntity.getGatewayAccount().getType(),
                 lockState);
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeExpiryService.java
@@ -206,7 +206,7 @@ public class ChargeExpiryService {
                                             "provider. Attempting to update charge state to [%s]", status.getValue()),
                                     kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
                                     kv(GATEWAY_ACCOUNT_ID, chargeEntity.getGatewayAccount().getId()),
-                                    kv(PROVIDER, chargeEntity.getGatewayAccount().getGatewayName()));
+                                    kv(PROVIDER, chargeEntity.getPaymentProvider()));
 
                             // first try to transition to the terminal state gracefully if allowed, otherwise force the
                             // transition
@@ -368,7 +368,7 @@ public class ChargeExpiryService {
                     chargeEntity.getGatewayTransactionId(),
                     chargeEntity.getAmount(),
                     OperationType.CANCELLATION.getValue(),
-                    gatewayAccount.getGatewayName(),
+                    chargeEntity.getPaymentProvider(),
                     gatewayAccount.getType(),
                     newStatus);
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -625,7 +625,7 @@ public class ChargeService {
                         gatewayAccount.getId(),
                         chargeEntity.getAmount(),
                         operationType.getValue(),
-                        gatewayAccount.getGatewayName(),
+                        chargeEntity.getPaymentProvider(),
                         gatewayAccount.getType(),
                         operationType.getLockingStatus());
 

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -211,7 +211,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 LOGGER.warn("epdq.authorise-3ds.result.mismatch for chargeId={}, gatewayAccountId={}, frontendstatus={}, gatewaystatus={}",
                         request.getChargeExternalId(), request.getGatewayAccount().getId(), auth3DResult, authoriseStatus);
                 metricRegistry.counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s",
-                        request.getGatewayAccount().getGatewayName(),
+                        EPDQ.getName(),
                         request.getAuth3dsResult().getAuth3dsResultOutcome(),
                         authoriseStatus.name()))
                         .inc();

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -66,7 +66,7 @@ public class ChargeNotificationProcessor {
                 newStatus,
                 gatewayTransactionId,
                 gatewayAccount.getId(),
-                gatewayAccount.getGatewayName(),
+                chargeEntity.getPaymentProvider(),
                 gatewayAccount.getType());
     }
     
@@ -76,11 +76,11 @@ public class ChargeNotificationProcessor {
             return true;
         } catch (InvalidForceStateTransitionException ie) {
             logger.error(format("%s (%s) notification '%s' could not force transition from %s to %s",
-                    gatewayAccount.getGatewayName(), gatewayAccount.getId(), gatewayTransactionId, oldStatus, newStatus),
+                    chargeEntity.getPaymentProvider(), gatewayAccount.getId(), gatewayTransactionId, oldStatus, newStatus),
                     kv(PAYMENT_EXTERNAL_ID, chargeEntity.getExternalId()),
                     kv(PROVIDER_PAYMENT_ID, gatewayTransactionId),
                     kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
-                    kv(PROVIDER, gatewayAccount.getGatewayName()));
+                    kv(PROVIDER, chargeEntity.getPaymentProvider()));
             return false;
         }
     }
@@ -94,7 +94,7 @@ public class ChargeNotificationProcessor {
                 kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
                 kv(PROVIDER_PAYMENT_ID, gatewayTransactionId),
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
-                kv(PROVIDER, gatewayAccount.getGatewayName()));
+                kv(PROVIDER, charge.getPaymentGatewayName()));
         
         Event event = new CaptureConfirmedByGatewayNotification(charge.getExternalId(), ZonedDateTime.now());
         eventService.emitEvent(event);

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/RefundNotificationProcessor.java
@@ -64,7 +64,7 @@ public class RefundNotificationProcessor {
         RefundEntity refundEntity = optionalRefundEntity.get();
         RefundStatus oldStatus = refundEntity.getStatus();
 
-        refundService.transitionRefundState(refundEntity, gatewayAccountEntity, newStatus);
+        refundService.transitionRefundState(refundEntity, gatewayAccountEntity, newStatus, charge);
 
         if (RefundStatus.REFUNDED.equals(newStatus)) {
             userNotificationService.sendRefundIssuedEmail(refundEntity, charge, gatewayAccountEntity);
@@ -78,7 +78,7 @@ public class RefundNotificationProcessor {
                 oldStatus,
                 newStatus,
                 gatewayAccountEntity.getId(),
-                gatewayAccountEntity.getGatewayName(),
+                charge.getPaymentGatewayName(),
                 gatewayAccountEntity.getType());
     }
 }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/AuthorisationService.java
@@ -64,7 +64,7 @@ public class AuthorisationService {
 
     void emitAuthorisationMetric(ChargeEntity charge, String operation) {
         metricRegistry.counter(String.format("gateway-operations.%s.%s.%s.result.%s",
-                charge.getGatewayAccount().getGatewayName(),
+                charge.getPaymentProvider(),
                 charge.getGatewayAccount().getType(),
                 operation,
                 charge.getStatus())

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseService.java
@@ -105,7 +105,7 @@ public class CardAuthoriseService {
             
             metricRegistry.counter(String.format(
                     "gateway-operations.%s.%s.authorise.%s.result.%s",
-                    updatedCharge.getGatewayAccount().getGatewayName(),
+                    updatedCharge.getPaymentProvider(),
                     updatedCharge.getGatewayAccount().getType(),
                     authorisationRequestSummary.billingAddress() == PRESENT ? "with-billing-address" : "without-billing-address",
                     newStatus.toString())).inc();

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -123,7 +123,7 @@ public class CardCaptureService {
                 captureResponse, oldStatus, nextStatus);
 
         metricRegistry.counter(format("gateway-operations.%s.%s.capture.result.%s",
-                charge.getGatewayAccount().getGatewayName(),
+                charge.getPaymentProvider(),
                 charge.getGatewayAccount().getType(),
                 nextStatus.toString())).inc();
 

--- a/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/statetransition/StateTransitionService.java
@@ -95,7 +95,7 @@ public class StateTransitionService {
         metricRegistry.counter(String.format(
                 "state-transition.%s.%s.to.%s",
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getType(),
-                chargeEventEntity.getChargeEntity().getGatewayAccount().getGatewayName(),
+                chargeEventEntity.getChargeEntity().getPaymentProvider(),
                 targetChargeState)).inc();
     }
     
@@ -103,7 +103,7 @@ public class StateTransitionService {
         metricRegistry.meter(String.format(
                 "state-transition.%s.%s.to.%s.rate",
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getType(),
-                chargeEventEntity.getChargeEntity().getGatewayAccount().getGatewayName(),
+                chargeEventEntity.getChargeEntity().getPaymentProvider(),
                 targetChargeState)).mark();
     }
 
@@ -111,7 +111,7 @@ public class StateTransitionService {
         metricRegistry.counter(String.format(
                 "state-transition.%s.%s.to.%s",
                 chargeEventEntity.getChargeEntity().getGatewayAccount().getType(),
-                chargeEventEntity.getChargeEntity().getGatewayAccount().getGatewayName(),
+                chargeEventEntity.getChargeEntity().getPaymentProvider(),
                 targetChargeState)).inc();
     }
 

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthoriseService.java
@@ -118,7 +118,7 @@ public class WalletAuthoriseService {
         LOGGER.info("{} authorisation {} - charge_external_id={}, payment provider response={}",
                 walletType.toString(), successOrFailure, chargeEntity.getExternalId(), operationResponse.toString());
         metricRegistry.counter(format("gateway-operations.%s.%s.authorise.%s.result.%s",
-                chargeEntity.getGatewayAccount().getGatewayName(),
+                chargeEntity.getPaymentProvider(),
                 chargeEntity.getGatewayAccount().getType(),
                 walletType.equals(WalletType.GOOGLE_PAY) ? "google-pay" : "apple-pay",
                 successOrFailure)).inc();
@@ -155,7 +155,7 @@ public class WalletAuthoriseService {
 
         metricRegistry.counter(String.format(
                 "gateway-operations.%s.%s.%s.authorise.result.%s",
-                updatedCharge.getGatewayAccount().getGatewayName(),
+                updatedCharge.getPaymentProvider(),
                 updatedCharge.getGatewayAccount().getType(),
                 updatedCharge.getGatewayAccount().getId(),
                 status.toString())).inc();

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider3dsIT.java
@@ -65,7 +65,7 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
         Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertFalse(response.isSuccessful());
-        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "AUTHORISED", REJECTED.name()));
+        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", "epdq", "AUTHORISED", REJECTED.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
 
@@ -76,7 +76,7 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
         Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isException());
-        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "AUTHORISED", "ERROR"));
+        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", "epdq", "AUTHORISED", "ERROR"));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
 
@@ -87,7 +87,7 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
         Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertTrue(response.isException());
-        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "ERROR", AUTHORISED.name()));
+        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", "epdq", "ERROR", AUTHORISED.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
 
@@ -98,7 +98,7 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
         Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertFalse(response.isSuccessful());
-        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "DECLINED", AUTHORISED.name()));
+        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", "epdq", "DECLINED", AUTHORISED.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
 
@@ -109,7 +109,7 @@ public class EpdqPaymentProvider3dsIT extends BaseEpdqPaymentProviderIT {
         Gateway3DSAuthorisationResponse response = provider.authorise3dsResponse(request);
         verifyPaymentProviderRequest(successAuthQueryRequest());
         assertFalse(response.isSuccessful());
-        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", request.getGatewayAccount().getGatewayName(), "DECLINED", ERROR.name()));
+        verify(mockMetricRegistry, times(1)).counter(format("epdq.authorise-3ds.result.mismatch.account.%s.frontendstatus.%s.gatewaystatus.%s", "epdq", "DECLINED", ERROR.name()));
         verify(mockMetricRegistry.counter(""), times(1)).inc();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -757,7 +757,7 @@ public class RefundServiceTest {
                 .build();
         RefundEntity refundEntity = aValidRefundEntity().withAmount(100L).build();
 
-        refundService.transitionRefundState(refundEntity, charge.getGatewayAccount(), CREATED);
+        refundService.transitionRefundState(refundEntity, charge.getGatewayAccount(), CREATED, Charge.from(charge));
         verify(mockStateTransitionService).offerRefundStateTransition(refundEntity, CREATED);
     }
 


### PR DESCRIPTION
Use the payment provider stored on the charge, rather than the active payment provider for the gateway account for metrics and logging, as these may not be the same if the account has switched or is in the process of switching providers.