### PR TITLE
PP-7856 - Remove redundant @JsonView annotation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java
@@ -104,7 +104,6 @@ public class GatewayAccountResource {
     @GET
     @Path("/v1/api/accounts/{accountId}")
     @Produces(APPLICATION_JSON)
-    @JsonView(GatewayAccountEntity.Views.ApiView.class)
     public Response getGatewayAccount(@PathParam("accountId") Long accountId) {
         logger.debug("Getting gateway account for account id {}", accountId);
         return gatewayAccountService


### PR DESCRIPTION
Description:
- Method returns GatewayAccountResourceDTO not GatewayAccountEntity so the annotation is redundant