### PR TITLE
bau: Fix failing CI build

### DIFF
--- a/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/QueueMessageContractTest.java
@@ -65,7 +65,7 @@ import static uk.gov.service.payments.commons.model.Source.CARD_EXTERNAL_TELEPHO
 
 @RunWith(PactRunner.class)
 @Provider("connector")
-@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}"},
+@PactBroker(scheme = "https", host = "${PACT_BROKER_HOST:pact-broker-test.cloudapps.digital}", tags = {"${PACT_CONSUMER_TAG}", "test"},
         authentication = @PactBrokerAuth(username = "${PACT_BROKER_USERNAME}", password = "${PACT_BROKER_PASSWORD}"),
         consumers = {"ledger"})
 @IgnoreNoPactsToVerify


### PR DESCRIPTION
Currently ledger builds are failing on

```
10:08:53  + pact-broker can-i-deploy --pacticipant ledger --version e389e12a3a0640e7b900a668b26516f575b092b4 --to test --broker-base-url https://pact-broker-test.cloudapps.digital/ -u **** -p ****
10:08:53  Computer says no ¯\_(ツ)_/¯
10:08:53
10:08:53  CONSUMER    | C.VERSION                      | PROVIDER  | P.VERSION                      | SUCCESS? | RESULT#
10:08:53  ------------|--------------------------------|-----------|--------------------------------|----------|--------
10:08:53  ledger      | e389e12a3a0640e7b900a668b26... | connector | ???                            | ???      |
```
for example.

During a ledger build on jenkins, when running the pact provider test, the pact
provider (connector) test needs to run against the ledger version tagged with
"test".
[This](https://github.com/alphagov/pay-connector/commit/f6cab9995798f2ef6df7e2aa66d06d0d51e57be7#diff-c355b34db18aa7dd24a0a9f857bae1097f148411eabd43c76ce1e87b431a0db2R37)
seems to have been an oversight as the other test classes
(FrontendContractTest, PublicApiContractTest and SelfServiceContractTest) are
running against the consumer version tagged with "test".