### PR TITLE
PP-8960 Add task to collect fee for failed payments to queue

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/config/TaskQueueConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/TaskQueueConfig.java
@@ -5,12 +5,17 @@ import io.dropwizard.Configuration;
 public class TaskQueueConfig extends Configuration {
 
     private Boolean taskQueueEnabled;
+    private Boolean collectFeeForStripeFailedPayments;
     private int queueSchedulerNumberOfThreads;
     private int queueSchedulerThreadDelayInSeconds;
     private int failedMessageRetryDelayInSeconds;
 
     public Boolean getTaskQueueEnabled() {
         return taskQueueEnabled;
+    }
+
+    public Boolean getCollectFeeForStripeFailedPayments() {
+        return collectFeeForStripeFailedPayments;
     }
 
     public int getQueueSchedulerNumberOfThreads() {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/PaymentTask.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/PaymentTask.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import java.util.Objects;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PaymentTask {
@@ -25,5 +27,18 @@ public class PaymentTask {
 
     public String getTask() {
         return task;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PaymentTask that = (PaymentTask) o;
+        return Objects.equals(paymentExternalId, that.paymentExternalId) && Objects.equals(task, that.task);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(paymentExternalId, task);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
@@ -1,0 +1,55 @@
+package uk.gov.pay.connector.queue.tasks;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.jooq.tools.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.common.model.api.ExternalChargeState;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+
+import javax.inject.Inject;
+
+import static net.logstash.logback.argument.StructuredArguments.kv;
+
+public class TaskQueueService {
+
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public static final String COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME = "collect_fee_for_stripe_failed_payment";
+    private TaskQueue taskQueue;
+
+    @Inject
+    public TaskQueueService(TaskQueue taskQueue) {
+        this.taskQueue = taskQueue;
+    }
+
+    public void offerTasksOnStateTransition(ChargeEntity chargeEntity) {
+        boolean isTerminallyFailed = chargeEntity.getChargeStatus().isExpungeable() &&
+                chargeEntity.getChargeStatus().toExternal() != ExternalChargeState.EXTERNAL_SUCCESS;
+
+        if (isTerminallyFailed &&
+                chargeEntity.getPaymentGatewayName() == PaymentGatewayName.STRIPE &&
+                !StringUtils.isEmpty(chargeEntity.getGatewayTransactionId())) {
+            addCollectStripeFeeForFailedPaymentTask(chargeEntity);
+        }
+    }
+
+    private void addCollectStripeFeeForFailedPaymentTask(ChargeEntity chargeEntity) {
+        PaymentTask paymentTask = new PaymentTask(chargeEntity.getExternalId(), COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME);
+        try {
+            taskQueue.addTaskToQueue(paymentTask);
+            logger.info("Added payment task message to queue", ArrayUtils.addAll(
+                    chargeEntity.getStructuredLoggingArgs(),
+                    kv("task_name", COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME)
+            ));
+        } catch (Exception e) {
+            logger.error("Error adding payment task message to queue", ArrayUtils.addAll(
+                    chargeEntity.getStructuredLoggingArgs(),
+                    kv("task_name", COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME),
+                    kv("error", e.getMessage()),
+                    kv("stack_trace", e.getStackTrace())
+            ));
+        }
+    }
+}

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -163,6 +163,7 @@ payoutReconcileProcessConfig:
 
 taskQueue:
   taskQueueEnabled: ${TASK_QUEUE_ENABLED:-false}
+  collectFeeForStripeFailedPayments: ${COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENTS:-false}
   failedMessageRetryDelayInSeconds: ${TASK_QUEUE_MESSAGE_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerNumberOfThreads: ${TASKS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
   queueSchedulerThreadDelayInSeconds: ${TASKS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/Card3dsResponseAuthServiceTest.java
@@ -31,6 +31,7 @@ import uk.gov.pay.connector.gateway.worldpay.Worldpay3dsRequiredParams;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.util.AuthUtils;
 
@@ -75,6 +76,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
     private RefundService mockedRefundService;
     @Mock
     private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
+    @Mock
+    private TaskQueueService mockTaskQueueService;
 
     private static final String GENERATED_TRANSACTION_ID = "generated-transaction-id";
 
@@ -102,7 +105,8 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
 
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao, null,
                 null, mockConfiguration, null, mockStateTransitionService, ledgerService,
-                mockedRefundService, mockEventService, mockGatewayAccountCredentialsService, northAmericanRegionMapper);
+                mockedRefundService, mockEventService, mockGatewayAccountCredentialsService, northAmericanRegionMapper,
+                mockTaskQueueService);
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
 
         card3dsResponseAuthService = new Card3dsResponseAuthService(mockedProviders, chargeService, authorisationService, mockConfiguration);
@@ -331,7 +335,7 @@ public class Card3dsResponseAuthServiceTest extends CardServiceTest {
         assertThat(response.isSuccessful(), is(false));
         assertThat(charge.getStatus(), is(AUTHORISATION_REJECTED.getValue()));
     }
-    
+
     @Test
     public void authoriseShouldThrowAnOperationAlreadyInProgressRuntimeExceptionWhenTimeout() {
         when(mockExecutorService.execute(any())).thenReturn(Pair.of(IN_PROGRESS, null));

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardAuthoriseServiceTest.java
@@ -51,6 +51,7 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.paymentprocessor.api.AuthorisationResponse;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
@@ -136,6 +137,9 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
 
     @Mock
     private AuthorisationRequestSummaryStructuredLogging mockAuthorisationRequestSummaryStructuredLogging;
+
+    @Mock
+    private TaskQueueService mockTaskQueueService;
     
     private CardAuthoriseService cardAuthorisationService;
 
@@ -151,7 +155,7 @@ public class CardAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
                 stateTransitionService, ledgerService, mockRefundService, mockEventService, 
-                mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper);
+                mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper, mockTaskQueueService);
 
         AuthorisationService authorisationService = new AuthorisationService(mockExecutorService, mockEnvironment);
         cardAuthorisationService = new CardAuthoriseService(

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -41,6 +41,7 @@ import uk.gov.pay.connector.northamericaregion.NorthAmericanRegionMapper;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.capture.CaptureQueue;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
@@ -117,6 +118,8 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
     @Mock
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
+    @Mock
+    private TaskQueueService mockTaskQueueService;
 
     @Before
     public void beforeTest() {
@@ -127,7 +130,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         chargeService = new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null,
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, 
-                mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper);
+                mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper, mockTaskQueueService);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
                 mockCaptureQueue);

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueServiceTest.java
@@ -1,0 +1,137 @@
+package uk.gov.pay.connector.queue.tasks;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.PaymentGatewayName;
+import uk.gov.pay.connector.gateway.processor.RefundNotificationProcessor;
+import uk.gov.pay.connector.queue.QueueException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.queue.tasks.TaskQueueService.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME;
+
+@ExtendWith(MockitoExtension.class)
+class TaskQueueServiceTest {
+
+    @Mock
+    private TaskQueue mockTaskQueue;
+
+    @InjectMocks
+    private TaskQueueService taskQueueService;
+
+    @Mock
+    private Appender<ILoggingEvent> mockAppender;
+
+    @Captor
+    ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @BeforeEach
+    void setUp() {
+        Logger root = (Logger) LoggerFactory.getLogger(TaskQueueService.class);
+        root.setLevel(Level.INFO);
+        root.addAppender(mockAppender);
+    }
+
+    @Test
+    void shouldOfferFeeTask_whenChargeIsTerminallyFailed_andStripe_andGatewayIdPresent() throws Exception {
+        var chargeEntity = aValidChargeEntity()
+                .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                .withGatewayTransactionId("a-gateway-transaction-id")
+                .withStatus(ChargeStatus.EXPIRED)
+                .build();
+
+        taskQueueService.offerTasksOnStateTransition(chargeEntity);
+
+        var expectedPaymentTask = new PaymentTask(chargeEntity.getExternalId(), COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME);
+        verify(mockTaskQueue).addTaskToQueue(eq(expectedPaymentTask));
+    }
+
+    @Test
+    void shouldNotOfferFeeTask_whenChargeIsFailedButNotTerminal() throws Exception {
+        var chargeEntity = aValidChargeEntity()
+                .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                .withGatewayTransactionId("a-gateway-transaction-id")
+                .withStatus(ChargeStatus.EXPIRE_CANCEL_READY)
+                .build();
+
+        taskQueueService.offerTasksOnStateTransition(chargeEntity);
+
+        verify(mockTaskQueue, never()).addTaskToQueue(any());
+    }
+
+    @Test
+    void shouldNotOfferFeeTask_whenChargeIsCaptured() throws Exception {
+        var chargeEntity = aValidChargeEntity()
+                .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                .withGatewayTransactionId("a-gateway-transaction-id")
+                .withStatus(ChargeStatus.CAPTURED)
+                .build();
+
+        taskQueueService.offerTasksOnStateTransition(chargeEntity);
+
+        verify(mockTaskQueue, never()).addTaskToQueue(any());
+    }
+
+    @Test
+    void shouldOfferFeeTask_whenChargeIsNotStripe() throws Exception {
+        var chargeEntity = aValidChargeEntity()
+                .withPaymentProvider(PaymentGatewayName.WORLDPAY.getName())
+                .withGatewayTransactionId("a-gateway-transaction-id")
+                .withStatus(ChargeStatus.EXPIRED)
+                .build();
+
+        taskQueueService.offerTasksOnStateTransition(chargeEntity);
+
+        verify(mockTaskQueue, never()).addTaskToQueue(any());
+    }
+
+    @Test
+    void shouldOfferFeeTask_whenChargeHasNoGatewayTransationId() throws Exception {
+        var chargeEntity = aValidChargeEntity()
+                .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                .withStatus(ChargeStatus.EXPIRED)
+                .build();
+
+        taskQueueService.offerTasksOnStateTransition(chargeEntity);
+
+        verify(mockTaskQueue, never()).addTaskToQueue(any());
+    }
+
+    @Test
+    void shouldSwallowExceptionThrownWhenAddingToQueue() throws Exception {
+        doThrow(new QueueException("Something went wrong")).when(mockTaskQueue).addTaskToQueue(any());
+
+        var chargeEntity = aValidChargeEntity()
+                .withPaymentProvider(PaymentGatewayName.STRIPE.getName())
+                .withGatewayTransactionId("a-gateway-transaction-id")
+                .withStatus(ChargeStatus.EXPIRED)
+                .build();
+
+        taskQueueService.offerTasksOnStateTransition(chargeEntity);
+
+        verify(mockAppender).doAppend(loggingEventArgumentCaptor.capture());
+
+        LoggingEvent loggingEvent = loggingEventArgumentCaptor.getValue();
+        assertThat(loggingEvent.getLevel(), is(Level.ERROR));
+        assertThat(loggingEvent.getMessage(), is("Error adding payment task message to queue"));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/wallets/WalletAuthoriseServiceTest.java
@@ -48,6 +48,7 @@ import uk.gov.pay.connector.paymentprocessor.service.AuthorisationService;
 import uk.gov.pay.connector.paymentprocessor.service.CardExecutorService;
 import uk.gov.pay.connector.paymentprocessor.service.CardServiceTest;
 import uk.gov.pay.connector.queue.statetransition.StateTransitionService;
+import uk.gov.pay.connector.queue.tasks.TaskQueueService;
 import uk.gov.pay.connector.refund.service.RefundService;
 import uk.gov.pay.connector.wallets.applepay.AppleDecryptedPaymentData;
 import uk.gov.pay.connector.wallets.googlepay.api.GooglePayAuthRequest;
@@ -127,6 +128,9 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
     
     @Mock
     private GatewayAccountCredentialsService mockGatewayAccountCredentialsService;
+    
+    @Mock
+    private TaskQueueService mockTaskQueueService;
 
     private WalletAuthoriseService walletAuthoriseService;
 
@@ -159,7 +163,7 @@ public class WalletAuthoriseServiceTest extends CardServiceTest {
         ChargeService chargeService = spy(new ChargeService(null, mockedChargeDao, mockedChargeEventDao,
                 null, null, mockConfiguration, null, mockStateTransitionService,
                 ledgerService, mockRefundService, mockEventService, mockGatewayAccountCredentialsService,
-                mockNorthAmericanRegionMapper));
+                mockNorthAmericanRegionMapper, mockTaskQueueService));
         walletAuthoriseService = new WalletAuthoriseService(
                 mockedProviders,
                 chargeService,


### PR DESCRIPTION
Upon a charge state transition, add a
"collect_fee_for_stripe_failed_payment" task to the payment task queue
if all of the following are true:
- the charge is in a terminal state
- the charge is failed
- the charge is a Stripe charge
- the charge has a gateway_transaction_id set

Used the `isExpungeable` property of ChargeStatus to determine whether
the status is terminal or not, as this is true only for terminal
statuses.