### PR TITLE
PP-8446 Allow gateway accounts to be filtered on service ID

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -29,8 +30,8 @@ public class GatewayAccountSearchParams {
     private String accountIds;
 
     @QueryParam("serviceIds")
-    @Pattern(regexp = "^(?:[a-zA-Z0-9]++(\\,+|$))*+$",
-            message = "Parameter [serviceIds] must be a comma separated list of alpha numeric strings")
+    @Pattern(regexp = "^(?:[A-z0-9]+,?)+$",
+            message = "Parameter [serviceIds] must be a comma separated list of alphanumeric strings")
     private String serviceIds;
 
     // This is a string value rather than boolean as if the parameter isn't provided, it should not filter by
@@ -108,13 +109,13 @@ public class GatewayAccountSearchParams {
 
     private List<String> getAccountIdsAsList() {
         return isBlank(accountIds)
-                ? new ArrayList<>()
+                ? List.of()
                 : List.of(accountIds.split(","));
     }
 
     private List<String> getServiceIdsAsList() {
         return isBlank(serviceIds)
-                ? new ArrayList<>()
+                ? List.of()
                 : List.of(serviceIds.split(","));
     }
 
@@ -123,26 +124,18 @@ public class GatewayAccountSearchParams {
 
         List<String> accountIdsList = getAccountIdsAsList();
         if (!accountIdsList.isEmpty()) {
-            StringBuilder filter = new StringBuilder(" ga.id IN (");
+            StringJoiner filter = new StringJoiner(",", " ga.id IN (", ")");
             for (int i = 0; i < accountIdsList.size(); i++) {
-                filter.append("#").append(ACCOUNT_IDS_SQL_FIELD).append(i);
-                if (i != accountIdsList.size() - 1) {
-                    filter.append(",");
-                }
+                filter.add("#" + ACCOUNT_IDS_SQL_FIELD + i);
             }
-            filter.append(")");
             filters.add(filter.toString());
         }
         List<String> serviceIdsList = getServiceIdsAsList();
         if (!serviceIdsList.isEmpty()) {
-            StringBuilder filter = new StringBuilder(" ga.service_id IN (");
+            StringJoiner filter = new StringJoiner(",", " ga.service_id IN (", ")");
             for (int i = 0; i < serviceIdsList.size(); i++) {
-                filter.append("#").append(SERVICE_IDS_SQL_FIELD).append(i);
-                if (i != serviceIdsList.size() - 1) {
-                    filter.append(",");
-                }
+                filter.add("#" + SERVICE_IDS_SQL_FIELD + i);
             }
-            filter.append(")");
             filters.add(filter.toString());
         }
         if (StringUtils.isNotEmpty(motoEnabled)) {

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -19,6 +19,7 @@ public class GatewayAccountSearchParamsTest {
     public void shouldReturnFilterTemplatesWithAllParameters() {
         var params = new GatewayAccountSearchParams();
         params.setAccountIds("1,2");
+        params.setServiceIds("serviceidone,serviceidtwo,serviceidthree");
         params.setMotoEnabled("false");
         params.setApplePayEnabled("true");
         params.setGooglePayEnabled("true");
@@ -30,6 +31,7 @@ public class GatewayAccountSearchParamsTest {
         List<String> filterTemplates = params.getFilterTemplates();
         assertThat(filterTemplates, containsInAnyOrder(
                 " ga.id IN (#accountIds0,#accountIds1)",
+                " ga.service_id IN (#serviceId0,#serviceId1,#serviceId2)",
                 " ga.allow_moto = #allowMoto",
                 " ga.allow_apple_pay = #allowApplePay",
                 " ga.allow_google_pay = #allowGooglePay",
@@ -70,6 +72,7 @@ public class GatewayAccountSearchParamsTest {
     public void shouldReturnQueryMapWithAllParameters() {
         var params = new GatewayAccountSearchParams();
         params.setAccountIds("1,22");
+        params.setServiceIds("serviceidone,serviceidtwo,serviceidthree");
         params.setMotoEnabled("false");
         params.setApplePayEnabled("true");
         params.setGooglePayEnabled("true");
@@ -79,9 +82,12 @@ public class GatewayAccountSearchParamsTest {
         params.setProviderSwitchEnabled("true");
 
         Map<String, Object> queryMap = params.getQueryMap();
-        assertThat(queryMap, aMapWithSize(9));
+        assertThat(queryMap, aMapWithSize(12));
         assertThat(queryMap, hasEntry("accountIds0", 1L));
         assertThat(queryMap, hasEntry("accountIds1", 22L));
+        assertThat(queryMap, hasEntry("serviceId0", "serviceidone"));
+        assertThat(queryMap, hasEntry("serviceId1", "serviceidtwo"));
+        assertThat(queryMap, hasEntry("serviceId2", "serviceidthree"));
         assertThat(queryMap, hasEntry("allowMoto", false));
         assertThat(queryMap, hasEntry("allowApplePay", true));
         assertThat(queryMap, hasEntry("allowGooglePay", true));

--- a/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/GatewayAccountFrontendResourceIT.java
@@ -245,14 +245,16 @@ public class GatewayAccountFrontendResourceIT extends GatewayAccountResourceTest
     @Test
     public void shouldFilterGetGatewayAccountForExistingAccountByServiceId() {
         String accountId = createAGatewayAccountFor("worldpay");
+        String secondAccountId = createAGatewayAccountFor("worldpay");
         String serviceId = "someexternalserviceid";
         GatewayAccountPayload gatewayAccountPayload = GatewayAccountPayload.createDefault().withMerchantId("a-merchant-id");
         databaseTestHelper.updateCredentialsFor(Long.parseLong(accountId), gson.toJson(gatewayAccountPayload.getCredentials()));
         databaseTestHelper.updateServiceNameFor(Long.parseLong(accountId), gatewayAccountPayload.getServiceName());
         databaseTestHelper.updateServiceIdFor(Long.parseLong(accountId), serviceId);
+        databaseTestHelper.updateServiceIdFor(Long.parseLong(secondAccountId), "notsearchedforserviceid");
 
         givenSetup().accept(JSON)
-                .get("/v1/frontend/accounts?serviceIds=" + serviceId)
+                .get("/v1/frontend/accounts?serviceIds=somemissingserviceid,anotherserviceid," + serviceId)
                 .then()
                 .statusCode(200)
                 .body("accounts", hasSize(1))

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -583,6 +583,15 @@ public class DatabaseTestHelper {
         );
     }
 
+    public void updateServiceIdFor(long accountId, String serviceId) {
+        jdbi.withHandle(handle ->
+                handle.createUpdate("UPDATE gateway_accounts set service_id=:serviceId WHERE id=:gatewayAccountId")
+                        .bind("gatewayAccountId", accountId)
+                        .bind("serviceId", serviceId)
+                        .execute()
+        );
+    }
+
     public void updateCorporateCreditCardSurchargeAmountFor(long accountId, long corporateCreditCardSurchargeAmount) {
         jdbi.withHandle(handle ->
                 handle.createUpdate("UPDATE gateway_accounts set corporate_credit_card_surcharge_amount=:corporateCreditCardSurchargeAmount WHERE id=:gatewayAccountId")


### PR DESCRIPTION
The `service_id` column on the `gateway_accounts` table has a standard
`btree` index.

Add support for filtering the `/v1/frontend/accounts` route for accounts
that belong to a particular list of service identifiers with the
`serviceIds` parameter.

There are a number of changes that could be made to the param -> filter
methodology here but this is implemented to follow the pattern already
established.