### PR TITLE
Revert "Revert "PP-8732 Migrate events `live` property to boxed Boolean value""

### DIFF
--- a/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/PaymentEvent.java
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime;
 
 public class PaymentEvent extends Event {
     private String serviceId;
-    private boolean live;
+    private Boolean live;
     
     public PaymentEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
@@ -31,7 +31,7 @@ public class PaymentEvent extends Event {
         return ResourceType.PAYMENT;
     }
 
-    public boolean isLive() {
+    public Boolean isLive() {
         return live;
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/payout/PayoutEvent.java
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime;
 
 public class PayoutEvent extends Event {
     private String serviceId;
-    private boolean live;
+    private Boolean live;
 
     public PayoutEvent(String serviceId, boolean live, String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
@@ -25,7 +25,7 @@ public class PayoutEvent extends Event {
         return ResourceType.PAYOUT;
     }
 
-    public boolean isLive() {
+    public Boolean isLive() {
         return live;
     }
 

--- a/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/refund/RefundEvent.java
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime;
 
 public abstract class RefundEvent extends Event {
     private String serviceId;
-    private boolean live;
+    private Boolean live;
     private String parentResourceExternalId;
 
     public RefundEvent(String serviceId, boolean live, String resourceExternalId, String parentResourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
@@ -31,7 +31,7 @@ public abstract class RefundEvent extends Event {
         return parentResourceExternalId;
     }
 
-    public boolean isLive() {
+    public Boolean isLive() {
         return live;
     }
 

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/PaymentIncludedInPayoutTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.time.ZonedDateTime;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -23,6 +24,7 @@ public class PaymentIncludedInPayoutTest {
         assertThat(json, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(json, hasJsonPath("$.resource_external_id", equalTo(paymentExternalId)));
         assertThat(json, hasJsonPath("$.timestamp", equalTo(eventDateStr)));
+        assertThat(json, hasNoJsonPath("$.live"));
 
         assertThat(json, hasJsonPath("$.event_details.gateway_payout_id", equalTo(gatewayPayoutId)));
     }

--- a/src/test/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayoutTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/refund/RefundIncludedInPayoutTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import java.time.ZonedDateTime;
 
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -23,6 +24,7 @@ public class RefundIncludedInPayoutTest {
         assertThat(json, hasJsonPath("$.resource_type", equalTo("refund")));
         assertThat(json, hasJsonPath("$.resource_external_id", equalTo(paymentExternalId)));
         assertThat(json, hasJsonPath("$.timestamp", equalTo(eventDateStr)));
+        assertThat(json, hasNoJsonPath("$.live"));
 
         assertThat(json, hasJsonPath("$.event_details.gateway_payout_id", equalTo(gatewayPayoutId)));
     }


### PR DESCRIPTION
Turtles all the way down.

Consumer pacts (Ledger) have been updated to no longer specify default fixtures where it shouldn't actually expect values. This should allow the Connector (producer) pacts to pass with this behaviour fix.

Reverts alphagov/pay-connector#3278
