### PR TITLE
PP-8441: Add `serviceId` & `isLive` to top-level of Refund events 

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -116,7 +116,7 @@ public class EventFactory {
         Charge charge = chargeService.findCharge(refundHistory.getChargeExternalId()).get();
 
         Event refundEvent = createRefundEvent(refundHistory, refundStateTransition.getStateTransitionEventClass(),
-                charge.getGatewayAccountId());
+                charge);
         Optional<Event> refundAvailabilityEvent = createRefundAvailabilityUpdatedEvent(
                 charge,
                 refundHistory.getHistoryStartDate(),
@@ -160,14 +160,16 @@ public class EventFactory {
         }
     }
 
-    public static Event createRefundEvent(RefundHistory refundHistory, Class<? extends RefundEvent> eventClass, Long gatewayAccountId) {
+    public static Event createRefundEvent(RefundHistory refundHistory, Class<? extends RefundEvent> eventClass, Charge charge) {
         try {
             if (eventClass == RefundCreatedByService.class) {
-                return RefundCreatedByService.from(refundHistory, gatewayAccountId);
+                return RefundCreatedByService.from(refundHistory, charge);
             } else if (eventClass == RefundCreatedByUser.class) {
-                return RefundCreatedByUser.from(refundHistory, gatewayAccountId);
+                return RefundCreatedByUser.from(refundHistory, charge);
             } else {
-                return eventClass.getConstructor(String.class, String.class, RefundEventWithGatewayTransactionIdDetails.class, ZonedDateTime.class).newInstance(
+                return eventClass.getConstructor(String.class, boolean.class, String.class, String.class, RefundEventWithGatewayTransactionIdDetails.class, ZonedDateTime.class).newInstance(
+                        charge.getServiceId(),
+                        charge.isLive(),
                         refundHistory.getExternalId(),
                         refundHistory.getChargeExternalId(),
                         new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
@@ -7,12 +7,14 @@ import java.time.ZonedDateTime;
 
 public class RefundCreatedByService extends RefundEvent {
 
-    private RefundCreatedByService(String resourceExternalId, String parentResourceExternalId, RefundCreatedByServiceEventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+    private RefundCreatedByService(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId, RefundCreatedByServiceEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundCreatedByService from(RefundHistory refundHistory, Long gatewayAccountId) {
         return new RefundCreatedByService(
+                refundHistory.getServiceId(),
+                refundHistory.isLive(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundCreatedByServiceEventDetails(

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByService.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByServiceEventDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
@@ -11,15 +12,15 @@ public class RefundCreatedByService extends RefundEvent {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
-    public static RefundCreatedByService from(RefundHistory refundHistory, Long gatewayAccountId) {
+    public static RefundCreatedByService from(RefundHistory refundHistory, Charge charge) {
         return new RefundCreatedByService(
-                refundHistory.getServiceId(),
-                refundHistory.isLive(),
+                charge.getServiceId(),
+                charge.isLive(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundCreatedByServiceEventDetails(
                         refundHistory.getAmount(),
-                        gatewayAccountId.toString()),
+                        charge.getGatewayAccountId().toString()),
                 refundHistory.getHistoryStartDate()
         );
 

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundCreatedByUserEventDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
@@ -11,16 +12,16 @@ public class RefundCreatedByUser extends RefundEvent {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
-    public static RefundCreatedByUser from(RefundHistory refundHistory, Long gatewayAccountId) {
+    public static RefundCreatedByUser from(RefundHistory refundHistory, Charge charge) {
         return new RefundCreatedByUser(
-                refundHistory.getServiceId(),
-                refundHistory.isLive(),
+                charge.getServiceId(),
+                charge.isLive(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundCreatedByUserEventDetails(
                         refundHistory.getAmount(),
                         refundHistory.getUserExternalId(),
-                        gatewayAccountId.toString(),
+                        charge.getGatewayAccountId().toString(),
                         refundHistory.getUserEmail()),
                 refundHistory.getHistoryStartDate());
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByUser.java
@@ -7,12 +7,14 @@ import java.time.ZonedDateTime;
 
 public class RefundCreatedByUser extends RefundEvent {
 
-    private RefundCreatedByUser(String resourceExternalId, String parentResourceExternalId, RefundCreatedByUserEventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
+    private RefundCreatedByUser(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId, RefundCreatedByUserEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, parentResourceExternalId, eventDetails, timestamp);
     }
 
     public static RefundCreatedByUser from(RefundHistory refundHistory, Long gatewayAccountId) {
         return new RefundCreatedByUser(
+                refundHistory.getServiceId(),
+                refundHistory.isLive(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundCreatedByUserEventDetails(

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
@@ -12,10 +13,10 @@ public class RefundError extends RefundEvent {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
-    public RefundError from(RefundHistory refundHistory) {
+    public RefundError from(RefundHistory refundHistory, Charge charge) {
         return new RefundError(
-                refundHistory.getServiceId(),
-                refundHistory.isLive(),
+                charge.getServiceId(),
+                charge.isLive(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundError.java
@@ -7,13 +7,16 @@ import java.time.ZonedDateTime;
 
 public class RefundError extends RefundEvent {
 
-    public RefundError(String resourceExternalId, String parentResourceExternalId,
+    public RefundError(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
                        RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public RefundError from(RefundHistory refundHistory) {
-        return new RefundError(refundHistory.getExternalId(),
+        return new RefundError(
+                refundHistory.getServiceId(),
+                refundHistory.isLive(),
+                refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
                 refundHistory.getHistoryStartDate());

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
@@ -18,11 +18,6 @@ public abstract class RefundEvent extends Event {
         this.live = live;
     }
     
-    public RefundEvent(String resourceExternalId, String parentResourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, eventDetails, timestamp);
-        this.parentResourceExternalId = parentResourceExternalId;
-    }
-
     public RefundEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
     }

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -7,13 +7,16 @@ import java.time.ZonedDateTime;
 
 public class RefundSubmitted extends RefundEvent {
 
-    public RefundSubmitted(String resourceExternalId, String parentResourceExternalId,
+    public RefundSubmitted(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSubmitted from(RefundHistory refundHistory) {
-        return new RefundSubmitted(refundHistory.getExternalId(),
+        return new RefundSubmitted(
+                refundHistory.getServiceId(),
+                refundHistory.isLive(),
+                refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
                 refundHistory.getHistoryStartDate());

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSubmitted.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
@@ -12,10 +13,10 @@ public class RefundSubmitted extends RefundEvent {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
-    public static RefundSubmitted from(RefundHistory refundHistory) {
+    public static RefundSubmitted from(Charge charge, RefundHistory refundHistory) {
         return new RefundSubmitted(
-                refundHistory.getServiceId(),
-                refundHistory.isLive(),
+                charge.getServiceId(),
+                charge.isLive(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -7,13 +7,15 @@ import java.time.ZonedDateTime;
 
 public class RefundSucceeded extends RefundEvent {
 
-    public RefundSucceeded(String resourceExternalId, String parentResourceExternalId,
+    public RefundSucceeded(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId,
                            RefundEventWithGatewayTransactionIdDetails referenceDetails, ZonedDateTime timestamp) {
-        super(resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
+        super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
     public static RefundSucceeded from(RefundHistory refundHistory) {
-        return new RefundSucceeded(refundHistory.getExternalId(),
+        return new RefundSucceeded(refundHistory.getServiceId(),
+                refundHistory.isLive(),
+                refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),
                 refundHistory.getHistoryStartDate());

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundSucceeded.java
@@ -1,5 +1,6 @@
 package uk.gov.pay.connector.events.model.refund;
 
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.events.eventdetails.refund.RefundEventWithGatewayTransactionIdDetails;
 import uk.gov.pay.connector.refund.model.domain.RefundHistory;
 
@@ -12,9 +13,9 @@ public class RefundSucceeded extends RefundEvent {
         super(serviceId, live, resourceExternalId, parentResourceExternalId, referenceDetails, timestamp);
     }
 
-    public static RefundSucceeded from(RefundHistory refundHistory) {
-        return new RefundSucceeded(refundHistory.getServiceId(),
-                refundHistory.isLive(),
+    public static RefundSucceeded from(Charge charge, RefundHistory refundHistory) {
+        return new RefundSucceeded(charge.getServiceId(),
+                charge.isLive(),
                 refundHistory.getExternalId(),
                 refundHistory.getChargeExternalId(),
                 new RefundEventWithGatewayTransactionIdDetails(refundHistory.getGatewayTransactionId()),

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -64,10 +64,6 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     @Column(name = "external_id")
     private String externalId;
-    
-    private String serviceId;
-    
-    private boolean live;
 
     private Long amount;
 
@@ -108,20 +104,10 @@ public class RefundEntity extends AbstractVersionedEntity {
         this.userExternalId = userExternalId;
         this.userEmail = userEmail;
         this.chargeExternalId = chargeExternalId;
-        this.serviceId = serviceId;
-        this.live = live;
     }
 
     public String getExternalId() {
         return externalId;
-    }
-
-    public String getServiceId() {
-        return serviceId;
-    }
-
-    public boolean isLive() {
-        return live;
     }
     
     public String getGatewayTransactionId() { 

--- a/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
+++ b/src/main/java/uk/gov/pay/connector/refund/model/domain/RefundEntity.java
@@ -64,6 +64,10 @@ public class RefundEntity extends AbstractVersionedEntity {
 
     @Column(name = "external_id")
     private String externalId;
+    
+    private String serviceId;
+    
+    private boolean live;
 
     private Long amount;
 
@@ -104,10 +108,20 @@ public class RefundEntity extends AbstractVersionedEntity {
         this.userExternalId = userExternalId;
         this.userEmail = userEmail;
         this.chargeExternalId = chargeExternalId;
+        this.serviceId = serviceId;
+        this.live = live;
     }
 
     public String getExternalId() {
         return externalId;
+    }
+
+    public String getServiceId() {
+        return serviceId;
+    }
+
+    public boolean isLive() {
+        return live;
     }
     
     public String getGatewayTransactionId() { 

--- a/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
+++ b/src/main/java/uk/gov/pay/connector/tasks/HistoricalEventEmitter.java
@@ -131,7 +131,7 @@ public class HistoricalEventEmitter {
         Charge charge = chargeService.findCharge(refundHistory.getChargeExternalId())
                 .orElseThrow(() -> new ChargeNotFoundRuntimeException(refundHistory.getChargeExternalId()));
         Event event = EventFactory.createRefundEvent(refundHistory, refundEventClass,
-                charge.getGatewayAccountId());
+                charge);
 
         if (shouldForceEmission) {
             emitRefundEvent(refundHistory, refundEventClass, event);

--- a/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/events/dao/EmittedEventDaoIT.java
@@ -213,7 +213,7 @@ public class EmittedEventDaoIT extends DaoITestBase {
     }
 
     private RefundSubmitted aRefundSubmittedEvent(ZonedDateTime eventTimestamp) {
-        return new RefundSubmitted("my-resource-external-id",
+        return new RefundSubmitted("service-id", true, "my-resource-external-id",
                 "parent-external-id",
                 null, eventTimestamp);
     }

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundCreatedByServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.pay.connector.events.model.refund;
 
 import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
@@ -15,8 +16,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RefundCreatedByServiceTest {
 
-    private final ChargeEntity charge = ChargeEntityFixture.aValidChargeEntity()
+    private final ChargeEntity chargeEntity = ChargeEntityFixture.aValidChargeEntity()
             .withGatewayAccountEntity(ChargeEntityFixture.defaultGatewayAccountEntity()).build();
+    private final Charge charge = Charge.from(chargeEntity);
     private ZonedDateTime createdDate = ZonedDateTime.now().minusSeconds(5L);
     private UTCDateTimeConverter timeConverter = new UTCDateTimeConverter();
 
@@ -24,20 +26,20 @@ public class RefundCreatedByServiceTest {
             timeConverter.convertToDatabaseColumn(createdDate), 1L,
             timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(1L)),
             timeConverter.convertToDatabaseColumn(createdDate.plusSeconds(2L)),
-            null, "gateway_transaction_id", charge.getExternalId(),
+            null, "gateway_transaction_id", chargeEntity.getExternalId(),
             null);
 
     @Test
     public void serializesEventDetailsGivenRefund() {
         RefundCreatedByService refundCreatedByService = RefundCreatedByService
-                .from(refundHistory, charge.getGatewayAccount().getId());
+                .from(refundHistory, charge);
 
-        assertThat(refundCreatedByService.getParentResourceExternalId(), is(charge.getExternalId()));
+        assertThat(refundCreatedByService.getParentResourceExternalId(), is(chargeEntity.getExternalId()));
         assertThat(refundCreatedByService.getResourceExternalId(), is("external_id"));
 
         RefundCreatedByServiceEventDetails details = (RefundCreatedByServiceEventDetails) refundCreatedByService.getEventDetails();
 
         assertThat(details.getAmount(), is(50L));
-        assertThat(details.getGatewayAccountId(), is(charge.getGatewayAccount().getId().toString()));
+        assertThat(details.getGatewayAccountId(), is(chargeEntity.getGatewayAccount().getId().toString()));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/events/StateTransitionsIT.java
@@ -117,6 +117,8 @@ public class StateTransitionsIT extends ChargingITestBase {
                 .findFirst().get();
         assertThat(message1.get("event_type").getAsString(), is("REFUND_CREATED_BY_SERVICE"));
         assertThat(message1.get("resource_external_id").getAsString(), is(refundId));
+        assertThat(message1.get("service_id").getAsString(), is("external-service-id"));
+        assertThat(message1.get("live").getAsBoolean(), is(false));
         assertThat(message1.get("parent_resource_external_id").getAsString(), is(chargeId));
         assertThat(message1.get("event_details").getAsJsonObject().get("amount").getAsInt(), is(50));
 
@@ -138,6 +140,8 @@ public class StateTransitionsIT extends ChargingITestBase {
                 .findFirst().get();
         assertThat(message3.get("event_type").getAsString(), is("REFUND_SUBMITTED"));
         assertThat(message3.get("resource_external_id").getAsString(), is(refundId));
+        assertThat(message3.get("service_id").getAsString(), is("external-service-id"));
+        assertThat(message3.get("live").getAsBoolean(), is(false));
 
         JsonObject message4 = messages.stream()
                 .map(m -> new JsonParser().parse(m.getBody()).getAsJsonObject())
@@ -147,6 +151,8 @@ public class StateTransitionsIT extends ChargingITestBase {
         assertThat(message4.get("event_type").getAsString(), is("REFUND_SUCCEEDED"));
         assertThat(message4.get("resource_external_id").getAsString(), is(refundId));
         assertThat(message4.get("event_details").getAsJsonObject().get("gateway_transaction_id").getAsString(), is(notNullValue()));
+        assertThat(message4.get("service_id").getAsString(), is("external-service-id"));
+        assertThat(message4.get("live").getAsBoolean(), is(false));
     }
 
     private ZonedDateTime getTimestampFromMessage(Message message) {

--- a/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/StateTransitionServiceTest.java
@@ -10,6 +10,9 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.events.EventService;
@@ -36,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_READY;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.ENTERING_CARD_DETAILS;
 import static uk.gov.pay.connector.events.model.ResourceType.PAYMENT;
@@ -131,7 +135,8 @@ public class StateTransitionServiceTest {
         RefundHistory refundHistory = aValidRefundHistoryEntity()
                 .withExternalId("external-id")
                 .build();
-        RefundCreatedByUser refundCreatedByUser = RefundCreatedByUser.from(refundHistory, 1L);
+        ChargeEntity chargeEntity = aValidChargeEntity().build();
+        RefundCreatedByUser refundCreatedByUser = RefundCreatedByUser.from(refundHistory, Charge.from(chargeEntity) );
         ZonedDateTime doNotEmitRetryUntil = now(UTC);
 
         stateTransitionService.offerStateTransition(refundStateTransition, refundCreatedByUser, doNotEmitRetryUntil);


### PR DESCRIPTION
## WHAT YOU DID
Follow-up to #3225 which adds the `isLive` and `serviceId` fields to Refund models using data from the Charge.

Will require corresponding Pact changes.

## How to test

- How should it be reviewed? 

Check code makes sense.
Check fields are exposed in Events once deployed to testing environment.

- What feedback do you need? 
- If manual testing is needed, give suggested testing steps.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
