### PR TITLE
PP-8695: Remove Jenkins ECS deploys step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,13 +122,12 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
+    stage('Check Pact Compatibility') {
       when {
         branch 'master'
       }
       steps {
         checkPactCompatibility("connector", gitCommit(), "test")
-        deployEcs("connector")
       }
     }
     stage('Smoke Tests') {


### PR DESCRIPTION
Jenkins doesn't deploy to ECS now and we have now removed the old EC2 based
services so the deploy step is no longer required.