### PR TITLE
PP-8438 Set service ID on charge when available on gateway account

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -202,7 +202,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
             Source source,
             String gatewayTransactionId,
             CardDetailsEntity cardDetails,
-            boolean moto
+            boolean moto,
+            String serviceId
     ) {
         this.amount = amount;
         this.status = status.getValue();
@@ -222,6 +223,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         this.gatewayTransactionId = gatewayTransactionId;
         this.cardDetails = cardDetails;
         this.moto = moto;
+        this.serviceId = serviceId;
     }
 
     public Long getId() {
@@ -500,6 +502,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         private ExternalMetadata externalMetadata;
         private Source source;
         private boolean moto;
+        private String serviceId;
 
         private WebChargeEntityBuilder() {
         }
@@ -574,6 +577,11 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
             return this;
         }
 
+        public WebChargeEntityBuilder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
+            return this;
+        }
+
         public ChargeEntity build() {
             return new ChargeEntity(
                     amount,
@@ -592,7 +600,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                     source,
                     null,
                     null,
-                    moto);
+                    moto,
+                    serviceId);
         }
     }
 
@@ -607,6 +616,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         private String description;
         private ServicePaymentReference reference;
         private ExternalMetadata externalMetadata;
+        private String serviceId;
 
         private TelephoneChargeEntityBuilder() {
         }
@@ -666,6 +676,11 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
             return this;
         }
 
+        public TelephoneChargeEntityBuilder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
+            return this;
+        }
+
         public ChargeEntity build() {
             return new ChargeEntity(
                     amount,
@@ -684,7 +699,8 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
                     CARD_EXTERNAL_TELEPHONE,
                     gatewayTransactionId,
                     cardDetails,
-                    false);
+                    false,
+                    serviceId);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -197,6 +197,7 @@ public class ChargeService {
                 .withExternalMetadata(storeExtraFieldsInMetaData(telephoneChargeRequest))
                 .withGatewayTransactionId(telephoneChargeRequest.getProviderId())
                 .withCardDetails(cardDetails)
+                .withServiceId(gatewayAccount.getServiceId())
                 .build();
 
         chargeDao.persist(chargeEntity);
@@ -260,6 +261,7 @@ public class ChargeService {
                     .withExternalMetadata(chargeRequest.getExternalMetadata().orElse(null))
                     .withSource(chargeRequest.getSource())
                     .withMoto(chargeRequest.isMoto())
+                    .withServiceId(gatewayAccount.getServiceId())
                     .build();
 
             chargeRequest.getPrefilledCardHolderDetails()

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -61,6 +61,7 @@ public class ChargeEntityFixture {
     private boolean moto;
     private Exemption3ds exemption3ds;
     private String paymentProvider = "sandbox";
+    private String serviceId = null;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -142,7 +143,8 @@ public class ChargeEntityFixture {
                 source,
                 gatewayTransactionId,
                 cardDetails,
-                moto);
+                moto,
+                serviceId);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setCorporateSurcharge(corporateSurcharge);
@@ -314,6 +316,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withPaymentProvider(String paymentProvider) {
         this.paymentProvider = paymentProvider;
+        return this;
+    }
+
+    public ChargeEntityFixture withServiceId(String serviceId) {
+        this.serviceId = serviceId;
         return this;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceCreateTest.java
@@ -106,6 +106,7 @@ public class ChargeServiceCreateTest extends ChargeServiceTest {
                 .withStatus(AUTHORISATION_SUCCESS)
                 .withGatewayTransactionId("1PROV")
                 .withCardDetails(cardDetails)
+                .withServiceId("a-valid-external-service-id")
                 .build();
 
         when(mockedChargeDao.findByGatewayTransactionIdAndAccount(gatewayAccount.getId(), "1PROV"))

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -207,6 +207,25 @@ public class ChargeDaoIT extends DaoITestBase {
     }
 
     @Test
+    public void shouldCreateANewChargeWithServiceId() {
+        var serviceId = "a-valid-external-service-id";
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withId(null)
+                .withGatewayAccountEntity(gatewayAccount)
+                .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
+                .withServiceId(serviceId)
+                .build();
+
+        assertThat(chargeEntity.getId(), is(nullValue()));
+
+        chargeDao.persist(chargeEntity);
+
+        Optional<ChargeEntity> charge = chargeDao.findById(chargeEntity.getId());
+
+        assertThat(charge.get().getServiceId(), is(serviceId));
+    }
+
+    @Test
     public void shouldCreateANewChargeWithExternalMetadata() {
         ExternalMetadata expectedExternalMetadata = new ExternalMetadata(
                 Map.of("key1", "String1",


### PR DESCRIPTION
Set `serviceId` property on charge based on the gateway account's
configuration.

Apply this to
* web charge builders
* telephone notification charge builders

Assert that when a charge entity has the values set that propagates
through to the appropriate database columns.