### PR TITLE
PP-8397 Get credentials from ChargeEntity for payment inflight operations

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandler.java
@@ -41,7 +41,7 @@ public class EpdqCaptureHandler implements CaptureHandler {
                     EPDQ,
                     request.getGatewayAccount().getType(), 
                     buildCaptureOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(EPDQ.getName())));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, EpdqCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());
@@ -50,11 +50,11 @@ public class EpdqCaptureHandler implements CaptureHandler {
 
     private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
         var epdqPayloadDefinitionForCaptureOrder = new EpdqPayloadDefinitionForCaptureOrder();
-        epdqPayloadDefinitionForCaptureOrder.setUserId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForCaptureOrder.setPassword(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForCaptureOrder.setPspId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinitionForCaptureOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinitionForCaptureOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinitionForCaptureOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
         epdqPayloadDefinitionForCaptureOrder.setPayId(request.getTransactionId());
-        epdqPayloadDefinitionForCaptureOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForCaptureOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForCaptureOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProvider.java
@@ -119,7 +119,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 EPDQ,
                 request.getGatewayAccount().getType(),
                 buildAuthoriseOrder(request, frontendUrl), 
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(EPDQ.getName())));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
         return getEpdqGatewayResponse(response, EpdqAuthorisationResponse.class);
     }
 
@@ -148,7 +148,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 EPDQ,
                 request.getGatewayAccount().getType(),
                 buildCancelOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(EPDQ.getName())));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
         return getEpdqGatewayResponse(response, EpdqCancelResponse.class);
     }
 
@@ -199,7 +199,7 @@ public class EpdqPaymentProvider implements PaymentProvider {
                     EPDQ,
                     request.getGatewayAccount().getType(),
                     buildQueryOrderRequestFor(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(EPDQ.getName())));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
             GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getEpdqGatewayResponse(response, EpdqAuthorisationResponse.class);
             BaseAuthoriseResponse.AuthoriseStatus authoriseStatus = gatewayResponse.getBaseResponse()
                     .map(BaseAuthoriseResponse::authoriseStatus).orElse(ERROR);
@@ -285,10 +285,10 @@ public class EpdqPaymentProvider implements PaymentProvider {
     private GatewayOrder buildQueryOrderRequestFor(Auth3dsResponseGatewayRequest request) {
         var epdqPayloadDefinitionForQueryOrder = new EpdqPayloadDefinitionForQueryOrder();
         epdqPayloadDefinitionForQueryOrder.setOrderId(request.getChargeExternalId());
-        epdqPayloadDefinitionForQueryOrder.setPassword(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForQueryOrder.setUserId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForQueryOrder.setPspId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_MERCHANT_ID));
-        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForQueryOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinitionForQueryOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinitionForQueryOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinitionForQueryOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForQueryOrder.createGatewayOrder();
     }
 
@@ -316,12 +316,12 @@ public class EpdqPaymentProvider implements PaymentProvider {
         }
 
         epdqPayloadDefinition.setOrderId(request.getChargeExternalId());
