### PR TITLE
PP-8438 Optionally accept `service_id` on create account route

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountEntity.java
@@ -435,6 +435,10 @@ public class GatewayAccountEntity extends AbstractVersionedEntity {
         this.serviceName = serviceName;
     }
 
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
+    }
+
     public void setCardTypes(List<CardTypeEntity> cardTypes) {
         this.cardTypes = cardTypes;
     }

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountRequest.java
@@ -29,6 +29,8 @@ public class GatewayAccountRequest {
 
     private String serviceName;
 
+    private final String serviceId;
+
     private String description;
 
     private String analyticsId;
@@ -40,11 +42,13 @@ public class GatewayAccountRequest {
     public GatewayAccountRequest(@JsonProperty("type") String providerAccountType,
                                  @JsonProperty("payment_provider") String paymentProvider,
                                  @JsonProperty("service_name") String serviceName,
+                                 @JsonProperty("service_id") String serviceId,
                                  @JsonProperty("description") String description,
                                  @JsonProperty("analytics_id") String analyticsId,
                                  @JsonProperty("requires_3ds") boolean requires3ds
     ) {
         this.serviceName = serviceName;
+        this.serviceId = serviceId;
         this.description = description;
         this.analyticsId = analyticsId;
         this.requires3ds = requires3ds;
@@ -84,6 +88,10 @@ public class GatewayAccountRequest {
 
     public String getServiceName() {
         return serviceName;
+    }
+
+    public String getServiceId() {
+        return serviceId;
     }
 
     public String getDescription() {

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/StripeGatewayAccountRequest.java
@@ -16,13 +16,14 @@ public class StripeGatewayAccountRequest extends GatewayAccountRequest {
     public StripeGatewayAccountRequest(@JsonProperty("type") String providerAccountType,
                                        @JsonProperty("payment_provider") String paymentProvider,
                                        @JsonProperty("service_name") String serviceName,
+                                       @JsonProperty("service_id") String serviceId,
                                        @JsonProperty("description") String description,
                                        @JsonProperty("analytics_id") String analyticsId,
                                        @JsonProperty("credentials") StripeCredentials credentials,
                                        @JsonProperty("requires_3ds") boolean requires3ds
     ) {
 
-        super(providerAccountType, paymentProvider, serviceName, description, analyticsId, requires3ds);
+        super(providerAccountType, paymentProvider, serviceName, serviceId, description, analyticsId, requires3ds);
         this.credentials = Optional.ofNullable(credentials);
     }
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/service/GatewayAccountObjectConverter.java
@@ -24,6 +24,7 @@ public class GatewayAccountObjectConverter {
         gatewayAccountEntity.setExternalId(randomUuid());
 
         gatewayAccountEntity.setServiceName(gatewayAccountRequest.getServiceName());
+        gatewayAccountEntity.setServiceId(gatewayAccountRequest.getServiceId());
         gatewayAccountEntity.setDescription(gatewayAccountRequest.getDescription());
         gatewayAccountEntity.setAnalyticsId(gatewayAccountRequest.getAnalyticsId());
         gatewayAccountEntity.setRequires3ds(gatewayAccountRequest.getRequires3ds());

--- a/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/CreateGatewayAccountResourceIT.java
@@ -51,6 +51,16 @@ public class CreateGatewayAccountResourceIT extends GatewayAccountResourceTestBa
     }
 
     @Test
+    public void createAGatewayAccountWithServiceId() {
+        String gatewayAccountId = createAGatewayAccountWithServiceId("some-special-service-id");
+        givenSetup()
+                .get(ACCOUNTS_API_URL + gatewayAccountId)
+                .then()
+                .statusCode(200)
+                .body("service_id", is("some-special-service-id"));
+    }
+
+    @Test
     public void createStripeGatewayAccountWithoutCredentials() {
         Map<String, Object> payload = ImmutableMap.of(
                 "type", "test",

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -68,16 +68,6 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
     }
 
     @Test
-    public void getAccountShouldReturnServiceId() {
-        String gatewayAccountId = createAGatewayAccountWithServiceId("some-special-service-id");
-        givenSetup()
-                .get(ACCOUNTS_API_URL + gatewayAccountId)
-                .then()
-                .statusCode(200)
-                .body("service_id", is("some-special-service-id"));
-    }
-
-    @Test
     public void getAccountShouldReturnDescriptionAndAnalyticsId() {
         String gatewayAccountId = createAGatewayAccountFor("worldpay", "desc", "id");
         givenSetup()

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceIT.java
@@ -2,13 +2,10 @@ package uk.gov.pay.connector.it.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.gson.Gson;
 import io.restassured.http.ContentType;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.postgresql.util.PGobject;
-import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
@@ -22,7 +19,6 @@ import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.CONFLICT;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -32,11 +28,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.WORLDPAY;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
-import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
-import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.JsonEncoder.toJson;
-import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 @RunWith(DropwizardJUnitRunner.class)
 @DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
@@ -73,6 +65,16 @@ public class GatewayAccountResourceIT extends GatewayAccountResourceTestBase {
                 .then()
                 .statusCode(200)
                 .body("card_types", is(nullValue()));
+    }
+
+    @Test
+    public void getAccountShouldReturnServiceId() {
+        String gatewayAccountId = createAGatewayAccountWithServiceId("some-special-service-id");
+        givenSetup()
+                .get(ACCOUNTS_API_URL + gatewayAccountId)
+                .then()
+                .statusCode(200)
+                .body("service_id", is("some-special-service-id"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -58,9 +58,9 @@ public class GatewayAccountResourceTestBase {
     protected String createAGatewayAccountFor(String provider, String desc, String analyticsId) {
         return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, desc, analyticsId));
     }
-    
+
     protected String createAGatewayAccountFor(String provider, String description, String analyticsId, String requires3ds, String type) {
-        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, description, analyticsId, requires3ds, type));
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, description, analyticsId, requires3ds, type, "a-service-external-id"));
     }
 
     public static String extractGatewayAccountId(ValidatableResponse validatableResponse) {
@@ -72,10 +72,14 @@ public class GatewayAccountResourceTestBase {
     }
 
     public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId) {
-        return createAGatewayAccountFor(port, testProvider, description, analyticsId, null, "test");
+        return createAGatewayAccountFor(port, testProvider, description, analyticsId, null, "test", "a-service-external-id");
     }
 
-    public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId, String requires3ds, String type) {
+    protected String createAGatewayAccountWithServiceId(String serviceId) {
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), "sandbox", "description", "analytics-id", "", "test", serviceId));
+    }
+
+    public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId, String requires3ds, String type, String serviceId) {
         Map<String, String> payload = Maps.newHashMap();
         payload.put("payment_provider", testProvider);
         if (description != null) {
@@ -89,6 +93,9 @@ public class GatewayAccountResourceTestBase {
         }
         if (type != null) {
             payload.put("type", type);
+        }
+        if (serviceId != null) {
+            payload.put("service_id", serviceId);
         }
         return given().port(port)
                 .contentType(JSON)

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountResourceTestBase.java
@@ -60,7 +60,7 @@ public class GatewayAccountResourceTestBase {
     }
 
     protected String createAGatewayAccountFor(String provider, String description, String analyticsId, String requires3ds, String type) {
-        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, description, analyticsId, requires3ds, type, "a-service-external-id"));
+        return extractGatewayAccountId(createAGatewayAccountFor(testContext.getPort(), provider, description, analyticsId, requires3ds, type, null));
     }
 
     public static String extractGatewayAccountId(ValidatableResponse validatableResponse) {
@@ -72,7 +72,7 @@ public class GatewayAccountResourceTestBase {
     }
 
     public static ValidatableResponse createAGatewayAccountFor(int port, String testProvider, String description, String analyticsId) {
-        return createAGatewayAccountFor(port, testProvider, description, analyticsId, null, "test", "a-service-external-id");
+        return createAGatewayAccountFor(port, testProvider, description, analyticsId, null, "test", null);
     }
 
     protected String createAGatewayAccountWithServiceId(String serviceId) {


### PR DESCRIPTION
POST `/v1/api/accounts/` accepts `service_id` in the request body and
writes this to the corresponding database column.

Parameter is currently nullable in order to not break before consumers
are updated.