### PR TITLE
PP-8342 - Use getGatewayCredentials throughout

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqRefundHandler.java
@@ -52,12 +52,12 @@ public class EpdqRefundHandler implements RefundHandler {
 
     private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
         var epdqPayloadDefinitionForRefundOrder = new EpdqPayloadDefinitionForRefundOrder();
-        epdqPayloadDefinitionForRefundOrder.setUserId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_USERNAME));
-        epdqPayloadDefinitionForRefundOrder.setPassword(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_PASSWORD));
-        epdqPayloadDefinitionForRefundOrder.setPspId(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_MERCHANT_ID));
+        epdqPayloadDefinitionForRefundOrder.setUserId(request.getGatewayCredentials().get(CREDENTIALS_USERNAME));
+        epdqPayloadDefinitionForRefundOrder.setPassword(request.getGatewayCredentials().get(CREDENTIALS_PASSWORD));
+        epdqPayloadDefinitionForRefundOrder.setPspId(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID));
         epdqPayloadDefinitionForRefundOrder.setPayId(request.getTransactionId());
         epdqPayloadDefinitionForRefundOrder.setAmount(request.getAmount());
-        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase(request.getGatewayAccount().getCredentials(EPDQ.getName()).get(CREDENTIALS_SHA_IN_PASSPHRASE));
+        epdqPayloadDefinitionForRefundOrder.setShaInPassphrase(request.getGatewayCredentials().get(CREDENTIALS_SHA_IN_PASSPHRASE));
         return epdqPayloadDefinitionForRefundOrder.createGatewayOrder();
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayRefundHandler.java
@@ -52,6 +52,6 @@ public class SmartpayRefundHandler implements RefundHandler {
     }
 
     private String getMerchantCode(GatewayRequest request) {
-        return request.getGatewayAccount().getCredentials(SMARTPAY.getName()).get(CREDENTIALS_MERCHANT_ID);
+        return request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -13,6 +13,8 @@ import uk.gov.pay.connector.gateway.util.XMLUnmarshaller;
 import uk.gov.pay.connector.gateway.util.XMLUnmarshallerException;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.util.IpDomainMatcher;
 
@@ -121,8 +123,7 @@ public class WorldpayNotificationService {
         }
 
         Charge charge = maybeCharge.get();
-        Optional<GatewayAccountEntity> mayBeGatewayAccountEntity =
-                gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId());
+        Optional<GatewayAccountEntity> mayBeGatewayAccountEntity = gatewayAccountService.getGatewayAccount(charge.getGatewayAccountId());
 
         if (mayBeGatewayAccountEntity.isEmpty()) {
             logger.error("{} notification {} could not be processed (associated gateway account [{}] not found for charge [{}] {}, {})",

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayRefundHandler.java
@@ -49,7 +49,7 @@ public class WorldpayRefundHandler implements RefundHandler {
     private GatewayOrder buildRefundOrder(RefundGatewayRequest request) {
         return aWorldpayRefundOrderRequestBuilder()
                 .withReference(request.getRefundExternalId())
-                .withMerchantCode(request.getGatewayAccount().getCredentials(WORLDPAY.getName()).get(CREDENTIALS_MERCHANT_ID))
+                .withMerchantCode(request.getGatewayCredentials().get(CREDENTIALS_MERCHANT_ID))
                 .withAmount(request.getAmount())
                 .withTransactionId(request.getTransactionId())
                 .build();

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/BaseEpdqNotificationServiceTest.java
@@ -16,6 +16,7 @@ import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.util.CidrUtils;
 import uk.gov.pay.connector.util.IpAddressMatcher;
 
@@ -39,6 +40,8 @@ abstract class BaseEpdqNotificationServiceTest {
     @Mock
     protected GatewayAccountService mockGatewayAccountService;
     @Mock
+    protected GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
+    @Mock
     protected ChargeNotificationProcessor mockChargeNotificationProcessor;
     @Mock
     protected RefundNotificationProcessor mockRefundNotificationProcessor;
@@ -58,6 +61,7 @@ abstract class BaseEpdqNotificationServiceTest {
                 mockChargeNotificationProcessor,
                 mockRefundNotificationProcessor,
                 mockGatewayAccountService,
+                mockGatewayAccountCredentialsService,
                 new IpAddressMatcher(new InetAddressValidator()),
                 ALLOWED_IP_ADDRESSES
         );

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -47,6 +47,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldUpdateChargeToAuthorisationRejected_IfEpdqStatusIs2() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISATION_REFUSED);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -57,6 +58,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldUpdateChargeToAuthorisationSuccess_IfEpdqStatusIs5() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -67,6 +69,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldUpdateChargeToCaptured_IfEpdqStatusIs9() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_PAYMENT_REQUESTED);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -78,6 +81,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
         final String payload = notificationPayloadForTransaction(payId, EPDQ_PAYMENT_REQUESTED);
         charge = getCharge(true);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -93,6 +97,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
                 .withGatewayTransactionId(payId)
                 .build());
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -106,6 +111,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
                 .withStatus(USER_CANCEL_SUBMITTED)
                 .build());
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -119,6 +125,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
                 .withStatus(EXPIRE_CANCEL_SUBMITTED)
                 .build());
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -132,6 +139,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
                 .withStatus(CAPTURED)
                 .build());
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -143,6 +151,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
         charge = getCharge(false);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -154,6 +163,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
         final String payload = notificationPayloadForTransaction(payId, EPDQ_AUTHORISED_CANCELLED);
         charge = getCharge(true);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -172,6 +182,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldRefund_IfEpdqStatusIs7() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_PAYMENT_DELETED);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -182,6 +193,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldRefund_IfEpdqStatusIs8() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_REFUND);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -192,6 +204,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldBeARefundError_IfEpdqStatusIs83() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_REFUND_REFUSED);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -202,6 +215,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldBeARefundError_IfEpdqStatusIs73() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_DELETION_REFUSED);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -212,6 +226,7 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     void shouldBeARefundError_IfEpdqStatusIs94() {
         final String payload = notificationPayloadForTransaction(payId, EPDQ_REFUND_DECLINED_BY_ACQUIRER);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceTest.java
@@ -12,7 +12,6 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,6 +42,7 @@ class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest {
                 payId,
                 EPDQ_PAYMENT_REQUESTED);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -60,6 +60,7 @@ class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest {
                 .build());
         charge.setHistoric(true);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -73,6 +74,7 @@ class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest {
                 payId,
                 EPDQ_REFUND);
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.of(gatewayAccountCredentialsEntity));
         setUpChargeServiceToReturnCharge(Optional.of(charge));
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
@@ -100,6 +102,20 @@ class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest {
                 EPDQ_REFUND);
         setUpChargeServiceToReturnCharge(Optional.of(charge));
         setUpGatewayAccountToReturnGatewayAccountEntity(Optional.empty());
