### PR TITLE
PP-8947 - Drop unique constraint on charge_id column in fees

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1729,4 +1729,10 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet id="drop unique constraint for charge_id column on fee table to allow for multiple fees per charge" author="">
+        <dropUniqueConstraint
+                tableName="fees"
+                constraintName="fees_charge_id_key"
+                uniqueColumns="charge_id" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Description:
- As part of this story we want to allow multiple fees for a single charge so we have to drop the
UNIQUE constraint on charge_id to allow this in the fees table
