### PR TITLE
PP-8628 Parity check authorisation summary

### DIFF
--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/AuthorisationSummary.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/AuthorisationSummary.java
@@ -1,0 +1,20 @@
+package uk.gov.pay.connector.client.ledger.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthorisationSummary {
+    @JsonProperty("three_d_secure")
+    private ThreeDSecure threeDSecure;
+
+    public ThreeDSecure getThreeDSecure() {
+        return threeDSecure;
+    }
+
+    public void setThreeDSecure(ThreeDSecure threeDSecure) {
+        this.threeDSecure = threeDSecure;
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/LedgerTransaction.java
@@ -50,6 +50,7 @@ public class LedgerTransaction {
     private String refundedByUserEmail;
     private String parentTransactionId;
     private String serviceId;
+    private AuthorisationSummary authorisationSummary;
 
     public LedgerTransaction() {
 
@@ -296,4 +297,12 @@ public class LedgerTransaction {
     }
 
     public String getServiceId() { return serviceId; }
+
+    public AuthorisationSummary getAuthorisationSummary() {
+        return authorisationSummary;
+    }
+
+    public void setAuthorisationSummary(AuthorisationSummary authorisationSummary) {
+        this.authorisationSummary = authorisationSummary;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/client/ledger/model/ThreeDSecure.java
+++ b/src/main/java/uk/gov/pay/connector/client/ledger/model/ThreeDSecure.java
@@ -1,0 +1,31 @@
+package uk.gov.pay.connector.client.ledger.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ThreeDSecure {
+    private boolean required;
+    
+    private String version;
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}


### PR DESCRIPTION
Parity check the `authorisation_summary.three_d_secure.required` and `authorisation_summary.three_d_secure.version` fields with ledger.

Do not parity check payments created before 1st September 2021 as some non-expunged charges still exist in connector and these have not been backfilled with the authorisation_summary in ledger.