### PR TITLE
PP-8440 Set default service id on charge fixture

### DIFF
--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType.TEST;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.CREATED;
 import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
 
 public class ChargeEntityFixture {
 
@@ -61,7 +62,7 @@ public class ChargeEntityFixture {
     private boolean moto;
     private Exemption3ds exemption3ds;
     private String paymentProvider = "sandbox";
-    private String serviceId;
+    private String serviceId = randomUuid();
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();


### PR DESCRIPTION
Since we now expect this to be set on Charge creation, seems ok to set a default value in fixture. Also has happy side effect of making all the pacts correct.
