### PR TITLE
PP-8239 Insert into history table for gateway_account_credentials

### DIFF
--- a/src/main/java/uk/gov/pay/connector/common/model/domain/HistoryCustomizer.java
+++ b/src/main/java/uk/gov/pay/connector/common/model/domain/HistoryCustomizer.java
@@ -1,4 +1,4 @@
-package uk.gov.pay.connector.refund.model.domain;
+package uk.gov.pay.connector.common.model.domain;
 
 import org.eclipse.persistence.config.DescriptorCustomizer;
 import org.eclipse.persistence.descriptors.ClassDescriptor;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -5,9 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.eclipse.persistence.annotations.Customizer;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.util.CredentialsConverter;
+import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 
@@ -31,6 +33,7 @@ import java.util.Map;
 @SequenceGenerator(name = "gateway_account_credentials_id_seq",
         sequenceName = "gateway_account_credentials_id_seq", allocationSize = 1)
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@Customizer(HistoryCustomizer.class)
 public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 
     @Id

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.eclipse.persistence.annotations.Customizer;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.common.model.domain.AbstractVersionedEntity;
+import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 

--- a/src/test/java/uk/gov/pay/connector/model/domain/HistoryCustomizerTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/HistoryCustomizerTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.pay.connector.refund.model.domain.HistoryCustomizer;
+import uk.gov.pay.connector.common.model.domain.HistoryCustomizer;
 
 import java.util.Vector;
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -958,6 +958,14 @@ public class DatabaseTestHelper {
                         .first());
     }
 
+    public List<Map<String, Object>> getGatewayAccountCredentialsHistory(long credentialsId) {
+        return jdbi.withHandle(handle ->
+                handle.createQuery("SELECT * FROM gateway_account_credentials_history where id = :id")
+                        .bind("id", credentialsId)
+                        .mapToMap()
+                        .list());
+    }
+
     public void insertGatewayAccountCredentials(AddGatewayAccountCredentialsParams params) {
         PGobject credentialsJson = buildCredentialsJson(params);
 


### PR DESCRIPTION
Use the `@Customizer` annotation on GatewayAccountCredentialsEntity in the same way as used for RefundEntity so that JPA automatically inserts into the gateway_account_credentials_history table when the entity is updated.