### PR TITLE
PP-8945 Calculate and transfer fees for failed payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
@@ -1,0 +1,95 @@
+package uk.gov.pay.connector.gateway.stripe.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
+import uk.gov.pay.connector.gateway.stripe.json.StripeCharge;
+import uk.gov.pay.connector.gateway.stripe.json.StripePaymentIntent;
+import uk.gov.pay.connector.gateway.stripe.json.StripeTransferResponse;
+import uk.gov.pay.connector.gateway.stripe.request.StripeGetPaymentIntentRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.util.List;
+import java.util.Optional;
+
+public class StripeFailedPaymentFeeCollectionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StripeFailedPaymentFeeCollectionHandler.class);
+    
+    private final GatewayClient client;
+    private final StripeGatewayConfig stripeGatewayConfig;
+    private final JsonObjectMapper jsonObjectMapper;
+
+    public StripeFailedPaymentFeeCollectionHandler(
+            GatewayClient gatewayClient,
+            StripeGatewayConfig stripeGatewayConfig,
+            JsonObjectMapper jsonObjectMapper) {
+        this.client = gatewayClient;
+        this.stripeGatewayConfig = stripeGatewayConfig;
+        this.jsonObjectMapper = jsonObjectMapper;
+    }
+
+    public void calculateAndTransferFees(Charge charge, GatewayAccountEntity gatewayAccount, GatewayAccountCredentialsEntity gatewayAccountCredentials)
+            throws GatewayException {
+        // TODO: no Stripe charge exists if the 3DS attempt is failed, so this method of determining whether a payment has been through 3DS will need to change
+        boolean threeDsFeeApplicable = getStripeCharge(charge, gatewayAccount, gatewayAccountCredentials)
+                .map(this::isThreeDsFeeApplicable)
+                .orElse(false);
+        int fee = stripeGatewayConfig.getRadarFeeInPence();
+        if (threeDsFeeApplicable) {
+            fee += stripeGatewayConfig.getThreeDsFeeInPence();
+        }
+
+        transferFeeFromConnectAccount(fee, charge, gatewayAccount, gatewayAccountCredentials);
+    }
+
+    private boolean isThreeDsFeeApplicable(StripeCharge stripeCharge) {
+        return stripeCharge.getPaymentMethodDetails() != null &&
+                stripeCharge.getPaymentMethodDetails().getCard() != null &&
+                stripeCharge.getPaymentMethodDetails().getCard().getThreeDSecure() != null &&
+                stripeCharge.getPaymentMethodDetails().getCard().getThreeDSecure().getAuthenticated();
+    }
+
+    private Optional<StripeCharge> getStripeCharge(Charge charge, GatewayAccountEntity gatewayAccount, GatewayAccountCredentialsEntity gatewayAccountCredentials) throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        StripePaymentIntent paymentIntent = getPaymentIntent(charge, gatewayAccount, gatewayAccountCredentials);
+        List<StripeCharge> charges = paymentIntent.getChargesCollection().getCharges();
+        if (charges.size() > 1) {
+            throw new RuntimeException("Expected at most 1 Charge for PaymentIntent, found " + charges.size());
+        }
+        return charges.stream().findFirst();
+    }
+
+    private StripePaymentIntent getPaymentIntent(Charge charge,
+                                                 GatewayAccountEntity gatewayAccount,
+                                                 GatewayAccountCredentialsEntity gatewayAccountCredentials)
+            throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        GatewayClientRequest request = StripeGetPaymentIntentRequest.of(charge, gatewayAccount, gatewayAccountCredentials, stripeGatewayConfig);
+        String rawResponse = client.getRequestFor(request).getEntity();
+        return jsonObjectMapper.getObject(rawResponse, StripePaymentIntent.class);
+    }
+
+    private void transferFeeFromConnectAccount(int feeAmount,
+                                               Charge charge,
+                                               GatewayAccountEntity gatewayAccount,
+                                               GatewayAccountCredentialsEntity gatewayAccountCredentials)
+            throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        StripeTransferInRequest transferInRequest = StripeTransferInRequest.of(String.valueOf(feeAmount), gatewayAccount, gatewayAccountCredentials, charge.getGatewayTransactionId(), charge.getExternalId(), stripeGatewayConfig);
+        String rawResponse = client.postRequestFor(transferInRequest).getEntity();
+        StripeTransferResponse stripeTransferResponse = jsonObjectMapper.getObject(rawResponse, StripeTransferResponse.class);
+
+        LOGGER.info("To collect fees for failed payment {}, transferred net amount {} - transfer id {} - from Stripe Connect account id {} in transfer group {}",
+                charge.getExternalId(),
+                feeAmount,
+                stripeTransferResponse.getId(),
+                stripeTransferResponse.getDestinationStripeAccountId(),
+                stripeTransferResponse.getStripeTransferGroup()
+        );
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeRefundHandler.java
@@ -90,8 +90,8 @@ public class StripeRefundHandler {
     }
     
     private StripePaymentIntent getPaymentIntent(RefundGatewayRequest request) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {
-        final String refundResponse = client.getRequestFor(StripeGetPaymentIntentRequest.of(request, stripeGatewayConfig)).getEntity();
-        return jsonObjectMapper.getObject(refundResponse, StripePaymentIntent.class);
+        final String rawResponse = client.getRequestFor(StripeGetPaymentIntentRequest.of(request, stripeGatewayConfig)).getEntity();
+        return jsonObjectMapper.getObject(rawResponse, StripePaymentIntent.class);
     }
 
     private StripeRefund refundCharge(RefundGatewayRequest request, String stripeChargeId) throws GatewayException.GenericGatewayException, GatewayErrorException, GatewayException.GatewayConnectionTimeoutException {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/ThreeDSecure.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/ThreeDSecure.java
@@ -6,8 +6,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class ThreeDSecure {
 
     private String version;
+    
+    private Boolean authenticated;
 
     public String getVersion() {
         return version;
+    }
+
+    public Boolean getAuthenticated() {
+        return authenticated;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
@@ -1,10 +1,13 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
 import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
 import java.util.Map;
 
@@ -13,21 +16,31 @@ public class StripeGetPaymentIntentRequest extends StripeRequest {
 
     private StripeGetPaymentIntentRequest(
             GatewayAccountEntity gatewayAccount,
-            String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             Map<String, String> credentials,
             String paymentIntentId) {
-        super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
+        super(gatewayAccount, null, stripeGatewayConfig, credentials);
         this.paymentIntentId = paymentIntentId;
     }
 
     public static GatewayClientRequest of(RefundGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {
         return new StripeGetPaymentIntentRequest(
                 request.getGatewayAccount(),
-                request.getRefundExternalId(),
                 stripeGatewayConfig,
                 request.getGatewayCredentials(),
                 request.getTransactionId()
+        );
+    }
+    
+    public static GatewayClientRequest of(Charge charge, 
+                                          GatewayAccountEntity gatewayAccountEntity,
+                                          GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity, 
+                                          StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeGetPaymentIntentRequest(
+                gatewayAccountEntity,
+                stripeGatewayConfig,
+                gatewayAccountCredentialsEntity.getCredentials(),
+                charge.getGatewayTransactionId()
         );
     }
 
@@ -38,11 +51,6 @@ public class StripeGetPaymentIntentRequest extends StripeRequest {
 
     @Override
     protected OrderRequestType orderRequestType() {
-        return OrderRequestType.REFUND;
-    }
-
-    @Override
-    protected String idempotencyKeyType() {
-        return "get_payment_intent";
+        return OrderRequestType.QUERY;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -4,9 +4,11 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /***
  * Represents a request to transfer an amount from a Stripe Connect account to 
@@ -42,6 +44,23 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 request.getChargeExternalId()
         );
     }
+    
+    public static StripeTransferInRequest of(String feeAmount,
+                                             GatewayAccountEntity gatewayAccount,
+                                             GatewayAccountCredentialsEntity gatewayAccountCredentials,
+                                             String paymentIntentId,
+                                             String chargeExternalId,
+                                             StripeGatewayConfig stripeGatewayConfig) {
+        return new StripeTransferInRequest(
+                feeAmount,
+                gatewayAccount,
+                paymentIntentId,
+                chargeExternalId,
+                stripeGatewayConfig,
+                chargeExternalId,
+                gatewayAccountCredentials.getCredentials(),
+                chargeExternalId);
+    }
 
     @Override
     public Map<String, String> params() {
@@ -70,5 +89,18 @@ public class StripeTransferInRequest extends StripeTransferRequest {
     @Override
     protected OrderRequestType orderRequestType() {
         return OrderRequestType.REFUND;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StripeTransferInRequest that = (StripeTransferInRequest) o;
+        return Objects.equals(transferGroup, that.transferGroup);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(transferGroup);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
@@ -2,6 +2,16 @@ package uk.gov.pay.connector.queue.tasks;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.exception.ChargeNotFoundRuntimeException;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountCredentialsNotFoundException;
+import uk.gov.pay.connector.gatewayaccount.exception.GatewayAccountNotFoundException;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.queue.QueueException;
 
 import javax.inject.Inject;
@@ -9,16 +19,29 @@ import java.util.List;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.pay.connector.queue.tasks.TaskQueueService.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME;
 import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
 
 public class TaskQueueMessageHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskQueueMessageHandler.class);
     private final TaskQueue taskQueue;
+    private final ChargeService chargeService;
+    private final GatewayAccountDao gatewayAccountDao;
+    private final GatewayAccountCredentialsService gatewayAccountCredentialsService;
+    private StripePaymentProvider stripePaymentProvider;
 
     @Inject
-    public TaskQueueMessageHandler(TaskQueue taskQueue) {
+    public TaskQueueMessageHandler(TaskQueue taskQueue,
+                                   ChargeService chargeService,
+                                   GatewayAccountDao gatewayAccountDao,
+                                   GatewayAccountCredentialsService gatewayAccountCredentialsService,
+                                   StripePaymentProvider stripePaymentProvider) {
         this.taskQueue = taskQueue;
+        this.chargeService = chargeService;
+        this.gatewayAccountDao = gatewayAccountDao;
+        this.gatewayAccountCredentialsService = gatewayAccountCredentialsService;
+        this.stripePaymentProvider = stripePaymentProvider;
     }
 
     public void processMessages() throws QueueException {
@@ -31,8 +54,14 @@ public class TaskQueueMessageHandler {
                         kv(PAYMENT_EXTERNAL_ID, paymentTaskMessage.getPaymentExternalId())
                 );
 
-                if ("COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT".equals(paymentTaskMessage.getTask())) {
-                    //TODO: Transfer from connect account to platform account to be done as part of PP-8945 
+                if (paymentTaskMessage.getTask().equals(COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME)) {
+                    Charge charge = chargeService.findCharge(paymentTaskMessage.getPaymentExternalId())
+                            .orElseThrow(() -> new ChargeNotFoundRuntimeException(paymentTaskMessage.getPaymentExternalId()));
+                    GatewayAccountEntity gatewayAccount = gatewayAccountDao.findById(charge.getGatewayAccountId())
+                            .orElseThrow(() -> new GatewayAccountNotFoundException(charge.getGatewayAccountId()));
+                    GatewayAccountCredentialsEntity gatewayAccountCredentials = gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccount)
+                            .orElseThrow(() -> new GatewayAccountCredentialsNotFoundException("Unable to find credentials for charge " + charge.getExternalId()));
+                    stripePaymentProvider.transferFeesForFailedPayments(charge, gatewayAccount, gatewayAccountCredentials);
                 } else {
                     LOGGER.error("Task [{}] is not supported", paymentTaskMessage.getTask());
                 }
@@ -40,11 +69,13 @@ public class TaskQueueMessageHandler {
                 taskQueue.markMessageAsProcessed(paymentTaskMessage.getQueueMessage());
             } catch (Exception e) {
                 LOGGER.error(format("Error processing payment task from SQS message [queueMessageId=%s] [errorMessage=%s]",
-                        paymentTaskMessage.getQueueMessageId(),
-                        e.getMessage()),
+                                paymentTaskMessage.getQueueMessageId(),
+                                e.getMessage()),
                         kv(PAYMENT_EXTERNAL_ID, paymentTaskMessage.getPaymentExternalId())
                 );
             }
         }
     }
+
+    
 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueService.java
@@ -5,7 +5,6 @@ import org.jooq.tools.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.ConnectorConfiguration;
-import uk.gov.pay.connector.app.config.TaskQueueConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
 import uk.gov.pay.connector.gateway.PaymentGatewayName;

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandlerTest.java
@@ -1,0 +1,146 @@
+package uk.gov.pay.connector.gateway.stripe.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.app.StripeGatewayConfig;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.gateway.GatewayClient;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.stripe.request.StripeGetPaymentIntentRequest;
+import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.util.JsonObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PAYMENT_INTENT_WITH_MULTIPLE_CHARGES;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_TRANSFER_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
+
+@ExtendWith(MockitoExtension.class)
+class StripeFailedPaymentFeeCollectionHandlerTest {
+
+    @Mock
+    private GatewayClient gatewayClient;
+
+    @Mock
+    private StripeGatewayConfig stripeGatewayConfig;
+
+    @Captor
+    private ArgumentCaptor<StripeTransferInRequest> stripeTransferInRequestCaptor;
+
+    private final JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
+
+    public static final int radarFee = 7;
+    public static final int threeDsFee = 6;
+
+    private final String chargeExternalId = "a-charge-external-id";
+    private final String stripeAccountId = "stripe-connect-account-id";
+    private final String stripePlatformAccountId = "stripe-plarform-account-id";
+    private final String paymentIntentId = "pi_1FHESeEZsufgnuO08A2FUSPy";
+
+    private final GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+            .withPaymentProvider("stripe")
+            .withCredentials(Map.of("stripe_account_id", stripeAccountId))
+            .build();
+    private final GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+            .withGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity))
+            .build();
+    private final ChargeEntity chargeEntity = aValidChargeEntity()
+            .withExternalId(chargeExternalId)
+            .withGatewayAccountEntity(gatewayAccountEntity)
+            .withStatus(ChargeStatus.EXPIRED)
+            .withGatewayTransactionId(paymentIntentId)
+            .build();
+    private final Charge charge = Charge.from(chargeEntity);
+
+    private StripeFailedPaymentFeeCollectionHandler stripeFailedPaymentFeeCollectionHandler;
+
+    @BeforeEach
+    void setup() {
+        stripeFailedPaymentFeeCollectionHandler = new StripeFailedPaymentFeeCollectionHandler(
+                gatewayClient, stripeGatewayConfig, objectMapper);
+    }
+
+    @Test
+    void shouldTransferFeeForChargeThatHasBeenThrough3ds() throws Exception {
+        mockGetRequestResponse(STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE);
+        setupCommonMocksForCollectFeeSuccess();
+        when(stripeGatewayConfig.getThreeDsFeeInPence()).thenReturn(threeDsFee);
+
+        stripeFailedPaymentFeeCollectionHandler.calculateAndTransferFees(charge, gatewayAccountEntity, gatewayAccountCredentialsEntity);
+
+        verifyTransferRequestPayload(13);
+    }
+
+    @Test
+    void shouldTransferFeeForChargeThatHasNotBeenThrough3ds() throws Exception {
+        mockGetRequestResponse(STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE);
+        setupCommonMocksForCollectFeeSuccess();
+
+        stripeFailedPaymentFeeCollectionHandler.calculateAndTransferFees(charge, gatewayAccountEntity, gatewayAccountCredentialsEntity);
+        verifyTransferRequestPayload(7);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenMultipleChargesForPaymentIntent() throws Exception {
+        mockGetRequestResponse(STRIPE_GET_PAYMENT_INTENT_WITH_MULTIPLE_CHARGES);
+        assertThrows(RuntimeException.class, () -> stripeFailedPaymentFeeCollectionHandler.calculateAndTransferFees(charge, gatewayAccountEntity, gatewayAccountCredentialsEntity));
+        verify(gatewayClient, never()).postRequestFor(any(StripeTransferInRequest.class));
+    }
+
+    private void verifyTransferRequestPayload(int amount) throws Exception {
+        verify(gatewayClient).postRequestFor(stripeTransferInRequestCaptor.capture());
+        String payload = stripeTransferInRequestCaptor.getValue().getGatewayOrder().getPayload();
+
+        assertThat(payload, CoreMatchers.containsString("destination=" + stripePlatformAccountId));
+        assertThat(payload, CoreMatchers.containsString("amount=" + amount));
+        assertThat(payload, CoreMatchers.containsString("transfer_group=" + chargeExternalId));
+        assertThat(payload, CoreMatchers.containsString("expand%5B%5D=balance_transaction"));
+        assertThat(payload, CoreMatchers.containsString("expand%5B%5D=destination_payment"));
+        assertThat(payload, CoreMatchers.containsString("currency=GBP"));
+        assertThat(payload, CoreMatchers.containsString("metadata%5Bstripe_charge_id%5D=" + paymentIntentId));
+        assertThat(payload, CoreMatchers.containsString("metadata%5Bgovuk_pay_transaction_external_id%5D=" + chargeExternalId));
+    }
+
+    private void setupCommonMocksForCollectFeeSuccess() throws Exception {
+        mockPostTransferSuccess();
+        when(stripeGatewayConfig.getPlatformAccountId()).thenReturn(stripePlatformAccountId);
+        when(stripeGatewayConfig.getRadarFeeInPence()).thenReturn(radarFee);
+    }
+    
+    private void mockGetRequestResponse(String stripeGetPaymentIntentWith3dsAuthorisedResponse) throws Exception {
+        GatewayClient.Response response = mock(GatewayClient.Response.class);
+        when(response.getEntity()).thenReturn(load(stripeGetPaymentIntentWith3dsAuthorisedResponse));
+        when(gatewayClient.getRequestFor(any(StripeGetPaymentIntentRequest.class))).thenReturn(response);
+    }
+
+    private void mockPostTransferSuccess() throws Exception {
+        GatewayClient.Response response = mock(GatewayClient.Response.class);
+        when(response.getEntity()).thenReturn(load(STRIPE_TRANSFER_RESPONSE));
+        when(gatewayClient.postRequestFor(any(StripeTransferInRequest.class))).thenReturn(response);
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -11,49 +11,100 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
+import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
+import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
+import static uk.gov.pay.connector.queue.tasks.TaskQueueService.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class TaskQueueMessageHandlerTest {
-
+    
     @Mock
     private TaskQueue taskQueue;
-
-    @InjectMocks
-    TaskQueueMessageHandler taskQueueMessageHandler;
-
+    
+    @Mock
+    private ChargeService chargeService;
+    
+    @Mock
+    private GatewayAccountDao gatewayAccountDao;
+    
+    @Mock
+    private GatewayAccountCredentialsService gatewayAccountCredentialsService;
+    
+    @Mock
+    private StripePaymentProvider stripePaymentProvider;
+    
     @Mock
     private Appender<ILoggingEvent> logAppender;
 
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
+    
+    private TaskQueueMessageHandler taskQueueMessageHandler;
+    
+    
+    private final String chargeExternalId = "a-charge-external-id";
+    
+    private final GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
+            .withPaymentProvider("stripe")
+            .build();
+    private final GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
+            .withGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity))
+            .build();
+    private final ChargeEntity chargeEntity = aValidChargeEntity()
+            .withExternalId(chargeExternalId)
+            .withGatewayAccountEntity(gatewayAccountEntity)
+            .withStatus(ChargeStatus.EXPIRED)
+            .build();
+    private final Charge charge = Charge.from(chargeEntity);
 
     @BeforeEach
     public void setup() {
+        taskQueueMessageHandler = new TaskQueueMessageHandler(
+                taskQueue,
+                chargeService,
+                gatewayAccountDao,
+                gatewayAccountCredentialsService,
+                stripePaymentProvider);
+        
         Logger errorLogger = (Logger) LoggerFactory.getLogger(TaskQueueMessageHandler.class);
         errorLogger.setLevel(Level.ERROR);
         errorLogger.addAppender(logAppender);
     }
 
     @Test
-    public void shouldMarkMessageAsProcessed() throws QueueException {
-        PaymentTaskMessage paymentTaskMessage = setupQueueMessage("payment-external-id-123", "COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT");
+    public void shouldProcessCollectFeeTask() throws Exception {
+        PaymentTaskMessage paymentTaskMessage = setupQueueMessage(chargeExternalId, COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME);
+        when(chargeService.findCharge(chargeExternalId)).thenReturn(Optional.of(charge));
+        when(gatewayAccountDao.findById(gatewayAccountEntity.getId())).thenReturn(Optional.of(gatewayAccountEntity));
+        when(gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(Optional.of(gatewayAccountCredentialsEntity));
 
         taskQueueMessageHandler.processMessages();
 
+        verify(stripePaymentProvider).transferFeesForFailedPayments(charge, gatewayAccountEntity, gatewayAccountCredentialsEntity);
         verify(taskQueue).markMessageAsProcessed(paymentTaskMessage.getQueueMessage());
     }
 

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -158,6 +158,8 @@ public class TestTemplateResourceLoader {
     public static final String STRIPE_PAYMENT_INTENT_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_success_response.json";
     public static final String STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_intent_requires_3ds_response.json";
     public static final String STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/payment_intent_cancel_response.json";
+    public static final String STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_3ds_authorised_success_response.json";
+    public static final String STRIPE_GET_PAYMENT_INTENT_WITH_MULTIPLE_CHARGES = TEMPLATE_BASE_NAME + "/stripe/get_payment_intent_with_multiple_charges.json";
     public static final String STRIPE_PAYMENT_METHOD_SUCCESS_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/create_payment_method_success_response.json";
     public static final String STRIPE_ERROR_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/error_response.json";
     public static final String STRIPE_REFUND_FULL_CHARGE_RESPONSE = TEMPLATE_BASE_NAME + "/stripe/refund_full_charge.json";

--- a/src/test/resources/templates/stripe/get_payment_intent_with_3ds_authorised_success_response.json
+++ b/src/test/resources/templates/stripe/get_payment_intent_with_3ds_authorised_success_response.json
@@ -1,0 +1,156 @@
+{
+  "id": "pi_1FHESeEZsufgnuO08A2FUSPy",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+      {
+        "id": "ch_3K6dQPHj08j2jFuB1f9K4dcde",
+        "object": "charge",
+        "amount": 1000,
+        "amount_captured": 1000,
+        "amount_refunded": 0,
+        "application": null,
+        "application_fee": null,
+        "application_fee_amount": null,
+        "balance_transaction": "txn_3K6dQPHj08j2jFuB1SPsBP30",
+        "billing_details": {
+          "address": {
+            "city": "London",
+            "country": "GB",
+            "line1": "Addr line 1",
+            "line2": "Addr line 2",
+            "postal_code": "E1 8QS",
+            "state": null
+          },
+          "email": null,
+          "name": "test",
+          "phone": null
+        },
+        "calculated_statement_descriptor": "Stripe",
+        "captured": true,
+        "created": 1639497633,
+        "currency": "gbp",
+        "customer": null,
+        "description": "a description",
+        "destination": null,
+        "dispute": null,
+        "disputed": false,
+        "failure_code": null,
+        "failure_message": null,
+        "fraud_details": {
+        },
+        "invoice": null,
+        "livemode": false,
+        "metadata": {
+        },
+        "on_behalf_of": "acct_1Gxx6bH2Md25oweR",
+        "order": null,
+        "outcome": {
+          "network_status": "approved_by_network",
+          "reason": null,
+          "risk_level": "normal",
+          "risk_score": 43,
+          "seller_message": "Payment complete.",
+          "type": "authorized"
+        },
+        "paid": true,
+        "payment_intent": "pi_1FHESeEZsufgnuO08A2FUSPy",
+        "payment_method": "pm_1K6dQOHj08j2jFuBvnonlSaq",
+        "payment_method_details": {
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": "pass",
+              "address_postal_code_check": "pass",
+              "cvc_check": "pass"
+            },
+            "country": "FR",
+            "exp_month": 10,
+            "exp_year": 2023,
+            "fingerprint": "5qfi9J14ppzu8JCn",
+            "funding": "credit",
+            "installments": null,
+            "last4": "3155",
+            "network": "visa",
+            "three_d_secure": {
+              "authenticated": true,
+              "authentication_flow": "challenge",
+              "result": "authenticated",
+              "result_reason": null,
+              "succeeded": true,
+              "version": "1.0.2"
+            },
+            "wallet": null
+          },
+          "type": "card"
+        },
+        "receipt_email": null,
+        "receipt_number": null,
+        "receipt_url": "https://pay.stripe.com/receipts/acct_1DJf72Hj08j2jFas2/ch_3K6dQPHj08j2jFuB1f9K4dco/rcpt_KmBot9ei7uTBWDRNPb0by0lgczhAERW",
+        "refunded": false,
+        "refunds": {
+          "object": "list",
+          "data": [
+
+          ],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/charges/ch_3K6dQPHj08j2jFuB1f9K4dco/refunds"
+        },
+        "review": null,
+        "shipping": null,
+        "source": null,
+        "source_transfer": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": "rg7gqgpf9do5qs19nvannj4oiq"
+      }
+    ],
+    "has_more": false,
+    "total_count": 1,
+    "url": "/v1/charges?payment_intent=pi_1FHESeEZsufgnuO08A2FUSPy"
+  },
+  "client_secret": "secret",
+  "confirmation_method": "automatic",
+  "created": 1568141588,
+  "currency": "gbp",
+  "customer": null,
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": null,
+  "on_behalf_of": "acct_1EVFduJTPZ7tq2xO",
+  "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "requires_capture",
+  "transfer_data": null,
+  "transfer_group": "bc3rl3m7po6do0mt7r11kbt588"
+}

--- a/src/test/resources/templates/stripe/get_payment_intent_with_multiple_charges.json
+++ b/src/test/resources/templates/stripe/get_payment_intent_with_multiple_charges.json
@@ -1,0 +1,259 @@
+{
+  "id": "pi_1FHESeEZsufgnuO08A2FUSPy",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "manual",
+  "charges": {
+    "object": "list",
+    "data": [
+      {
+        "id": "ch_3K6dQPHj08j2jFuB1f9K4dcde",
+        "object": "charge",
+        "amount": 1000,
+        "amount_captured": 1000,
+        "amount_refunded": 0,
+        "application": null,
+        "application_fee": null,
+        "application_fee_amount": null,
+        "balance_transaction": "txn_3K6dQPHj08j2jFuB1SPsBP30",
+        "billing_details": {
+          "address": {
+            "city": "London",
+            "country": "GB",
+            "line1": "Addr line 1",
+            "line2": "Addr line 2",
+            "postal_code": "E1 8QS",
+            "state": null
+          },
+          "email": null,
+          "name": "test",
+          "phone": null
+        },
+        "calculated_statement_descriptor": "Stripe",
+        "captured": true,
+        "created": 1639497633,
+        "currency": "gbp",
+        "customer": null,
+        "description": "a description",
+        "destination": null,
+        "dispute": null,
+        "disputed": false,
+        "failure_code": null,
+        "failure_message": null,
+        "fraud_details": {
+        },
+        "invoice": null,
+        "livemode": false,
+        "metadata": {
+        },
+        "on_behalf_of": "acct_1Gxx6bH2Md25oweR",
+        "order": null,
+        "outcome": {
+          "network_status": "approved_by_network",
+          "reason": null,
+          "risk_level": "normal",
+          "risk_score": 43,
+          "seller_message": "Payment complete.",
+          "type": "authorized"
+        },
+        "paid": true,
+        "payment_intent": "pi_1FHESeEZsufgnuO08A2FUSPy",
+        "payment_method": "pm_1K6dQOHj08j2jFuBvnonlSaq",
+        "payment_method_details": {
+          "card": {
+            "brand": "visa",
+            "checks": {
+              "address_line1_check": "pass",
+              "address_postal_code_check": "pass",
+              "cvc_check": "pass"
+            },
+            "country": "FR",
+            "exp_month": 10,
+            "exp_year": 2023,
+            "fingerprint": "5qfi9J14ppzu8JCn",
+            "funding": "credit",
+            "installments": null,
+            "last4": "3155",
+            "network": "visa",
+            "three_d_secure": {
+              "authenticated": true,
+              "authentication_flow": "challenge",
+              "result": "authenticated",
+              "result_reason": null,
+              "succeeded": true,
+              "version": "1.0.2"
+            },
+            "wallet": null
+          },
+          "type": "card"
+        },
+        "receipt_email": null,
+        "receipt_number": null,
+        "receipt_url": "https://pay.stripe.com/receipts/acct_1DJf72Hj08j2jFas2/ch_3K6dQPHj08j2jFuB1f9K4dco/rcpt_KmBot9ei7uTBWDRNPb0by0lgczhAERW",
+        "refunded": false,
+        "refunds": {
+          "object": "list",
+          "data": [
+
+          ],
+          "has_more": false,
+          "total_count": 0,
+          "url": "/v1/charges/ch_3K6dQPHj08j2jFuB1f9K4dco/refunds"
+        },
+        "review": null,
+        "shipping": null,
+        "source": null,
+        "source_transfer": null,
+        "statement_descriptor": null,
+        "statement_descriptor_suffix": null,
+        "status": "succeeded",
+        "transfer_data": null,
+        "transfer_group": "rg7gqgpf9do5qs19nvannj4oiq"
+      },
+      "id": "ch_3K6dQPHj08j2jFuB1f9K4dcde",
+      "object": "charge",
+      "amount": 1000,
+      "amount_captured": 1000,
+      "amount_refunded": 0,
+      "application": null,
+      "application_fee": null,
+      "application_fee_amount": null,
+      "balance_transaction": "txn_3K6dQPHj08j2jFuB1SPsBP30",
+      "billing_details": {
+        "address": {
+          "city": "London",
+          "country": "GB",
+          "line1": "Addr line 1",
+          "line2": "Addr line 2",
+          "postal_code": "E1 8QS",
+          "state": null
+        },
+        "email": null,
+        "name": "test",
+        "phone": null
+      },
+      "calculated_statement_descriptor": "Stripe",
+      "captured": true,
+      "created": 1639497633,
+      "currency": "gbp",
+      "customer": null,
+      "description": "a description",
+      "destination": null,
+      "dispute": null,
+      "disputed": false,
+      "failure_code": null,
+      "failure_message": null,
+      "fraud_details": {
+      },
+      "invoice": null,
+      "livemode": false,
+      "metadata": {
+      },
+      "on_behalf_of": "acct_1Gxx6bH2Md25oweR",
+      "order": null,
+      "outcome": {
+        "network_status": "approved_by_network",
+        "reason": null,
+        "risk_level": "normal",
+        "risk_score": 43,
+        "seller_message": "Payment complete.",
+        "type": "authorized"
+      },
+      "paid": true,
+      "payment_intent": "pi_1FHESeEZsufgnuO08A2FUSPy",
+      "payment_method": "pm_1K6dQOHj08j2jFuBvnonlSaq",
+      "payment_method_details": {
+        "card": {
+          "brand": "visa",
+          "checks": {
+            "address_line1_check": "pass",
+            "address_postal_code_check": "pass",
+            "cvc_check": "pass"
+          },
+          "country": "FR",
+          "exp_month": 10,
+          "exp_year": 2023,
+          "fingerprint": "5qfi9J14ppzu8JCn",
+          "funding": "credit",
+          "installments": null,
+          "last4": "3155",
+          "network": "visa",
+          "three_d_secure": {
+            "authenticated": true,
+            "authentication_flow": "challenge",
+            "result": "authenticated",
+            "result_reason": null,
+            "succeeded": true,
+            "version": "1.0.2"
+          },
+          "wallet": null
+        },
+        "type": "card"
+      },
+      "receipt_email": null,
+      "receipt_number": null,
+      "receipt_url": "https://pay.stripe.com/receipts/acct_1DJf72Hj08j2jFas2/ch_3K6dQPHj08j2jFuB1f9K4dco/rcpt_KmBot9ei7uTBWDRNPb0by0lgczhAERW",
+      "refunded": false,
+      "refunds": {
+        "object": "list",
+        "data": [
+
+        ],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges/ch_3K6dQPHj08j2jFuB1f9K4dco/refunds"
+      },
+      "review": null,
+      "shipping": null,
+      "source": null,
+      "source_transfer": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": "rg7gqgpf9do5qs19nvannj4oiq"
+      }
+    ],
+    "has_more": false,
+    "total_count": 2,
+    "url": "/v1/charges?payment_intent=pi_1FHESeEZsufgnuO08A2FUSPy"
+  },
+  "client_secret": "secret",
+  "confirmation_method": "automatic",
+  "created": 1568141588,
+  "currency": "gbp",
+  "customer": null,
+  "description": null,
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+  },
+  "next_action": null,
+  "on_behalf_of": "acct_1EVFduJTPZ7tq2xO",
+  "payment_method": "pm_1FHESdEZsufgnuO0bzghQoZ2",
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "statement_descriptor": null,
+  "statement_descriptor_suffix": null,
+  "status": "requires_capture",
+  "transfer_data": null,
+  "transfer_group": "bc3rl3m7po6do0mt7r11kbt588"
+}


### PR DESCRIPTION
When a "collect_fee_for_stripe_failed_payment" task is processed on the task queue, calculate the fee due by determining whether or not the payment went through 3DS. If it went through 3DS, both the 3DS and Radar fees apply. If the payment did not go through 3DS, only the Radar fee applies.

Make a request to Stripe to transfer the amount for the failed fee from the connect account to the platform account.

Note that the method used to determine whether the payment has been through 3DS does not currently work for payments that failed 3DS as there will be no charge in Stripe. We'll need to change how we do this when
we get more information from them, but leaving this as a placeholder for now. This methodology is therefore not tested as fully as would be liked as it is expected to change.

This commit does not deal with storing the fees in the database and emitting events to ledger.