### PR TITLE
PP-8270 Move not-null constraint to separate change set

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1643,7 +1643,6 @@
     <changeSet id="add send_payer_email_to_gateway column to gateway_accounts table" author="">
         <addColumn tableName="gateway_accounts">
             <column name="send_payer_email_to_gateway" type="boolean" defaultValue="false">
-                <constraints nullable="false"/>
             </column>
         </addColumn>
     </changeSet>
@@ -1656,6 +1655,10 @@
                              referencedColumnNames="id" nullable="true"/>
             </column>
         </addColumn>
+    </changeSet>
+
+    <changeSet id="set send_payer_email_to_gateway to not null" author="">
+        <addNotNullConstraint tableName="gateway_accounts" columnName="send_payer_email_to_gateway"/>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- DB migration for 'add send_payer_email_to_gateway column' change set ran without 'non null' constraint in all environments. So the constraint added afterwards is causing liquibase to fail due to incorrect checksum.
- Added a separate change set for non-null constraint on `gateway_accounts.send_payer_email_to_gateway`.