-        epdqPayloadDefinition.setPassword(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinition.setUserId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinition.setPspId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinition.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinition.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinition.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
         epdqPayloadDefinition.setAmount(request.getAmount());
         epdqPayloadDefinition.setAuthCardDetails(request.getAuthCardDetails());
-        epdqPayloadDefinition.setShaInPassphrase(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinition.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinition.createGatewayOrder();
     }
 
@@ -331,10 +331,10 @@ public class EpdqPaymentProvider implements PaymentProvider {
                 .ifPresentOrElse(
                         epdqPayloadDefinitionForCancelOrder::setPayId,
                         () -> epdqPayloadDefinitionForCancelOrder.setOrderId(request.getExternalChargeId()));
-        epdqPayloadDefinitionForCancelOrder.setUserId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForCancelOrder.setPassword(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForCancelOrder.setPspId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_MERCHANT_ID));
-        epdqPayloadDefinitionForCancelOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForCancelOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinitionForCancelOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinitionForCancelOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinitionForCancelOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForCancelOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/Auth3dsResponseGatewayRequest.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.gateway.model.Auth3dsResult;
 import uk.gov.pay.connector.gateway.model.ProviderSessionIdentifier;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class Auth3dsResponseGatewayRequest implements GatewayRequest {
@@ -47,6 +48,11 @@ public class Auth3dsResponseGatewayRequest implements GatewayRequest {
     @Override
     public GatewayOperation getRequestType() {
         return GatewayOperation.AUTHORISE;
+    }
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 
     public static Auth3dsResponseGatewayRequest valueOf(ChargeEntity charge, Auth3dsResult auth3DsResult) {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/AuthorisationGatewayRequest.java
@@ -5,6 +5,7 @@ import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.Map;
 import java.util.Optional;
 
 public abstract class AuthorisationGatewayRequest implements GatewayRequest {
@@ -32,6 +33,11 @@ public abstract class AuthorisationGatewayRequest implements GatewayRequest {
 
     public String getChargeExternalId() {
         return charge.getExternalId();
+    }
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CancelGatewayRequest.java
@@ -4,6 +4,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.Map;
+
 public class CancelGatewayRequest implements GatewayRequest {
 
     private ChargeEntity charge;
@@ -28,6 +30,11 @@ public class CancelGatewayRequest implements GatewayRequest {
     @Override
     public GatewayOperation getRequestType() {
         return GatewayOperation.CANCEL;
+    }
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 
     public String getExternalChargeId() {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CaptureGatewayRequest.java
@@ -5,6 +5,8 @@ import uk.gov.pay.connector.charge.util.CorporateCardSurchargeCalculator;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 
+import java.util.Map;
+
 public class CaptureGatewayRequest implements GatewayRequest {
 
     private ChargeEntity charge;
@@ -37,6 +39,11 @@ public class CaptureGatewayRequest implements GatewayRequest {
     @Override
     public GatewayOperation getRequestType() {
         return GatewayOperation.CAPTURE;
+    }
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 
     public static CaptureGatewayRequest valueOf(ChargeEntity charge) {

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/CardAuthorisationGatewayRequest.java
@@ -3,6 +3,8 @@ package uk.gov.pay.connector.gateway.model.request;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
 
+import java.util.Map;
+
 public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest {
     private AuthCardDetails authCardDetails;
     
@@ -18,5 +20,9 @@ public class CardAuthorisationGatewayRequest extends AuthorisationGatewayRequest
     public static CardAuthorisationGatewayRequest valueOf(ChargeEntity charge, AuthCardDetails authCardDetails) {
         return new CardAuthorisationGatewayRequest(charge, authCardDetails);
     }
-    
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentials();
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/GatewayRequest.java
@@ -3,8 +3,12 @@ package uk.gov.pay.connector.gateway.model.request;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gateway.GatewayOperation;
 
+import java.util.Map;
+
 public interface GatewayRequest {
     GatewayAccountEntity getGatewayAccount();
 
     GatewayOperation getRequestType();
+
+    Map<String, String> getGatewayCredentials();
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -1,9 +1,12 @@
 package uk.gov.pay.connector.gateway.model.request;
 
+import org.apache.commons.lang3.NotImplementedException;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.gateway.GatewayOperation;
+
+import java.util.Map;
 
 public class RefundGatewayRequest implements GatewayRequest {
 
@@ -41,6 +44,11 @@ public class RefundGatewayRequest implements GatewayRequest {
     @Override
     public GatewayOperation getRequestType() {
         return GatewayOperation.REFUND;
+    }
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        throw  new NotImplementedException("Method not implemented for Refunds.");
     }
 
     public String getRefundExternalId() {

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandler.java
@@ -34,7 +34,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
                     SMARTPAY,
                     request.getGatewayAccount().getType(),
                     buildCaptureOrderFor(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(SMARTPAY.getName())));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, SmartpayCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());
@@ -44,7 +44,7 @@ public class SmartpayCaptureHandler implements CaptureHandler {
     private GatewayOrder buildCaptureOrderFor(CaptureGatewayRequest request) {
         return SmartpayOrderRequestBuilder.aSmartpayCaptureOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
-                .withMerchantCode(request.getGatewayAccount().getCredentials(SMARTPAY.getName()).get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withAmount(request.getAmountAsString())
                 .build();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -90,7 +90,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
                 SMARTPAY,
                 request.getGatewayAccount().getType(),
                 buildAuthoriseOrderFor(request), 
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(SMARTPAY.getName())));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
         return getSmartpayGatewayResponse(response, SmartpayAuthorisationResponse.class);
     }
 
@@ -112,7 +112,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
                     SMARTPAY,
                     request.getGatewayAccount().getType(),
                     build3dsResponseAuthOrderFor(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(SMARTPAY.getName())));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
             GatewayResponse<BaseAuthoriseResponse> gatewayResponse = getSmartpayGatewayResponse(response, Smartpay3dsAuthorisationResponse.class);
             
             if (gatewayResponse.getBaseResponse().isEmpty())
@@ -150,7 +150,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
                 SMARTPAY,
                 request.getGatewayAccount().getType(),
                 buildCancelOrderFor(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(SMARTPAY.getName())));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
         return getSmartpayGatewayResponse(response, SmartpayCancelResponse.class);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -55,7 +55,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     WorldpayOrderBuilder.buildAuthoriseOrderWithExemptionEngine(request, withExemptionEngine),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(WORLDPAY.getName())));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
 
             if (response.getEntity().contains("request3DSecure")) {
                 LOGGER.info(format("Worldpay authorisation response when 3ds required for %s: %s", request.getChargeExternalId(), sanitiseMessage(response.getEntity())));

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandler.java
@@ -41,7 +41,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
                     buildCaptureOrder(request),
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(WORLDPAY.getName())));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
             return CaptureResponse.fromBaseCaptureResponse(unmarshallResponse(response, WorldpayCaptureResponse.class), PENDING);
         } catch (GatewayException e) {
             return CaptureResponse.fromGatewayError(e.toGatewayError());
@@ -51,7 +51,7 @@ public class WorldpayCaptureHandler implements CaptureHandler {
     private GatewayOrder buildCaptureOrder(CaptureGatewayRequest request) {
         return aWorldpayCaptureOrderRequestBuilder()
                 .withDate(LocalDate.now(ZoneOffset.UTC))
-                .withMerchantCode(request.getGatewayAccount().getCredentials(WORLDPAY.getName()).get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withAmount(request.getAmountAsString())
                 .withTransactionId(request.getTransactionId())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderBuilder.java
@@ -35,7 +35,7 @@ public interface WorldpayOrderBuilder {
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
                 .with3dsRequired(is3dsRequired)
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(request.getGatewayAccount().getCredentials(WORLDPAY.getName()).get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withDescription(request.getDescription())
                 .withAmount(request.getAmount())
                 .withAuthorisationDetails(request.getAuthCardDetails());

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProvider.java
@@ -257,7 +257,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                     request.getGatewayAccount().getType(),
                     build3dsResponseAuthOrder(request),
                     cookies,
-                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(WORLDPAY.getName())));
+                    getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
             GatewayResponse<WorldpayOrderStatusResponse> gatewayResponse = getWorldpayGatewayResponse(response);
             
             calculateAndStoreExemption(request.getCharge(), gatewayResponse);
@@ -299,7 +299,7 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 WORLDPAY,
                 request.getGatewayAccount().getType(),
                 buildCancelOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(WORLDPAY.getName())));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
         return getWorldpayGatewayResponse(response);
     }
 
@@ -318,14 +318,14 @@ public class WorldpayPaymentProvider implements PaymentProvider, WorldpayGateway
                 .withPaResponse3ds(request.getAuth3dsResult().getPaResponse())
                 .withSessionId(WorldpayAuthoriseOrderSessionId.of(request.getChargeExternalId()))
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(request.getGatewayAccount().getCredentials(WORLDPAY.getName()).get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .build();
     }
 
     private GatewayOrder buildCancelOrder(CancelGatewayRequest request) {
         return aWorldpayCancelOrderRequestBuilder()
                 .withTransactionId(request.getTransactionId())
-                .withMerchantCode(request.getGatewayAccount().getCredentials(WORLDPAY.getName()).get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .build();
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandler.java
@@ -41,7 +41,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
                 WORLDPAY,
                 request.getGatewayAccount().getType(),
                 buildWalletAuthoriseOrder(request),
-                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayAccount().getCredentials(WORLDPAY.getName())));
+                getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
         
         return getWorldpayGatewayResponse(response);
     }
@@ -69,7 +69,7 @@ public class WorldpayWalletAuthorisationHandler implements WalletAuthorisationHa
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getUserAgentHeader())
                 .withUserAgentHeader(request.getWalletAuthorisationData().getPaymentInfo().getAcceptHeader())
                 .withTransactionId(request.getTransactionId().orElse(""))
-                .withMerchantCode(request.getGatewayAccount().getCredentials(WORLDPAY.getName()).get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withDescription(request.getDescription())
                 .withAmount(request.getAmount())
                 .build();

--- a/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/WalletAuthorisationGatewayRequest.java
@@ -4,6 +4,8 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.request.AuthorisationGatewayRequest;
 import uk.gov.pay.connector.wallets.model.WalletAuthorisationData;
 
+import java.util.Map;
+
 public class WalletAuthorisationGatewayRequest extends AuthorisationGatewayRequest {
     private WalletAuthorisationData walletAuthorisationData;
 
@@ -18,5 +20,10 @@ public class WalletAuthorisationGatewayRequest extends AuthorisationGatewayReque
 
     public static WalletAuthorisationGatewayRequest valueOf(ChargeEntity charge, WalletAuthorisationData applePaymentData) {
         return new WalletAuthorisationGatewayRequest(charge, applePaymentData);
+    }
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        return charge.getGatewayAccountCredentialsEntity().getCredentials();
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -101,6 +101,13 @@ public abstract class BaseEpdqPaymentProviderIT {
 
     private Invocation.Builder mockClientInvocationBuilder;
 
+    private final Map<String, String> credentials = Map.of(
+            CREDENTIALS_MERCHANT_ID, "merchant-id",
+            CREDENTIALS_USERNAME, "username",
+            CREDENTIALS_PASSWORD, "password",
+            CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphrase"
+    );
+
     @Before
     public void setup() {
         GatewayClientFactory gatewayClientFactory = new GatewayClientFactory(mockClientFactory);
@@ -236,12 +243,7 @@ public abstract class BaseEpdqPaymentProviderIT {
 
         GatewayAccountCredentialsEntity credentialsEntity = aGatewayAccountCredentialsEntity()
                 .withPaymentProvider("epdq")
-                .withCredentials(Map.of(
-                        CREDENTIALS_MERCHANT_ID, "merchant-id",
-                        CREDENTIALS_USERNAME, "username",
-                        CREDENTIALS_PASSWORD, "password",
-                        CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphrase"
-                ))
+                .withCredentials(credentials)
                 .build();
         gatewayAccount.setGatewayAccountCredentials(List.of(credentialsEntity));
         return gatewayAccount;
@@ -282,6 +284,9 @@ public abstract class BaseEpdqPaymentProviderIT {
                 .withGatewayAccountEntity(buildTestGatewayAccountWith3dsEntity())
                 .withExternalId("mq4ht90j2oir6am585afk58kml")
                 .withTransactionId("payId")
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withCredentials(credentials)
+                        .build())
                 .build();
         Auth3dsResult auth3dsResult = new Auth3dsResult();
         auth3dsResult.setAuth3dsResult(auth3dsFrontendResult);
@@ -300,6 +305,9 @@ public abstract class BaseEpdqPaymentProviderIT {
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId("mq4ht90j2oir6am585afk58kml")
                 .withGatewayAccountEntity(accountEntity)
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withCredentials(credentials)
+                        .build())
                 .build();
         return new CardAuthorisationGatewayRequest(chargeEntity, buildTestAuthCardDetails());
     }
@@ -308,6 +316,9 @@ public abstract class BaseEpdqPaymentProviderIT {
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId("mq4ht90j2oir6am585afk58kml")
                 .withGatewayAccountEntity(accountEntity)
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withCredentials(credentials)
+                        .build())
                 .build();
 
         return new CardAuthorisationGatewayRequest(chargeEntity, buildTestAuthCardDetails());
@@ -317,6 +328,9 @@ public abstract class BaseEpdqPaymentProviderIT {
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId("mq4ht90j2oir6am585afk58kml")
                 .withGatewayAccountEntity(accountEntity)
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withCredentials(credentials)
+                        .build())
                 .build();
 
         Address address = new Address();
@@ -344,6 +358,9 @@ public abstract class BaseEpdqPaymentProviderIT {
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withExternalId("mq4ht90j2oir6am585afk58kml")
                 .withGatewayAccountEntity(accountEntity)
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withCredentials(credentials)
+                        .build())
                 .build();
         return new CardAuthorisationGatewayRequest(chargeEntity, buildTestAuthCardDetails());
     }
@@ -367,6 +384,9 @@ public abstract class BaseEpdqPaymentProviderIT {
         return aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withTransactionId("payId")
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withCredentials(credentials)
+                        .build())
                 .build();
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqCaptureHandlerTest.java
@@ -134,6 +134,14 @@ public class EpdqCaptureHandlerTest {
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(accountEntity)
                 .withTransactionId("payId")
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withCredentials(Map.of(
+                                CREDENTIALS_MERCHANT_ID, "merchant-id",
+                                CREDENTIALS_USERNAME, "username",
+                                CREDENTIALS_PASSWORD, "password",
+                                CREDENTIALS_SHA_IN_PASSPHRASE, "sha-passphrase"
+                        ))
+                        .build())
                 .build();
         return CaptureGatewayRequest.valueOf(chargeEntity);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayCaptureHandlerTest.java
@@ -41,6 +41,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_USERNAME;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
@@ -74,7 +77,17 @@ public class SmartpayCaptureHandlerTest {
         when(client.postRequestFor(any(URI.class), eq(SMARTPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(testResponse);
 
-        ChargeEntity chargeEntity = aValidChargeEntity().withGatewayAccountEntity(aServiceAccount()).build();
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(aServiceAccount())
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("smartpay")
+                        .withCredentials(Map.of(
+                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "password",
+                                CREDENTIALS_PASSWORD, "password"
+                        ))
+                        .build())
+                .build();
         if (corporateSurchargeAmount != null) {
             chargeEntity.setCorporateSurcharge(corporateSurchargeAmount);
         }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandlerTest.java
@@ -26,7 +26,6 @@ import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayReques
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.XPathUtils;
@@ -111,7 +110,16 @@ class WorldpayAuthoriseHandlerTest {
                 .withState(ACTIVE)
                 .build();
         gatewayAccountEntity.setGatewayAccountCredentials(List.of(creds));
-        chargeEntityFixture = aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity);
+        chargeEntityFixture = aValidChargeEntity()
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("worldpay")
+                        .withCredentials(Map.of(
+                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "worldpay-password",
+                                CREDENTIALS_PASSWORD, "password"
+                        ))
+                        .build())
+                .withGatewayAccountEntity(gatewayAccountEntity);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayCaptureHandlerTest.java
@@ -64,6 +64,12 @@ public class WorldpayCaptureHandlerTest {
     @Mock
     private Response response;
 
+    private final Map<String, String> credentials = Map.of(
+            CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+            CREDENTIALS_USERNAME, "worldpay-password",
+            CREDENTIALS_PASSWORD, "password"
+    );
+
     @Before
     public void setup() {
         worldpayCaptureHandler = new WorldpayCaptureHandler(client, ImmutableMap.of(TEST.toString(), URI.create("http://worldpay.test")));
@@ -78,7 +84,13 @@ public class WorldpayCaptureHandlerTest {
         when(client.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(response);
 
-        var chargeEntity = aValidChargeEntity().withGatewayAccountEntity(aServiceAccount()).build();
+        var chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(aServiceAccount())
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("worldpay")
+                        .withCredentials(credentials)
+                        .build())
+                .build();
         if (corporateSurchargeAmount != null) {
             chargeEntity.setCorporateSurcharge(corporateSurchargeAmount);
         }
@@ -138,6 +150,10 @@ public class WorldpayCaptureHandlerTest {
     private CaptureGatewayRequest getCaptureRequest() {
         ChargeEntity chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(aServiceAccount())
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("worldpay")
+                        .withCredentials(credentials)
+                        .build())
                 .build();
         return CaptureGatewayRequest.valueOf(chargeEntity);
     }
@@ -151,10 +167,7 @@ public class WorldpayCaptureHandlerTest {
                 .build();
 
         var creds = aGatewayAccountCredentialsEntity()
-                .withCredentials(Map.of(
-                        CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
-                        CREDENTIALS_USERNAME, "worldpay-password",
-                        CREDENTIALS_PASSWORD, "password"))
+                .withCredentials(credentials)
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .withPaymentProvider(WORLDPAY.getName())
                 .withState(ACTIVE)

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -147,7 +147,16 @@ public class WorldpayPaymentProviderTest {
                 eventService);
 
         gatewayAccountEntity = aServiceAccount();
-        chargeEntityFixture = aValidChargeEntity().withGatewayAccountEntity(gatewayAccountEntity);
+        chargeEntityFixture = aValidChargeEntity()
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("worldpay")
+                        .withCredentials(Map.of(
+                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "worldpay-password",
+                                CREDENTIALS_PASSWORD, "password"
+                        ))
+                        .build())
+                .withGatewayAccountEntity(gatewayAccountEntity);
 
         Logger root = (Logger) LoggerFactory.getLogger(WorldpayPaymentProvider.class);
         root.setLevel(Level.INFO);
@@ -504,6 +513,14 @@ public class WorldpayPaymentProviderTest {
                 .withExternalId("uniqueSessionId")
                 .withTransactionId("MyUniqueTransactionId!")
                 .withProviderSessionId(providerSessionId)
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("worldpay")
+                        .withCredentials(Map.of(
+                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "worldpay-password",
+                                CREDENTIALS_PASSWORD, "password"
+                        ))
+                        .build())
                 .build();
 
         when(authoriseClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyList(), anyMap()))

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/wallets/WorldpayWalletAuthorisationHandlerTest.java
@@ -79,7 +79,17 @@ public class WorldpayWalletAuthorisationHandlerTest {
     @Before
     public void setUp() throws Exception {
         worldpayWalletAuthorisationHandler = new WorldpayWalletAuthorisationHandler(mockGatewayClient, Map.of(TEST.toString(), WORLDPAY_URL));
-        chargeEntity = ChargeEntityFixture.aValidChargeEntity().withDescription("This is the description").build();
+        chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+                .withDescription("This is the description")
+                .withGatewayAccountCredentialsEntity(aGatewayAccountCredentialsEntity()
+                        .withPaymentProvider("worldpay")
+                        .withCredentials(Map.of(
+                                CREDENTIALS_MERCHANT_ID, "MERCHANTCODE",
+                                CREDENTIALS_USERNAME, "worldpay-password",
+                                CREDENTIALS_PASSWORD, "password"
+                        ))
+                        .build())
+                .build();
         gatewayAccountEntity = aGatewayAccountEntity()
                 .withGatewayName("worldpay")
                 .withType(TEST)

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -578,6 +578,7 @@ public class DatabaseFixtures {
         ParityCheckStatus parityCheckStatus;
         private String description = "Test description";
         private ZonedDateTime parityCheckDate;
+        Long gatewayCredentialId;
 
         public TestCardDetails getCardDetails() {
             return cardDetails;
@@ -668,6 +669,11 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestCharge withGatewayCredentialId(Long gatewayCredentialId) {
+            this.gatewayCredentialId = gatewayCredentialId;
+            return this;
+        }
+
         public TestCharge insert() {
             if (testAccount == null)
                 throw new IllegalStateException("Test Account must be provided.");
@@ -691,6 +697,7 @@ public class DatabaseFixtures {
                     .withCorporateSurcharge(corporateCardSurcharge)
                     .withParityCheckStatus(parityCheckStatus)
                     .withParityCheckDate(parityCheckDate)
+                    .withGatewayCredentialId(gatewayCredentialId)
                     .build());
 
             if (cardDetails != null) {

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseApplePayIT.java
@@ -11,12 +11,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.LoggerFactory;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
 import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceAuthoriseIT.java
@@ -486,7 +486,7 @@ public class CardResourceAuthoriseIT extends ChargingITestBase {
                 .insert();
 
         ChargeUtils.ExternalChargeId chargeId = createNewChargeWithAccountId(ENTERING_CARD_DETAILS, null,
-                String.valueOf(accountId), databaseTestHelper, WORLDPAY.getName());
+                String.valueOf(accountId), databaseTestHelper, WORLDPAY.getName(), worldpayCredentialsParams.getId());
 
         worldpayMockClient.mockAuthorisationSuccess();
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CardResourceCaptureIT.java
@@ -3,11 +3,11 @@ package uk.gov.pay.connector.it.resources;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.base.ChargingITestBase;
 import uk.gov.pay.connector.junit.DropwizardConfig;
 import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import java.util.Map;
 

--- a/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
+++ b/src/test/java/uk/gov/pay/connector/it/util/ChargeUtils.java
@@ -44,6 +44,25 @@ public class ChargeUtils {
 
     public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId,
                                                                 String accountId, DatabaseTestHelper databaseTestHelper,
+                                                                String paymentProvider, Long gatewayCredentialId) {
+        long chargeId = RandomUtils.nextInt();
+        ExternalChargeId externalChargeId = ExternalChargeId.fromChargeId(chargeId);
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId.toString())
+                .withGatewayAccountId(accountId)
+                .withPaymentProvider(paymentProvider)
+                .withAmount(6234L)
+                .withStatus(status)
+                .withTransactionId(gatewayTransactionId)
+                .withEmail("email@fake.test")
+                .withGatewayCredentialId(gatewayCredentialId)
+                .build());
+        return externalChargeId;
+    }
+
+    public static ExternalChargeId createNewChargeWithAccountId(ChargeStatus status, String gatewayTransactionId,
+                                                                String accountId, DatabaseTestHelper databaseTestHelper,
                                                                 String paymentProvider) {
         return createNewChargeWithAccountId(status, gatewayTransactionId, accountId,
                 databaseTestHelper, "email@fake.test", paymentProvider);

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -35,6 +35,7 @@ public class AddChargeParams {
     private final ParityCheckStatus parityCheckStatus;
     private final CardType cardType;
     private final ZonedDateTime parityCheckDate;
+    private final Long gatewayCredentialId;
 
     private AddChargeParams(AddChargeParamsBuilder builder) {
         chargeId = builder.chargeId;
@@ -58,6 +59,7 @@ public class AddChargeParams {
         parityCheckStatus = builder.parityCheckStatus;
         parityCheckDate = builder.parityCheckDate;
         cardType = builder.cardType;
+        gatewayCredentialId = builder.gatewayCredentialId;
     }
 
     public Long getChargeId() {
@@ -144,6 +146,10 @@ public class AddChargeParams {
         return cardType;
     }
 
+    public Long getGatewayCredentialId() {
+        return gatewayCredentialId;
+    }
+
     public static final class AddChargeParamsBuilder {
         private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
@@ -166,6 +172,7 @@ public class AddChargeParams {
         private ParityCheckStatus parityCheckStatus;
         private CardType cardType;
         private ZonedDateTime parityCheckDate;
+        private Long gatewayCredentialId;
 
         private AddChargeParamsBuilder() {
         }
@@ -277,6 +284,11 @@ public class AddChargeParams {
         
         public AddChargeParamsBuilder withCardType(CardType chargeType) {
             this.cardType = chargeType;
+            return this;
+        }
+
+        public AddChargeParamsBuilder withGatewayCredentialId(Long gatewayCredentialId) {
+            this.gatewayCredentialId = gatewayCredentialId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -101,12 +101,12 @@ public class DatabaseTestHelper {
                         "status, gateway_account_id, return_url, gateway_transaction_id, " +
                         "description, created_date, reference, version, email, language, " +
                         "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
-                        "external_metadata, card_type, payment_provider) " +
+                        "external_metadata, card_type, payment_provider, gateway_account_credential_id) " +
                         "VALUES(:id, :external_id, :amount, " +
                         ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                         ":description, :created_date, :reference, :version, :email, :language, " +
                         ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
-                        ":external_metadata, :card_type, :payment_provider)")
+                        ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())
@@ -127,6 +127,7 @@ public class DatabaseTestHelper {
                         .bindBySqlType("external_metadata", jsonMetadata, OTHER)
                         .bind("card_type", addChargeParams.getCardType())
                         .bind("payment_provider", addChargeParams.getPaymentProvider())
+                        .bind("gateway_account_credential_id", addChargeParams.getGatewayCredentialId())
                         .execute());
     }
 


### PR DESCRIPTION
## WHAT YOU DID

- For all payment in-flight operations (authorise, cancel, capture, 3ds)
- We currently get credentials from GatewayAccountEntity based on charge’s payment_provider. `charges` table now stores credential ID when payments are created and this can be used everywhere instead.
- `GatewayAccountCredentialsEntity` on `ChargeEntity` is eagerly (default) fetched from database, so should be available all the time `ChargeEntity` is retrieved.
- update/refactor tests accordingly
