### PR TITLE
PP-8415 Stop logging payment reference

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -150,9 +150,11 @@ public class ChargeCreateRequest {
     }
 
     public String toStringWithoutPersonalIdentifiableInformation() {
+        // Don't include:
+        // description - some services include PII
+        // reference - can come from user input for payment links, in the past they have mistakenly entered card numbers
         return "ChargeCreateRequest{" +
                 "amount=" + amount +
-                ", reference='" + reference + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
                 ", delayed_capture=" + delayedCapture +
                 ", source=" + source +

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -346,7 +346,9 @@ public class ChargeResponse {
 
     @Override
     public String toString() {
-        // Some services put PII in the description, so don’t include it in the stringification
+        // Don't include:
+        // description - some services include PII
+        // reference - can come from user input for payment links, in the past they have mistakenly entered card numbers
         return "ChargeResponse{" +
                 "dataLinks=" + dataLinks +
                 ", chargeId='" + chargeId + '\'' +
@@ -355,7 +357,6 @@ public class ChargeResponse {
                 ", cardBrand='" + cardBrand + '\'' +
                 ", gatewayTransactionId='" + gatewayTransactionId + '\'' +
                 ", returnUrl='" + returnUrl + '\'' +
-                ", reference='" + reference + '\'' +
                 ", providerName='" + providerName + '\'' +
                 ", createdDate=" + createdDate +
                 ", refundSummary=" + refundSummary +


### PR DESCRIPTION
The payment reference can come from user input for a payment link payment. We've seen users mistakenly entering their card number in the reference field.

It is a lot of effort to remove log lines from all places when this happens, so stop logging the reference in all cases. We can still find out the reference or search for payments by the reference in toolbox.
