### PR TITLE
PP-8461 Add events_details to GatewayRequires3dsAuthorisation event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/GatewayRequires3dsAuthorisationEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/GatewayRequires3dsAuthorisationEventDetails.java
@@ -1,0 +1,37 @@
+package uk.gov.pay.connector.events.eventdetails.charge;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.events.eventdetails.EventDetails;
+
+import java.util.Optional;
+
+public class GatewayRequires3dsAuthorisationEventDetails extends EventDetails {
+
+    private final boolean requires3DS;
+    private String version3DS;
+
+    public GatewayRequires3dsAuthorisationEventDetails(String version3DS) {
+        this.requires3DS = true;
+        this.version3DS = version3DS;
+    }
+
+    public static GatewayRequires3dsAuthorisationEventDetails from(ChargeEntity charge) {
+        return new GatewayRequires3dsAuthorisationEventDetails(
+                Optional.ofNullable(charge.get3dsRequiredDetails())
+                        .map(Auth3dsRequiredEntity::getThreeDsVersion)
+                        .orElse(null)
+        );
+    }
+
+    @JsonProperty("version_3ds")
+    public String getVersion3DS() {
+        return version3DS;
+    }
+
+    @JsonProperty("requires_3ds")
+    public boolean isRequires3DS() {
+        return requires3DS;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/RefundAvailabilityUpdatedEventDetails.java
@@ -1,12 +1,10 @@
 package uk.gov.pay.connector.events.eventdetails.charge;
 
 import uk.gov.pay.connector.charge.model.domain.Charge;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.util.RefundCalculator;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
 import uk.gov.pay.connector.refund.model.domain.Refund;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 
 import java.util.List;
 

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -14,6 +14,7 @@ import uk.gov.pay.connector.events.model.charge.CancelledByUser;
 import uk.gov.pay.connector.events.model.charge.CaptureConfirmed;
 import uk.gov.pay.connector.events.model.charge.CaptureSubmitted;
 import uk.gov.pay.connector.events.model.charge.GatewayErrorDuringAuthorisation;
+import uk.gov.pay.connector.events.model.charge.GatewayRequires3dsAuthorisation;
 import uk.gov.pay.connector.events.model.charge.GatewayTimeoutDuringAuthorisation;
 import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
@@ -141,6 +142,8 @@ public class EventFactory {
                 return PaymentNotificationCreated.from(chargeEvent);
             } else if (eventClass == CancelledByUser.class) {
                 return CancelledByUser.from(chargeEvent);
+            } else if (eventClass == GatewayRequires3dsAuthorisation.class) {
+                return GatewayRequires3dsAuthorisation.from(chargeEvent);
             } else if (eventClass == BackfillerRecreatedUserEmailCollected.class) {
                 return BackfillerRecreatedUserEmailCollected.from(chargeEvent.getChargeEntity());
             } else {

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtained.java
@@ -6,12 +6,16 @@ import uk.gov.pay.connector.events.eventdetails.charge.Gateway3dsInfoObtainedEve
 import java.time.ZonedDateTime;
 
 public class Gateway3dsInfoObtained extends PaymentEvent {
-    public Gateway3dsInfoObtained(String resourceExternalId, Gateway3dsInfoObtainedEventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+
+    public Gateway3dsInfoObtained(String serviceId, boolean live, String resourceExternalId,
+                                  Gateway3dsInfoObtainedEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 
     public static Gateway3dsInfoObtained from(ChargeEntity charge, ZonedDateTime eventDate) {
         return new Gateway3dsInfoObtained(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 Gateway3dsInfoObtainedEventDetails.from(charge),
                 eventDate);

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisation.java
@@ -1,9 +1,22 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.GatewayRequires3dsAuthorisationEventDetails;
+
 import java.time.ZonedDateTime;
 
-public class GatewayRequires3dsAuthorisation extends PaymentEventWithoutDetails {
-    public GatewayRequires3dsAuthorisation(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+public class GatewayRequires3dsAuthorisation extends PaymentEvent {
+    public GatewayRequires3dsAuthorisation(String serviceId, boolean live, String resourceExternalId,
+                                           GatewayRequires3dsAuthorisationEventDetails eventDetails,
+                                           ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static GatewayRequires3dsAuthorisation from(ChargeEventEntity chargeEvent) {
+        ChargeEntity charge = chargeEvent.getChargeEntity();
+        return new GatewayRequires3dsAuthorisation(charge.getServiceId(), charge.getGatewayAccount().isLive(),
+                charge.getExternalId(), GatewayRequires3dsAuthorisationEventDetails.from(charge),
+                chargeEvent.getUpdated());
     }
 }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisationTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/GatewayRequires3dsAuthorisationTest.java
@@ -1,0 +1,62 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+
+public class GatewayRequires3dsAuthorisationTest {
+
+    private final ChargeEntityFixture chargeEntity = aValidChargeEntity();
+
+    @Test
+    public void serializesEventDetailsGivenChargeEvent() throws JsonProcessingException {
+        ZonedDateTime updated = ZonedDateTime.parse("2018-03-12T16:25:02.123456Z");
+
+        Auth3dsRequiredEntity auth3dsRequiredEntity = new Auth3dsRequiredEntity();
+        auth3dsRequiredEntity.setThreeDsVersion("2.1.0");
+        chargeEntity.withAuth3dsDetailsEntity(auth3dsRequiredEntity);
+
+        ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
+        when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity.build());
+        when(chargeEvent.getUpdated()).thenReturn(updated);
+
+        String actual = GatewayRequires3dsAuthorisation.from(chargeEvent).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_REQUIRES_3DS_AUTHORISATION")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEvent.getChargeEntity().getExternalId())));
+
+        assertThat(actual, hasJsonPath("$.event_details.requires_3ds", equalTo(true)));
+        assertThat(actual, hasJsonPath("$.event_details.version_3ds", equalTo("2.1.0")));
+    }
+
+    @Test
+    public void serializesEventCorrectlyWhenVersion3dsIsNotAvailable() throws JsonProcessingException {
+        ChargeEventEntity chargeEvent = mock(ChargeEventEntity.class);
+        when(chargeEvent.getChargeEntity()).thenReturn(chargeEntity.build());
+        when(chargeEvent.getGatewayEventDate()).thenReturn(Optional.empty());
+
+        String actual = GatewayRequires3dsAuthorisation.from(chargeEvent).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_REQUIRES_3DS_AUTHORISATION")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEvent.getChargeEntity().getExternalId())));
+
+        assertThat(actual, hasJsonPath("$.event_details.requires_3ds", equalTo(true)));
+        assertThat(actual, hasNoJsonPath("$.event_details.version_3ds"));
+    }
+
+}


### PR DESCRIPTION
## WHAT
- Added event details to GatewayRequires3dsAuthorisation event which emits 3DS version (if available) and also `requires_3ds` field. Currently ledger doesn't have any info on transaction indicating that payment has gone through 3DS and the new `requires_3ds` field can be used by Ledger to provide following `authorisation_summary` (get one/search payment)
	```
	“authorisation_summary”: {
	  "three_d_secure": {
	      "required": true,
	      "version": "2.2.0/2.1.0/1.0.2"
	  }
	}
	```
- Also updated `Gateway3dsInfoObtained` to use new PaymentEvent constructor (which uses service_id and live flag)
