### PR TITLE
PP-8945 Use GET request when getting payment intent for refund

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/GatewayClient.java
@@ -75,6 +75,11 @@ public class GatewayClient {
         return executeRequest(url, gatewayAccountType, request.getOrderRequestType(), metricsPrefix, requestCallable);
     }
 
+    public GatewayClient.Response getRequestFor(GatewayClientRequest request)
+            throws GatewayException.GenericGatewayException, GatewayConnectionTimeoutException, GatewayErrorException {
+        return getRequestFor(request.getUrl(), request.getPaymentProvider(), request.getGatewayAccountType(), request.getGatewayOrder().getOrderRequestType(), emptyList(), request.getHeaders());
+    }
+
     public GatewayClient.Response getRequestFor(URI url,
                                                 PaymentGatewayName gatewayName,
                                                 String gatewayAccountType,

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -90,7 +90,7 @@ public class StripeRefundHandler {
     }
     
     private StripePaymentIntent getPaymentIntent(RefundGatewayRequest request) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
-        final String refundResponse = client.postRequestFor(StripeGetPaymentIntentRequest.of(request, stripeGatewayConfig)).getEntity();
+        final String refundResponse = client.getRequestFor(StripeGetPaymentIntentRequest.of(request, stripeGatewayConfig)).getEntity();
         return jsonObjectMapper.getObject(refundResponse, StripePaymentIntent.class);
     }
 

--- a/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/stripe/StripeRefundsResourceIT.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.restassured.RestAssured.given;
@@ -144,7 +145,7 @@ public class StripeRefundsResourceIT extends ChargingITestBase {
         assertThat(refundsFoundByChargeExternalId.size(), is(1));
         assertThat(refundsFoundByChargeExternalId.get(0).get("status"), is("REFUNDED"));
         String refundId = response.extract().path("refund_id");
-        wireMockServer.verify(postRequestedFor(urlEqualTo("/v1/payment_intents/" + defaultTestCharge.getTransactionId())));
+        wireMockServer.verify(getRequestedFor(urlEqualTo("/v1/payment_intents/" + defaultTestCharge.getTransactionId())));
         wireMockServer.verify(postRequestedFor(urlEqualTo("/v1/refunds"))
                 .withHeader("Idempotency-Key", equalTo("refund" + refundId))
                 .withRequestBody(containing("charge=ch_123456"))

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import uk.gov.pay.connector.util.TestTemplateResourceLoader;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.matching;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -31,6 +32,11 @@ public class StripeMockClient {
 
     private void setupResponse(String responseBody, String path, int status) {
         wireMockServer.stubFor(post(urlPathEqualTo(path)).withHeader(CONTENT_TYPE, matching(APPLICATION_FORM_URLENCODED))
+                .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON).withStatus(status).withBody(responseBody)));
+    }
+
+    private void setupGetResponse(String responseBody, String path, int status) {
+        wireMockServer.stubFor(get(urlPathEqualTo(path))
                 .willReturn(aResponse().withHeader(CONTENT_TYPE, APPLICATION_JSON).withStatus(status).withBody(responseBody)));
     }
 
@@ -71,7 +77,7 @@ public class StripeMockClient {
 
     public void mockGetPaymentIntent(String paymentIntentId) {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE);
-        setupResponse(payload, "/v1/payment_intents/" + paymentIntentId, 200);
+        setupGetResponse(payload, "/v1/payment_intents/" + paymentIntentId, 200);
     }
 
     public void mockCreatePaymentIntent() {


### PR DESCRIPTION
We have added the ability to make a GET request to the GatewayClient. Use this, rather than a POST request when retrieving the payment intent from Stripe when making a refund.

Have tested this locally, connecting to the Stripe test environment and the refund goes through successfully.
