### PR TITLE
PP-8948 Add Task queue message receiver

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -54,6 +54,7 @@ import uk.gov.pay.connector.healthcheck.SQSHealthCheck;
 import uk.gov.pay.connector.healthcheck.resource.HealthCheckResource;
 import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
 import uk.gov.pay.connector.paymentprocessor.resource.DiscrepancyResource;
+import uk.gov.pay.connector.queue.managed.TaskQueueMessageReceiver;
 import uk.gov.pay.connector.queue.managed.CaptureMessageReceiver;
 import uk.gov.pay.connector.queue.managed.PayoutReconcileMessageReceiver;
 import uk.gov.pay.connector.queue.managed.StateTransitionMessageReceiver;
@@ -71,7 +72,6 @@ import uk.gov.service.payments.logging.GovUkPayDropwizardRequestJsonLogLayoutFac
 import uk.gov.service.payments.logging.LoggingFilter;
 import uk.gov.service.payments.logging.LogstashConsoleAppenderFactory;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.EnumSet.of;
@@ -156,6 +156,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
             setupSchedulers(environment, injector);
         }
         environment.lifecycle().manage(injector.getInstance(PayoutReconcileMessageReceiver.class));
+        environment.lifecycle().manage(injector.getInstance(TaskQueueMessageReceiver.class));
 
         setupSmartpayBasicAuth(environment, injector.getInstance(SmartpayAccountSpecificAuthenticator.class));
 

