### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,18 @@
 {
-  "exclude": {
-    "files": "^.secrets.baseline$",
-    "lines": null
-  },
-  "generated_at": "2021-08-18T07:40:15Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +21,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,11 +34,14 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
     },
     {
       "name": "PrivateKeyDetector"
@@ -51,575 +53,741 @@
       "name": "SoftlayerDetector"
     },
     {
+      "name": "SquareOAuthDetector"
+    },
+    {
       "name": "StripeDetector"
     },
     {
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
     "dev.yml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "dev.yml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 10,
-        "type": "Base64 High Entropy String"
+        "line_number": 10
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "dev.yml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 11,
-        "type": "Base64 High Entropy String"
+        "line_number": 11
       },
       {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
         "hashed_secret": "ca90626bf4bdc776a996f1cdad1f3873f7fa36d8",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
+        "line_number": 21
       },
       {
+        "type": "Secret Keyword",
+        "filename": "dev.yml",
         "hashed_secret": "0838dfce4c5ff12e20d5509df30db2851cbfae29",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
-        "type": "Secret Keyword"
+        "line_number": 29
       }
     ],
     "docs/api_specification.md": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "docs/api_specification.md",
         "hashed_secret": "fa1ab503d57a889458acec40b9bd9e3a8af00ff4",
         "is_verified": false,
-        "line_number": 1307,
-        "type": "Hex High Entropy String"
+        "line_number": 381
       },
       {
-        "hashed_secret": "0ea7458942ab65e0a340cf4fd28ca00d93c494f3",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "docs/api_specification.md",
+        "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 1417,
-        "type": "Secret Keyword"
+        "line_number": 2699
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/api_specification.md",
+        "hashed_secret": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
+        "is_verified": false,
+        "line_number": 3024
       }
     ],
