### PR TITLE
BAU: Fix Jackson Databind deprecation warning

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/Supplemental.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/Supplemental.java
@@ -2,12 +2,12 @@ package uk.gov.pay.connector.charge.model.telephone;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Optional;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Supplemental {
 
     @JsonProperty

--- a/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/telephone/TelephoneChargeCreateRequest.java
@@ -1,6 +1,6 @@
 package uk.gov.pay.connector.charge.model.telephone;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.pay.connector.charge.validation.telephone.ValidCardBrand;
@@ -12,7 +12,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Optional;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class TelephoneChargeCreateRequest {
     
     @NotNull(message = "Field [amount] cannot be null")

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/Address.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/Address.java
@@ -2,14 +2,14 @@ package uk.gov.pay.connector.client.ledger.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Address {
 
     private String line1;

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/CardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/CardDetails.java
@@ -3,14 +3,14 @@ package uk.gov.pay.connector.client.ledger.model;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CardDetails {
 

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.client.ledger.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.service.payments.commons.model.Source;
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class LedgerTransaction {
 
     private String transactionId;

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/RefundTransactionsForPayment.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/RefundTransactionsForPayment.java
@@ -1,12 +1,12 @@
 package uk.gov.pay.connector.client.ledger.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import java.util.List;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RefundTransactionsForPayment {
 

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/EventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/EventDetails.java
@@ -1,10 +1,10 @@
 package uk.gov.pay.connector.events.eventdetails;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class EventDetails {
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/Event.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/Event.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.dropwizard.jackson.Jackson;
@@ -14,7 +14,7 @@ import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public abstract class Event {
     private static final ObjectMapper MAPPER = Jackson.newObjectMapper();

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripePayout.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.gateway.stripe.json;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.stripe.model.Payout;
 
@@ -11,7 +11,7 @@ import java.util.Objects;
 import static uk.gov.pay.connector.util.DateTimeUtils.toUTCZonedDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class StripePayout {
     String id;
     Long amount;

--- a/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccountcredentials/model/GatewayAccountCredentialsEntity.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.gatewayaccountcredentials.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.eclipse.persistence.annotations.Customizer;
@@ -32,7 +32,7 @@ import java.util.Map;
 @Table(name = "gateway_account_credentials")
 @SequenceGenerator(name = "gateway_account_credentials_id_seq",
         sequenceName = "gateway_account_credentials_id_seq", allocationSize = 1)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @Customizer(HistoryCustomizer.class)
 public class GatewayAccountCredentialsEntity extends AbstractVersionedEntity {
 

--- a/src/main/java/uk/gov/pay/connector/queue/payout/Payout.java
+++ b/src/main/java/uk/gov/pay/connector/queue/payout/Payout.java
@@ -1,7 +1,7 @@
 package uk.gov.pay.connector.queue.payout;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -11,7 +11,7 @@ import uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSeri
 import java.time.ZonedDateTime;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Payout {
 
     private String gatewayPayoutId;

--- a/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/applepay/api/ApplePayAuthRequest.java
@@ -2,7 +2,7 @@ package uk.gov.pay.connector.wallets.applepay.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import uk.gov.pay.connector.wallets.WalletAuthorisationRequest;
 import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
@@ -10,7 +10,7 @@ import uk.gov.pay.connector.wallets.model.WalletPaymentInfo;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplePayAuthRequest implements WalletAuthorisationRequest {
     @NotNull @Valid private WalletPaymentInfo paymentInfo;
@@ -33,7 +33,7 @@ public class ApplePayAuthRequest implements WalletAuthorisationRequest {
         this.encryptedPaymentData = encryptedPaymentData;
     }
 
-    @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class EncryptedPaymentData {
         private String data;
@@ -68,7 +68,7 @@ public class ApplePayAuthRequest implements WalletAuthorisationRequest {
             this.signature = signature;
         }
 
-        @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Header {
             private String publicKeyHash;

--- a/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
+++ b/src/main/java/uk/gov/pay/connector/wallets/model/WalletPaymentInfo.java
@@ -1,14 +1,14 @@
 package uk.gov.pay.connector.wallets.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.connector.gateway.model.PayersCardType;
 
 import java.util.Optional;
 
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class WalletPaymentInfo {
     


### PR DESCRIPTION
## WHAT YOU DID
Fix deprecation warning
This was `@Deprecated` see https://fasterxml.github.io/jackson-databind/javadoc/2.12/com/fasterxml/jackson/databind/PropertyNamingStrategy.html for more details

## How to test

- How should it be reviewed? 
Code should still compile and be functionally equivalent.
- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
