### PR TITLE
PP-8947 - Add FeeType field to FeeEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
@@ -26,10 +26,9 @@ import java.time.ZonedDateTime;
         sequenceName = "charges_charge_id_seq", allocationSize = 1)
 public class FeeEntity {
     
-    public FeeEntity() { 
-        
+    public FeeEntity() {
     }
-    
+
     public FeeEntity(ChargeEntity chargeEntity, Long amount) { 
         this.externalId = RandomIdGenerator.newId();
         this.chargeEntity = chargeEntity;
@@ -45,6 +44,10 @@ public class FeeEntity {
 
     @Column(name = "external_id")
     private String externalId;
+
+    @Column(name = "fee_type")
+    @Convert(converter = FeeTypeConverter.class)
+    private FeeType feeType;
 
     @JsonIgnore
     @OneToOne
@@ -70,5 +73,9 @@ public class FeeEntity {
     
     public long getAmountCollected() {
         return amountCollected;
+    }
+
+    public void setFeeType(FeeType feeType) {
+        this.feeType = feeType;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeType.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeType.java
@@ -1,0 +1,28 @@
+package uk.gov.pay.connector.charge.model.domain;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+
+public enum FeeType {
+    RADAR("radar"),
+    THREE_D_S("three_ds"),
+    TRANSACTION("transaction");
+    
+    FeeType(String name) {
+        this.name = name;
+    }
+    
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public static FeeType fromString(String feeTypeValue) {
+        return Arrays.stream(FeeType.values())
+                .filter(feeTypeEnum -> StringUtils.equals(feeTypeEnum.getName(), feeTypeValue))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("fee type not recognized: " + feeTypeValue));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeTypeConverter.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeTypeConverter.java
@@ -1,0 +1,17 @@
+package uk.gov.pay.connector.charge.model.domain;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class FeeTypeConverter implements AttributeConverter<FeeType, String> {
+    @Override
+    public String convertToDatabaseColumn(FeeType feeType) {
+        return feeType == null ? null : feeType.getName();
+    }
+
+    @Override
+    public FeeType convertToEntityAttribute(String feeType) {
+        return feeType == null ? null : FeeType.fromString(feeType);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/FeeTypeConverterTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/FeeTypeConverterTest.java
@@ -1,0 +1,52 @@
+package uk.gov.pay.connector.charge.model.domain;
+
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FeeTypeConverterTest {
+    
+    private FeeTypeConverter feeTypeConverter = new FeeTypeConverter();
+    
+    @Test
+    void shouldReturnNullForDatabaseColumnValueFromNull() {
+        String databaseColumn = feeTypeConverter.convertToDatabaseColumn(null);
+        assertThat(databaseColumn, is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void shouldReturnCorrectFeeTypeValueForDatabaseColumnFromFeeType(FeeType feeType) {
+        String databaseColumn = feeTypeConverter.convertToDatabaseColumn(feeType);
+
+        assertThat(databaseColumn, is(feeType.getName()));
+    }
+
+    @Test
+    void shouldReturnNullForNullString() {
+        FeeType feeType = feeTypeConverter.convertToEntityAttribute(null);
+        assertThat(feeType, is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"radar", "three_ds", "transaction" })
+    void shouldReturnCorrectFeeTypeForCorrespondingFeeType(String feeTypeValue) {
+        FeeType feeType = feeTypeConverter.convertToEntityAttribute(feeTypeValue);
+        assertThat(feeType.getName(), is(feeTypeValue));
+    }
+    
+    @Test
+    void shouldThrowIllegalArgumentExceptionForUnrecognizedFeeType() {
+        var thrown = assertThrows(IllegalArgumentException.class,
+                () -> feeTypeConverter.convertToEntityAttribute("unknown"));
+        assertThat(thrown.getMessage(), Matchers.is("fee type not recognized: unknown"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.charge.model.FirstDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.LastDigitsCardNumber;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.gatewayaccount.model.EmailCollectionMode;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
@@ -704,7 +705,7 @@ public class DatabaseFixtures {
             return this;
         }
 
-        public TestCharge withCorporateCardSurcarge(Long corporateCardSurcharge) {
+        public TestCharge withCorporateCardSurcharge(Long corporateCardSurcharge) {
             this.corporateCardSurcharge = corporateCardSurcharge;
             return this;
         }
@@ -924,6 +925,7 @@ public class DatabaseFixtures {
         private long feeDue = 100L;
         private long feeCollected = 100L;
         private String gatewayTransactionId = "transaction_id";
+        private FeeType feeType = FeeType.TRANSACTION;
 
         public TestFee withTestCharge(TestCharge charge) {
             this.testCharge = charge;
@@ -945,10 +947,15 @@ public class DatabaseFixtures {
             return this;
         }
 
+        public TestFee withFeeType(FeeType feeType) {
+            this.feeType = feeType;
+            return this;
+        }
+
         public TestFee insert() {
             if (testCharge == null)
                 throw new IllegalStateException("Test charge must be provided.");
-            databaseTestHelper.addFee(externalId, testCharge.getChargeId(), feeDue, feeCollected, createdDate, gatewayTransactionId);
+            databaseTestHelper.addFee(externalId, testCharge.getChargeId(), feeDue, feeCollected, createdDate, gatewayTransactionId, feeType);
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/connector/it/dao/FeeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/FeeDaoIT.java
@@ -1,0 +1,74 @@
+package uk.gov.pay.connector.it.dao;
+
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+import uk.gov.pay.connector.charge.model.domain.FeeType;
+import uk.gov.pay.connector.fee.dao.FeeDao;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+
+public class FeeDaoIT extends DaoITestBase {
+    private FeeDao feeDao;
+    private DatabaseFixtures.TestCharge defaultTestCharge;
+
+    @Before
+    public void setUp() {
+        feeDao = env.getInstance(FeeDao.class);
+        DatabaseFixtures.TestAccount defaultTestAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+
+        defaultTestCharge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withTestAccount(defaultTestAccount)
+                .insert();
+    }
+
+    @After
+    public void truncate() {
+        databaseTestHelper.truncateAllData();
+    }
+    
+    @Test
+    public void persist_shouldCreateAFeeWithNullableType() {
+        ChargeEntityFixture chargeEntityFixture = new ChargeEntityFixture();
+        ChargeEntity defaultChargeTestEntity = chargeEntityFixture.build();
+        long chargeId = defaultTestCharge.getChargeId();
+        defaultChargeTestEntity.setId(chargeId);
+        FeeEntity feeEntity = new FeeEntity(defaultChargeTestEntity, 100L);
+        feeDao.persist(feeEntity);
+        List<Map<String, Object>> feesForCharge = databaseTestHelper.getFeesByChargeId(chargeId);
+
+        assertThat(feesForCharge.size(), is(1));
+        assertThat(feesForCharge.get(0).get("charge_id"), is(chargeId));
+        assertThat(feesForCharge.get(0).get("fee_type"), is(nullValue()));
+    }
+
+    @Test
+    public void persist_shouldCreateAFeeWithTransactionType() {
+        ChargeEntityFixture chargeEntityFixture = new ChargeEntityFixture();
+        ChargeEntity defaultChargeTestEntity = chargeEntityFixture.build();
+        long chargeId = defaultTestCharge.getChargeId();
+        defaultChargeTestEntity.setId(chargeId);
+        FeeEntity feeEntity = new FeeEntity(defaultChargeTestEntity, 100L);
+        feeEntity.setFeeType(FeeType.TRANSACTION);
+        feeDao.persist(feeEntity);
+        List<Map<String, Object>> feesForCharge = databaseTestHelper.getFeesByChargeId(chargeId);
+
+        assertThat(feesForCharge.size(), is(1));
+        assertThat(feesForCharge.get(0).get("charge_id"), is(chargeId));
+        assertThat(feesForCharge.get(0).get("fee_type"), is(FeeType.TRANSACTION.getName()));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceIT.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.it.resources;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
@@ -323,7 +324,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
 
 
         createCharge(externalChargeId, chargeId);
-        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
+        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id", FeeType.TRANSACTION);
 
         connectorRestApiClient
                 .withAccountId(accountId)
@@ -344,7 +345,7 @@ public class ChargesApiResourceIT extends ChargingITestBase {
         long defaultCorporateSurchargeAmount = 150L;
 
         createCharge(externalChargeId, chargeId);
-        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
+        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id", FeeType.TRANSACTION);
 
         connectorRestApiClient
                 .withAccountId(accountId)

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -5,6 +5,7 @@ import io.restassured.response.ValidatableResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 import uk.gov.pay.connector.app.ConnectorApp;
@@ -164,7 +165,7 @@ public class ChargesFrontendResourceIT {
         String externalChargeId = postToCreateACharge(expectedAmount);
         final long chargeId = databaseTestHelper.getChargeIdByExternalId(externalChargeId);
         final long feeCollected = 100L;
-        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
+        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id", FeeType.TRANSACTION);
 
         getChargeFromResource(externalChargeId)
                 .statusCode(OK.getStatusCode())
@@ -178,7 +179,7 @@ public class ChargesFrontendResourceIT {
         String externalChargeId = postToCreateACharge(expectedAmount);
         final long chargeId = databaseTestHelper.getChargeIdByExternalId(externalChargeId);
         final long feeCollected = 100L;
-        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id");
+        databaseTestHelper.addFee(RandomIdGenerator.newId(), chargeId, 100L, feeCollected, ZonedDateTime.now(), "irrelevant_id", FeeType.TRANSACTION);
 
         getChargeFromResource(externalChargeId)
                 .statusCode(OK.getStatusCode())

--- a/src/test/java/uk/gov/pay/connector/model/RefundResponseTest.java
+++ b/src/test/java/uk/gov/pay/connector/model/RefundResponseTest.java
@@ -7,18 +7,16 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
-import uk.gov.pay.connector.refund.model.domain.RefundEntity;
 import uk.gov.pay.connector.model.domain.RefundEntityFixture;
-import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 import uk.gov.pay.connector.refund.model.RefundResponse;
 import uk.gov.pay.connector.refund.model.RefundsResponse;
+import uk.gov.pay.connector.refund.model.domain.RefundEntity;
+import uk.gov.pay.connector.refund.model.domain.RefundStatus;
 
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-
 import java.util.List;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.mockito.Mockito.when;

--- a/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
+++ b/src/test/java/uk/gov/pay/connector/pact/ContractTest.java
@@ -13,6 +13,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState;
 import uk.gov.pay.connector.it.dao.DatabaseFixtures;
 import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
@@ -283,7 +284,7 @@ public class ContractTest {
 
         GatewayAccountUtil.setUpGatewayAccount(dbHelper, Long.valueOf(gatewayAccountId));
         setUpSingleCharge(gatewayAccountId, chargeId, chargeExternalId, ChargeStatus.CAPTURED, Instant.now(), false);
-        dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphanumeric(10));
+        dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), randomAlphanumeric(10), FeeType.TRANSACTION);
     }
 
     @State("a charge with gateway account id 42 and charge id abcdef1234 exists")
@@ -327,7 +328,7 @@ public class ContractTest {
                 .withEmail("test@test.com")
                 .withDelayedCapture(true)
                 .build());
-        dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), params.get("gateway_transaction_id"));
+        dbHelper.addFee(randomAlphanumeric(10), chargeId, 5, 5, ZonedDateTime.now(), params.get("gateway_transaction_id"), FeeType.TRANSACTION);
         dbHelper.updateCharge3dsDetails(chargeId, null, null, null, "2.1.0");
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -41,7 +41,6 @@ import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
-import uk.gov.pay.connector.refund.dao.RefundDao;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -8,6 +8,8 @@ import org.postgresql.util.PGobject;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.cardtype.model.domain.CardTypeEntity;
 import uk.gov.pay.connector.charge.exception.ExternalMetadataConverterException;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
 import uk.gov.pay.connector.common.model.domain.Address;
 import uk.gov.pay.connector.gateway.model.AuthCardDetails;
@@ -428,6 +430,14 @@ public class DatabaseTestHelper {
                         .list());
     }
 
+    public List<Map<String, Object>> getFeesByChargeId(long chargeId) {
+        return jdbi.withHandle(h ->
+                h.createQuery("SELECT * FROM fees WHERE charge_id = :chargeId")
+                        .bind("chargeId", chargeId)
+                        .mapToMap()
+                        .list());
+    }
+
     public Map<String, Object> getEmailForAccountAndType(Long accountId, EmailNotificationType type) {
 
         return jdbi.withHandle(h ->
@@ -836,16 +846,17 @@ public class DatabaseTestHelper {
         );
     }
 
-    public void addFee(String externalId, long chargeId, long feeDue, long feeCollected, ZonedDateTime createdDate, String gatewayTransactionId) {
+    public void addFee(String externalId, long chargeId, long feeDue, long feeCollected, ZonedDateTime createdDate, String gatewayTransactionId, FeeType feeType) {
         jdbi.withHandle(handle ->
                 handle
-                        .createUpdate("INSERT INTO fees(external_id, charge_id, amount_due, amount_collected, created_date, gateway_transaction_id) VALUES (:external_id, :charge_id, :amount_due, :amount_collected, :created_date, :gateway_transaction_id)")
+                        .createUpdate("INSERT INTO fees(external_id, charge_id, amount_due, amount_collected, created_date, gateway_transaction_id, fee_type) VALUES (:external_id, :charge_id, :amount_due, :amount_collected, :created_date, :gateway_transaction_id, :fee_type)")
                         .bind("external_id", externalId)
                         .bind("charge_id", chargeId)
                         .bind("amount_due", feeDue)
                         .bind("amount_collected", feeCollected)
                         .bind("created_date", Timestamp.from(createdDate.toInstant()))
                         .bind("gateway_transaction_id", gatewayTransactionId)
+                        .bind("fee_type", feeType.getName())
                         .execute()
         );
     }


### PR DESCRIPTION
Description:
- Adds FeeType field to FeeEntity object for the [database migration](https://github.com/alphagov/pay-connector/pull/3323)
- Removed some unused imports whilst working on the PR
- Paired with @SandorArpa