### PR TITLE
PP-8281 Use charge payment provider

### DIFF
--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -29,11 +29,11 @@ public class QueryService {
     }
     
     public ChargeQueryResponse getChargeGatewayStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) throws GatewayException {
-        return providers.byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
+        return providers.byName(PaymentGatewayName.valueFrom(charge.getPaymentGatewayName()))
                 .queryPaymentStatus(charge, gatewayAccountEntity);
     }   
     public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) throws GatewayException {
-        return providers.byName(PaymentGatewayName.valueFrom(charge.getGatewayAccount().getGatewayName()))
+        return providers.byName(charge.getPaymentGatewayName())
                 .queryPaymentStatus(Charge.from(charge), charge.getGatewayAccount());
     }
 

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -79,7 +79,7 @@ public class RefundService {
                 () -> new GatewayAccountNotFoundException(accountId));
         RefundEntity refundEntity = createRefund(charge, gatewayAccountEntity, refundRequest);
         GatewayRefundResponse gatewayRefundResponse = providers
-                .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
+                .byName(PaymentGatewayName.valueFrom(charge.getPaymentGatewayName()))
                 .refund(RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccountEntity));
         RefundEntity refund = processRefund(gatewayRefundResponse, refundEntity.getId(), gatewayAccountEntity, charge);
         return new ChargeRefundResponse(gatewayRefundResponse, refund);