-    "src/main/resources/config/config.yaml": [
+    "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java": [
       {
-        "hashed_secret": "7bf0f17f8eabd223f4b6551adbfa239a297b8715",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 46,
-        "type": "Secret Keyword"
+        "line_number": 12
       }
     ],
-    "src/test/java/uk/gov/pay/connector/charge/util/JwtGeneratorTest.java": [
+    "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java": [
       {
-        "hashed_secret": "4c199ea2f7063b78445614f03ca369183bd8f221",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/main/java/uk/gov/pay/connector/gatewayaccount/resource/GatewayAccountResource.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
+        "line_number": 75
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationTest.java": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationTest.java",
         "hashed_secret": "a0ca29e11f7dc5f324abde1944dc25a200b6bd45",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 20,
-        "type": "Hex High Entropy String"
+        "line_number": 20
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNew3dsOrderTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 72
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPayloadDefinitionForNewOrderTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 64
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGeneratorTest.java": [
       {
-        "hashed_secret": "70ed17e2a6f7f0a378187c2badc268dc48809759",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 45,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGeneratorTest.java",
         "hashed_secret": "71a8c912d5ada769f09a7b9fa7da2295fd49d416",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 62,
-        "type": "Hex High Entropy String"
+        "line_number": 28
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGeneratorTest.java",
+        "hashed_secret": "70ed17e2a6f7f0a378187c2badc268dc48809759",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGeneratorTest.java",
         "hashed_secret": "41821168eb98abaf4739ac5e6203bb4eda0d04fe",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 80,
-        "type": "Hex High Entropy String"
+        "line_number": 80
       },
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqSha512SignatureGeneratorTest.java",
         "hashed_secret": "8598a060aba13a300f2725bcf481f0bf49a57f9b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 98,
-        "type": "Hex High Entropy String"
+        "line_number": 98
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/epdq/payload/EpdqPayloadDefinitionForNew3ds2OrderTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 89
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/smartpay/auth/SmartpayAccountSpecificAuthenticatorTest.java": [
       {
-        "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/smartpay/auth/SmartpayAccountSpecificAuthenticatorTest.java",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 26,
-        "type": "Secret Keyword"
+        "line_number": 25
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/smartpay/auth/SmartpayAccountSpecificAuthenticatorTest.java",
+        "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
+        "is_verified": false,
+        "line_number": 26
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java",
         "hashed_secret": "c2baab12724c0f29014dc172042a17ebbd9b60d4",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 111,
-        "type": "Secret Keyword"
+        "line_number": 111
       },
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java",
         "hashed_secret": "4991aba1cb28cabc042aa415f2689cf359bb4af2",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 112,
-        "type": "Secret Keyword"
+        "line_number": 112
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 560,
-        "type": "Base64 High Entropy String"
+        "line_number": 579
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java",
+        "hashed_secret": "a0d988a5c9ccfb53b1e1604eab338ecba25b3485",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3dsFlexJwtMacKeyValidatorTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3dsFlexJwtMacKeyValidatorTest.java",
+        "hashed_secret": "a0d988a5c9ccfb53b1e1604eab338ecba25b3485",
+        "is_verified": false,
+        "line_number": 32
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
+        "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
+        "is_verified": false,
+        "line_number": 159
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsRequestValidatorTest.java",
+        "hashed_secret": "d951d773b511b017529f9c2188b43e8518f24b56",
+        "is_verified": false,
+        "line_number": 182
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/gatewayaccountcredentials/resource/GatewayAccountCredentialsResourceIT.java",
+        "hashed_secret": "e472e4dc23e4530d4fddeb6571b1c23447ab4c24",
+        "is_verified": false,
+        "line_number": 308
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 147,
-        "type": "Base64 High Entropy String"
+        "line_number": 147
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 148,
-        "type": "Base64 High Entropy String"
+        "line_number": 148
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java",
         "hashed_secret": "c272ed583c5dfbb2013e22812d200068997d5969",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 155,
-        "type": "Base64 High Entropy String"
+        "line_number": 155
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java",
         "hashed_secret": "9c98d4fa9b3055dede39101f223aa53c2b830d95",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 157,
-        "type": "Base64 High Entropy String"
+        "line_number": 157
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
         "hashed_secret": "0eb769315deba70a52cf0292f6f163580aed36ab",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 44,
-        "type": "Base64 High Entropy String"
+        "line_number": 44
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
+        "hashed_secret": "3faa7b358a992ffcff0150d4c3ceb26f6556c11e",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
+        "hashed_secret": "508779dbbaa9267286609a2ed45a5c8bdfa489b8",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/contract/GooglePayForWorldpayTest.java",
+        "hashed_secret": "a2a95d1ffa553770c0859718c31faf251ca7306f",
+        "is_verified": false,
+        "line_number": 46
       }
     ],
     "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceAllowWebPaymentsIT.java",
         "hashed_secret": "e9b6cb662f24d2346839fb0b797ad778c290994e",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 132,
-        "type": "Hex High Entropy String"
+        "line_number": 143
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/model/domain/googlepay/GooglePayAuthRequestFixture.java": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/model/domain/googlepay/GooglePayAuthRequestFixture.java",
+        "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java",
+        "hashed_secret": "f182dd26dca3b13579d94c83c1d8cccba160ff77",
+        "is_verified": false,
+        "line_number": 102
       }
     ],
     "src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java": [
       {
-        "hashed_secret": "7e0a1242bd8ef9044f27dca45f5f72ad5a1125bf",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 137,
-        "type": "Hex High Entropy String"
-      },
-      {
+        "type": "Hex High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java",
         "hashed_secret": "61407b57b06661de9d8f2858e0e5917fb6b55e48",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 148,
-        "type": "Hex High Entropy String"
+        "line_number": 148
       }
     ],
     "src/test/java/uk/gov/pay/connector/util/PostgresContainer.java": [
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/util/PostgresContainer.java",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
-        "type": "Secret Keyword"
+        "line_number": 34
       }
     ],
     "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/java/uk/gov/pay/connector/util/WorldpayXMLUnmarshallerTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 123,
-        "type": "Base64 High Entropy String"
+        "line_number": 123
+      }
+    ],
+    "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/java/uk/gov/pay/connector/wallets/applepay/ApplePayDecrypterTest.java",
+        "hashed_secret": "191ddcb30706655ed25c833de411be885d662fec",
+        "is_verified": false,
+        "line_number": 54
       }
     ],
     "src/test/resources/applepay/token.json": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/applepay/token.json",
         "hashed_secret": "9c98d4fa9b3055dede39101f223aa53c2b830d95",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 3,
-        "type": "Base64 High Entropy String"
+        "line_number": 3
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/applepay/token.json",
         "hashed_secret": "c272ed583c5dfbb2013e22812d200068997d5969",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 4,
-        "type": "Base64 High Entropy String"
+        "line_number": 4
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/applepay/token.json",
         "hashed_secret": "2b5620026862563e61e31e6cfbeb7551148c39bc",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 7,
-        "type": "Base64 High Entropy String"
+        "line_number": 7
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/applepay/token.json",
         "hashed_secret": "be54950d938040748a64e6cbbe239bb85ed6ab38",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 8,
-        "type": "Base64 High Entropy String"
+        "line_number": 8
       }
     ],
     "src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
