### PR TITLE
BAU — Upgrade jetty-io from 9.4.35.v20201120 to 9.4.43.v20210629

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>9.4.35.v20201120</version>
+            <version>9.4.43.v20210629</version>
         </dependency>
         <dependency>
             <groupId>black.door</groupId>


### PR DESCRIPTION
⏫