### PR TITLE
PP-8342 - Add credential_external_id to Charge and LedgerTransaction

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -13,6 +13,7 @@ public class Charge {
     private String status;
     private String externalStatus;
     private String gatewayTransactionId;
+    private String credentialExternalId;
     private Long corporateSurcharge;
     private String refundAvailabilityStatus;
     private String reference;
@@ -24,13 +25,14 @@ public class Charge {
     private boolean historic;
 
     public Charge(String externalId, Long amount, String status, String externalStatus, String gatewayTransactionId,
-                  Long corporateSurcharge, String refundAvailabilityStatus, String reference,
+                  String credentialExternalId, Long corporateSurcharge, String refundAvailabilityStatus, String reference,
                   String description, Instant createdDate, String email, Long gatewayAccountId, String paymentGatewayName, boolean historic) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
         this.externalStatus = externalStatus;
         this.gatewayTransactionId = gatewayTransactionId;
+        this.credentialExternalId = credentialExternalId;
         this.corporateSurcharge = corporateSurcharge;
         this.refundAvailabilityStatus = refundAvailabilityStatus;
         this.reference = reference;
@@ -44,6 +46,11 @@ public class Charge {
 
     public static Charge from(ChargeEntity chargeEntity) {
         ChargeStatus chargeStatus = ChargeStatus.fromString(chargeEntity.getStatus());
+        String credentialExternalId = null;
+
+        if (chargeEntity.getGatewayAccountCredentialsEntity() != null) {
+            credentialExternalId = chargeEntity.getGatewayAccountCredentialsEntity().getExternalId();
+        }
 
         return new Charge(
                 chargeEntity.getExternalId(),
@@ -51,6 +58,7 @@ public class Charge {
                 chargeEntity.getStatus(),
                 chargeStatus.toExternal().toString(),
                 chargeEntity.getGatewayTransactionId(),
+                credentialExternalId,
                 chargeEntity.getCorporateSurcharge().orElse(null),
                 null, 
                 chargeEntity.getReference().toString(),
@@ -80,6 +88,7 @@ public class Charge {
                 null,
                 externalStatus,
                 transaction.getGatewayTransactionId(),
+                transaction.getCredentialExternalId(),
                 transaction.getCorporateCardSurcharge(),
                 externalRefundState,
                 transaction.getReference(),
@@ -136,36 +145,6 @@ public class Charge {
         return email;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        Charge charge = (Charge) obj;
-        return Objects.equals(externalId, charge.externalId) &&
-                Objects.equals(amount, charge.amount) &&
-                Objects.equals(status, charge.status) &&
-                Objects.equals(gatewayTransactionId, charge.gatewayTransactionId) &&
-                Objects.equals(corporateSurcharge, charge.corporateSurcharge) &&
-                Objects.equals(historic, charge.historic) &&
-                Objects.equals(refundAvailabilityStatus, charge.refundAvailabilityStatus) &&
-                Objects.equals(reference, charge.reference) &&
-                Objects.equals(description, charge.description) &&
-                Objects.equals(createdDate, charge.createdDate) &&
-                Objects.equals(email, charge.email);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(externalId, amount, status, externalStatus, gatewayTransactionId, corporateSurcharge,
-                refundAvailabilityStatus, reference, description, createdDate, email, gatewayAccountId,
-                paymentGatewayName, historic);
-    }
-
     public String getExternalStatus() {
         return externalStatus;
     }
@@ -180,5 +159,44 @@ public class Charge {
 
     public void setHistoric(boolean historic) {
         this.historic = historic;
+    }
+
+    public String getCredentialExternalId() {
+        return credentialExternalId;
+    }
+
+    public void setCredentialExternalId(String credentialExternalId) {
+        this.credentialExternalId = credentialExternalId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Charge charge = (Charge) obj;
+        return Objects.equals(externalId, charge.externalId) &&
+                Objects.equals(amount, charge.amount) &&
+                Objects.equals(status, charge.status) &&
+                Objects.equals(gatewayTransactionId, charge.gatewayTransactionId) &&
+                Objects.equals(credentialExternalId, charge.credentialExternalId) &&
+                Objects.equals(corporateSurcharge, charge.corporateSurcharge) &&
+                Objects.equals(historic, charge.historic) &&
+                Objects.equals(refundAvailabilityStatus, charge.refundAvailabilityStatus) &&
+                Objects.equals(reference, charge.reference) &&
+                Objects.equals(description, charge.description) &&
+                Objects.equals(createdDate, charge.createdDate) &&
+                Objects.equals(email, charge.email);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(externalId, amount, status, externalStatus, gatewayTransactionId, credentialExternalId, corporateSurcharge,
+                refundAvailabilityStatus, reference, description, createdDate, email, gatewayAccountId,
+                paymentGatewayName, historic);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -21,6 +21,7 @@ public class LedgerTransaction {
     private String transactionId;
     private Long amount;
     private String gatewayAccountId;
+    private String credentialExternalId;
     private String description;
     private String reference;
     private String email;
@@ -135,6 +136,14 @@ public class LedgerTransaction {
 
     public void setTransactionId(String transactionId) {
         this.transactionId = transactionId;
+    }
+
+    public String getCredentialExternalId() {
+        return credentialExternalId;
+    }
+
+    public void setCredentialExternalId(String credentialExternalId) {
+        this.credentialExternalId = credentialExternalId;
     }
 
     public TransactionState getState() {

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -228,7 +228,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     
     private Charge getCharge(boolean isHistoric){
         return new Charge("external-id", 10L, null, null, "transaction-id",
-                10L, null, "ref-1", "desc", Instant.now(),
+                "credential-external-id", 10L, null, "ref-1", "desc", Instant.now(),
                 "test@example.org", 123L, "epdq", isHistoric);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -11,7 +11,6 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;

--- a/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/LedgerTransactionFixture.java
@@ -46,6 +46,7 @@ public class LedgerTransactionFixture {
     private String reference;
     private String email;
     private String gatewayTransactionId;
+    private String credentialExternalId;
     private String returnUrl;
     private SupportedLanguage language;
     private CardDetails cardDetails;
@@ -84,6 +85,7 @@ public class LedgerTransactionFixture {
                         .withEmail(chargeEntity.getEmail())
                         .withReturnUrl(chargeEntity.getReturnUrl())
                         .withGatewayTransactionId(chargeEntity.getGatewayTransactionId())
+                        .withCredentialExternalId(chargeEntity.getGatewayAccountCredentialsEntity().getExternalId())
                         .withDelayedCapture(chargeEntity.isDelayedCapture())
                         .withSource(chargeEntity.getSource())
                         .withMoto(chargeEntity.isMoto())
@@ -175,6 +177,7 @@ public class LedgerTransactionFixture {
         ledgerTransaction.setReference(reference);
         ledgerTransaction.setEmail(email);
         ledgerTransaction.setGatewayTransactionId(gatewayTransactionId);
+        ledgerTransaction.setCredentialExternalId(credentialExternalId);
         ledgerTransaction.setReturnUrl(returnUrl);
         ledgerTransaction.setLanguage(language);
         ledgerTransaction.setCardDetails(cardDetails);
@@ -255,6 +258,11 @@ public class LedgerTransactionFixture {
 
     public LedgerTransactionFixture withGatewayTransactionId(String gatewayTransactionId) {
         this.gatewayTransactionId = gatewayTransactionId;
+        return this;
+    }
+
+    public LedgerTransactionFixture withCredentialExternalId(String credentialExternalId) {
+        this.credentialExternalId = credentialExternalId;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -155,7 +155,7 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
 
     private Charge getHistoricCharge(ExternalChargeRefundAvailability availability) {
         return new Charge("external-id", 500L, null, "success", "transaction-id",
-                0L, availability.getStatus(), "ref-1", "desc", Instant.now(),
+                "credentials_external_id", 0L, availability.getStatus(), "ref-1", "desc", Instant.now(),
                 "test@example.org", 123L, "epdq", true);
     }
 }


### PR DESCRIPTION
Description:
- credential_external_id is needed to retrieve the gateway account credentials for a charge when performing a refund so needs to be added
 to both Charge and LedgerTransaction model entities
- Ledger currently sends credential_external_id so can just be added to LedgerTransaction
- See RefundResource.submitRefund() which uses chargeService.findCharge() which returns a Charge model that is used to perform the refund