### PR TITLE
PP-8460 store 3DS version info for Stripe payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/model/Auth3dsResult.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/Auth3dsResult.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.gateway.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class Auth3dsResult implements AuthorisationDetails {
 
     public enum Auth3dsResultOutcome {
@@ -13,6 +15,8 @@ public class Auth3dsResult implements AuthorisationDetails {
     private Auth3dsResultOutcome auth3dsResultOutcome;
 
     private String md;
+
+    private String threeDsVersion;
 
     @JsonProperty("pa_response")
     public void setPaResponse(String paResponse) {
@@ -41,12 +45,22 @@ public class Auth3dsResult implements AuthorisationDetails {
         return this.md;
     }
 
+    public String getThreeDsVersion() {
+        return threeDsVersion;
+    }
+
+    @JsonProperty("three_ds_version")
+    public void setThreeDsVersion(String threeDsVersion) {
+        this.threeDsVersion = threeDsVersion;
+    }
+
     @Override
     public String toString() {
         return "Auth3dsDetails{" +
                 "paResponse='" + paResponse + '\'' +
                 ", auth3DsResult=" + auth3dsResultOutcome +
                 ", md='" + md + '\'' +
+                ", threeDsVersion='" + threeDsVersion + '\'' +
                 '}';
     }
 
@@ -57,9 +71,10 @@ public class Auth3dsResult implements AuthorisationDetails {
 
         Auth3dsResult that = (Auth3dsResult) o;
 
-        if (paResponse != null ? !paResponse.equals(that.paResponse) : that.paResponse != null) return false;
+        if (!Objects.equals(paResponse, that.paResponse)) return false;
         if (auth3dsResultOutcome != that.auth3dsResultOutcome) return false;
-        return md != null ? md.equals(that.md) : that.md == null;
+        if (!Objects.equals(threeDsVersion, that.threeDsVersion)) return false;
+        return Objects.equals(md, that.md);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/response/Gateway3DSAuthorisationResponse.java
@@ -51,6 +51,10 @@ public class Gateway3DSAuthorisationResponse {
         return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", null, null);
     }
 
+    public static Gateway3DSAuthorisationResponse of(BaseAuthoriseResponse.AuthoriseStatus authorisationStatus, Gateway3dsRequiredParams gateway3dsRequiredParams) {
+        return new Gateway3DSAuthorisationResponse(authorisationStatus, null, "", gateway3dsRequiredParams, null);
+    }
+
     public boolean isSuccessful() {
         return authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED
                 || authorisationStatus == BaseAuthoriseResponse.AuthoriseStatus.AUTH_3DS_READY;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/Stripe3dsSourceAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/Stripe3dsSourceAuthorisationResponse.java
@@ -33,7 +33,7 @@ public class Stripe3dsSourceAuthorisationResponse implements BaseAuthoriseRespon
 
     @Override
     public Optional<? extends Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
-        return Optional.of(new Stripe3dsRequiredParams(jsonResponse.getRedirectUrl()));
+        return jsonResponse.getRedirectUrl() == null ? Optional.empty() : Optional.of(new Stripe3dsRequiredParams(jsonResponse.getRedirectUrl(), null));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationResponse.java
@@ -52,8 +52,8 @@ public class StripeAuthorisationResponse implements BaseAuthoriseResponse {
 
     @Override
     public Optional<Gateway3dsRequiredParams> getGatewayParamsFor3ds() {
-        return Optional.ofNullable(redirectUrl)
-                .map(Stripe3dsRequiredParams::new);
+        return redirectUrl == null ? Optional.empty() :
+                Optional.of(new Stripe3dsRequiredParams(redirectUrl, null));
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -19,6 +19,7 @@ import uk.gov.pay.connector.gateway.GatewayException.GenericGatewayException;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
+import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.request.Auth3dsResponseGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CancelGatewayRequest;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -36,9 +37,9 @@ import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
 import uk.gov.pay.connector.gateway.stripe.json.StripeCharge;
 import uk.gov.pay.connector.gateway.stripe.json.StripeErrorResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeAuthoriseRequest;
+import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
@@ -111,17 +112,17 @@ public class StripePaymentProvider implements PaymentProvider {
     public Gateway3DSAuthorisationResponse authorise3dsResponse(Auth3dsResponseGatewayRequest request) {
 
         if (request.getAuth3dsResult() != null && request.getAuth3dsResult().getAuth3dsResultOutcome() != null) {
-
+            Gateway3dsRequiredParams params = new Stripe3dsRequiredParams(null, request.getAuth3dsResult().getThreeDsVersion());
             switch (request.getAuth3dsResult().getAuth3dsResultOutcome()) {
                 case CANCELED:
-                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.CANCELLED);
+                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.CANCELLED, params);
                 case ERROR:
-                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.ERROR);
+                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.ERROR, params);
                 case DECLINED:
-                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED);
+                    return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.REJECTED, params);
                 case AUTHORISED:
                     if (request.getTransactionId().get().startsWith("pi_")) {
-                        return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED);
+                        return Gateway3DSAuthorisationResponse.of(BaseAuthoriseResponse.AuthoriseStatus.AUTHORISED, params);
                     }
                     return authorise3DSSource(request);
             }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/PaymentMethodDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/PaymentMethodDetails.java
@@ -1,0 +1,15 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PaymentMethodDetails {
+
+    @JsonProperty("three_d_secure")
+    private ThreeDSecure threeDSecure;
+
+    public ThreeDSecure getThreeDSecure() {
+        return threeDSecure;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeCharge.java
@@ -24,6 +24,9 @@ public class StripeCharge {
     @JsonProperty("status")
     private String status;
 
+    @JsonProperty("payment_method_details")
+    private PaymentMethodDetails paymentMethodDetails;
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     private static class BalanceTransaction {
 
@@ -61,5 +64,9 @@ public class StripeCharge {
 
     public String getStatus() {
         return status;
+    }
+
+    public PaymentMethodDetails getPaymentMethodDetails() {
+        return paymentMethodDetails;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePaymentIntent.java
@@ -30,8 +30,8 @@ public class StripePaymentIntent {
     }
     
     public Optional<StripeCharge> getCharge() {
-        return chargesCollection.getCharges().stream()
-                .findFirst();
+        return chargesCollection != null ? chargesCollection.getCharges().stream().findFirst() :
+            Optional.empty();
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/ThreeDSecure.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/ThreeDSecure.java
@@ -1,0 +1,13 @@
+package uk.gov.pay.connector.gateway.stripe.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ThreeDSecure {
+
+    private String version;
+
+    public String getVersion() {
+        return version;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/response/Stripe3dsRequiredParams.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/response/Stripe3dsRequiredParams.java
@@ -6,15 +6,19 @@ import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 public class Stripe3dsRequiredParams implements Gateway3dsRequiredParams {
 
     private final String issuerUrl;
+    private final String threeDsVersion;
 
-    public Stripe3dsRequiredParams(String issuerUrl) {
+    public Stripe3dsRequiredParams(String issuerUrl, String threeDsVersion) {
         this.issuerUrl = issuerUrl;
+        this.threeDsVersion = threeDsVersion;
     }
+
 
     @Override
     public Auth3dsRequiredEntity toAuth3dsRequiredEntity() {
         Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
         auth3dsRequiredEntity.setIssuerUrl(issuerUrl);
+        auth3dsRequiredEntity.setThreeDsVersion(threeDsVersion);
         return auth3dsRequiredEntity;
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java
@@ -146,7 +146,7 @@ class StripeNotificationServiceTest {
     }
 
     @Test
-    void should_log_the_requirements_and_payoutsDisabled_json_when_an_account_updated_event_is_received() {
+    void shouldLogTheRequirementsAndPayoutsDisabledJson_whenAnAccountUpdatedEventIsReceived() {
         Logger root = (Logger) LoggerFactory.getLogger(StripeAccountUpdatedHandler.class);
         root.setLevel(Level.INFO);
         root.addAppender(mockAppender);
@@ -324,7 +324,8 @@ class StripeNotificationServiceTest {
         final boolean result = notificationService.handleNotificationFor(payload, signPayload(payload), FORWARDED_IP_ADDRESSES);
 
         assertTrue(result);
-        verify(mockCard3dsResponseAuthService).process3DSecureAuthorisationWithoutLocking(externalId, getAuth3dsResult(Auth3dsResult.Auth3dsResultOutcome.AUTHORISED));
+        verify(mockCard3dsResponseAuthService).process3DSecureAuthorisationWithoutLocking(externalId,
+                getAuth3dsResult(Auth3dsResult.Auth3dsResultOutcome.AUTHORISED, "2.0.1"));
     }
 
     @Test
@@ -350,7 +351,8 @@ class StripeNotificationServiceTest {
         final boolean result = notificationService.handleNotificationFor(payload, signPayload(payload), FORWARDED_IP_ADDRESSES);
 
         assertTrue(result);
-        verify(mockCard3dsResponseAuthService).process3DSecureAuthorisationWithoutLocking(externalId, getAuth3dsResult(Auth3dsResult.Auth3dsResultOutcome.DECLINED));
+        verify(mockCard3dsResponseAuthService).process3DSecureAuthorisationWithoutLocking(externalId,
+                getAuth3dsResult(Auth3dsResult.Auth3dsResultOutcome.DECLINED, "2.0.1"));
     }
 
     @Test
@@ -464,7 +466,7 @@ class StripeNotificationServiceTest {
 
         assertFalse(result);
     }
-
+    
     private static String sampleStripeNotification(String location,
                                                    String eventId,
                                                    StripeNotificationType stripeNotificationType) {
@@ -474,8 +476,13 @@ class StripeNotificationServiceTest {
     }
 
     private Auth3dsResult getAuth3dsResult(Auth3dsResult.Auth3dsResultOutcome auth3dsResultOutcome) {
+        return getAuth3dsResult(auth3dsResultOutcome, null);
+    }
+
+    private Auth3dsResult getAuth3dsResult(Auth3dsResult.Auth3dsResultOutcome auth3dsResultOutcome, String threeDsVersion) {
         Auth3dsResult auth3dsResult = new Auth3dsResult();
         auth3dsResult.setAuth3dsResult(auth3dsResultOutcome.toString());
+        auth3dsResult.setThreeDsVersion(threeDsVersion);
         return auth3dsResult;
     }
 }

--- a/src/test/resources/templates/stripe/notification_payment_intent.json
+++ b/src/test/resources/templates/stripe/notification_payment_intent.json
@@ -22,7 +22,12 @@
           {
             "id": "ch_1FF3RuEZsufgnuO0IPT8CY3o",
             "object": "charge",
-            "amount": 1000
+            "amount": 1000,
+            "payment_method_details": {
+              "three_d_secure": {
+                "version": "2.0.1"
+              }
+            }
           }
         ]
       }


### PR DESCRIPTION
## WHAT YOU DID
- For Stripe payments that go through 3DS journey, record 3DS version available from Stripe.