-        "type": "Base64 High Entropy String"
+        "line_number": 29
       },
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml",
+        "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
-        "type": "Base64 High Entropy String"
+        "line_number": 30
       },
       {
-        "hashed_secret": "2a200a21084c92b28c4ddfdcfc311b960849da86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 75,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "a7c5ccd7f932860c32b2826b0980a7b75c6f0e61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 76,
-        "type": "Secret Keyword"
-      },
-      {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/client-factory-test-config-with-smartpay-timeout-override.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
-        "type": "Secret Keyword"
+        "line_number": 135
       }
     ],
     "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
-        "type": "Base64 High Entropy String"
+        "line_number": 29
       },
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
+        "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
-        "type": "Base64 High Entropy String"
+        "line_number": 30
       },
       {
-        "hashed_secret": "2a200a21084c92b28c4ddfdcfc311b960849da86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 75,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "a7c5ccd7f932860c32b2826b0980a7b75c6f0e61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 76,
-        "type": "Secret Keyword"
-      },
-      {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/client-factory-test-config-with-worldpay-timeout-override.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 134,
-        "type": "Secret Keyword"
+        "line_number": 135
       }
     ],
     "src/test/resources/config/client-factory-test-config.yaml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
-        "type": "Base64 High Entropy String"
+        "line_number": 29
       },
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/client-factory-test-config.yaml",
+        "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
+        "is_verified": false,
+        "line_number": 29
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
-        "type": "Base64 High Entropy String"
+        "line_number": 30
       },
       {
-        "hashed_secret": "2a200a21084c92b28c4ddfdcfc311b960849da86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 65,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "a7c5ccd7f932860c32b2826b0980a7b75c6f0e61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 66,
-        "type": "Secret Keyword"
-      },
-      {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/client-factory-test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 124,
-        "type": "Secret Keyword"
+        "line_number": 125
       }
     ],
     "src/test/resources/config/test-config.yaml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 33,
-        "type": "Base64 High Entropy String"
+        "line_number": 33
       },
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/test-config.yaml",
+        "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 34,
-        "type": "Base64 High Entropy String"
+        "line_number": 34
       },
       {
-        "hashed_secret": "2a200a21084c92b28c4ddfdcfc311b960849da86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 71,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "a7c5ccd7f932860c32b2826b0980a7b75c6f0e61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
-        "type": "Secret Keyword"
-      },
-      {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/test-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 130,
-        "type": "Secret Keyword"
+        "line_number": 131
       }
     ],
     "src/test/resources/config/test-it-config.yaml": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 35,
-        "type": "Base64 High Entropy String"
+        "line_number": 35
       },
       {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/test-it-config.yaml",
+        "hashed_secret": "c58c6ebfd2904b9a692b473eb040ee8bad186a1b",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "ab85666a760f1a3fa02b3ac84953be727ce3dbfa",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 36,
-        "type": "Base64 High Entropy String"
+        "line_number": 36
       },
       {
-        "hashed_secret": "2a200a21084c92b28c4ddfdcfc311b960849da86",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 71,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "a7c5ccd7f932860c32b2826b0980a7b75c6f0e61",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 72,
-        "type": "Secret Keyword"
-      },
-      {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/config/test-it-config.yaml",
         "hashed_secret": "08cd923367890009657eab812753379bdb321eeb",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 131,
-        "type": "Secret Keyword"
+        "line_number": 131
+      }
+    ],
+    "src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/googlepay/auth-request-with-empty-last-digits-card-number.json",
+        "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "src/test/resources/googlepay/example-3ds-auth-request-without-email.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/googlepay/example-3ds-auth-request-without-email.json",
+        "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "src/test/resources/googlepay/example-3ds-auth-request.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/googlepay/example-3ds-auth-request.json",
+        "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "src/test/resources/googlepay/example-auth-request-without-email.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/googlepay/example-auth-request-without-email.json",
+        "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
+        "is_verified": false,
+        "line_number": 8
       }
     ],
     "src/test/resources/googlepay/example-auth-request.json": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/googlepay/example-auth-request.json",
         "hashed_secret": "609736b2c1a39f26d4ec38c0265a5f3087d78098",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 9,
-        "type": "Base64 High Entropy String"
+        "line_number": 9
       }
     ],
     "src/test/resources/googlepay/test-private-key.pem": [
       {
+        "type": "Private Key",
+        "filename": "src/test/resources/googlepay/test-private-key.pem",
         "hashed_secret": "f0778f3e140a61d5bbbed5430773e52af2f5fba4",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 1,
-        "type": "Private Key"
+        "line_number": 1
       }
     ],
     "src/test/resources/templates/stripe/authorisation_failed_response.json": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/templates/stripe/authorisation_failed_response.json",
         "hashed_secret": "dfad3c614192aacdde5068837b2cd4e632586b26",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 3,
