### PR TITLE
PP-8342 - RefundRequest uses GatewayAccountCredentialsEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/request/RefundGatewayRequest.java
@@ -78,14 +78,15 @@ public class RefundGatewayRequest implements GatewayRequest {
      * </p>
      */
     public static RefundGatewayRequest valueOf(Charge charge, RefundEntity refundEntity,
-                                               GatewayAccountEntity gatewayAccountEntity) {
+                                               GatewayAccountEntity gatewayAccountEntity,
+                                               GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
         return new RefundGatewayRequest(
                 charge.getGatewayTransactionId(),
                 gatewayAccountEntity,
                 String.valueOf(refundEntity.getAmount()),
                 refundEntity.getExternalId(),
                 charge.getExternalId(),
-                gatewayAccountEntity.getGatewayAccountCredentialsEntity(charge.getPaymentGatewayName())
+                gatewayAccountCredentialsEntity
         );
     }
     

--- a/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
+++ b/src/test/java/uk/gov/pay/connector/expunge/service/LedgerStub.java
@@ -108,10 +108,10 @@ public class LedgerStub {
     }
 
     public void returnErrorForFindRefundsForPayment(String chargeExternalId) {
-        ResponseDefinitionBuilder repsonse = aResponse().withStatus(500);
+        ResponseDefinitionBuilder response = aResponse().withStatus(500);
         String url = format("/v1/transaction/%s/transaction", chargeExternalId);
        wireMockServer.stubFor(WireMock.get(urlPathEqualTo(url))
-                .willReturn(repsonse));
+                .willReturn(response));
 
     }
 

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqPaymentProviderIT.java
@@ -233,7 +233,7 @@ public abstract class BaseEpdqPaymentProviderIT {
 
     private RefundGatewayRequest buildTestRefundRequest(Charge charge, GatewayAccountEntity gatewayAccountEntity, GatewayAccountCredentialsEntity credentialsEntity) {
         RefundEntity refundEntity = new RefundEntity(charge.getAmount() - 100, userExternalId, userEmail, charge.getExternalId());
-        return RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccountEntity);
+        return RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccountEntity, credentialsEntity);
     }
 
     private GatewayAccountEntity buildTestGatewayAccountEntity() {

--- a/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProviderTest.java
@@ -1,11 +1,8 @@
 package uk.gov.pay.connector.gateway.sandbox;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
@@ -36,7 +33,6 @@ import static uk.gov.pay.connector.gateway.model.ErrorType.GENERIC_GATEWAY_ERROR
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SandboxPaymentProviderTest {
 
     private SandboxPaymentProvider provider;
@@ -47,11 +43,8 @@ public class SandboxPaymentProviderTest {
     private static final String AUTH_REJECTED_CARD_NUMBER = "4000000000000069";
     private static final String AUTH_ERROR_CARD_NUMBER = "4000000000000119";
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         provider = new SandboxPaymentProvider();
         credentialsEntity = aGatewayAccountCredentialsEntity()
                 .withCredentials(Map.of())
@@ -63,18 +56,18 @@ public class SandboxPaymentProviderTest {
     }
 
     @Test
-    public void getPaymentGatewayName_shouldGetExpectedName() {
+    void getPaymentGatewayName_shouldGetExpectedName() {
         assertThat(provider.getPaymentGatewayName().getName(), is("sandbox"));
     }
 
     @Test
-    public void shouldGenerateTransactionId() {
+    void shouldGenerateTransactionId() {
         assertThat(provider.generateTransactionId().isPresent(), is(true));
         assertThat(provider.generateTransactionId().get(), is(instanceOf(String.class)));
     }
 
     @Test
-    public void authorise_shouldBeAuthorisedWhenCardNumIsExpectedToSucceedForAuthorisation() {
+    void authorise_shouldBeAuthorisedWhenCardNumIsExpectedToSucceedForAuthorisation() {
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_SUCCESS_CARD_NUMBER);
         GatewayResponse gatewayResponse = provider.authorise(new CardAuthorisationGatewayRequest(ChargeEntityFixture.aValidChargeEntity().build(), authCardDetails));
@@ -93,7 +86,7 @@ public class SandboxPaymentProviderTest {
     }
 
     @Test
-    public void authorise_shouldNotBeAuthorisedWhenCardNumIsExpectedToBeRejectedForAuthorisation() {
+    void authorise_shouldNotBeAuthorisedWhenCardNumIsExpectedToBeRejectedForAuthorisation() {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_REJECTED_CARD_NUMBER);
@@ -113,7 +106,7 @@ public class SandboxPaymentProviderTest {
     }
 
     @Test
-    public void authorise_shouldGetGatewayErrorWhenCardNumIsExpectedToFailForAuthorisation() {
+    void authorise_shouldGetGatewayErrorWhenCardNumIsExpectedToFailForAuthorisation() {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo(AUTH_ERROR_CARD_NUMBER);
@@ -130,7 +123,7 @@ public class SandboxPaymentProviderTest {
     }
 
     @Test
-    public void authorise_shouldGetGatewayErrorWhenCardNumDoesNotExistForAuthorisation() {
+    void authorise_shouldGetGatewayErrorWhenCardNumDoesNotExistForAuthorisation() {
 
         AuthCardDetails authCardDetails = new AuthCardDetails();
         authCardDetails.setCardNo("3456789987654567");
@@ -147,12 +140,12 @@ public class SandboxPaymentProviderTest {
     }
 
     @Test
-    public void refund_shouldSucceedWhenRefundingAnyCharge() {
+    void refund_shouldSucceedWhenRefundingAnyCharge() {
         ChargeEntity chargeEntity = ChargeEntityFixture
                 .aValidChargeEntity()
                 .withPaymentProvider(SANDBOX.getName())
                 .build();
-        GatewayRefundResponse refundResponse = provider.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), RefundEntityFixture.aValidRefundEntity().build(), gatewayAccountEntity));
+        GatewayRefundResponse refundResponse = provider.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), RefundEntityFixture.aValidRefundEntity().build(), gatewayAccountEntity, credentialsEntity));
 
         assertThat(refundResponse.isSuccessful(), is(true));
         assertThat(refundResponse.getReference().isPresent(), is(true));
@@ -162,7 +155,7 @@ public class SandboxPaymentProviderTest {
     }
 
     @Test
-    public void cancel_shouldSucceedWhenCancellingAnyCharge() {
+    void cancel_shouldSucceedWhenCancellingAnyCharge() {
 
         GatewayResponse<BaseCancelResponse> gatewayResponse = provider.cancel(CancelGatewayRequest.valueOf(ChargeEntityFixture.aValidChargeEntity().build()));
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeRefundHandlerTest.java
@@ -88,8 +88,7 @@ public class StripeRefundHandlerTest {
                 .withAmount(100L)
                 .build();
         when(charge.getGatewayTransactionId()).thenReturn("gatewayTransactionId");
-        when(charge.getPaymentGatewayName()).thenReturn(STRIPE.getName());
-        refundRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount);
+        refundRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount, gatewayAccountCredentialsEntity);
     }
 
     @Test
@@ -99,7 +98,7 @@ public class StripeRefundHandlerTest {
                 .withAmount(100L)
                 .withGatewayTransactionId("pi_123")
                 .build();
-        refundRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount);
+        refundRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount, gatewayAccountCredentialsEntity);
         mockTransferSuccess();
         mockRefundSuccess();
 

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeRefundRequestTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -34,19 +33,17 @@ public class StripeRefundRequestTest {
     private final String stripeBaseUrl = "stripeUrl";
 
     private StripeRefundRequest stripeRefundRequest;
+    private GatewayAccountEntity gatewayAccount;
 
     @Mock
     RefundEntity refundEntity;
     @Mock
     Charge charge;
 
-    GatewayAccountEntity gatewayAccount;
     @Mock
     StripeGatewayConfig stripeGatewayConfig;
     @Mock
     StripeAuthTokens stripeAuthTokens;
-    @Mock
-    ChargeDao chargeDao;
     
     @Before
     public void setUp() {
@@ -67,9 +64,7 @@ public class StripeRefundRequestTest {
         when(stripeGatewayConfig.getUrl()).thenReturn(stripeBaseUrl);
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
 
-        when(charge.getPaymentGatewayName()).thenReturn(STRIPE.getName());
-
-        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount);
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount, gatewayAccountCredentialsEntity);
 
         stripeRefundRequest = StripeRefundRequest.of(refundGatewayRequest, stripeChargeId, stripeGatewayConfig);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequestTest.java
@@ -7,7 +7,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.app.StripeAuthTokens;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
@@ -48,8 +47,6 @@ public class StripeTransferInRequestTest {
     StripeGatewayConfig stripeGatewayConfig;
     @Mock
     StripeAuthTokens stripeAuthTokens;
-    @Mock
-    ChargeDao chargeDao;
 
 
     @Before
@@ -66,7 +63,6 @@ public class StripeTransferInRequestTest {
         gatewayAccount.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity));
 
         when(charge.getExternalId()).thenReturn(chargeExternalId);
-        when(charge.getPaymentGatewayName()).thenReturn(STRIPE.getName());
 
         when(refundEntity.getAmount()).thenReturn(refundAmount);
         when(refundEntity.getExternalId()).thenReturn(refundExternalId);
@@ -75,7 +71,7 @@ public class StripeTransferInRequestTest {
         when(stripeGatewayConfig.getAuthTokens()).thenReturn(stripeAuthTokens);
         when(stripeGatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
 
-        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount);
+        final RefundGatewayRequest refundGatewayRequest = RefundGatewayRequest.valueOf(charge, refundEntity, gatewayAccount, gatewayAccountCredentialsEntity);
 
         stripeTransferInRequest = StripeTransferInRequest.of(refundGatewayRequest, stripeChargeId, stripeGatewayConfig);
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandlerTest.java
@@ -84,7 +84,7 @@ class WorldpayRefundHandlerTest {
         when(refundGatewayClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenThrow(new GatewayException.GatewayErrorException("Unexpected HTTP status code 400 from gateway"));
 
-        worldpayRefundHandler.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity));
+        worldpayRefundHandler.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity, credentialsEntity));
 
         String expectedRefundRequest =
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -88,7 +88,7 @@ public class ChargingITestBase {
 
     protected WireMockServer wireMockServer;
 
-   protected AddGatewayAccountCredentialsParams credentialParams;
+    protected AddGatewayAccountCredentialsParams credentialParams;
 
     public ChargingITestBase(String paymentProvider) {
         this.paymentProvider = paymentProvider;

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -40,6 +40,7 @@ import uk.gov.pay.connector.gateway.model.response.Gateway3DSAuthorisationRespon
 import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.TestClientFactory;
@@ -91,6 +92,7 @@ public class EpdqPaymentProviderTest {
     private String shaInPassphrase = envOrThrow("GDS_CONNECTOR_EPDQ_SHA_IN_PASSPHRASE");
     private ChargeEntity chargeEntity;
     private GatewayAccountEntity gatewayAccountEntity;
+    private GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
     private EpdqPaymentProvider paymentProvider;
 
     @Mock
@@ -370,13 +372,14 @@ public class EpdqPaymentProviderTest {
             gatewayAccountEntity.setId(123L);
             gatewayAccountEntity.setType(TEST);
             gatewayAccountEntity.setRequires3ds(require3ds);
+            gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                    .withCredentials(validEpdqCredentials)
+                    .withGatewayAccountEntity(gatewayAccountEntity)
+                    .withPaymentProvider(EPDQ.getName())
+                    .build();
 
             gatewayAccountEntity.setGatewayAccountCredentials(
-                    List.of(aGatewayAccountCredentialsEntity()
-                            .withCredentials(validEpdqCredentials)
-                            .withGatewayAccountEntity(gatewayAccountEntity)
-                            .withPaymentProvider(EPDQ.getName())
-                            .build()));
+                    List.of(gatewayAccountCredentialsEntity));
 
             if (requires3ds2) {
                 gatewayAccountEntity.setIntegrationVersion3ds(2);
@@ -400,7 +403,7 @@ public class EpdqPaymentProviderTest {
 
     private RefundGatewayRequest buildRefundRequest(ChargeEntity chargeEntity, Long refundAmount) {
         return RefundGatewayRequest.valueOf(Charge.from(chargeEntity), new RefundEntity(refundAmount, userExternalId, userEmail, chargeEntity.getExternalId()),
-                gatewayAccountEntity);
+                gatewayAccountEntity, gatewayAccountCredentialsEntity);
     }
 
     private CancelGatewayRequest buildCancelRequest(ChargeEntity chargeEntity, String transactionId) {

--- a/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/SmartpayPaymentProviderTest.java
@@ -33,6 +33,7 @@ import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayAuthorisationResponse;
 import uk.gov.pay.connector.gateway.smartpay.SmartpayPaymentProvider;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.util.TestClientFactory;
@@ -72,6 +73,7 @@ public class SmartpayPaymentProviderTest {
     private String password;
     private ChargeEntity chargeEntity;
     private GatewayAccountEntity gatewayAccountEntity;
+    private GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
     private MetricRegistry mockMetricRegistry;
     private Environment mockEnvironment;
 
@@ -93,15 +95,16 @@ public class SmartpayPaymentProviderTest {
                 "username", username,
                 "password", password);
         gatewayAccountEntity = new GatewayAccountEntity();
+        gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+                .withCredentials(validSmartPayCredentials)
+                .withGatewayAccountEntity(gatewayAccountEntity)
+                .withPaymentProvider(SMARTPAY.getName())
+                .withState(ACTIVE)
+                .build();
         gatewayAccountEntity.setId(123L);
         gatewayAccountEntity.setType(TEST);
         gatewayAccountEntity.setGatewayAccountCredentials(
-                List.of(aGatewayAccountCredentialsEntity()
-                        .withCredentials(validSmartPayCredentials)
-                        .withGatewayAccountEntity(gatewayAccountEntity)
-                        .withPaymentProvider(SMARTPAY.getName())
-                        .withState(ACTIVE)
-                        .build()));
+                List.of(gatewayAccountCredentialsEntity));
 
         chargeEntity = aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccountEntity).build();
@@ -290,7 +293,7 @@ public class SmartpayPaymentProviderTest {
         assertTrue(captureGatewayResponse.isSuccessful());
 
         RefundEntity refundEntity = new RefundEntity(1L, userExternalId, userEmail, chargeEntity.getExternalId());
-        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity);
+        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity, gatewayAccountCredentialsEntity);
         GatewayRefundResponse refundResponse = smartpay.refund(refundRequest);
 
         assertThat(refundResponse.isSuccessful(), is(true));

--- a/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/StripePaymentProviderTest.java
@@ -19,6 +19,8 @@ import uk.gov.pay.connector.gateway.model.response.GatewayRefundResponse;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.rules.DropwizardAppWithPostgresRule;
@@ -56,11 +58,14 @@ public class StripePaymentProviderTest {
 
     private static final Long chargeAmount = 500L;
     private GatewayAccountEntity gatewayAccountEntity;
+    private GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
 
     @Before
     public void setup() {
         stripePaymentProvider = app.getInstanceFromGuiceContainer(StripePaymentProvider.class);
         gatewayAccountEntity = new GatewayAccountEntity();
+        gatewayAccountCredentialsEntity = GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity().build();
+        gatewayAccountEntity.setGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity));
     }
 
     @Test
@@ -146,7 +151,7 @@ public class StripePaymentProviderTest {
         stripePaymentProvider.capture(request);
         final RefundEntity refundEntity = new RefundEntity(chargeAmount, "some-user-external-id", userEmail, chargeEntity.getExternalId());
 
-        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity);
+        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity, gatewayAccountCredentialsEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.isSuccessful());
@@ -162,7 +167,7 @@ public class StripePaymentProviderTest {
         stripePaymentProvider.capture(request);
         final RefundEntity refundEntity = new RefundEntity(chargeAmount / 2, "some-user-external-id", userEmail, chargeEntity.getExternalId());
 
-        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity);
+        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity, gatewayAccountCredentialsEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.isSuccessful());
@@ -178,7 +183,7 @@ public class StripePaymentProviderTest {
         stripePaymentProvider.capture(request);
         final RefundEntity refundEntity = new RefundEntity(chargeAmount + 1L, "some-user-external-id", userEmail, chargeEntity.getExternalId());
 
-        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity);
+        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity, gatewayAccountCredentialsEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.getError().isPresent());
@@ -196,14 +201,14 @@ public class StripePaymentProviderTest {
         stripePaymentProvider.capture(request);
         final RefundEntity refundEntity = new RefundEntity(chargeAmount, "some-user-external-id", userEmail, chargeEntity.getExternalId());
 
-        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity);
+        RefundGatewayRequest refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, gatewayAccountEntity, gatewayAccountCredentialsEntity);
         GatewayRefundResponse refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.isSuccessful());
 
         RefundEntity secondRefundEntity = new RefundEntity(1L, "some-user-external-id", userEmail, chargeEntity.getExternalId());
 
-        refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), secondRefundEntity, gatewayAccountEntity);
+        refundRequest = RefundGatewayRequest.valueOf(Charge.from(chargeEntity), secondRefundEntity, gatewayAccountEntity, gatewayAccountCredentialsEntity);
         refundResponse = stripePaymentProvider.refund(refundRequest);
 
         assertTrue(refundResponse.getError().isPresent());

--- a/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/WorldpayPaymentProviderTest.java
@@ -34,6 +34,7 @@ import uk.gov.pay.connector.gateway.worldpay.WorldpayPaymentProvider;
 import uk.gov.pay.connector.gateway.worldpay.WorldpayRefundHandler;
 import uk.gov.pay.connector.gateway.worldpay.wallets.WorldpayWalletAuthorisationHandler;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.logging.AuthorisationLogger;
 import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
@@ -79,6 +80,7 @@ public class WorldpayPaymentProviderTest {
 
     private GatewayAccountEntity validGatewayAccount;
     private GatewayAccountEntity validGatewayAccountFor3ds;
+    private GatewayAccountCredentialsEntity validGatewayAccountCredentialsEntity;
     private Map<String, String> validCredentials;
     private Map<String, String> validCredentials3ds;
     private ChargeEntity chargeEntity;
@@ -109,23 +111,19 @@ public class WorldpayPaymentProviderTest {
 
 
         validGatewayAccount = new GatewayAccountEntity();
-        validGatewayAccount.setId(1234L);
-        validGatewayAccount.setType(TEST);
-        validGatewayAccount.setGatewayAccountCredentials(List.of(aGatewayAccountCredentialsEntity()
+        validGatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
                 .withCredentials(validCredentials)
                 .withGatewayAccountEntity(validGatewayAccount)
                 .withPaymentProvider(WORLDPAY.getName())
                 .withState(ACTIVE)
-                .build()));
+                .build();
+        validGatewayAccount.setId(1234L);
+        validGatewayAccount.setType(TEST);
+        validGatewayAccount.setGatewayAccountCredentials(List.of());
         validGatewayAccountFor3ds = new GatewayAccountEntity();
         validGatewayAccountFor3ds.setId(1234L);
         validGatewayAccountFor3ds.setType(TEST);
-        validGatewayAccountFor3ds.setGatewayAccountCredentials(List.of(aGatewayAccountCredentialsEntity()
-                .withCredentials(validCredentials3ds)
-                .withGatewayAccountEntity(validGatewayAccountFor3ds)
-                .withPaymentProvider(WORLDPAY.getName())
-                .withState(ACTIVE)
-                .build()));
+        validGatewayAccountFor3ds.setGatewayAccountCredentials(List.of(validGatewayAccountCredentialsEntity));
 
         mockMetricRegistry = mock(MetricRegistry.class);
         mockHistogram = mock(Histogram.class);
@@ -357,7 +355,7 @@ public class WorldpayPaymentProviderTest {
 
         RefundEntity refundEntity = new RefundEntity(1L, userExternalId, userEmail, chargeEntity.getExternalId());
 
-        GatewayRefundResponse refundResponse = paymentProvider.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, validGatewayAccount));
+        GatewayRefundResponse refundResponse = paymentProvider.refund(RefundGatewayRequest.valueOf(Charge.from(chargeEntity), refundEntity, validGatewayAccount, validGatewayAccountCredentialsEntity));
 
         assertTrue(refundResponse.isSuccessful());
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/epdq/EpdqRefundsResourceIT.java
@@ -43,7 +43,6 @@ import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.EPDQ;
 import static uk.gov.pay.connector.gateway.epdq.EpdqPaymentProvider.ROUTE_FOR_MAINTENANCE_ORDER;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_MERCHANT_ID;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccount.CREDENTIALS_PASSWORD;
@@ -68,8 +67,10 @@ public class EpdqRefundsResourceIT extends ChargingITestBase {
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
-                .withAccountId(Long.valueOf(accountId))
-                .withPaymentProvider("epdq");
+                .withAccountId(Long.parseLong(accountId))
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayAccountCredentials(List.of(credentialParams))
+                .withCredentials(credentials);
 
         defaultTestCharge = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
@@ -77,7 +78,8 @@ public class EpdqRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
-                .withPaymentProvider(EPDQ.getName())
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
                 .insert();
     }
 
@@ -134,7 +136,7 @@ public class EpdqRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURE_SUBMITTED)
-                .withPaymentProvider(EPDQ.getName())
+                .withPaymentProvider(getPaymentProvider())
                 .insert();
 
         Long refundAmount = captureSubmittedCharge.getAmount();
@@ -187,6 +189,8 @@ public class EpdqRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(ENTERING_CARD_DETAILS)
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
                 .insert();
 
         Long refundAmount = 20L;

--- a/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/sandbox/SandboxRefundsResourceIT.java
@@ -64,7 +64,10 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
-                .withAccountId(Long.valueOf(accountId));
+                .withAccountId(Long.parseLong(accountId))
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayAccountCredentials(List.of(credentialParams))
+                .withCredentials(credentials);
 
         defaultTestCharge = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
@@ -72,7 +75,8 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
-                .withPaymentProvider(SANDBOX.getName())
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
                 .insert();
     }
 
