### PR TITLE
PP-8279 Remove charge email sanitisation at write

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -340,7 +340,7 @@ public class ChargeService {
         return chargeDao.findByExternalId(chargeId)
                 .map(chargeEntity -> {
                     if (chargePatchRequest.getPath().equals(ChargesApiResource.EMAIL_KEY)) {
-                        chargeEntity.setEmail(sanitize(chargePatchRequest.getValue()));
+                        chargeEntity.setEmail(chargePatchRequest.getValue());
                         eventService.emitAndRecordEvent(UserEmailCollected.from(chargeEntity, now(UTC)));
                     }
                     return Optional.of(chargeEntity);

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -325,24 +325,6 @@ public class ChargesFrontendResourceIT {
     }
 
     @Test
-    public void sanitize_patchValidEmailOnChargeWithReplaceOp_shouldReturnOk_withSanitizedData() {
-
-        String chargeId = postToCreateACharge(expectedAmount);
-        String email = "r-12-34-5  Ju&^6501-76@example.com";
-        String sanitizedEmail = "r-**-**-*  Ju&^****-**@example.com";
-
-        String patchBody = createPatch("replace", "email", email);
-
-        ValidatableResponse response = connectorRestApi
-                .withChargeId(chargeId)
-                .patchCharge(patchBody);
-
-        response.statusCode(OK.getStatusCode())
-                .contentType(JSON)
-                .body("email", is(sanitizedEmail));
-    }
-
-    @Test
     public void patchValidEmailOnChargeWithAnyOpExceptReplace_shouldReturnBadRequest() {
         String chargeId = postToCreateACharge(expectedAmount);
         String patchBody = createPatch("delete", "email", "a@b.c");


### PR DESCRIPTION
Remove call to sanitise numbers in strings from the patch email address
endpoint.

This is called any time that the card payments page submits an
email separately from the main card details. The card payments service will
always validate to ensure a correct email format is used which precludes
plain card numbers having been accidentally entered.

Now that valid email addresses consisting of only numbers are no longer
restricted, allow persisting them un-redacted. Relates to https://github.com/alphagov/pay-frontend/pull/2295

Services are able to provide emails with invalid formats through
pre-filled data in a payment request however that code path isn't related
to the card payments page.
