### PR TITLE
PP-8218 remove stripe gateway check

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/StripeAccountSetupResource.java
@@ -43,7 +43,6 @@ public class StripeAccountSetupResource {
     @Produces(APPLICATION_JSON)
     public StripeAccountSetup getStripeAccountSetup(@PathParam("accountId") Long accountId) {
         return gatewayAccountService.getGatewayAccount(accountId)
-                .filter(StripeAccountUtils::isStripeGatewayAccount)
                 .map(gatewayAccountEntity -> stripeAccountSetupService.getCompletedTasks(gatewayAccountEntity.getId()))
                 .orElseThrow(NotFoundException::new);
     }
@@ -53,7 +52,6 @@ public class StripeAccountSetupResource {
     @Consumes(APPLICATION_JSON)
     public Response patchStripeAccountSetup(@PathParam("accountId") Long accountId, JsonNode payload) {
         return gatewayAccountService.getGatewayAccount(accountId)
-                .filter(StripeAccountUtils::isStripeGatewayAccount)
                 .map(gatewayAccountEntity -> {
                     stripeAccountSetupRequestValidator.validatePatchRequest(payload);
                     List<StripeAccountSetupUpdateRequest> updateRequests = StreamSupport

--- a/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/StripeAccountSetupResourceIT.java
@@ -72,7 +72,7 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
         givenSetup()
                 .get("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
                 .then()
-                .statusCode(404);
+                .statusCode(200);
     }
 
     @Test
@@ -170,7 +170,7 @@ public class StripeAccountSetupResourceIT extends GatewayAccountResourceTestBase
                         "value", true))))
                 .patch("/v1/api/accounts/" + gatewayAccountId + "/stripe-setup")
                 .then()
-                .statusCode(404);
+                .statusCode(200);
     }
 
     private void addCompletedTask(long gatewayAccountId, StripeAccountSetupTask task) {


### PR DESCRIPTION
## WHAT YOU DID
- remove isStripeGatewayAccount check from /stripe-setup endpoint. This check is no longer valid. Gateway is not top level assigned to PPS but rather on a credential level.
