### PR TITLE
PP-8450 Add `send_reference_to_gateway` column to gateway_accounts table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1706,4 +1706,12 @@
             <column name="service_id" type="varchar(32)"/>
         </addColumn>
     </changeSet>
+
+    <changeSet id="add send_reference_to_gateway column to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="send_reference_to_gateway" type="boolean" defaultValue="false">
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
- We currently send `description` available on charge to Worldpay payment provider (authorisation payload field `description`) and some services require `reference` instead of description.
- Adds new field to gateway_accounts table which will be used to include payment `reference` (if send_reference_to_gateway is true) in authorisation payload or the payment `description`
