### PR TITLE
PP-8373 Query charges by payment_provider on charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
+++ b/src/main/java/uk/gov/pay/connector/charge/dao/ChargeDao.java
@@ -113,7 +113,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
         String query = "SELECT c FROM ChargeEntity c " +
                 "WHERE c.gatewayTransactionId = :gatewayTransactionId " +
-                "AND c.gatewayAccount.gatewayName = :provider";
+                "AND c.paymentProvider = :provider";
 
         return entityManager.get()
                 .createQuery(query, ChargeEntity.class)
@@ -269,7 +269,7 @@ public class ChargeDao extends JpaDao<ChargeEntity> {
 
     public List<ChargeEntity> findWithPaymentProviderAndStatusIn(String provider, List<ChargeStatus> statuses, int limit) {
         return entityManager.get()
-                .createQuery("SELECT c FROM ChargeEntity c WHERE c.gatewayAccount.gatewayName = :provider AND c.status in :statuses", ChargeEntity.class)
+                .createQuery("SELECT c FROM ChargeEntity c WHERE c.paymentProvider = :provider AND c.status in :statuses", ChargeEntity.class)
                 .setParameter("provider", provider)
                 .setParameter("statuses", statuses)
                 .setMaxResults(limit)

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -871,11 +871,12 @@ public class ChargeDaoIT extends DaoITestBase {
                 .update();
     }
 
-    private TestCharge insertTestChargeWithStatus(DatabaseFixtures.TestAccount epdqAccount, ChargeStatus created) {
+    private TestCharge insertTestChargeWithStatus(DatabaseFixtures.TestAccount testAccount, ChargeStatus created) {
         return DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper).aTestCharge()
-                .withTestAccount(epdqAccount)
+                .withTestAccount(testAccount)
                 .withChargeStatus(created)
+                .withPaymentProvider(testAccount.getPaymentProvider())
                 .insert();
     }
 


### PR DESCRIPTION
## WHAT YOU DID
- Update charge dao methods to query charges by payment_provider on charge instead of payment_provider on gateway_account.
