### PR TITLE
PP-8342 - Discrepancy checker uses GatewayAccountCredentialsEntity

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -287,7 +287,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java",
         "hashed_secret": "c6b43e7d8e68a66c283fd8760118b89592f6498d",
         "is_verified": false,
-        "line_number": 579
+        "line_number": 581
       }
     ],
     "src/test/java/uk/gov/pay/connector/gatewayaccount/validation/Worldpay3DsFlexIssuerOrOrganisationalUnitIdValidatorTest.java": [
@@ -793,5 +793,5 @@
       }
     ]
   },
-  "generated_at": "2021-08-20T08:44:30Z"
+  "generated_at": "2021-08-20T09:09:01Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/ChargeQueryGatewayRequest.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.gateway;
+
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.gateway.model.request.GatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+
+import java.util.Map;
+
+public class ChargeQueryGatewayRequest implements GatewayRequest {
+    
+    private final GatewayAccountEntity gatewayAccountEntity;
+    private final GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
+    private final String chargeExternalId;
+    private final String transactionId;
+
+    public ChargeQueryGatewayRequest(GatewayAccountEntity gatewayAccountEntity, GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity, String chargeExternalId, String transactionId) {
+        this.gatewayAccountEntity = gatewayAccountEntity;
+        this.gatewayAccountCredentialsEntity = gatewayAccountCredentialsEntity;
+        this.chargeExternalId = chargeExternalId;
+        this.transactionId = transactionId;
+    }
+
+    @Override
+    public GatewayAccountEntity getGatewayAccount() {
+        return gatewayAccountEntity;
+    }
+
+    @Override
+    public GatewayOperation getRequestType() {
+        return GatewayOperation.QUERY;
+    }
+
+    public String getChargeExternalId() {
+        return chargeExternalId;
+    }
+
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    @Override
+    public Map<String, String> getGatewayCredentials() {
+        return gatewayAccountCredentialsEntity.getCredentials();
+    }
+    
+    public static ChargeQueryGatewayRequest valueOf(Charge charge, GatewayAccountEntity gatewayAccountEntity, GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity) {
+        return new ChargeQueryGatewayRequest(
+                gatewayAccountEntity,
+                gatewayAccountCredentialsEntity,
+                charge.getExternalId(),
+                charge.getGatewayTransactionId()
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/PaymentProvider.java
@@ -30,7 +30,7 @@ public interface PaymentProvider {
 
     GatewayResponse authorise(CardAuthorisationGatewayRequest request) throws GatewayException;
 
-    ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) throws GatewayException;
+    ChargeQueryResponse queryPaymentStatus(ChargeQueryGatewayRequest chargeQueryGatewayRequest) throws GatewayException;
 
     Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/sandbox/SandboxPaymentProvider.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -60,7 +61,7 @@ public class SandboxPaymentProvider implements PaymentProvider, SandboxGatewayRe
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
+    public ChargeQueryResponse queryPaymentStatus(ChargeQueryGatewayRequest chargeQueryGatewayRequest) {
         throw new UnsupportedOperationException("Querying payment status not currently supported by Sandbox");
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayPaymentProvider.java
@@ -6,6 +6,7 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
@@ -160,7 +161,7 @@ public class SmartpayPaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
+    public ChargeQueryResponse queryPaymentStatus(ChargeQueryGatewayRequest chargeQueryGatewayRequest) {
         throw new UnsupportedOperationException("Querying payment status not currently supported by Smartpay");
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
@@ -97,7 +98,7 @@ public class StripePaymentProvider implements PaymentProvider {
     }
 
     @Override
-    public ChargeQueryResponse queryPaymentStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
+    public ChargeQueryResponse queryPaymentStatus(ChargeQueryGatewayRequest chargeQueryGatewayRequest) {
         throw new UnsupportedOperationException("Querying payment status not currently supported by Stripe");
     }
 

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyService.java
@@ -54,7 +54,7 @@ public class DiscrepancyService {
         return chargeIds.stream()
                 .map(chargeExternalId -> chargeService.findCharge(chargeExternalId)
                         .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId)))
-                .map(this::getGatewayStatusComparision);
+                .map(this::getGatewayStatusComparison);
     }
 
     private GatewayStatusComparison resolve(GatewayStatusComparison gatewayStatusComparison) {
@@ -89,7 +89,7 @@ public class DiscrepancyService {
         return charge.getCreatedDate().plus(Duration.ofDays(minimumAge)).isBefore(Instant.now());
     }
 
-    private GatewayStatusComparison getGatewayStatusComparision(Charge charge) {
+    private GatewayStatusComparison getGatewayStatusComparison(Charge charge) {
         return gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId())
                 .map(gatewayAccountEntity -> {
                     try {

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/QueryService.java
@@ -5,11 +5,15 @@ import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProviders;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountCredentialsNotFoundException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
@@ -21,20 +25,33 @@ import static uk.gov.service.payments.logging.LoggingKeys.PROVIDER;
 
 public class QueryService {
     private final PaymentProviders providers;
+    private final GatewayAccountCredentialsService gatewayAccountCredentialsService;
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Inject
-    public QueryService(PaymentProviders providers) {
+    public QueryService(PaymentProviders providers, GatewayAccountCredentialsService gatewayAccountCredentialsService) {
         this.providers = providers;
+        this.gatewayAccountCredentialsService = gatewayAccountCredentialsService;
     }
     
     public ChargeQueryResponse getChargeGatewayStatus(Charge charge, GatewayAccountEntity gatewayAccountEntity) throws GatewayException {
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = findGatewayAccountCredentialsEntityFromCharge(charge, gatewayAccountEntity);
+
         return providers.byName(PaymentGatewayName.valueFrom(charge.getPaymentGatewayName()))
-                .queryPaymentStatus(charge, gatewayAccountEntity);
+                .queryPaymentStatus(ChargeQueryGatewayRequest.valueOf(charge, gatewayAccountEntity, gatewayAccountCredentialsEntity));
     }   
-    public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity charge) throws GatewayException {
-        return providers.byName(charge.getPaymentGatewayName())
-                .queryPaymentStatus(Charge.from(charge), charge.getGatewayAccount());
+    public ChargeQueryResponse getChargeGatewayStatus(ChargeEntity chargeEntity) throws GatewayException {
+        Charge charge = Charge.from(chargeEntity);
+        GatewayAccountEntity gatewayAccountEntity = chargeEntity.getGatewayAccount();
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = findGatewayAccountCredentialsEntityFromCharge(charge, gatewayAccountEntity);
+
+        return providers.byName(chargeEntity.getPaymentGatewayName())
+                .queryPaymentStatus(ChargeQueryGatewayRequest.valueOf(charge, gatewayAccountEntity, gatewayAccountCredentialsEntity));
+    }
+
+    private GatewayAccountCredentialsEntity findGatewayAccountCredentialsEntityFromCharge(Charge charge, GatewayAccountEntity gatewayAccountEntity) {
+        return gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)
+                .orElseThrow(() -> new GatewayAccountCredentialsNotFoundException("Unable to find gateway account credentials to use to refund charge."));
     }
 
     public boolean canQueryChargeGatewayStatus(PaymentGatewayName paymentGatewayName) {

--- a/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
+++ b/src/main/java/uk/gov/pay/connector/refund/service/RefundService.java
@@ -85,7 +85,7 @@ public class RefundService {
         GatewayAccountEntity gatewayAccountEntity = gatewayAccountDao.findById(accountId).orElseThrow(
                 () -> new GatewayAccountNotFoundException(accountId));
         GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)
-                .orElseThrow(() -> new GatewayAccountCredentialsNotFoundException(format("Unable to find gateway account credentials to use to refund charge.", gatewayAccountEntity.getExternalId())));
+                .orElseThrow(() -> new GatewayAccountCredentialsNotFoundException("Unable to find gateway account credentials to use to refund charge."));
         RefundEntity refundEntity = createRefund(charge, gatewayAccountEntity, refundRequest);
         GatewayRefundResponse gatewayRefundResponse = providers
                 .byName(PaymentGatewayName.valueFrom(charge.getPaymentGatewayName()))

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderIT.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqPaymentProviderIT.java
@@ -5,6 +5,7 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.ErrorType;
@@ -132,7 +133,8 @@ public class EpdqPaymentProviderIT extends BaseEpdqPaymentProviderIT {
     public void shouldSuccessfullyQueryChargeStatus() throws Exception {
         mockPaymentProviderResponse(200, successQueryAuthorisedResponse());
         ChargeEntity chargeEntity = buildChargeEntity();
-        ChargeQueryResponse response = provider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
+        ChargeQueryGatewayRequest request = ChargeQueryGatewayRequest.valueOf(Charge.from(chargeEntity), chargeEntity.getGatewayAccount(), chargeEntity.getGatewayAccountCredentialsEntity());
+        ChargeQueryResponse response = provider.queryPaymentStatus(request);
         assertThat(response.getMappedStatus(), is(Optional.of(AUTHORISATION_SUCCESS)));
         assertThat(response.foundCharge(), is(true));
     }
@@ -141,7 +143,8 @@ public class EpdqPaymentProviderIT extends BaseEpdqPaymentProviderIT {
     public void shouldReturnQueryResponseWhenChargeNotFound() throws Exception {
         mockPaymentProviderResponse(200, errorQueryResponse());
         ChargeEntity chargeEntity = buildChargeEntity();
-        ChargeQueryResponse response = provider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
+        ChargeQueryGatewayRequest request = ChargeQueryGatewayRequest.valueOf(Charge.from(chargeEntity), chargeEntity.getGatewayAccount(), chargeEntity.getGatewayAccountCredentialsEntity());
+        ChargeQueryResponse response = provider.queryPaymentStatus(request);
         assertThat(response.getMappedStatus(), is(Optional.empty()));
         assertThat(response.foundCharge(), is(false));
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.events.eventdetails.charge.Gateway3dsExemptionResultObtainedEventDetails;
 import uk.gov.pay.connector.events.model.Event;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
@@ -551,7 +552,8 @@ public class WorldpayPaymentProviderTest {
         when(inquiryClient.postRequestFor(any(URI.class), eq(WORLDPAY), eq("test"), any(GatewayOrder.class), anyMap()))
                 .thenReturn(response);
 
-        ChargeQueryResponse chargeQueryResponse = worldpayPaymentProvider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
+        ChargeQueryGatewayRequest chargeQueryGatewayRequest = ChargeQueryGatewayRequest.valueOf(Charge.from(chargeEntity), chargeEntity.getGatewayAccount(), chargeEntity.getGatewayAccountCredentialsEntity());
+        ChargeQueryResponse chargeQueryResponse = worldpayPaymentProvider.queryPaymentStatus(chargeQueryGatewayRequest);
 
         assertThat(chargeQueryResponse.getMappedStatus(), is(Optional.of(ChargeStatus.AUTHORISATION_SUCCESS)));
         assertThat(chargeQueryResponse.foundCharge(), is(true));

--- a/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/contract/EpdqPaymentProviderTest.java
@@ -21,6 +21,7 @@ import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
@@ -306,7 +307,8 @@ public class EpdqPaymentProviderTest {
         GatewayResponse<BaseAuthoriseResponse> response = paymentProvider.authorise(request);
         assertThat(response.isSuccessful(), is(true));
 
-        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
+        ChargeQueryGatewayRequest chargeQueryGatewayRequest = ChargeQueryGatewayRequest.valueOf(Charge.from(chargeEntity), chargeEntity.getGatewayAccount(), chargeEntity.getGatewayAccountCredentialsEntity());
+        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(chargeQueryGatewayRequest);
         assertThat(chargeQueryResponse.getMappedStatus(), is(Optional.of(ChargeStatus.AUTHORISATION_SUCCESS)));
         assertThat(chargeQueryResponse.foundCharge(), is(true));
     }
@@ -314,7 +316,8 @@ public class EpdqPaymentProviderTest {
     @Test
     public void shouldReturnQueryResponseWhenChargeNotFound() throws Exception {
         setUpAndCheckThatEpdqIsUp();
-        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(Charge.from(chargeEntity), chargeEntity.getGatewayAccount());
+        ChargeQueryGatewayRequest chargeQueryGatewayRequest = ChargeQueryGatewayRequest.valueOf(Charge.from(chargeEntity), chargeEntity.getGatewayAccount(), chargeEntity.getGatewayAccountCredentialsEntity());
+        ChargeQueryResponse chargeQueryResponse = paymentProvider.queryPaymentStatus(chargeQueryGatewayRequest);
         assertThat(chargeQueryResponse.getMappedStatus(), is(Optional.empty()));
         assertThat(chargeQueryResponse.foundCharge(), is(false));
     }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/DiscrepancyServiceTest.java
@@ -1,10 +1,11 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
@@ -28,7 +29,7 @@ import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATIO
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.EXPIRED;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DiscrepancyServiceTest {
 
     private DiscrepancyService discrepancyService;
@@ -47,13 +48,13 @@ public class DiscrepancyServiceTest {
     @Mock
     private BaseInquiryResponse mockGatewayResponse;
 
-    @Before
-    public void beforeTest() {
+    @BeforeEach
+    void beforeTest() {
         discrepancyService = new DiscrepancyService(chargeService, queryService, expiryService, gatewayAccountService);
     }
 
     @Test
-    public void aChargeShouldBeCancellable_whenPayAndGatewayStatusesAllowItAndIsOlderThan2Days() throws GatewayException {
+    void aChargeShouldBeCancellable_whenPayAndGatewayStatusesAllowItAndIsOlderThan2Days() throws GatewayException {
         ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(EXPIRED)
@@ -72,7 +73,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenPayAndGatewayStatusesMatch() throws GatewayException {
+    void aChargeShouldNotBeCancellable_whenPayAndGatewayStatusesMatch() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(AUTHORISATION_SUCCESS)
@@ -83,7 +84,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenPayStatusIsSuccess() throws GatewayException {
+    void aChargeShouldNotBeCancellable_whenPayStatusIsSuccess() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(CAPTURED)
@@ -94,7 +95,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenPayStatusIsUnfinished() throws GatewayException {
+    void aChargeShouldNotBeCancellable_whenPayStatusIsUnfinished() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(AUTHORISATION_3DS_READY)
@@ -105,7 +106,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenGatewayStatusIsFinished() throws GatewayException {
+    void aChargeShouldNotBeCancellable_whenGatewayStatusIsFinished() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(3)))
                 .withStatus(EXPIRED)
@@ -116,7 +117,7 @@ public class DiscrepancyServiceTest {
     }
 
     @Test
-    public void aChargeShouldNotBeCancellable_whenChargeIsLessThan2DaysOld() throws GatewayException {
+    void aChargeShouldNotBeCancellable_whenChargeIsLessThan2DaysOld() throws GatewayException {
         ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
                 .withCreatedDate(Instant.now().minus(Duration.ofDays(1)))
                 .withStatus(EXPIRED)

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/QueryServiceTest.java
@@ -1,27 +1,37 @@
 package uk.gov.pay.connector.paymentprocessor.service;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.PaymentProviders;
 import uk.gov.pay.connector.gateway.model.response.BaseInquiryResponse;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
+
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.defaultGatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.defaultGatewayAccountEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_3DS_REQUIRED;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class QueryServiceTest {
     
     @Mock
@@ -31,34 +41,94 @@ public class QueryServiceTest {
     private PaymentProviders paymentProviders;
 
     @Mock
+    private GatewayAccountCredentialsService gatewayAccountCredentialsService;
+
+    @Mock
     private BaseInquiryResponse mockGatewayResponse;
 
     @InjectMocks
     private QueryService queryService;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         when(paymentProviders.byName(any())).thenReturn(paymentProvider);
     }
 
     @Test
-    public void isTerminableWithGateway_returnsTrueForNotFinishedExternalStatus() throws Exception {
+    void returnSuccessfulGatewayResponse() throws Exception {
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(defaultGatewayAccountEntity())
+                .build();
+        Charge charge = Charge.from(chargeEntity);
+        GatewayAccountEntity gatewayAccountEntity = chargeEntity.getGatewayAccount();
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = chargeEntity.getGatewayAccountCredentialsEntity();
+        ChargeQueryResponse response = new ChargeQueryResponse(AUTHORISATION_3DS_REQUIRED, mockGatewayResponse);
+
+        when(paymentProvider.queryPaymentStatus(any(ChargeQueryGatewayRequest.class))).thenReturn(response);
+        when(gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(Optional.of(gatewayAccountCredentialsEntity));
+
+        assertThat(queryService.getChargeGatewayStatus(chargeEntity), is(response));
+    }
+
+    @Test
+    void returnChargeStatusFromGateway() throws Exception {
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(defaultGatewayAccountEntity())
+                .withGatewayAccountCredentialsEntity(defaultGatewayAccountCredentialsEntity())
+                .build();
+        Charge charge = Charge.from(chargeEntity);
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = chargeEntity.getGatewayAccountCredentialsEntity();
+        GatewayAccountEntity gatewayAccountEntity = chargeEntity.getGatewayAccount();
+        ChargeQueryResponse response = new ChargeQueryResponse(AUTHORISATION_3DS_REQUIRED, mockGatewayResponse);
+
+        when(gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(Optional.of(gatewayAccountCredentialsEntity));
+        when(paymentProvider.queryPaymentStatus(any(ChargeQueryGatewayRequest.class))).thenReturn(response);
+        Optional<ChargeStatus> chargeStatus = queryService.getMappedGatewayStatus(chargeEntity);
+
+        assertThat(chargeStatus.isPresent(), is(true));
+        assertThat(chargeStatus.get(), is(AUTHORISATION_3DS_REQUIRED));
+    }
+
+    @Test
+    void returnEmptyOptionalIfGatewayThrowsAnException() throws Exception {
         ChargeEntity chargeEntity = aValidChargeEntity().build();
         Charge charge = Charge.from(chargeEntity);
+        GatewayAccountEntity gatewayAccountEntity = chargeEntity.getGatewayAccount();
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = chargeEntity.getGatewayAccountCredentialsEntity();
+
+        when(paymentProvider.queryPaymentStatus(any(ChargeQueryGatewayRequest.class))).thenThrow(UnsupportedOperationException.class);
+        when(gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(Optional.of(gatewayAccountCredentialsEntity));
+        Optional<ChargeStatus> chargeStatus = queryService.getMappedGatewayStatus(chargeEntity);
+
+        assertThat(chargeStatus.isPresent(), is(false));
+    }
+
+    @Test
+    void isTerminableWithGateway_returnsTrueForNotFinishedExternalStatus() throws Exception {
+        ChargeEntity chargeEntity = aValidChargeEntity()
+                .withGatewayAccountEntity(defaultGatewayAccountEntity())
+                .build();
+        Charge charge = Charge.from(chargeEntity);
+        GatewayAccountEntity gatewayAccountEntity = chargeEntity.getGatewayAccount();
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = chargeEntity.getGatewayAccountCredentialsEntity();
 
         ChargeQueryResponse response = new ChargeQueryResponse(AUTHORISATION_3DS_REQUIRED, mockGatewayResponse);
-        when(paymentProvider.queryPaymentStatus(charge, chargeEntity.getGatewayAccount())).thenReturn(response);
+        when(paymentProvider.queryPaymentStatus(any(ChargeQueryGatewayRequest.class))).thenReturn(response);
+        when(gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(Optional.of(gatewayAccountCredentialsEntity));
 
         assertThat(queryService.isTerminableWithGateway(chargeEntity), is(true));
     }
 
     @Test
-    public void isTerminableWithGateway_returnsFalseForFinishedExternalStatus() throws Exception {
+    void isTerminableWithGateway_returnsFalseForFinishedExternalStatus() throws Exception {
         ChargeEntity chargeEntity = aValidChargeEntity().build();
         Charge charge = Charge.from(chargeEntity);
+        GatewayAccountEntity gatewayAccountEntity = chargeEntity.getGatewayAccount();
+        GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = chargeEntity.getGatewayAccountCredentialsEntity();
 
         ChargeQueryResponse response = new ChargeQueryResponse(CAPTURED, mockGatewayResponse);
-        when(paymentProvider.queryPaymentStatus(charge, chargeEntity.getGatewayAccount())).thenReturn(response);
+        when(paymentProvider.queryPaymentStatus(any(ChargeQueryGatewayRequest.class))).thenReturn(response);
+        when(gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(Optional.of(gatewayAccountCredentialsEntity));
 
         assertThat(queryService.isTerminableWithGateway(chargeEntity), is(false));
     }


### PR DESCRIPTION
Description:
- Refactored PaymentProvider.queryPaymentStatus() to take ChargeQueryGatewayRequest as a parameter
- Added some tests to QueryService to test methods which weren't covered by existing tests
- Delegated responsibility to QueryService to find the GatewayAccountCredentialsEntity so that the existing getChargeGatewayStatus method signature
needn't be modified