### PR TITLE
PP-8628 Send capture success details for forced capture event

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/EventFactory.java
@@ -146,6 +146,8 @@ public class EventFactory {
                 return GatewayRequires3dsAuthorisation.from(chargeEvent);
             } else if (eventClass == BackfillerRecreatedUserEmailCollected.class) {
                 return BackfillerRecreatedUserEmailCollected.from(chargeEvent.getChargeEntity());
+            } else if (eventClass == StatusCorrectedToCapturedToMatchGatewayStatus.class) {
+                return StatusCorrectedToCapturedToMatchGatewayStatus.from(chargeEvent);
             } else {
                 return eventClass.getConstructor(String.class,
                         boolean.class, String.class, ZonedDateTime.class).newInstance(

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/StatusCorrectedToCapturedToMatchGatewayStatus.java
@@ -1,9 +1,25 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
+import uk.gov.pay.connector.events.eventdetails.charge.CaptureConfirmedEventDetails;
+
 import java.time.ZonedDateTime;
 
-public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEventWithoutDetails {
-    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, ZonedDateTime timestamp) {
-        super(serviceId, live, resourceExternalId, timestamp);
+public class StatusCorrectedToCapturedToMatchGatewayStatus extends PaymentEvent {
+    public StatusCorrectedToCapturedToMatchGatewayStatus(String serviceId, boolean live, String resourceExternalId, CaptureConfirmedEventDetails eventDetails, ZonedDateTime timestamp) {
+        super(serviceId, live, resourceExternalId, eventDetails, timestamp);
+    }
+    
+    public static StatusCorrectedToCapturedToMatchGatewayStatus from(ChargeEventEntity chargeEvent) {
+        ChargeEntity charge = chargeEvent.getChargeEntity();
+        
+        return new StatusCorrectedToCapturedToMatchGatewayStatus(
+                charge.getServiceId(),
+                charge.getGatewayAccount().isLive(),
+                charge.getExternalId(),
+                CaptureConfirmedEventDetails.from(chargeEvent),
+                chargeEvent.getUpdated()
+        );
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/processor/ChargeNotificationProcessor.java
@@ -49,7 +49,7 @@ public class ChargeNotificationProcessor {
         try {
             chargeService.transitionChargeState(chargeEntity, newStatus, gatewayEventDate);
         } catch (InvalidStateTransitionException e) {
-            if (!forceTransitionChargeState(gatewayAccount, gatewayTransactionId, chargeEntity, oldStatus, newStatus)) {
+            if (!forceTransitionChargeState(gatewayAccount, gatewayTransactionId, chargeEntity, oldStatus, newStatus, gatewayEventDate)) {
                 return;
             }
         } catch (OptimisticLockException e) {
@@ -77,9 +77,9 @@ public class ChargeNotificationProcessor {
 
     }
     
-    private boolean forceTransitionChargeState(GatewayAccountEntity gatewayAccount, String gatewayTransactionId, ChargeEntity chargeEntity, String oldStatus, ChargeStatus newStatus) {
+    private boolean forceTransitionChargeState(GatewayAccountEntity gatewayAccount, String gatewayTransactionId, ChargeEntity chargeEntity, String oldStatus, ChargeStatus newStatus, ZonedDateTime gatewayEventDate) {
         try {
-            chargeService.forceTransitionChargeState(chargeEntity, newStatus);
+            chargeService.forceTransitionChargeState(chargeEntity, newStatus, gatewayEventDate);
             return true;
         } catch (InvalidForceStateTransitionException ie) {
             logger.error(format("%s (%s) notification '%s' could not force transition from %s to %s",

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/EventFactoryTest.java
@@ -54,6 +54,7 @@ import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentExpired;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
 import uk.gov.pay.connector.events.model.charge.RefundAvailabilityUpdated;
+import uk.gov.pay.connector.events.model.charge.StatusCorrectedToCapturedToMatchGatewayStatus;
 import uk.gov.pay.connector.events.model.charge.UnexpectedGatewayErrorDuringAuthorisation;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;
 import uk.gov.pay.connector.gateway.PaymentProvider;
@@ -324,6 +325,7 @@ public class EventFactoryTest {
                 new Object[]{CaptureConfirmed.class, CaptureConfirmedEventDetails.class},
                 new Object[]{CaptureErrored.class, EmptyEventDetails.class},
                 new Object[]{PaymentExpired.class, EmptyEventDetails.class},
+                new Object[]{StatusCorrectedToCapturedToMatchGatewayStatus.class, CaptureConfirmedEventDetails.class}
         };
     }
 

--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -36,6 +36,7 @@ import uk.gov.pay.connector.events.model.charge.PaymentCreated;
 import uk.gov.pay.connector.events.model.charge.PaymentDetailsEntered;
 import uk.gov.pay.connector.events.model.charge.PaymentIncludedInPayout;
 import uk.gov.pay.connector.events.model.charge.PaymentNotificationCreated;
+import uk.gov.pay.connector.events.model.charge.StatusCorrectedToCapturedToMatchGatewayStatus;
 import uk.gov.pay.connector.events.model.charge.UserEmailCollected;
 import uk.gov.pay.connector.events.model.payout.PayoutCreated;
 import uk.gov.pay.connector.events.model.payout.PayoutFailed;
@@ -349,5 +350,23 @@ public class QueueMessageContractTest {
                 ZonedDateTime.now());
 
         return gatewayRequires3dsAuthorisation.toJsonString();
+    }
+
+    @PactVerifyProvider("a status corrected to captured event")
+    public String verifyStatusCorrectedToCapturedToMatchGatewayStatusEvent() throws JsonProcessingException {
+        ChargeEventEntity chargeEventEntity = ChargeEventEntityFixture
+                .aValidChargeEventEntity()
+                .withGatewayEventDate(ZonedDateTime.now())
+                .build();
+
+        StatusCorrectedToCapturedToMatchGatewayStatus event = new StatusCorrectedToCapturedToMatchGatewayStatus(
+                chargeEventEntity.getChargeEntity().getServiceId(),
+                chargeEventEntity.getChargeEntity().getGatewayAccount().isLive(),
+                resourceId,
+                CaptureConfirmedEventDetails.from(chargeEventEntity),
+                ZonedDateTime.now()
+        );
+
+        return event.toJsonString();
     }
 }


### PR DESCRIPTION
When we receive a capture success notification, but the charge is in an unexpected state, we ignore the current state and update the status to captured and emit an event to ledger to do this.

However, this event did not include the capture details such as the captured date. We were also not storing the gateway_event_date for the event in connector so the capture event was derived from the updated date for the event rather than the date from the notification.

Fix both this by storing the gateway_event_date and attaching the same event details we attach for the standard CAPTURE_CONFIRMED event to the STATUS_CORRECTED_TO_CAPTURED_TO_MATCH_GATEWAY_STATUS event.