--- a/src/main/java/uk/gov/pay/connector/queue/managed/TaskQueueMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/TaskQueueMessageReceiver.java
@@ -1,0 +1,83 @@
+package uk.gov.pay.connector.queue.managed;
+
+import io.dropwizard.lifecycle.Managed;
+import io.dropwizard.setup.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.ConnectorConfiguration;
+import uk.gov.pay.connector.queue.tasks.TaskQueueMessageHandler;
+
+import javax.inject.Inject;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class TaskQueueMessageReceiver implements Managed {
+
+    private static final String TASK_QUEUE_MESSAGE_RECEIVER_THREAD_NAME = "sqs-message-tasksQueueMessageReceiver";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskQueueMessageReceiver.class);
+
+    private final int queueSchedulerThreadDelayInSeconds;
+    private final TaskQueueMessageHandler taskQueueMessageHandler;
+    private boolean taskQueueEnabled;
+    private ScheduledExecutorService tasksQueueScheduledExecutorService;
+
+    @Inject
+    public TaskQueueMessageReceiver(TaskQueueMessageHandler taskQueueMessageHandler, Environment environment,
+                                    ConnectorConfiguration connectorConfiguration) {
+        this.taskQueueMessageHandler = taskQueueMessageHandler;
+
+        int queueScheduleNumberOfThreads = 1;
+
+        tasksQueueScheduledExecutorService = environment
+                .lifecycle()
+                .scheduledExecutorService(TASK_QUEUE_MESSAGE_RECEIVER_THREAD_NAME)
+                .threads(queueScheduleNumberOfThreads)
+                .build();
+
+        queueSchedulerThreadDelayInSeconds = connectorConfiguration.getTaskQueueConfig().getQueueSchedulerThreadDelayInSeconds();
+        taskQueueEnabled = connectorConfiguration.getTaskQueueConfig().getTaskQueueEnabled();
+    }
+
+    @Override
+    public void start() {
+        if (taskQueueEnabled) {
+            int initialDelay = queueSchedulerThreadDelayInSeconds;
+            tasksQueueScheduledExecutorService.scheduleWithFixedDelay(
+                    this::processMessage,
+                    initialDelay,
+                    queueSchedulerThreadDelayInSeconds,
+                    TimeUnit.SECONDS);
+        }
+    }
+
+    @Override
+    public void stop() {
+        LOGGER.info("Shutting down task queue message receiver");
+        tasksQueueScheduledExecutorService.shutdown();
+        try {
+            if (tasksQueueScheduledExecutorService.awaitTermination(15, TimeUnit.SECONDS)) {
+                LOGGER.info("Task queue message receiver shut down cleanly");
+            } else {
+                LOGGER.error("Task queue still processing messages after shutdown wait time will now be forcefully stopped");
+                tasksQueueScheduledExecutorService.shutdownNow();
+                if (!tasksQueueScheduledExecutorService.awaitTermination(12, TimeUnit.SECONDS)) {
+                    LOGGER.error("Task queue receiver could not be forced stopped");
+                }
+            }
+        } catch (InterruptedException ex) {
+            LOGGER.error("Failed to shutdown task queue message receiver cleanly as the wait was interrupted.");
+            tasksQueueScheduledExecutorService.shutdownNow();
+            // Preserve interrupt status
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void processMessage() {
+        try {
+            taskQueueMessageHandler.processMessages();
+        } catch (Exception e) {
+            LOGGER.error("Exception processing message from task queue [error message={}]", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
@@ -1,0 +1,50 @@
+package uk.gov.pay.connector.queue.tasks;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.queue.QueueException;
+
+import javax.inject.Inject;
+import java.util.List;
+
+import static java.lang.String.format;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+
+public class TaskQueueMessageHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskQueueMessageHandler.class);
+    private final TaskQueue taskQueue;
+
+    @Inject
+    public TaskQueueMessageHandler(TaskQueue taskQueue) {
+        this.taskQueue = taskQueue;
+    }
+
+    public void processMessages() throws QueueException {
+        List<PaymentTaskMessage> paymentTaskMessages = taskQueue.retrieveTaskQueueMessages();
+        for (PaymentTaskMessage paymentTaskMessage : paymentTaskMessages) {
+            try {
+                LOGGER.info("Processing task from queue",
+                        kv("queueMessageId", paymentTaskMessage.getQueueMessageId()),
+                        kv("queueMessageReceiptHandle", paymentTaskMessage.getQueueMessageReceiptHandle()),
+                        kv(PAYMENT_EXTERNAL_ID, paymentTaskMessage.getPaymentExternalId())
+                );
+
+                if ("COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT".equals(paymentTaskMessage.getTask())) {
+                    //TODO: Transfer from connect account to platform account to be done as part of PP-8945 
+                } else {
+                    LOGGER.error("Task [{}] is not supported", paymentTaskMessage.getTask());
+                }
+
+                taskQueue.markMessageAsProcessed(paymentTaskMessage.getQueueMessage());
+            } catch (Exception e) {
+                LOGGER.error(format("Error processing payment task from SQS message [queueMessageId=%s] [errorMessage=%s]",
+                        paymentTaskMessage.getQueueMessageId(),
+                        e.getMessage()),
+                        kv(PAYMENT_EXTERNAL_ID, paymentTaskMessage.getPaymentExternalId())
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -1,0 +1,79 @@
+package uk.gov.pay.connector.queue.tasks;
+
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.Appender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.queue.QueueException;
+import uk.gov.pay.connector.queue.QueueMessage;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TaskQueueMessageHandlerTest {
+
+    @Mock
+    private TaskQueue taskQueue;
+
+    @InjectMocks
+    TaskQueueMessageHandler taskQueueMessageHandler;
+
+    @Mock
+    private Appender<ILoggingEvent> logAppender;
+
+    @Captor
+    private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+
+    @BeforeEach
+    public void setup() {
+        Logger errorLogger = (Logger) LoggerFactory.getLogger(TaskQueueMessageHandler.class);
+        errorLogger.setLevel(Level.ERROR);
+        errorLogger.addAppender(logAppender);
+    }
+
+    @Test
+    public void shouldMarkMessageAsProcessed() throws QueueException {
+        PaymentTaskMessage paymentTaskMessage = setupQueueMessage("payment-external-id-123", "COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT");
+
+        taskQueueMessageHandler.processMessages();
+
+        verify(taskQueue).markMessageAsProcessed(paymentTaskMessage.getQueueMessage());
+    }
+
+    @Test
+    public void shouldLogErrorIfTaskNameIsNotRecognised() throws QueueException {
+        PaymentTaskMessage paymentTaskMessage = setupQueueMessage("payment-external-id-123", "unknown-task-name");
+
+        taskQueueMessageHandler.processMessages();
+
+        verify(taskQueue).markMessageAsProcessed(paymentTaskMessage.getQueueMessage());
+
+        verify(logAppender).doAppend(loggingEventArgumentCaptor.capture());
+        assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("Task [unknown-task-name] is not supported"));
+    }
+
+    private PaymentTaskMessage setupQueueMessage(String paymentExternalId, String task) throws QueueException {
+        PaymentTask paymentTask = new PaymentTask(paymentExternalId, task);
+        QueueMessage mockQueueMessage = mock(QueueMessage.class);
+        PaymentTaskMessage paymentTaskMessage = PaymentTaskMessage.of(paymentTask, mockQueueMessage);
+        when(taskQueue.retrieveTaskQueueMessages()).thenReturn(List.of(paymentTaskMessage));
+        return paymentTaskMessage;
+    }
+}


### PR DESCRIPTION
## WHAT YOU DID
- Added scheduler to poll task queue for new messages
- Handler currently just reads from the queue and deletes them from task queue. Functionality to handle task 'COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT' to be added as part of PP-8945