### PR TITLE
PP-8947 - Refactors FeeEntity

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -460,7 +460,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
     public Optional<Long> getFeeAmount() {
         return fees.isEmpty() ? Optional.empty() :
             Optional.of(fees.stream()
-                .map(feeEntity -> feeEntity.getAmountCollected())
+                .map(FeeEntity::getAmountCollected)
                 .reduce(0L, Long::sum));
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
@@ -3,6 +3,7 @@ package uk.gov.pay.connector.charge.model.domain;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
 import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -16,7 +17,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
-import java.time.ZoneId;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 @Entity
@@ -29,20 +30,12 @@ public class FeeEntity {
     public FeeEntity() {
     }
 
-    public FeeEntity(ChargeEntity chargeEntity, Long amount) { 
+    public FeeEntity(ChargeEntity chargeEntity, Instant createdDate, Long amount, FeeType feeType) {
         this.externalId = RandomIdGenerator.newId();
         this.chargeEntity = chargeEntity;
         this.amountDue = amount;
         this.amountCollected = amount;
-        this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
-    }
-
-    public FeeEntity(ChargeEntity chargeEntity, Long amount, FeeType feeType) {
-        this.externalId = RandomIdGenerator.newId();
-        this.chargeEntity = chargeEntity;
-        this.amountDue = amount;
-        this.amountCollected = amount;
-        this.createdDate = ZonedDateTime.now(ZoneId.of("UTC"));
+        this.createdDate = createdDate;
         this.feeType = feeType;
     }
 
@@ -70,8 +63,8 @@ public class FeeEntity {
     private long amountCollected;
 
     @Column(name = "created_date")
-    @Convert(converter = UTCDateTimeConverter.class)
-    private ZonedDateTime createdDate;
+    @Convert(converter = InstantToUtcTimestampWithoutTimeZoneConverter.class)
+    private Instant createdDate;
 
     @Column(name = "collected_date")
     @Convert(converter = UTCDateTimeConverter.class)
@@ -82,6 +75,10 @@ public class FeeEntity {
     
     public long getAmountCollected() {
         return amountCollected;
+    }
+
+    public Instant getCreatedDate() {
+        return createdDate;
     }
 
     public FeeType getFeeType() {

--- a/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/FeeIncurredEventDetails.java
+++ b/src/main/java/uk/gov/pay/connector/events/eventdetails/charge/FeeIncurredEventDetails.java
@@ -46,4 +46,16 @@ public class FeeIncurredEventDetails extends EventDetails {
     public int hashCode() {
         return Objects.hash(fee, netAmount, feeBreakdown);
     }
+
+    public Long getFee() {
+        return fee;
+    }
+
+    public Long getNetAmount() {
+        return netAmount;
+    }
+
+    public List<Fee> getFeeBreakdown() {
+        return feeBreakdown;
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/exception/EventCreationException.java
+++ b/src/main/java/uk/gov/pay/connector/events/exception/EventCreationException.java
@@ -4,4 +4,8 @@ public class EventCreationException extends Exception {
     public EventCreationException(String id) {
         super(String.format("Failed to handle event during state transition message processing [eventId=%s]", id));
     }
+
+    public EventCreationException(String id, String message) {
+        super(String.format("Event id = [%s], exception = %s", id, message));
+    }
 }

--- a/src/main/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEvent.java
+++ b/src/main/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEvent.java
@@ -1,11 +1,33 @@
 package uk.gov.pay.connector.events.model.charge;
 
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
 import uk.gov.pay.connector.events.eventdetails.EventDetails;
+import uk.gov.pay.connector.events.eventdetails.charge.FeeIncurredEventDetails;
+import uk.gov.pay.connector.events.exception.EventCreationException;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 public class FeeIncurredEvent extends PaymentEvent {
     public FeeIncurredEvent(String resourceExternalId, EventDetails eventDetails, ZonedDateTime timestamp) {
         super(resourceExternalId, eventDetails, timestamp);
+    }
+
+    public static FeeIncurredEvent from(ChargeEntity charge) throws EventCreationException {
+        Instant earliestInstant = charge.getFees()
+                .stream()
+                .map(FeeEntity::getCreatedDate)
+                .min(Instant::compareTo)
+                .orElseThrow(() -> new EventCreationException(charge.getExternalId(), "Failed to create FeeIncurredEvent due to no fees present on charge"));
+
+        ZonedDateTime earliestCreatedDate = ZonedDateTime.ofInstant(earliestInstant, ZoneId.of("UTC"));
+
+        return new FeeIncurredEvent(
+                charge.getExternalId(),
+                FeeIncurredEventDetails.from(charge),
+                earliestCreatedDate
+        );
     }
 }

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -161,7 +161,7 @@ public class ChargeEntityFixture {
 
         if (this.fees != null) {
             fees.stream().forEach(partialFee -> {
-                FeeEntity fee = new FeeEntity(chargeEntity, partialFee.getAmount(), partialFee.getFeeType());
+                FeeEntity fee = new FeeEntity(chargeEntity, Instant.now(), partialFee.getAmount(), partialFee.getFeeType());
                 chargeEntity.setFee(fee);
             });
         }

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEventTest.java
@@ -1,0 +1,70 @@
+package uk.gov.pay.connector.events.model.charge;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+import uk.gov.pay.connector.events.exception.EventCreationException;
+
+import java.time.Instant;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.RADAR;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.THREE_D_S;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.TRANSACTION;
+
+class FeeIncurredEventTest {
+    private ChargeEntity chargeEntity;
+    private Instant radarFeeCreatedDate;
+    private Instant transactionFeeCreatedDate;
+    private Instant threeDsFeeCreatedDate;
+    
+    @BeforeEach
+    void setUp() {
+        chargeEntity = ChargeEntityFixture.aValidChargeEntity()
+                .withAmount(900L)
+                .withExternalId("paymentId")
+                .build();
+        radarFeeCreatedDate = Instant.parse("2021-10-01T10:00:00Z");
+        transactionFeeCreatedDate = Instant.parse("2021-11-01T11:00:00Z");
+        threeDsFeeCreatedDate = Instant.parse("2021-12-01T12:00:00Z");
+    }
+    
+    @Test
+    public void serializesFeeIncurredEventGivenChargeEntity() throws JsonProcessingException, EventCreationException {
+        FeeEntity radarFee = new FeeEntity(chargeEntity, radarFeeCreatedDate, 100L, RADAR);
+        FeeEntity transactionFee = new FeeEntity(chargeEntity, transactionFeeCreatedDate, 200L, TRANSACTION);
+        FeeEntity threeDsFee = new FeeEntity(chargeEntity, threeDsFeeCreatedDate, 300L, THREE_D_S);
+        chargeEntity.setFee(radarFee);
+        chargeEntity.setFee(transactionFee);
+        chargeEntity.setFee(threeDsFee);
+        String actual = FeeIncurredEvent.from(chargeEntity).toJsonString();
+
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo("2021-10-01T10:00:00.000000Z")));
+        assertThat(actual, hasJsonPath("$.event_type", equalTo("FEE_INCURRED_EVENT")));
+        assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
+        assertThat(actual, hasJsonPath("$.resource_external_id", equalTo("paymentId")));
+        assertThat(actual, hasJsonPath("$.event_details.fee", equalTo(600)));
+        assertThat(actual, hasJsonPath("$.event_details.net_amount", equalTo(300)));
+        assertThat(actual, hasJsonPath("$.event_details.fee_breakdown[0].fee_type", equalTo("radar")));
+        assertThat(actual, hasJsonPath("$.event_details.fee_breakdown[0].amount", equalTo(100)));
+        assertThat(actual, hasJsonPath("$.event_details.fee_breakdown[1].fee_type", equalTo("transaction")));
+        assertThat(actual, hasJsonPath("$.event_details.fee_breakdown[1].amount", equalTo(200)));
+        assertThat(actual, hasJsonPath("$.event_details.fee_breakdown[2].fee_type", equalTo("three_ds")));
+        assertThat(actual, hasJsonPath("$.event_details.fee_breakdown[2].amount", equalTo(300)));
+    }
+
+    @Test
+    public void creatingFeeIncurredEventThrowsEventCreationExceptionWhenNoFeesOnCharge() {
+        var thrown = assertThrows(EventCreationException.class,
+                () -> FeeIncurredEvent.from(chargeEntity).toJsonString());
+        assertThat(thrown.getMessage(), is(String.format("Event id = [%s], exception = Failed to create FeeIncurredEvent due to no fees present on charge", chargeEntity.getExternalId())));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/it/dao/FeeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/FeeDaoIT.java
@@ -10,6 +10,7 @@ import uk.gov.pay.connector.charge.model.domain.FeeEntity;
 import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.pay.connector.fee.dao.FeeDao;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -47,7 +48,7 @@ public class FeeDaoIT extends DaoITestBase {
         ChargeEntity defaultChargeTestEntity = chargeEntityFixture.build();
         long chargeId = defaultTestCharge.getChargeId();
         defaultChargeTestEntity.setId(chargeId);
-        FeeEntity feeEntity = new FeeEntity(defaultChargeTestEntity, 100L);
+        FeeEntity feeEntity = new FeeEntity(defaultChargeTestEntity, Instant.now(), 100L, null);
         feeDao.persist(feeEntity);
         List<Map<String, Object>> feesForCharge = databaseTestHelper.getFeesByChargeId(chargeId);
 
@@ -62,8 +63,7 @@ public class FeeDaoIT extends DaoITestBase {
         ChargeEntity defaultChargeTestEntity = chargeEntityFixture.build();
         long chargeId = defaultTestCharge.getChargeId();
         defaultChargeTestEntity.setId(chargeId);
-        FeeEntity feeEntity = new FeeEntity(defaultChargeTestEntity, 100L);
-        feeEntity.setFeeType(FeeType.TRANSACTION);
+        FeeEntity feeEntity = new FeeEntity(defaultChargeTestEntity, Instant.now(), 100L, FeeType.TRANSACTION);
         feeDao.persist(feeEntity);
         List<Map<String, Object>> feesForCharge = databaseTestHelper.getFeesByChargeId(chargeId);
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -49,6 +49,9 @@ import uk.gov.pay.connector.usernotification.service.UserNotificationService;
 
 import javax.persistence.OptimisticLockException;
 import javax.ws.rs.WebApplicationException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -123,6 +126,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
     protected NorthAmericanRegionMapper mockNorthAmericanRegionMapper;
     @Mock
     private TaskQueueService mockTaskQueueService;
+    private static final Clock GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK = Clock.fixed(Instant.parse("2020-01-01T10:10:10.100Z"), ZoneOffset.UTC);
 
     @Before
     public void beforeTest() {
@@ -136,7 +140,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
                 mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper, mockTaskQueueService);
 
         cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
-                mockCaptureQueue);
+                GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue);
 
         Logger root = (Logger) LoggerFactory.getLogger(CardCaptureService.class);
         root.setLevel(Level.INFO);
@@ -526,7 +530,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         doThrow(new QueueException()).when(mockCaptureQueue).sendForCapture(any());
 
         CardCaptureService cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService,
-                mockEnvironment, mockCaptureQueue
+                mockEnvironment,  GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue
         );
 
         String externalId = "external-id";
@@ -550,7 +554,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         when(mockedChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
 
         CardCaptureService cardCaptureService = new CardCaptureService(chargeService, feeDao, mockedProviders, mockUserNotificationService,
-                mockEnvironment, mockCaptureQueue
+                mockEnvironment,  GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue
         );
 
         try {


### PR DESCRIPTION
Description:
- Uses Instant rather than `ZonedDateTime` in the same way that `ChargeEntity` does for createdDate
- Added a test for `FeeIncurredEventDetails`