### PR TITLE
PP-8540 log the remote IP address when authorising a payment

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/epdq/EpdqAuthorisationRequestSummary.java
@@ -12,12 +12,14 @@ public class EpdqAuthorisationRequestSummary implements AuthorisationRequestSumm
     private final Presence billingAddress;
     private final Presence dataFor3ds;
     private final Presence dataFor3ds2;
+    private final String ipAddress;
 
     public EpdqAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         dataFor3ds = chargeEntity.getGatewayAccount().isRequires3ds() ? PRESENT : NOT_PRESENT;
         dataFor3ds2 = (chargeEntity.getGatewayAccount().isRequires3ds()
                 && chargeEntity.getGatewayAccount().getIntegrationVersion3ds() == 2) ? PRESENT : NOT_PRESENT;
+        ipAddress = authCardDetails.getIpAddress().orElse(null);
     }
 
     @Override
@@ -35,4 +37,8 @@ public class EpdqAuthorisationRequestSummary implements AuthorisationRequestSumm
         return dataFor3ds2;
     }
 
+    @Override
+    public String ipAddress() { 
+        return ipAddress; 
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthorisationRequestSummary.java
@@ -28,4 +28,8 @@ public interface AuthorisationRequestSummary {
         return NOT_APPLICABLE;
     }
 
+    default String ipAddress() { 
+        return null; 
+    };
+
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/smartpay/SmartpayAuthorisationRequestSummary.java
@@ -11,10 +11,12 @@ public class SmartpayAuthorisationRequestSummary implements AuthorisationRequest
 
     private final Presence billingAddress;
     private final Presence dataFor3ds;
+    private final String ipAddress;
 
     public SmartpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         dataFor3ds = chargeEntity.getGatewayAccount().isRequires3ds() ? PRESENT : NOT_PRESENT;
+        ipAddress = authCardDetails.getIpAddress().orElse(null);
     }
 
     @Override
