### PR TITLE
PP-8409 Emit capture event for historic charges

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationService.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CAPTURED;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.SMARTPAY;
 import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_ACCOUNT_ID;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
@@ -116,6 +117,12 @@ public class SmartpayNotificationService {
 
         if (interpretedStatus instanceof MappedChargeStatus) {
             if(charge.isHistoric()){
+                if (CAPTURED.equals(interpretedStatus.getChargeStatus())) {
+                    chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccountEntity, 
+                            notification.getOriginalReference(), charge, interpretedStatus.getChargeStatus());
+                    return;
+                }
+
                 logger.error("{} notification {} could not be processed as charge [{}] has been expunged from connector {} {}",
                         PAYMENT_GATEWAY_NAME, notification,
                         charge.getExternalId(),

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationService.java
@@ -139,11 +139,8 @@ public class WorldpayNotificationService {
         
         if (isCaptureNotification(notification)) {
             if(charge.isHistoric()){
-                logger.error("{} notification {} could not be processed as charge [{}] has been expunged from connector {} {}",
-                        PAYMENT_GATEWAY_NAME, notification,
-                        charge.getExternalId(),
-                        kv(PAYMENT_EXTERNAL_ID, charge.getExternalId()),
-                        kv(GATEWAY_ACCOUNT_ID, charge.getGatewayAccountId()));
+                chargeNotificationProcessor.processCaptureNotificationForExpungedCharge(gatewayAccountEntity, 
+                        notification.getTransactionId(), charge, CAPTURED);
                 return true;
             }
             chargeNotificationProcessor.invoke(notification.getTransactionId(), charge, CAPTURED, notification.getGatewayEventDate());

--- a/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/smartpay/SmartpayNotificationServiceTest.java
@@ -102,7 +102,7 @@ class SmartpayNotificationServiceTest {
     }
 
     @Test
-    void shouldNotUpdateCharge_WhenNotificationIsForCaptureAndChargeIsHistoric() {
+    void shouldUpdateCharge_WhenNotificationIsForCaptureAndChargeIsHistoric() {
         charge = Charge.from(ChargeEntityFixture.aValidChargeEntity()
                 .withStatus(AUTHORISATION_SUCCESS)
                 .build());
@@ -114,7 +114,7 @@ class SmartpayNotificationServiceTest {
 
         assertTrue(notificationService.handleNotificationFor(payload, FORWARDED_IP_ADDRESSES));
         verifyNoInteractions(mockRefundNotificationProcessor);
-        verifyNoInteractions(mockChargeNotificationProcessor);
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, originalReference, charge, CAPTURED);
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayNotificationServiceTest.java
@@ -93,7 +93,7 @@ class WorldpayNotificationServiceTest {
     }
 
     @Test
-    void givenAChargeCapturedNotification_shouldNotInvokeChargeNotificationProcessor_IfChargeIsHistoric() {
+    void givenAChargeCapturedNotification_shouldInvokeChargeNotificationProcessor_IfChargeIsHistoric() {
         charge = Charge.from(ChargeEntityFixture.aValidChargeEntity()
                 .withGatewayAccountEntity(gatewayAccountEntity)
                 .build());
@@ -111,7 +111,7 @@ class WorldpayNotificationServiceTest {
         final boolean result = notificationService.handleNotificationFor(ipAddress, payload);
 
         assertTrue(result);
-        verifyNoInteractions(mockChargeNotificationProcessor);
+        verify(mockChargeNotificationProcessor).processCaptureNotificationForExpungedCharge(gatewayAccountEntity, transactionId, charge, CAPTURED);
         verifyNoInteractions(mockRefundNotificationProcessor);
     }
 


### PR DESCRIPTION
We already emit a capture event for historic ePDQ charges, as we have seen times when we've received a capture success notification after the charge has been expunged.

We don't expect to have Worldpay and Smartpay charges expunged before we receive a capture notification, but there's no reason the behaviour shouldn't be the same if we did.

As we are reducing the time before expunge, this could also potentially make this more likely to happen.