@@ -275,7 +275,7 @@ public class RefundService {
         ExternalChargeRefundAvailability refundAvailability;
 
         refundAvailability = providers
-                .byName(PaymentGatewayName.valueFrom(gatewayAccountEntity.getGatewayName()))
+                .byName(PaymentGatewayName.valueFrom(charge.getPaymentGatewayName()))
                 .getExternalChargeRefundAvailability(charge, refundList);
         checkIfChargeIsRefundableOrTerminate(charge, refundAvailability, gatewayAccountEntity);
 

--- a/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/service/ChargeParityChecker.java
@@ -103,6 +103,7 @@ public class ChargeParityChecker {
         fieldsMatch = fieldsMatch && isEquals(chargeEntity.getDescription(), transaction.getDescription(), "description");
         fieldsMatch = fieldsMatch && isEquals(chargeEntity.getReference().toString(), transaction.getReference(), "reference");
         fieldsMatch = fieldsMatch && isEquals(chargeEntity.getLanguage(), transaction.getLanguage(), "language");
+        fieldsMatch = fieldsMatch && isEquals(chargeEntity.getPaymentProvider(), transaction.getPaymentProvider(), "payment_provider");
 
         // email may be empty in connector but not in ledger, if service provides email but turns off email address collection
         fieldsMatch = fieldsMatch && (
@@ -206,7 +207,6 @@ public class ChargeParityChecker {
 
     private boolean matchGatewayAccountFields(GatewayAccountEntity gatewayAccount, LedgerTransaction transaction) {
         boolean fieldsMatch = isEquals(gatewayAccount.getId().toString(), transaction.getGatewayAccountId(), "gateway_account_id");
-        fieldsMatch = fieldsMatch && isEquals(gatewayAccount.getGatewayName(), transaction.getPaymentProvider(), "payment_provider");
         fieldsMatch = fieldsMatch && isEquals(gatewayAccount.isLive(), transaction.getLive(), "live");
         return fieldsMatch;
     }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -391,7 +391,7 @@ public class ChargeServiceTest {
                 .withDescription(chargeEntity.getDescription())
                 .withState(new ExternalTransactionState(externalChargeState.getStatus(), externalChargeState.isFinished(), externalChargeState.getCode(), externalChargeState.getMessage()))
                 .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
-                .withProviderName(chargeEntity.getGatewayAccount().getGatewayName())
+                .withProviderName(chargeEntity.getPaymentProvider())
                 .withCreatedDate(chargeEntity.getCreatedDate())
                 .withEmail(chargeEntity.getEmail())
                 .withRefunds(refunds)

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
@@ -43,6 +43,7 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_MAINTENANCE_ORDER;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -76,6 +77,7 @@ public class EpdqRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
+                .withPaymentProvider(EPDQ.getName())
                 .insert();
     }
 
@@ -132,6 +134,7 @@ public class EpdqRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURE_SUBMITTED)
+                .withPaymentProvider(EPDQ.getName())
                 .insert();
 
         Long refundAmount = captureSubmittedCharge.getAmount();

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
@@ -40,6 +40,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 import static uk.gov.pay.connector.matcher.ZoneDateTimeAsStringWithinMatcher.isWithin;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
@@ -71,6 +72,7 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
+                .withPaymentProvider(SANDBOX.getName())
                 .insert();
     }
 
@@ -306,6 +308,7 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withAmount(1000L)
                 .withRefundSummary(refundSummary)
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
         ledgerStub.returnLedgerTransaction(chargeExternalId, charge);
 
@@ -318,6 +321,7 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
                 .withParentTransactionId(defaultTestCharge.getExternalChargeId())
                 .withAmount(300L)
                 .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
         ledgerStub.returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
 
@@ -340,6 +344,7 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withAmount(1000L)
                 .withRefundSummary(refundSummary)
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
         ledgerStub.returnLedgerTransaction(chargeExternalId, charge);
 
@@ -352,6 +357,7 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
                 .withParentTransactionId(defaultTestCharge.getExternalChargeId())
                 .withAmount(300L)
                 .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
         ledgerStub.returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundsResourceIT.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_REFUND_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
@@ -76,6 +77,7 @@ public class SmartpayRefundsResourceIT extends ChargingITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
                 .withTransactionId(randomAlphanumeric(10))
+                .withPaymentProvider(SMARTPAY.getName())
                 .insert();
         pspReference = randomNumeric(16);
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
@@ -31,6 +31,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -65,6 +66,7 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
                 .withTransactionId("pi_123")
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
+                .withPaymentProvider(STRIPE.getName())
                 .insert();
 
         stripeMockClient.mockGetPaymentIntent(defaultTestCharge.getTransactionId());
@@ -79,6 +81,7 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
                 .withTransactionId("ch_123")
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
+                .withPaymentProvider(STRIPE.getName())
                 .insert();
         String platformAccountId = "stripe_platform_account_id";
         String externalChargeId = testChargeCreatedWithStripeChargeAPI.getExternalChargeId();

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_REFUND_WORLDPAY_REQUEST;
 
@@ -73,6 +74,7 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
                 .withTransactionId("MyUniqueTransactionId!")
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
+                .withPaymentProvider(WORLDPAY.getName())
                 .insert();
     }
 

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -96,7 +96,7 @@ public class LedgerTransactionFixture {
         ledgerTransactionFixture.withCreatedDate(getEventDate(chargeEntity.getEvents(), List.of(CREATED, PAYMENT_NOTIFICATION_CREATED)));
         if (chargeEntity.getGatewayAccount() != null) {
             GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
-            ledgerTransactionFixture.withPaymentProvider(gatewayAccount.getGatewayName());
+            ledgerTransactionFixture.withPaymentProvider(chargeEntity.getPaymentProvider());
             ledgerTransactionFixture.withGatewayAccountId(gatewayAccount.getId());
             ledgerTransactionFixture.isLive(gatewayAccount.isLive());
         }

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -44,11 +44,9 @@ import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.google.common.collect.Maps.newHashMap;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -71,6 +69,7 @@ import static uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailabi
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SANDBOX;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.model.domain.LedgerTransactionFixture.aValidLedgerTransaction;
 import static uk.gov.pay.connector.model.domain.RefundEntityFixture.aValidRefundEntity;
@@ -106,9 +105,17 @@ public class RefundServiceTest {
     private StateTransitionService mockStateTransitionService;
     @Mock
     private LedgerService mockLedgerService;
-    private GatewayAccountEntity account;
+    
     private ChargeEntity chargeEntity;
     private List<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntityList = new ArrayList<>();
+
+    private final String externalChargeId = "chargeId";
+    private final Long accountId = 2L;
+    private final GatewayAccountEntity account = aGatewayAccountEntity()
+                .withId(accountId)
+                .withType(TEST)
+                .withGatewayAccountCredentials(gatewayAccountCredentialsEntityList)
+                .build();
 
     @Before
     public void setUp() {
@@ -122,14 +129,8 @@ public class RefundServiceTest {
 
     @Test
     public void shouldRefundSuccessfully_forWorldpay() {
-        String externalChargeId = "chargeId";
         Long refundAmount = 100L;
-        Long accountId = 2L;
-        String providerName = WORLDPAY.getName();
 
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -177,14 +178,8 @@ public class RefundServiceTest {
 
     @Test
     public void shouldRefundSuccessfully_forHistoricPayment() {
-        String externalChargeId = "chargeId";
         Long refundAmount = 100L;
-        Long accountId = 2L;
-        String providerName = WORLDPAY.getName();
-
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -202,6 +197,7 @@ public class RefundServiceTest {
         transaction.setDescription("description");
         transaction.setGatewayAccountId(String.valueOf(accountId));
         transaction.setCreatedDate(Instant.now().toString());
+        transaction.setPaymentProvider(WORLDPAY.getName());
 
         RefundEntity refundEntity = aValidRefundEntity().withChargeExternalId(externalChargeId).withAmount(refundAmount).build();
         RefundEntity spiedRefundEntity = spy(refundEntity);
@@ -249,14 +245,8 @@ public class RefundServiceTest {
 
     @Test
     public void shouldCreateARefundEntitySuccessfully() {
-        String externalChargeId = "chargeId";
         Long refundAmount = 100L;
-        Long accountId = 2L;
-        String providerName = WORLDPAY.getName();
 
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -267,6 +257,7 @@ public class RefundServiceTest {
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
                 .withStatus(CAPTURED)
+                .withPaymentProvider(WORLDPAY.getName())
                 .build();
 
         doAnswer(invocation -> {
@@ -283,14 +274,8 @@ public class RefundServiceTest {
 
     @Test
     public void shouldRefundSuccessfully_forSmartpay() {
-        String externalChargeId = "chargeId";
         Long amount = 100L;
-        Long accountId = 2L;
-        String providerName = SMARTPAY.getName();
-
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -302,6 +287,7 @@ public class RefundServiceTest {
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
                 .withStatus(CAPTURED)
+                .withPaymentProvider(SMARTPAY.getName())
                 .build();
 
         String refundExternalId = "refundExternalId";
@@ -340,14 +326,8 @@ public class RefundServiceTest {
 
     @Test
     public void shouldOverrideGeneratedReferenceIfProviderReturnAReference() {
-        String externalChargeId = "chargeId";
         Long amount = 100L;
-        Long accountId = 2L;
-        String providerName = WORLDPAY.getName();
 
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -361,6 +341,7 @@ public class RefundServiceTest {
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
                 .withStatus(CAPTURED)
+                .withPaymentProvider(WORLDPAY.getName())
                 .build();
 
         String refundExternalId = "someExternalId";
@@ -388,14 +369,8 @@ public class RefundServiceTest {
 
     @Test
     public void shouldStoreEmptyGatewayReferenceIfGatewayReturnsAnError() {
-        String externalChargeId = "chargeId";
         Long amount = 100L;
-        Long accountId = 2L;
-        String providerName = WORLDPAY.getName();
 
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -407,6 +382,7 @@ public class RefundServiceTest {
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
                 .withStatus(CAPTURED)
+                .withPaymentProvider(WORLDPAY.getName())
                 .build();
 
         String refundExternalId = "someExternalId";
@@ -432,13 +408,6 @@ public class RefundServiceTest {
 
     @Test
     public void shouldRefundAndSendEmail_whenGatewayRefundStateIsComplete_forChargeWithNoCorporateSurcharge() {
-        String externalChargeId = "chargeId";
-        Long accountId = 2L;
-        String providerName = SANDBOX.getName();
-
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -452,6 +421,7 @@ public class RefundServiceTest {
                 .withTransactionId(reference)
                 .withExternalId(externalChargeId)
                 .withStatus(CAPTURED)
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
         Optional<Charge> optionalCharge = Optional.of(Charge.from(chargeEntity));
 
@@ -460,13 +430,6 @@ public class RefundServiceTest {
 
     @Test
     public void shouldRefundAndSendEmail_whenGatewayRefundStatusIsComplete_forChargeWithCorporateSurcharge() {
-        String externalChargeId = "chargeId";
-        Long accountId = 2L;
-        String providerName = SANDBOX.getName();
-
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -482,6 +445,7 @@ public class RefundServiceTest {
                 .withTransactionId(reference)
                 .withExternalId(externalChargeId)
                 .withStatus(CAPTURED)
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
 
         // when there is a corporate surcharge we expect the amount available for refund to include this
@@ -526,11 +490,6 @@ public class RefundServiceTest {
 
     @Test
     public void shouldFailWhenChargeRefundIsNotAvailable() {
-        String externalChargeId = "chargeId";
-        Long accountId = 2L;
-        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -558,9 +517,6 @@ public class RefundServiceTest {
     @Test
     public void shouldFailWhenAmountAvailableForRefundMismatchesWithoutCorporateSurcharge() {
         Long amount = 1000L;
-        String externalChargeId = "chargeId";
-        Long accountId = 2L;
-        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
         account.setId(accountId);
         account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
@@ -593,11 +549,6 @@ public class RefundServiceTest {
     public void shouldFailWhenAmountAvailableForRefundWithCorporateSurchargeMismatches() {
         Long amount = 1000L;
         Long corporateSurcharge = 250L;
-        String externalChargeId = "chargeId";
-        Long accountId = 2L;
-        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -611,6 +562,7 @@ public class RefundServiceTest {
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transactionId")
                 .withStatus(AUTHORISATION_SUCCESS)
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
 
         when(mockGatewayAccountDao.findById(accountId)).thenReturn(Optional.of(account));
@@ -629,11 +581,6 @@ public class RefundServiceTest {
 
     @Test
     public void shouldFailWhenANewRefundHasBeenCreatedSincePreviouslyQueried() {
-        String externalChargeId = "chargeId";
-        Long accountId = 2L;
-        account = new GatewayAccountEntity(SANDBOX.getName(), newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -646,6 +593,7 @@ public class RefundServiceTest {
                 .withGatewayAccountEntity(account)
                 .withTransactionId("transactionId")
                 .withStatus(AUTHORISATION_SUCCESS)
+                .withPaymentProvider(SANDBOX.getName())
                 .build();
 
         when(mockGatewayAccountDao.findById(accountId)).thenReturn(Optional.of(account));
@@ -696,14 +644,8 @@ public class RefundServiceTest {
 
     @Test
     public void shouldUpdateRefundRecordToFailWhenRefundFails() {
-        String externalChargeId = "chargeId";
         Long amount = 100L;
-        Long accountId = 2L;
-        String providerName = WORLDPAY.getName();
-
-        account = new GatewayAccountEntity(providerName, newHashMap(), TEST);
-        account.setId(accountId);
-        account.setGatewayAccountCredentials(gatewayAccountCredentialsEntityList);
+        
         gatewayAccountCredentialsEntityList.add(GatewayAccountCredentialsEntityFixture
                 .aGatewayAccountCredentialsEntity()
                 .withGatewayAccountEntity(account)
@@ -714,6 +656,7 @@ public class RefundServiceTest {
                 .withTransactionId("transaction-id")
                 .withExternalId(externalChargeId)
                 .withStatus(CAPTURED)
+                .withPaymentProvider(WORLDPAY.getName())
                 .build();
 
         String refundReference = "someReference";


### PR DESCRIPTION
Use charge payment provider, rather than the provider for the active credentials on the account in the following scenarios:
- querying a charge with the gateway
- refunding a charge
- parity checking with ledger