@@ -25,6 +27,11 @@ public class SmartpayAuthorisationRequestSummary implements AuthorisationRequest
     @Override
     public Presence dataFor3ds() {
         return dataFor3ds;
+    }
+
+    @Override
+    public String ipAddress() {
+        return ipAddress;
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAuthorisationRequestSummary.java
@@ -9,14 +9,21 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 public class StripeAuthorisationRequestSummary implements AuthorisationRequestSummary {
 
     private final Presence billingAddress;
+    private final String ipAddress;
 
     public StripeAuthorisationRequestSummary(AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
+        ipAddress = authCardDetails.getIpAddress().orElse(null);
     }
 
     @Override
     public Presence billingAddress() {
         return billingAddress;
+    }
+    
+    @Override
+    public String ipAddress() { 
+        return ipAddress; 
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifier.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.util;
 
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 
+import java.util.Optional;
 import java.util.StringJoiner;
 
 public class AuthorisationRequestSummaryStringifier {
@@ -63,6 +64,9 @@ public class AuthorisationRequestSummaryStringifier {
             default:
                 break;
         }
+
+        Optional.ofNullable(authorisationRequestSummary.ipAddress())
+                .map(ipAddress -> stringJoiner.add("with remote IP " + ipAddress));
 
         return stringJoiner.toString();
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLogging.java
@@ -4,6 +4,7 @@ import net.logstash.logback.argument.StructuredArgument;
 import uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary;
 
 import java.util.ArrayList;
+import java.util.Optional;
 
 import static net.logstash.logback.argument.StructuredArguments.kv;
 
@@ -13,6 +14,7 @@ public class AuthorisationRequestSummaryStructuredLogging {
     public static final String DATA_FOR_3DS = "data_for_3ds";
     public static final String DATA_FOR_3DS2 = "data_for_3ds2";
     public static final String WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT = "worldpay_3ds_flex_device_data_collection_result";
+    public static final String IP_ADDRESS = "remote_ip_address";
 
     public StructuredArgument[] createArgs(AuthorisationRequestSummary authorisationRequestSummary) {
         var structuredArguments = new ArrayList<StructuredArgument>();
@@ -60,6 +62,9 @@ public class AuthorisationRequestSummaryStructuredLogging {
             default:
                 break;
         }
+
+        Optional.ofNullable(authorisationRequestSummary.ipAddress())
+                .map(ipAddress -> structuredArguments.add(kv(IP_ADDRESS, ipAddress)));
 
         return structuredArguments.toArray(new StructuredArgument[structuredArguments.size()]);
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthorisationRequestSummary.java
@@ -13,12 +13,15 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     private final Presence billingAddress;
     private final Presence dataFor3ds;
     private final Presence deviceDataCollectionResult;
+    private String ipAddress;
+    
 
     public WorldpayAuthorisationRequestSummary(ChargeEntity chargeEntity, AuthCardDetails authCardDetails) {
         billingAddress = authCardDetails.getAddress().map(address -> PRESENT).orElse(NOT_PRESENT);
         deviceDataCollectionResult = authCardDetails.getWorldpay3dsFlexDdcResult().map(address -> PRESENT).orElse(NOT_PRESENT);
         GatewayAccountEntity gatewayAccount = chargeEntity.getGatewayAccount();
         dataFor3ds = (deviceDataCollectionResult == PRESENT || gatewayAccount.isRequires3ds()) ? PRESENT : NOT_PRESENT;
+        ipAddress = authCardDetails.getIpAddress().orElse(null);
     }
 
     @Override
@@ -35,4 +38,11 @@ public class WorldpayAuthorisationRequestSummary implements AuthorisationRequest
     public Presence deviceDataCollectionResult() {
         return deviceDataCollectionResult;
     }
+
+    @Override
+    public String ipAddress() { 
+        return ipAddress; 
+    }
+
+
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStringifierTest.java
@@ -27,10 +27,11 @@ class AuthorisationRequestSummaryStringifierTest {
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
         given(mockAuthorisationRequestSummary.exemptionRequest()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
         
         String result = stringifier.stringify(mockAuthorisationRequestSummary);
         
-        assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption"));
+        assertThat(result, is(" with billing address and with 3DS data and without device data collection result and with exemption and with remote IP 1.1.1.1"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/util/AuthorisationRequestSummaryStructuredLoggingTest.java
@@ -19,6 +19,7 @@ import static uk.gov.pay.connector.gateway.model.AuthorisationRequestSummary.Pre
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.BILLING_ADDRESS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.DATA_FOR_3DS2;
+import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.IP_ADDRESS;
 import static uk.gov.pay.connector.gateway.util.AuthorisationRequestSummaryStructuredLogging.WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +35,7 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(PRESENT);
+        given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
 
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 
@@ -41,7 +43,8 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
                 kv(BILLING_ADDRESS, true),
                 kv(DATA_FOR_3DS, true),
                 kv(DATA_FOR_3DS2, true),
-                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true)
+                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, true),
+                kv(IP_ADDRESS, "1.1.1.1")
         ));
     }
 
@@ -80,13 +83,15 @@ class AuthorisationRequestSummaryStructuredLoggingTest {
         given(mockAuthorisationRequestSummary.dataFor3ds()).willReturn(PRESENT);
         given(mockAuthorisationRequestSummary.dataFor3ds2()).willReturn(NOT_APPLICABLE);
         given(mockAuthorisationRequestSummary.deviceDataCollectionResult()).willReturn(NOT_PRESENT);
+        given(mockAuthorisationRequestSummary.ipAddress()).willReturn("1.1.1.1");
 
         StructuredArgument[] result = structuredLogging.createArgs(mockAuthorisationRequestSummary);
 
         assertThat(result, is(arrayContaining(
                 kv(BILLING_ADDRESS, true),
                 kv(DATA_FOR_3DS, true),
-                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false)
+                kv(WORLDPAY_3DS_FLEX_DEVICE_DATA_COLLECTION_RESULT, false),
+                kv(IP_ADDRESS, "1.1.1.1")
         )));
     }
 


### PR DESCRIPTION
## WHAT YOU DID
Log IP address in authorisation request log message and structured logging

## How to test
Tests should make sense

Application should log IP address in log message and structured logging when authorising a payment

**Question** Is it preferable to return a `null` value in structured logging if no IP present? Currently, the key value is not included in this case.

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
