### PR TITLE
PP-8357 ePDQ contract test - set request entity processing to BUFFERED

### DIFF
--- a/src/test/java/uk/gov/pay/connector/util/TestClientFactory.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestClientFactory.java
@@ -8,6 +8,8 @@ import org.glassfish.jersey.client.spi.ConnectorProvider;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
+import static org.glassfish.jersey.client.RequestEntityProcessing.BUFFERED;
+
 public class TestClientFactory {
     public static Client createJerseyClient() {
         return createClientWithApacheConnectorAndTimeout(-1);
@@ -20,6 +22,8 @@ public class TestClientFactory {
         if (readTimeout > 0) {
             clientConfig.property(ClientProperties.READ_TIMEOUT, readTimeout);
         }
+        clientConfig.property(ClientProperties.REQUEST_ENTITY_PROCESSING, BUFFERED);
+
         Client client = ClientBuilder
                 .newBuilder()
                 .withConfig(clientConfig)


### PR DESCRIPTION
# WHAT
- ApacheConnectorProvider (https://eclipse-ee4j.github.io/jersey.github.io/apidocs/2.33/jersey/org/glassfish/jersey/apache/connector/ApacheConnectorProvider.html) used by `Client` for http requests, sets `Transfer-Encoding` HTTP header to `chunked` (by default) which streams entity to output stream. This has been the case all along. eDPDQ doesn't like this setting for test accounts any more (at least this is the difference observed) and returns standard error as below.

```
<?xml version="1.0"?>
<ncresponse

orderID=""
PAYID="0"
NCERROR="50001111"
STATUS="0">
</ncresponse>
```

- Set `REQUEST_ENTITY_PROCESSING` client property to `BUFFERED` for ePDQ contract tests which sets Content-Length header for the request. This works and should let us do manual testing if required.

