### PR TITLE
PP-8400 Log for a refund failed Stripe notification

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2021-07-05T14:20:21Z",
+  "generated_at": "2021-07-26T16:30:43Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -174,14 +174,14 @@
         "hashed_secret": "c2baab12724c0f29014dc172042a17ebbd9b60d4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 109,
+        "line_number": 111,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "4991aba1cb28cabc042aa415f2689cf359bb4af2",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 112,
         "type": "Secret Keyword"
       }
     ],

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationType.java
@@ -21,6 +21,7 @@ public enum StripeNotificationType {
     PAYOUT_PAID("payout.paid", PayoutPaid.class),
     PAYOUT_UPDATED("payout.updated", PayoutUpdated.class),
     PAYOUT_FAILED("payout.failed", PayoutFailed.class),
+    REFUND_UPDATED("charge.refund.updated"),
     UNKNOWN("");
 
     private final String type;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeRefundUpdatedHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeRefundUpdatedHandler.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.gateway.stripe;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
+
+import javax.inject.Inject;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+
+public class StripeRefundUpdatedHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StripeRefundUpdatedHandler.class);
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public StripeRefundUpdatedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+    
+    public void process(StripeNotification notification) {
+        try {
+            var dataObject = objectMapper.readValue(notification.getObject(), DataObject.class);
+            if (dataObject.status.equals("failed")) {
+                LOGGER.info("Received a charge.refund.updated event with status failed",
+                        kv("stripe_refund_id", dataObject.refundId),
+                        kv("stripe_payment_id", dataObject.paymentIntent),
+                        kv("failure_reason", dataObject.failureReason));
+            }
+        } catch (Exception e) {
+            LOGGER.error("{} notification parsing for charge.refund.updated source object failed: {}", STRIPE.getName(), e);
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class DataObject {
+
+        @JsonProperty("id")
+        private String refundId;
+        
+        @JsonProperty("status")
+        private String status;
+        
+        @JsonProperty("failure_reason")
+        private String failureReason;
+        
+        @JsonProperty("payment_intent")
+        private String paymentIntent;
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -171,6 +171,7 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_NOTIFICATION_3DS_SOURCE = TEMPLATE_BASE_NAME + "/stripe/notification_3ds_source.json";
     public static final String STRIPE_NOTIFICATION_PAYMENT_INTENT = TEMPLATE_BASE_NAME + "/stripe/notification_payment_intent.json";
     public static final String STRIPE_NOTIFICATION_ACCOUNT_UPDATED = TEMPLATE_BASE_NAME + "/stripe/account_updated.json";
+    public static final String STRIPE_NOTIFICATION_CHARGE_REFUND_UPDATED = TEMPLATE_BASE_NAME + "/stripe/charge_refund_updated.json";
 
     public static final String SQS_SEND_MESSAGE_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/send-message-response.xml";
     public static final String SQS_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/sqs/error-response.xml";

--- a/src/test/resources/templates/stripe/charge_refund_updated.json
+++ b/src/test/resources/templates/stripe/charge_refund_updated.json
@@ -1,0 +1,31 @@
+{
+  "created": 1326853478,
+  "livemode": false,
+  "id": "evt_00000000000000",
+  "type": "charge.refund.updated",
+  "object": "event",
+  "request": null,
+  "pending_webhooks": 1,
+  "api_version": "2019-05-16",
+  "data": {
+    "object": {
+      "id": "re_123456",
+      "object": "refund",
+      "payment_intent": "pi_123456",
+      "status": "failed",
+      "amount": 1000,
+      "balance_transaction": "txn_123456",
+      "charge": "ch_123456",
+      "created": 1627297208,
+      "currency": "gbp",
+      "failure_balance_transaction": "txn_123456",
+      "failure_reason": "expired_or_canceled_card",
+      "metadata": {
+      },
+      "reason": null,
+      "receipt_number": null,
+      "source_transfer_reversal": null,
+      "transfer_reversal": null
+    }
+  }
+}


### PR DESCRIPTION
When we receive a `charge.refund.updated` webhook from Stripe, log at info level if the "status" is failure.

We will add a Splunk alert for this log line as the failure needs to be manually rectified and the service notified.