@@ -306,9 +310,10 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
         LedgerTransaction charge = aValidLedgerTransaction()
                 .withExternalId(chargeExternalId)
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
+                .withCredentialExternalId(credentialParams.getExternalId())
                 .withAmount(1000L)
                 .withRefundSummary(refundSummary)
-                .withPaymentProvider(SANDBOX.getName())
+                .withPaymentProvider(getPaymentProvider())
                 .build();
         ledgerStub.returnLedgerTransaction(chargeExternalId, charge);
 
@@ -318,10 +323,12 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
 
         LedgerTransaction expungedRefund = aValidLedgerTransaction()
                 .withExternalId("ledger-refund-id")
+                .withGatewayAccountId(defaultTestAccount.getAccountId())
                 .withParentTransactionId(defaultTestCharge.getExternalChargeId())
+                .withCredentialExternalId(credentialParams.getExternalId())
                 .withAmount(300L)
                 .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
-                .withPaymentProvider(SANDBOX.getName())
+                .withPaymentProvider(getPaymentProvider())
                 .build();
         ledgerStub.returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
 
@@ -342,9 +349,10 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
         LedgerTransaction charge = aValidLedgerTransaction()
                 .withExternalId(chargeExternalId)
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
+                .withCredentialExternalId(credentialParams.getExternalId())
                 .withAmount(1000L)
                 .withRefundSummary(refundSummary)
