### PR TITLE
PP-8947 - Record FEE_INCURRED_EVENT to emitted_events table

### DIFF
--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -262,7 +262,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         assertThat(request.getValue().getTransactionId(), is(gatewayTxId));
 
         verify(mockFeeDao, times(3)).persist(any());
-        verify(mockEventService, times(1)).emitEvent(any(), eq(false));
+        verify(mockEventService, times(1)).emitAndRecordEvent(any());
 
         verifyNoInteractions(mockUserNotificationService);
     }


### PR DESCRIPTION
Description:
- This records the FEE_INCURRED_EVENT emission in the emitted_events table
- Previously the FEE_INCURRED_EVENT wasn't being created because there were no fees present on the ChargeEntity due to the @Transactional annotation.
This PR ensures that the fees are added whilst being persisted to the Fees table so allowing for the event to be created
- Verified locally that the event was both created and emitted and that the fees were present for V2 charge
- Paired with @SandorArpa 