### PR TITLE
PP-8333 Add integration tests for PSP switch

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayCardResourceIT.java
@@ -34,6 +34,7 @@ import static uk.gov.pay.connector.it.JsonRequestHelper.buildCorporateJsonAuthor
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonApplePayAuthorisationDetails;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsFor;
 import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonAuthorisationDetailsWithoutAddress;
+import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(
@@ -153,7 +154,7 @@ public class WorldpayCardResourceIT extends ChargingITestBase {
 
         assertFrontendChargeStatusIs(chargeId, AUTHORISATION_SUCCESS.toString());
 
-        verifyRequestBodyToWorldpay("/jsp/merchant/xml/paymentService.jsp");
+        verifyRequestBodyToWorldpay(WORLDPAY_URL);
     }
 
     private void verifyRequestBodyToWorldpay(String path) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayChargeCancelResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayChargeCancelResourceIT.java
@@ -14,6 +14,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToXml;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static uk.gov.pay.connector.rules.WorldpayMockClient.WORLDPAY_URL;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.WORLDPAY_VALID_CANCEL_WORLDPAY_REQUEST;
 
 @RunWith(DropwizardJUnitRunner.class)
@@ -39,7 +40,7 @@ public class WorldpayChargeCancelResourceIT extends ChargingITestBase {
                 .replace("{{merchantCode}}", "merchant-id")
                 .replace("{{transactionId}}", "MyUniqueTransactionId!");
 
-        verifyRequestBodyToWorldpay("/jsp/merchant/xml/paymentService.jsp", expectedRequestBody);
+        verifyRequestBodyToWorldpay(WORLDPAY_URL, expectedRequestBody);
     }
 
     private void verifyRequestBodyToWorldpay(String path, String body) {

--- a/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/WorldpayMockClient.java
@@ -29,6 +29,7 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 
 public class WorldpayMockClient {
 
+    public static final String WORLDPAY_URL = "/jsp/merchant/xml/paymentService.jsp";
     private WireMockServer wireMockServer;
 
     public WorldpayMockClient(WireMockServer wireMockServer) {
@@ -109,7 +110,7 @@ public class WorldpayMockClient {
 
     public void mockAuthorisationGatewayError() {
         wireMockServer.stubFor(
-                post(urlPathEqualTo("/jsp/merchant/xml/paymentService.jsp"))
+                post(urlPathEqualTo(WORLDPAY_URL))
                         .willReturn(
                                 aResponse().withStatus(404)
                         )
@@ -124,7 +125,7 @@ public class WorldpayMockClient {
 
     public void mockServerFault() {
         wireMockServer.stubFor(
-                post(urlPathEqualTo("/jsp/merchant/xml/paymentService.jsp"))
+                post(urlPathEqualTo(WORLDPAY_URL))
                         .willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER))
         );
     }
@@ -132,7 +133,7 @@ public class WorldpayMockClient {
     private void paymentServiceResponse(String responseBody) {
         //FIXME - This mocking approach is very poor. Needs to be revisited. Story PP-900 created.
         wireMockServer.stubFor(
-                post(urlPathEqualTo("/jsp/merchant/xml/paymentService.jsp"))
+                post(urlPathEqualTo(WORLDPAY_URL))
                         .willReturn(
                                 aResponse()
                                         .withHeader(CONTENT_TYPE, TEXT_XML)
@@ -144,7 +145,7 @@ public class WorldpayMockClient {
 
     private void bodyMatchingPaymentServiceResponse(String xpathContent, String responseBody) {
         wireMockServer.stubFor(
-                post(urlPathEqualTo("/jsp/merchant/xml/paymentService.jsp"))
+                post(urlPathEqualTo(WORLDPAY_URL))
                         .withRequestBody(matchingXPath(xpathContent))
                         .willReturn(
                                 aResponse()
@@ -156,12 +157,12 @@ public class WorldpayMockClient {
     }
 
     public void mockResponsesForExemptionEngineSoftDecline() {
-        wireMockServer.stubFor(post(urlEqualTo("/jsp/merchant/xml/paymentService.jsp")).inScenario("Exemption Engine soft decline")
+        wireMockServer.stubFor(post(urlEqualTo(WORLDPAY_URL)).inScenario("Exemption Engine soft decline")
                 .whenScenarioStateIs(STARTED)
                 .willReturn(aResponse().withStatus(200).withBody(load(WORLDPAY_EXEMPTION_REQUEST_SOFT_DECLINE_RESULT_REJECTED_RESPONSE)))
                 .willSetStateTo("Soft decline triggered"));
 
-        wireMockServer.stubFor(post(urlEqualTo("/jsp/merchant/xml/paymentService.jsp")).inScenario("Exemption Engine soft decline")
+        wireMockServer.stubFor(post(urlEqualTo(WORLDPAY_URL)).inScenario("Exemption Engine soft decline")
                 .whenScenarioStateIs("Soft decline triggered")
                 .willReturn(aResponse().withStatus(200).withBody(load(WORLDPAY_AUTHORISATION_SUCCESS_RESPONSE))));
     }


### PR DESCRIPTION
Add integration tests to ensure
- Active credentials are used for authorisation when there are multiple
- Refunds are made using the payment provider for the charge when credentials are RETIRED