### PR TITLE
PP-8437 Serialise service id on account charge entities

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -177,6 +177,9 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
     @Column(name = "payment_provider")
     private String paymentProvider;
 
+    @Column(name = "service_id")
+    private String serviceId;
+
     public ChargeEntity() {
         //for jpa
     }
@@ -279,6 +282,10 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getServiceId() {
+        return serviceId;
     }
 
     public String getProviderSessionId() {
@@ -473,6 +480,10 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
 
     public void setSource(Source source) {
         this.source = source;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
     }
 
     public static final class WebChargeEntityBuilder {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -76,6 +76,9 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @Column(name = "service_name")
     private String serviceName;
 
+    @Column(name = "service_id")
+    private String serviceId;
+
     @Column(name = "description")
     private String description;
 
@@ -278,6 +281,12 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
     @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
     public String getServiceName() {
         return serviceName;
+    }
+
+    @JsonProperty("service_id")
+    @JsonView(value = {Views.ApiView.class, Views.FrontendView.class})
+    public String getServiceId() {
+        return serviceId;
     }
 
     @JsonView(Views.FrontendView.class)

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountResourceDTO.java
@@ -32,6 +32,9 @@ public class GatewayAccountResourceDTO {
     @JsonProperty("service_name")
     private String serviceName;
 
+    @JsonProperty("service_id")
+    private String serviceId;
+
     @JsonProperty("analytics_id")
     private String analyticsId;
 
@@ -130,6 +133,7 @@ public class GatewayAccountResourceDTO {
         this.providerSwitchEnabled = gatewayAccountEntity.isProviderSwitchEnabled();
         this.sendPayerEmailToGateway = gatewayAccountEntity.isSendPayerEmailToGateway();
         this.sendPayerIpAddressToGateway = gatewayAccountEntity.isSendPayerIpAddressToGateway();
+        this.serviceId = gatewayAccountEntity.getServiceId();
     }
 
     public long getAccountId() {
@@ -154,6 +158,10 @@ public class GatewayAccountResourceDTO {
 
     public String getServiceName() {
         return serviceName;
+    }
+
+    public String getServiceId() {
+        return serviceId;
     }
 
     public String getAnalyticsId() {

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -325,6 +325,7 @@ public class DatabaseFixtures {
         private Map<String, String> credentialsMap = Map.of();
         private List<AddGatewayAccountCredentialsParams> gatewayAccountCredentialsParams;
         private String serviceName = "service_name";
+        private String serviceId = "valid-external-service-id";
         private String description = "a description";
         private String analyticsId = "an analytics id";
         private EmailCollectionMode emailCollectionMode = EmailCollectionMode.OPTIONAL;
@@ -368,6 +369,10 @@ public class DatabaseFixtures {
 
         public String getServiceName() {
             return serviceName;
+        }
+
+        public String getServiceId() {
+            return serviceId;
         }
 
         public String getDescription() {
@@ -438,6 +443,11 @@ public class DatabaseFixtures {
 
         public TestAccount withServiceName(String serviceName) {
             this.serviceName = serviceName;
+            return this;
+        }
+
+        public TestAccount withServiceId(String serviceId) {
+            this.serviceId = serviceId;
             return this;
         }
 
@@ -546,6 +556,7 @@ public class DatabaseFixtures {
                     .withMotoMaskCardNumberInput(motoMaskCardNumberInput)
                     .withMotoMaskCardSecurityCodeInput(motoMaskCardSecurityCodeInput)
                     .withAllowTelephonePaymentNotifications(allowTelephonePaymentNotifications)
+                    .withServiceId(serviceId)
                     .build());
             for (TestCardType cardType : cardTypes) {
                 databaseTestHelper.addAcceptedCardType(this.getAccountId(), cardType.getId());

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -124,6 +124,7 @@ public class GatewayAccountDaoIT extends DaoITestBase {
         assertThat(gatewayAccount.getGatewayName(), is(accountRecord.getPaymentProvider()));
         assertThat(gatewayAccount.getExternalId(), is(accountRecord.getExternalId()));
         assertThat(gatewayAccount.getServiceName(), is(accountRecord.getServiceName()));
+        assertThat(gatewayAccount.getServiceId(), is(accountRecord.getServiceId()));
         assertThat(gatewayAccount.getDescription(), is(accountRecord.getDescription()));
         assertThat(gatewayAccount.getAnalyticsId(), is(accountRecord.getAnalyticsId()));
         assertThat(gatewayAccount.getCorporateNonPrepaidCreditCardSurchargeAmount(), is(accountRecord.getCorporateCreditCardSurchargeAmount()));

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -188,7 +188,8 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .body("allow_zero_amount", is(false))
                 .body("integration_version_3ds", is(2))
                 .body("allow_telephone_payment_notifications", is(true))
-                .body("provider_switch_enabled", is(false));
+                .body("provider_switch_enabled", is(false))
+                .body("service_id", is("valid-external-service-id"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java
+++ b/src/test/java/uk/gov/pay/connector/pact/util/GatewayAccountUtil.java
@@ -17,6 +17,7 @@ public class GatewayAccountUtil {
                     .withDescription("aDescription")
                     .withAnalyticsId("8b02c7e542e74423aa9e6d0f0628fd58")
                     .withServiceName("a cool service")
+                    .withServiceId("a-valid-external-service-id")
                     .withCardTypeEntities(Collections.singletonList(dbHelper.getVisaDebitCard()))
                     .insert();
         } else {

--- a/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddGatewayAccountParams.java
@@ -38,6 +38,7 @@ public class AddGatewayAccountParams {
     private String externalId;
     private List<AddGatewayAccountCredentialsParams> credentials;
     private String serviceName;
+    private String serviceId;
     private GatewayAccountType type;
     private String description;
     private String analyticsId;
@@ -74,6 +75,10 @@ public class AddGatewayAccountParams {
 
     public String getServiceName() {
         return serviceName;
+    }
+
+    public String getServiceId() {
+        return serviceId;
     }
 
     public GatewayAccountType getType() {
@@ -146,6 +151,7 @@ public class AddGatewayAccountParams {
         private Map<String, String> credentialsMap = Map.of();
         private List<AddGatewayAccountCredentialsParams> gatewayAccountCredentialsParams;
         private String serviceName = "service name";
+        private String serviceId = "a-valid-service-external-id";
         private GatewayAccountType type = TEST;
         private String description = "description";
         private String analyticsId;
@@ -214,6 +220,11 @@ public class AddGatewayAccountParams {
 
         public AddGatewayAccountParamsBuilder withServiceName(String serviceName) {
             this.serviceName = serviceName;
+            return this;
+        }
+
+        public AddGatewayAccountParamsBuilder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
             return this;
         }
 
@@ -328,6 +339,7 @@ public class AddGatewayAccountParams {
             addGatewayAccountParams.requires3ds = this.requires3ds;
             addGatewayAccountParams.allowTelephonePaymentNotifications = this.allowTelephonePaymentNotifications;
             addGatewayAccountParams.providerSwitchEnabled = this.providerSwitchEnabled;
+            addGatewayAccountParams.serviceId = this.serviceId;
             return addGatewayAccountParams;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -50,7 +50,7 @@ public class DatabaseTestHelper {
                         "corporate_debit_card_surcharge_amount, corporate_prepaid_credit_card_surcharge_amount, " +
                         "corporate_prepaid_debit_card_surcharge_amount, allow_moto, moto_mask_card_number_input, " +
                         "moto_mask_card_security_code_input, allow_apple_pay, allow_google_pay, requires_3ds, " +
-                        "allow_telephone_payment_notifications, provider_switch_enabled) " +
+                        "allow_telephone_payment_notifications, provider_switch_enabled, service_id) " +
                         "VALUES (:id, :external_id, :service_name, :type, " +
                         ":description, :analytics_id, :email_collection_mode, :integration_version_3ds, " +
                         ":corporate_credit_card_surcharge_amount, :corporate_debit_card_surcharge_amount, " +
@@ -58,7 +58,7 @@ public class DatabaseTestHelper {
                         ":corporate_prepaid_debit_card_surcharge_amount, " +
                         ":allow_moto, :moto_mask_card_number_input, :moto_mask_card_security_code_input, " +
                         ":allow_apple_pay, :allow_google_pay, :requires_3ds, " +
-                        ":allow_telephone_payment_notifications, :provider_switch_enabled)")
+                        ":allow_telephone_payment_notifications, :provider_switch_enabled, :service_id)")
                         .bind("id", Long.valueOf(params.getAccountId()))
                         .bind("external_id", params.getExternalId())
                         .bind("service_name", params.getServiceName())
@@ -79,6 +79,7 @@ public class DatabaseTestHelper {
                         .bind("requires_3ds", params.isRequires3ds())
                         .bind("allow_telephone_payment_notifications", params.isAllowTelephonePaymentNotifications())
                         .bind("provider_switch_enabled", params.isProviderSwitchEnabled())
+                        .bind("service_id", params.getServiceId())
                         .execute());
         if (params.getCredentials() != null) {
             params.getCredentials().forEach(this::insertGatewayAccountCredentials);


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-connector/pull/3156

Add `serviceId` field to gateway account entities and resource maps. (and charge entity)

Update gateway account test fixtures to reflect service id and assert on resource.