-        "type": "Base64 High Entropy String"
+        "line_number": 3
       }
     ],
     "src/test/resources/templates/stripe/authorisation_success_response.json": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/templates/stripe/authorisation_success_response.json",
         "hashed_secret": "9bfcbc983b28380ccef92a9ec6ccfa4d128fb560",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 39,
-        "type": "Base64 High Entropy String"
+        "line_number": 39
       }
     ],
     "src/test/resources/templates/stripe/create_3ds_sources_response.json": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/templates/stripe/create_3ds_sources_response.json",
         "hashed_secret": "4d6d23e5ccef6c088f06c7890b526fee1cda5059",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 5,
-        "type": "Base64 High Entropy String"
+        "line_number": 5
       },
       {
-        "hashed_secret": "ffb8e39b3b19f2d6908caebbddb126ec6d825d5b",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/create_3ds_sources_response.json",
+        "hashed_secret": "4d6d23e5ccef6c088f06c7890b526fee1cda5059",
         "is_verified": false,
-        "line_number": 5,
-        "type": "Secret Keyword"
+        "line_number": 5
       },
       {
-        "hashed_secret": "9538a8477d59a164aee9bebd7b826e6020dfe0aa",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 13,
-        "type": "Secret Keyword"
-      },
-      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/templates/stripe/create_3ds_sources_response.json",
         "hashed_secret": "b99988a62017a49023886994f1806871100787fb",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 17,
-        "type": "Base64 High Entropy String"
+        "line_number": 17
       }
     ],
     "src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json": [
       {
-        "hashed_secret": "8aafe363656446db9ea4d16180c39427f3d6d576",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/create_payment_intent_requires_3ds_response.json",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 34,
-        "type": "Secret Keyword"
+        "line_number": 20
+      }
+    ],
+    "src/test/resources/templates/stripe/create_payment_intent_success_response.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/create_payment_intent_success_response.json",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 20
       }
     ],
     "src/test/resources/templates/stripe/create_payment_intent_with_charge_response.json": [
       {
-        "hashed_secret": "8aafe363656446db9ea4d16180c39427f3d6d576",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/create_payment_intent_with_charge_response.json",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 43,
-        "type": "Secret Keyword"
+        "line_number": 29
       }
     ],
     "src/test/resources/templates/stripe/create_sources_3ds_required_response.json": [
       {
-        "hashed_secret": "c06b6d9a6642aa13e6a81b7706a840512dbb9109",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/create_sources_3ds_required_response.json",
+        "hashed_secret": "f1612c3a13645df063e29eb88b40b4005ff17be2",
         "is_verified": false,
-        "line_number": 8,
-        "type": "Secret Keyword"
+        "line_number": 8
       }
     ],
     "src/test/resources/templates/stripe/create_sources_response.json": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/test/resources/templates/stripe/create_sources_response.json",
         "hashed_secret": "97ab8d35b454bd18d8e1a4b62f6e3a593785f68d",
-        "is_secret": false,
         "is_verified": false,
-        "line_number": 12,
-        "type": "Base64 High Entropy String"
+        "line_number": 12
       },
       {
-        "hashed_secret": "d1bac46e56ee81c167f8516f95275bbe2e5be596",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/create_sources_response.json",
+        "hashed_secret": "97ab8d35b454bd18d8e1a4b62f6e3a593785f68d",
         "is_verified": false,
-        "line_number": 12,
-        "type": "Secret Keyword"
+        "line_number": 12
       }
     ],
     "src/test/resources/templates/stripe/notification_3ds_source.json": [
       {
-        "hashed_secret": "b81fe678166fecdb16d846911399699485667e79",
-        "is_secret": false,
+        "type": "Secret Keyword",
+        "filename": "src/test/resources/templates/stripe/notification_3ds_source.json",
+        "hashed_secret": "4539cef32b0a1b3bb8020dc19add68612d435d55",
         "is_verified": false,
-        "line_number": 10,
-        "type": "Secret Keyword"
-      },
-      {
-        "hashed_secret": "fb56172db8acef9200c19d8ed820800839f113ec",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 16,
-        "type": "Secret Keyword"
+        "line_number": 10
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-18T16:15:12Z"
 }


### PR DESCRIPTION
## WHAT YOU DID
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`

## How to test

- Maake sure the `.pre-commit.yaml` has been added.
- Make sure the `.secrets.baseline` has been updated.
  - This file is automatically updated by using `detect-secrets`.