### PR TITLE
PP-8209 ignore no pacts to verify selfservice

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/TemporaryResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/TemporaryResource.java
@@ -1,0 +1,5 @@
+package uk.gov.pay.connector.gatewayaccount.resource;
+
+public class TemporaryResource {
+    // This class is temporary, it is used to force Concourse to build a new version of Docker for the test changes
+}

--- a/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/SelfServiceContractTest.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.pact;
 
+import au.com.dius.pact.provider.junit.IgnoreNoPactsToVerify;
 import au.com.dius.pact.provider.junit.PactRunner;
 import au.com.dius.pact.provider.junit.Provider;
 import au.com.dius.pact.provider.junit.loader.PactBroker;
@@ -16,6 +17,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 @PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"selfservice"})
+@IgnoreNoPactsToVerify
 public class SelfServiceContractTest extends ContractTest {
 
     @BeforeClass


### PR DESCRIPTION
## WHAT YOU DID
- removing a pact test from selfservice
- added temporary class, it is used to force Concourse to build a new version of Docker for the test changes
