### PR TITLE
PP-8441 add serviceId and live fields to Charge model

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -181,6 +181,10 @@ public class Charge {
         return serviceId;
     }
 
+    public boolean isLive(){
+        return live;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/Charge.java
@@ -23,10 +23,12 @@ public class Charge {
     private Long gatewayAccountId;
     private String paymentGatewayName;
     private boolean historic;
+    private String serviceId;
+    private boolean live;
 
     public Charge(String externalId, Long amount, String status, String externalStatus, String gatewayTransactionId,
                   String credentialExternalId, Long corporateSurcharge, String refundAvailabilityStatus, String reference,
-                  String description, Instant createdDate, String email, Long gatewayAccountId, String paymentGatewayName, boolean historic) {
+                  String description, Instant createdDate, String email, Long gatewayAccountId, String paymentGatewayName, boolean historic, String serviceId, boolean live) {
         this.externalId = externalId;
         this.amount = amount;
         this.status = status;
@@ -42,6 +44,8 @@ public class Charge {
         this.gatewayAccountId = gatewayAccountId;
         this.paymentGatewayName = paymentGatewayName;
         this.historic = historic;
+        this.serviceId = serviceId;
+        this.live = live;
     }
 
     public static Charge from(ChargeEntity chargeEntity) {
@@ -67,7 +71,9 @@ public class Charge {
                 chargeEntity.getEmail(),
                 chargeEntity.getGatewayAccount().getId(),
                 chargeEntity.getPaymentGatewayName().getName(),
-                false);
+                false,
+                chargeEntity.getServiceId(),
+                chargeEntity.getGatewayAccount().isLive());
     }
 
     public static Charge from(LedgerTransaction transaction) {
@@ -97,7 +103,9 @@ public class Charge {
                 transaction.getEmail(),
                 Long.valueOf(transaction.getGatewayAccountId()),
                 transaction.getPaymentProvider(),
-                true
+                true,
+                transaction.getServiceId(),
+                transaction.getLive()
         );
     }
 
@@ -167,6 +175,10 @@ public class Charge {
 
     public void setCredentialExternalId(String credentialExternalId) {
         this.credentialExternalId = credentialExternalId;
+    }
+    
+    public String getServiceId(){
+        return serviceId;
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -49,6 +49,7 @@ public class LedgerTransaction {
     private String refundedBy;
     private String refundedByUserEmail;
     private String parentTransactionId;
+    private String serviceId;
 
     public LedgerTransaction() {
 
@@ -160,6 +161,10 @@ public class LedgerTransaction {
 
     public void setGatewayAccountId(String gatewayAccountId) {
         this.gatewayAccountId = gatewayAccountId;
+    }
+
+    public void setServiceId(String serviceId) {
+        this.serviceId = serviceId;
     }
 
     public boolean isDelayedCapture() {
@@ -289,4 +294,6 @@ public class LedgerTransaction {
     public void setParentTransactionId(String parentTransactionId) {
         this.parentTransactionId = parentTransactionId;
     }
+
+    public String getServiceId() { return serviceId; }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -191,7 +191,7 @@ public class EventFactory {
 
                         return new RefundAvailabilityUpdated(
                                 c.getServiceId(),
-                                true,
+                                c.isLive(),
                                 c.getExternalId(),
                                 RefundAvailabilityUpdatedEventDetails.from(
                                         charge,

--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -190,14 +190,16 @@ public class EventFactory {
                                 .getExternalChargeRefundAvailability(charge, refundList);
 
                         return new RefundAvailabilityUpdated(
-                                        c.getExternalId(),
-                                        RefundAvailabilityUpdatedEventDetails.from(
-                                                charge,
-                                                refundList,
-                                                refundAvailability
-                                        ),
-                                        eventTimestamp
-                                );
+                                c.getServiceId(),
+                                true,
+                                c.getExternalId(),
+                                RefundAvailabilityUpdatedEventDetails.from(
+                                        charge,
+                                        refundList,
+                                        refundAvailability
+                                ),
+                                eventTimestamp
+                        );
                             }
                     )
                     .orElseThrow(() -> new EventCreationException(charge.getExternalId()));

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/CaptureConfirmedByGatewayNotification.java
@@ -3,7 +3,7 @@ package uk.gov.pay.connector.events.model.charge;
 import java.time.ZonedDateTime;
 
 public class CaptureConfirmedByGatewayNotification extends PaymentEventWithoutDetails {
-    public CaptureConfirmedByGatewayNotification(String resourceExternalId, ZonedDateTime timestamp) {
-        super(resourceExternalId, timestamp);
+    public CaptureConfirmedByGatewayNotification(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
@@ -30,7 +30,15 @@ public class PaymentEvent extends Event {
     public ResourceType getResourceType() {
         return ResourceType.PAYMENT;
     }
-    
+
+    public boolean isLive() {
+        return live;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
     @Override
     public String toString() {
         return "PaymentEvent{" +

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEventWithoutDetails.java
@@ -5,9 +5,7 @@ import uk.gov.pay.connector.events.eventdetails.EmptyEventDetails;
 import java.time.ZonedDateTime;
 
 public class PaymentEventWithoutDetails extends PaymentEvent {
-    public PaymentEventWithoutDetails(String resourceExternalId, ZonedDateTime timestamp) {
-        super(resourceExternalId, new EmptyEventDetails(), timestamp);
-    }
+
     public PaymentEventWithoutDetails(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
         super(serviceId, live, resourceExternalId, new EmptyEventDetails(), timestamp);
         

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdated.java
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime;
 
 public class RefundAvailabilityUpdated extends PaymentEvent {
 
-    public RefundAvailabilityUpdated(String resourceExternalId, RefundAvailabilityUpdatedEventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
+    public RefundAvailabilityUpdated(String serviceId, boolean live, String resourceExternalId, RefundAvailabilityUpdatedEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
@@ -25,6 +25,14 @@ public class PayoutEvent extends Event {
         return ResourceType.PAYOUT;
     }
 
+    public boolean isLive() {
+        return live;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
     @Override
     public String toString() {
         return "PayoutEvent{" +

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
@@ -35,4 +35,12 @@ public abstract class RefundEvent extends Event {
     public String getParentResourceExternalId() {
         return parentResourceExternalId;
     }
+
+    public boolean isLive() {
+        return live;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -96,7 +96,7 @@ public class ChargeNotificationProcessor {
                 kv(GATEWAY_ACCOUNT_ID, gatewayAccount.getId()),
                 kv(PROVIDER, charge.getPaymentGatewayName()));
         
-        Event event = new CaptureConfirmedByGatewayNotification(charge.getExternalId(), ZonedDateTime.now());
+        Event event = new CaptureConfirmedByGatewayNotification(charge.getServiceId(), charge.isLive(), charge.getExternalId(), ZonedDateTime.now());
         eventService.emitEvent(event);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -61,7 +61,7 @@ public class ChargeEntityFixture {
     private boolean moto;
     private Exemption3ds exemption3ds;
     private String paymentProvider = "sandbox";
-    private String serviceId = null;
+    private String serviceId;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -155,6 +155,7 @@ public class ChargeEntityFixture {
         chargeEntity.setWalletType(walletType);
         chargeEntity.setExemption3ds(exemption3ds);
         chargeEntity.setPaymentProvider(paymentProvider);
+        chargeEntity.setServiceId(serviceId);
 
         if (this.fee != null) {
             FeeEntity fee = new FeeEntity(chargeEntity, this.fee);

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceFindTest.java
@@ -283,6 +283,7 @@ public class ChargeServiceFindTest extends ChargeServiceTest {
         transaction.setAmount(chargeEntity.getAmount());
         transaction.setCreatedDate(Instant.now().toString());
         transaction.setGatewayAccountId(String.valueOf(GATEWAY_ACCOUNT_ID));
+        transaction.setLive(true);
         when(mockedChargeDao.findByExternalIdAndGatewayAccount(chargeEntity.getExternalId(), GATEWAY_ACCOUNT_ID)).thenReturn(Optional.empty());
 
         when(ledgerService.getTransactionForGatewayAccount(chargeEntity.getExternalId(), GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(transaction));
@@ -324,6 +325,7 @@ public class ChargeServiceFindTest extends ChargeServiceTest {
         transaction.setAmount(chargeEntity.getAmount());
         transaction.setCreatedDate(Instant.now().toString());
         transaction.setGatewayAccountId(String.valueOf(GATEWAY_ACCOUNT_ID));
+        transaction.setLive(true);
         when(mockedChargeDao.findByProviderAndTransactionId(
                 "sandbox",
                 chargeEntity.getExternalId()

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentCreatedTest.java
@@ -80,6 +80,17 @@ public class PaymentCreatedTest {
         assertThat(paymentCreatedEvent, hasJsonPath("$.event_details.email", equalTo("test@email.gov.uk")));
     }
 
+    @Test
+    void serializesPayloadWithServiceId() throws JsonProcessingException {
+        chargeEntityFixture
+                .withServiceId("test-service-id");
+
+        var paymentCreatedEvent = preparePaymentCreatedEvent();
+
+        assertBasePaymentCreatedDetails(paymentCreatedEvent);
+        assertThat(paymentCreatedEvent, hasJsonPath("$.service_id", equalTo("test-service-id")));
+    }
+
     @ParameterizedTest
     @MethodSource("eventStatusesForNonCreatedAndNonAuthWithCardDetails")
     public void serializesPayloadForNonCreatedWithCardDetails(ChargeStatus status) throws JsonProcessingException {

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/RefundAvailabilityUpdatedTest.java
@@ -25,6 +25,8 @@ public class RefundAvailabilityUpdatedTest {
         ChargeEntity charge = chargeEntity.build();
         
         String event = new RefundAvailabilityUpdated(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
                 charge.getExternalId(),
                 RefundAvailabilityUpdatedEventDetails.from(Charge.from(charge), List.of(), ExternalChargeRefundAvailability.EXTERNAL_FULL),
                 ZonedDateTime.now()

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -363,6 +363,8 @@ public class EventFactoryTest {
         transaction.setTotalAmount(charge.getAmount());
         transaction.setCreatedDate(Instant.now().toString());
         transaction.setGatewayAccountId(charge.getGatewayAccount().getId().toString());
+        transaction.setServiceId(charge.getServiceId());
+        transaction.setLive(charge.getGatewayAccount().isLive());
         when(chargeService.findCharge(transaction.getTransactionId())).thenReturn(Optional.of(Charge.from(transaction)));
 
         RefundHistory refundErrorHistory = RefundHistoryEntityFixture.aValidRefundHistoryEntity()

--- a/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/epdq/EpdqNotificationServiceStatusMapperTest.java
@@ -244,6 +244,6 @@ class EpdqNotificationServiceStatusMapperTest extends EpdqNotificationServiceTes
     private Charge getCharge(boolean isHistoric){
         return new Charge("external-id", 10L, null, null, "transaction-id",
                 "credential-external-id", 10L, null, "ref-1", "desc", Instant.now(),
-                "test@example.org", 123L, "epdq", isHistoric);
+                "test@example.org", 123L, "epdq", isHistoric, "service-id", true);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -70,6 +70,8 @@ public class ChargingITestBase {
     protected static final String EMAIL = randomAlphabetic(242) + "@example.com";
     protected static final long AMOUNT = 6234L;
 
+    protected static final String SERVICE_ID = "external-service-id";
+
     protected WorldpayMockClient worldpayMockClient;
     protected SmartpayMockClient smartpayMockClient;
     protected EpdqMockClient epdqMockClient;
@@ -125,6 +127,7 @@ public class ChargingITestBase {
                 .withPaymentProvider(getPaymentProvider())
                 .withGatewayAccountCredentials(List.of(credentialParams))
                 .withCredentials(credentials)
+                .withServiceId(SERVICE_ID)
                 .insert();
         connectorRestApiClient = new RestAssuredClient(testContext.getPort(), accountId);
     }
@@ -371,6 +374,7 @@ public class ChargingITestBase {
                 .withChargeId(chargeId)
                 .withExternalChargeId(externalChargeId)
                 .withGatewayAccountId(accountId)
+                .withServiceId(SERVICE_ID)
                 .withAmount(AMOUNT)
                 .withPaymentProvider(paymentProvider)
                 .withStatus(chargeStatus)

--- a/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
@@ -125,6 +125,8 @@ public class StateTransitionsIT extends ChargingITestBase {
                 .filter(m -> "REFUND_AVAILABILITY_UPDATED".equals(m.get("event_type").getAsString()))
                 .findFirst().get();
         assertThat(message2.get("event_type").getAsString(), is("REFUND_AVAILABILITY_UPDATED"));
+        assertThat(message2.get("service_id").getAsString(), is("external-service-id"));
+        assertThat(message2.get("live").getAsBoolean(), is(false));
         assertThat(message2.get("resource_external_id").getAsString(), is(chargeId));
         assertThat(message2.get("event_details").getAsJsonObject().get("refund_amount_available").getAsInt(), is(6184));
         assertThat(message2.get("event_details").getAsJsonObject().get("refund_amount_refunded").getAsInt(), is(50));

--- a/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
@@ -75,6 +75,8 @@ public class StateTransitionsIT extends ChargingITestBase {
 
         assertThat(cancelledMessage.get("resource_external_id").getAsString(), is(chargeId));
         assertThat(cancelledMessage.get("event_type").getAsString(), is("CANCELLED_BY_EXTERNAL_SERVICE"));
+        assertThat(cancelledMessage.get("service_id").getAsString(), is("external-service-id"));
+        assertThat(cancelledMessage.get("live").getAsBoolean(), is(false));
 
         Optional<JsonObject> refundMessage = messages.stream()
                 .map(m -> new JsonParser().parse(m.getBody()).getAsJsonObject())

--- a/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/DefaultExternalRefundAvailabilityCalculatorTest.java
@@ -156,6 +156,6 @@ public class DefaultExternalRefundAvailabilityCalculatorTest {
     private Charge getHistoricCharge(ExternalChargeRefundAvailability availability) {
         return new Charge("external-id", 500L, null, "success", "transaction-id",
                 "credentials_external_id", 0L, availability.getStatus(), "ref-1", "desc", Instant.now(),
-                "test@example.org", 123L, "epdq", true);
+                "test@example.org", 123L, "epdq", true, "service-id", true);
     }
 }

--- a/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/service/RefundServiceTest.java
@@ -194,6 +194,7 @@ public class RefundServiceTest {
         transaction.setGatewayAccountId(String.valueOf(accountId));
         transaction.setCreatedDate(Instant.now().toString());
         transaction.setPaymentProvider(WORLDPAY.getName());
+        transaction.setLive(true);
         Charge charge = Charge.from(transaction);
 
         RefundEntity refundEntity = aValidRefundEntity().withChargeExternalId(externalChargeId).withAmount(refundAmount).build();

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -36,6 +36,7 @@ public class AddChargeParams {
     private final CardType cardType;
     private final ZonedDateTime parityCheckDate;
     private final Long gatewayCredentialId;
+    private final String serviceId;
 
     private AddChargeParams(AddChargeParamsBuilder builder) {
         chargeId = builder.chargeId;
@@ -60,6 +61,7 @@ public class AddChargeParams {
         parityCheckDate = builder.parityCheckDate;
         cardType = builder.cardType;
         gatewayCredentialId = builder.gatewayCredentialId;
+        serviceId = builder.serviceId;
     }
 
     public Long getChargeId() {
@@ -150,6 +152,10 @@ public class AddChargeParams {
         return gatewayCredentialId;
     }
 
+    public String getServiceId() {
+        return serviceId;
+    }
+
     public static final class AddChargeParamsBuilder {
         private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
@@ -173,6 +179,7 @@ public class AddChargeParams {
         private CardType cardType;
         private ZonedDateTime parityCheckDate;
         private Long gatewayCredentialId;
+        private String serviceId;
 
         private AddChargeParamsBuilder() {
         }
@@ -183,6 +190,11 @@ public class AddChargeParams {
 
         public AddChargeParamsBuilder withChargeId(Long chargeId) {
             this.chargeId = chargeId;
+            return this;
+        }
+
+        public AddChargeParamsBuilder withServiceId(String serviceId) {
+            this.serviceId = serviceId;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -102,12 +102,12 @@ public class DatabaseTestHelper {
                         "status, gateway_account_id, return_url, gateway_transaction_id, " +
                         "description, created_date, reference, version, email, language, " +
                         "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
-                        "external_metadata, card_type, payment_provider, gateway_account_credential_id) " +
+                        "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id) " +
                         "VALUES(:id, :external_id, :amount, " +
                         ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                         ":description, :created_date, :reference, :version, :email, :language, " +
                         ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
-                        ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id)")
+                        ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())
@@ -129,6 +129,7 @@ public class DatabaseTestHelper {
                         .bind("card_type", addChargeParams.getCardType())
                         .bind("payment_provider", addChargeParams.getPaymentProvider())
                         .bind("gateway_account_credential_id", addChargeParams.getGatewayCredentialId())
+                        .bind("service_id", addChargeParams.getServiceId())
                         .execute());
     }
 


### PR DESCRIPTION
## WHAT YOU DID
Follow up to #3206 adding `serviceId` and `live` fields to Charge model. Remove some constructors which are no longer needed as we can use these fields from the model. 

## How to test

Code should compile
Tests should make sense

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
