### PR TITLE
PP-8437 Add service ID to card gateway accounts and charges

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1692,4 +1692,12 @@
         <dropColumn tableName="gateway_accounts" columnName="payment_provider"/>
     </changeSet>
 
+    <changeSet id="add service id to gateway accounts" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="service_id" type="varchar(32)"/>
+        </addColumn>
+        <createIndex tableName="gateway_accounts" indexName="idx_gateway_accounts_service_id">
+            <column name="service_id"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1700,4 +1700,10 @@
             <column name="service_id"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="add service id to charges" author="">
+        <addColumn tableName="charges">
+            <column name="service_id" type="varchar(32)"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Adds a `service_id` and standard btree index to the `gateway_accounts`
table, and a `service_id` column to charges.

Refunds should always have the `service_id` context of the transaction they were
made to refund against.

Set type to `varchar(32)` to match the format set by admin users for
service external IDs.

Future resources will need to perform queries on accounts by their
relation to service ID for gateway accounts, index this column.

Service ID index is not configured to run `CONCURRENTLY`. Non-concurrent
index creation may lock, insert, updates and deletes on the table, they
should not impact reads.

As there will be no data to actually index this operation should be
instantaneous in all environments, no reading of accounts for in-flight
payments should be impacted.