### PR TITLE
PP-7586 - Add send payer email and IP address fields to GatewayAccountResourceDTO

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -93,6 +93,12 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("worldpay_3ds_flex")
     private Worldpay3dsFlexCredentials worldpay3dsFlexCredentials;
 
+    @JsonProperty("send_payer_ip_address_to_gateway")
+    private boolean sendPayerIpAddressToGateway;
+
+    @JsonProperty("send_payer_email_to_gateway")
+    private boolean sendPayerEmailToGateway;
+
     public GatewayAccountResourceDTO() {
     }
 
@@ -122,6 +128,8 @@ public class GatewayAccountResourceDTO {
         this.allowTelephonePaymentNotifications = gatewayAccountEntity.isAllowTelephonePaymentNotifications();
         this.worldpay3dsFlexCredentials = gatewayAccountEntity.getWorldpay3dsFlexCredentials().orElse(null);
         this.providerSwitchEnabled = gatewayAccountEntity.isProviderSwitchEnabled();
+        this.sendPayerEmailToGateway = gatewayAccountEntity.isSendPayerEmailToGateway();
+        this.sendPayerIpAddressToGateway = gatewayAccountEntity.isSendPayerIpAddressToGateway();
     }
 
     public long getAccountId() {
@@ -226,6 +234,14 @@ public class GatewayAccountResourceDTO {
 
     public boolean isProviderSwitchEnabled() {
         return providerSwitchEnabled;
+    }
+
+    public boolean isSendPayerIpAddressToGateway() {
+        return sendPayerIpAddressToGateway;
+    }
+
+    public boolean isSendPayerEmailToGateway() {
+        return sendPayerEmailToGateway;
     }
 
     public Optional<Worldpay3dsFlexCredentials> getWorldpay3dsFlexCredentials() {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTOTest.java
@@ -41,6 +41,8 @@ public class GatewayAccountResourceDTOTest {
         entity.setMotoMaskCardSecurityCodeInput(true);
         entity.setAllowTelephonePaymentNotifications(true);
         entity.setProviderSwitchEnabled(true);
+        entity.setSendPayerEmailToGateway(true);
+        entity.setSendPayerIpAddressToGateway(true);
         entity.setWorldpay3dsFlexCredentialsEntity(aWorldpay3dsFlexCredentialsEntity().withExemptionEngine(true).build());
         entity.setGatewayAccountCredentials(List.of(
                 GatewayAccountCredentialsEntityFixture.
@@ -81,5 +83,7 @@ public class GatewayAccountResourceDTOTest {
         assertThat(dto.isAllowTelephonePaymentNotifications(), is(entity.isAllowTelephonePaymentNotifications()));
         assertThat(dto.getWorldpay3dsFlexCredentials(), is(entity.getWorldpay3dsFlexCredentials()));
         assertThat(dto.isProviderSwitchEnabled(), is(entity.isProviderSwitchEnabled()));
+        assertThat(dto.isSendPayerIpAddressToGateway(), is(true));
+        assertThat(dto.isSendPayerEmailToGateway(), is(true));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -183,6 +183,8 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .body("corporate_credit_card_surcharge_amount", is(0))
                 .body("allow_google_pay", is(false))
                 .body("allow_apple_pay", is(false))
+                .body("send_payer_ip_address_to_gateway", is(false))
+                .body("send_payer_email_to_gateway", is(false))
                 .body("allow_zero_amount", is(false))
                 .body("integration_version_3ds", is(2))
                 .body("allow_telephone_payment_notifications", is(true))


### PR DESCRIPTION
Description:
- As part of ensuring that GatewayAccountEntity and GatewayAccountResourceDTO align send_payer_ip_address_to_gateway and send_payer_email_to_gateway need to be included in
GatewayAccountResourceDTO