### PR TITLE
PP-5986 Increase Stripe notification wait time for 3DS payments

### DIFF
--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -111,7 +111,7 @@ stripe:
   platformAccountId: ${STRIPE_PLATFORM_ACCOUNT_ID}
   feePercentage: ${STRIPE_TRANSACTION_FEE_PERCENTAGE}
   collectFee: ${COLLECT_FEE_FEATURE_FLAG:-false}
-  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-1000}
+  notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-3000}
   credentials: ['stripe_account_id']
 
 executorServiceConfig:


### PR DESCRIPTION
## WHAT
- Currently Stripe payment notifications (for payment status post 3DS authorisation) wait for about a second for the frontend to update charge status to `AUTHORISATION_3DS_READY` to  avoid race condition (where both frontend and stripe notification attempts to update charge status). We have noticed that for about 23% of payments, notifications waited for max configured wait time (1000ms) and a few ended up causing 500/400 frontend errors (due to both frontend and notification updating charge at the same time or frontend error-ing because the charge is not expected state).
- Increase wait time for notification to 3 seconds. Note that this is maximum wait time. Stripe notification checks charge status every 200ms and continues to update charge, if the frontend has already updated charge status to `AUTHORISATION_3DS_READY`.