-                .withPaymentProvider(SANDBOX.getName())
+                .withPaymentProvider(getPaymentProvider())
                 .build();
         ledgerStub.returnLedgerTransaction(chargeExternalId, charge);
 
@@ -354,10 +362,12 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
 
         LedgerTransaction expungedRefund = aValidLedgerTransaction()
                 .withExternalId("ledger-refund-id")
+                .withGatewayAccountId(defaultTestAccount.getAccountId())
+                .withCredentialExternalId(credentialParams.getExternalId())
                 .withParentTransactionId(defaultTestCharge.getExternalChargeId())
                 .withAmount(300L)
                 .withStatus(ExternalRefundStatus.EXTERNAL_SUCCESS.getStatus())
-                .withPaymentProvider(SANDBOX.getName())
+                .withPaymentProvider(getPaymentProvider())
                 .build();
         ledgerStub.returnRefundsForPayment(chargeExternalId, List.of(expungedRefund));
 
@@ -375,6 +385,7 @@ public class SandboxRefundsResourceIT extends ChargingITestBase {
         LedgerTransaction charge = aValidLedgerTransaction()
                 .withExternalId(chargeExternalId)
                 .withGatewayAccountId(defaultTestAccount.getAccountId())
+                .withCredentialExternalId(credentialParams.getExternalId())
                 .withAmount(1000L)
                 .withRefundSummary(refundSummary)
                 .build();

--- a/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/smartpay/SmartpayRefundsResourceIT.java
@@ -44,7 +44,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURE_SUBMITTED;
-import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.pay.connector.matcher.RefundsMatcher.aRefundMatching;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.SMARTPAY_VALID_REFUND_SMARTPAY_REQUEST;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
@@ -67,8 +66,10 @@ public class SmartpayRefundsResourceIT extends ChargingITestBase {
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
-                .withPaymentProvider("smartpay")
-                .withAccountId(Long.valueOf(accountId));
+                .withAccountId(Long.parseLong(accountId))
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayAccountCredentials(List.of(credentialParams))
+                .withCredentials(credentials);
 
         defaultTestCharge = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
@@ -77,7 +78,8 @@ public class SmartpayRefundsResourceIT extends ChargingITestBase {
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
                 .withTransactionId(randomAlphanumeric(10))
-                .withPaymentProvider(SMARTPAY.getName())
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
                 .insert();
         pspReference = randomNumeric(16);
     }
@@ -163,6 +165,8 @@ public class SmartpayRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURE_SUBMITTED)
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
                 .insert();
 
         Long refundAmount = 20L;

--- a/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/worldpay/WorldpayRefundsResourceIT.java
@@ -73,7 +73,9 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
         defaultTestAccount = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
                 .aTestAccount()
-                .withAccountId(Long.valueOf(accountId));
+                .withAccountId(Long.parseLong(accountId))
+                .withGatewayAccountCredentials(List.of(credentialParams))
+                .withCredentials(credentials);
 
         defaultTestCharge = DatabaseFixtures
                 .withDatabaseTestHelper(databaseTestHelper)
@@ -82,7 +84,8 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
                 .withTransactionId("MyUniqueTransactionId!")
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURED)
-                .withPaymentProvider(WORLDPAY.getName())
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
                 .insert();
     }
 
@@ -214,6 +217,8 @@ public class WorldpayRefundsResourceIT extends ChargingITestBase {
                 .withAmount(100L)
                 .withTestAccount(defaultTestAccount)
                 .withChargeStatus(CAPTURE_SUBMITTED)
+                .withPaymentProvider(getPaymentProvider())
+                .withGatewayCredentialId(credentialParams.getId())
                 .insert();
 
         Long refundAmount = 20L;


### PR DESCRIPTION
Description:
- `RefundRequest` now accepts `GatewayAccountCredentialsEntity` so that `PaymentProvider` implementions of refund can call credentials directly rather than via `GatewayAccountEntity`