+
+        assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
+        verifyNoInteractions(mockChargeNotificationProcessor);
+        verifyNoInteractions(mockRefundNotificationProcessor);
+    }
+
+    @Test
+    void ifGatewayAccountCredentialsNotFound_shouldNotInvokeChargeOrRefundNotificationProcessor() {
+        final String payload = notificationPayloadForTransaction(
+                payId,
+                EPDQ_REFUND);
+        setUpChargeServiceToReturnCharge(Optional.of(charge));
+        setUpGatewayAccountToReturnGatewayAccountEntity(Optional.of(gatewayAccountEntity));
+        setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional.empty());
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
         verifyNoInteractions(mockChargeNotificationProcessor);
@@ -165,6 +181,10 @@ class EpdqNotificationServiceTest extends BaseEpdqNotificationServiceTest {
 
     protected void setUpGatewayAccountToReturnGatewayAccountEntity(Optional<GatewayAccountEntity> gatewayAccountEntity) {
         when(mockGatewayAccountService.getGatewayAccount(charge.getGatewayAccountId())).thenReturn(gatewayAccountEntity);
+    }
+
+    protected void setUpGatewayAccountCredentialsToReturnGatewayAccountCredentialsEntity(Optional<GatewayAccountCredentialsEntity> gatewayAccountCredentialsEntity) {
+        when(mockGatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(gatewayAccountCredentialsEntity);
     }
 
     protected void setUpChargeServiceToReturnCharge(Optional<Charge> charge) {


### PR DESCRIPTION
Description:
- Worldpay, Smartpay and Stripe don't rely on the credentials so no need to update their notification service
- Epdq notifications do depend on credentials
