### PR TITLE
PP-8947 - Fix CaptureConfirmed Event to properly check fees

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -30,6 +30,7 @@ import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import javax.persistence.Access;
 import javax.persistence.AccessType;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Embedded;
@@ -115,7 +116,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
     @JoinColumn(name = "gateway_account_credential_id", updatable = false)
     private GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
 
-    @OneToMany(mappedBy = "chargeEntity")
+    @OneToMany(mappedBy = "chargeEntity", cascade = CascadeType.PERSIST)
     private List<FeeEntity> fees = new ArrayList<>();
 
     @OneToMany(mappedBy = "chargeEntity")
@@ -453,7 +454,7 @@ public class ChargeEntity extends AbstractVersionedEntity implements Nettable {
         this.corporateSurcharge = corporateSurcharge;
     }
 
-    public void setFee(FeeEntity fee) {
+    public void addFee(FeeEntity fee) {
         this.fees.add(fee);
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -617,18 +617,14 @@ public class ChargeService {
         }).orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeExternalId));
     }
 
-    public ChargeEntity updateChargePostCapture(String chargeId, ChargeStatus nextStatus) {
-        return chargeDao.findByExternalId(chargeId)
-                .map(chargeEntity -> {
-                    if (nextStatus == CAPTURED) {
-                        transitionChargeState(chargeEntity, CAPTURE_SUBMITTED);
-                        transitionChargeState(chargeEntity, CAPTURED);
-                    } else {
-                        transitionChargeState(chargeEntity, nextStatus);
-                    }
-                    return chargeEntity;
-                })
-                .orElseThrow(() -> new ChargeNotFoundRuntimeException(chargeId));
+    public ChargeEntity updateChargePostCapture(ChargeEntity chargeEntity, ChargeStatus nextStatus) {
+        if (nextStatus == CAPTURED) {
+            transitionChargeState(chargeEntity, CAPTURE_SUBMITTED);
+            transitionChargeState(chargeEntity, CAPTURED);
+        } else {
+            transitionChargeState(chargeEntity, nextStatus);
+        }
+        return chargeEntity;
     }
 
     private void setTransactionId(ChargeEntity chargeEntity, String transactionId) {

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -162,7 +162,7 @@ public class ChargeEntityFixture {
         if (this.fees != null) {
             fees.stream().forEach(partialFee -> {
                 FeeEntity fee = new FeeEntity(chargeEntity, Instant.now(), partialFee.getAmount(), partialFee.getFeeType());
-                chargeEntity.setFee(fee);
+                chargeEntity.addFee(fee);
             });
         }
 

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEventTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/FeeIncurredEventTest.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.events.model.charge;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
@@ -42,9 +41,9 @@ class FeeIncurredEventTest {
         FeeEntity radarFee = new FeeEntity(chargeEntity, radarFeeCreatedDate, 100L, RADAR);
         FeeEntity transactionFee = new FeeEntity(chargeEntity, transactionFeeCreatedDate, 200L, TRANSACTION);
         FeeEntity threeDsFee = new FeeEntity(chargeEntity, threeDsFeeCreatedDate, 300L, THREE_D_S);
-        chargeEntity.setFee(radarFee);
-        chargeEntity.setFee(transactionFee);
-        chargeEntity.setFee(threeDsFee);
+        chargeEntity.addFee(radarFee);
+        chargeEntity.addFee(transactionFee);
+        chargeEntity.addFee(threeDsFee);
         String actual = FeeIncurredEvent.from(chargeEntity).toJsonString();
 
         assertThat(actual, hasJsonPath("$.timestamp", equalTo("2021-10-01T10:00:00.000000Z")));

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.connector.paymentprocessor.service;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.fee.model.Fee;
+import uk.gov.pay.connector.gateway.CaptureResponse;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang.math.RandomUtils.nextInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.RADAR;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.THREE_D_S;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.TRANSACTION;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class CardCaptureServiceIT extends ChargingITestBase {
+
+    public CardCaptureServiceIT() {
+        super("stripe");
+    }
+    
+    @Test
+    public void shouldPersistFeesForStripeV2Charge() {
+        long chargeId = nextInt();
+        String externalChargeId = RandomIdGenerator.newId();
+
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withChargeId(chargeId)
+                .withExternalChargeId(externalChargeId)
+                .withPaymentProvider(STRIPE.getName())
+                .withGatewayAccountId(accountId)
+                .withAmount(10000)
+                .withStatus(ChargeStatus.CAPTURE_READY)
+                .build());
+
+        String oldChargeStatus = ChargeStatus.CAPTURE_READY.getValue();
+        String transactionId = "transactionId";
+        List<Fee> feeList = List.of(Fee.of(RADAR, 10L), Fee.of(THREE_D_S, 20L), Fee.of(TRANSACTION, 480L));
+        CaptureResponse captureResponse = new CaptureResponse(transactionId, CaptureResponse.ChargeState.COMPLETE, 100L, feeList);
+
+        // Trigger the post gateway capture response programmatically which normally would be invoked by the scheduler.
+        testContext.getInstanceFromGuiceContainer(CardCaptureService.class).processGatewayCaptureResponse(externalChargeId, oldChargeStatus, captureResponse);
+
+        List<Map<String, Object>> listOfFees = databaseTestHelper.getFeesByChargeId(chargeId);
+        List<String> feeTypeColumnValues = listOfFees.stream().map(map -> map.get("fee_type").toString()).collect(Collectors.toList());
+        List<String> feeAmountColumnValues = listOfFees.stream().map(map -> map.get("amount_collected").toString()).collect(Collectors.toList());
+
+        assertThat(listOfFees.size(), is(3));
+        assertThat(feeTypeColumnValues, containsInAnyOrder("radar", "three_ds", "transaction"));
+        assertThat(feeAmountColumnValues, containsInAnyOrder("10", "20", "480"));
+
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -33,7 +33,6 @@ import uk.gov.pay.connector.common.exception.ConflictRuntimeException;
 import uk.gov.pay.connector.common.exception.IllegalStateRuntimeException;
 import uk.gov.pay.connector.common.exception.OperationAlreadyInProgressRuntimeException;
 import uk.gov.pay.connector.events.EventService;
-import uk.gov.pay.connector.fee.dao.FeeDao;
 import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.model.request.CaptureGatewayRequest;
@@ -101,8 +100,6 @@ public class CardCaptureServiceTest extends CardServiceTest {
     private UserNotificationService mockUserNotificationService;
     private CardCaptureService cardCaptureService;
     @Mock
-    private FeeDao mockFeeDao;
-    @Mock
     private Appender<ILoggingEvent> mockAppender;
     @Mock
     private CaptureQueue mockCaptureQueue;
@@ -139,7 +136,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
                 mockStateTransitionService, ledgerService, mockedRefundService, mockEventService, 
                 mockGatewayAccountCredentialsService, mockNorthAmericanRegionMapper, mockTaskQueueService);
 
-        cardCaptureService = new CardCaptureService(chargeService, mockFeeDao, mockedProviders, mockUserNotificationService, mockEnvironment,
+        cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService, mockEnvironment,
                 GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);
 
         Logger root = (Logger) LoggerFactory.getLogger(CardCaptureService.class);
@@ -227,7 +224,6 @@ public class CardCaptureServiceTest extends CardServiceTest {
         verify(mockedPaymentProvider, times(1)).capture(request.capture());
         assertThat(request.getValue().getTransactionId(), is(gatewayTxId));
 
-        verify(mockFeeDao, times(1)).persist(any());
         verifyNoInteractions(mockEventService);
 
         verifyNoInteractions(mockUserNotificationService);
@@ -261,7 +257,6 @@ public class CardCaptureServiceTest extends CardServiceTest {
         verify(mockedPaymentProvider, times(1)).capture(request.capture());
         assertThat(request.getValue().getTransactionId(), is(gatewayTxId));
 
-        verify(mockFeeDao, times(3)).persist(any());
         verify(mockEventService, times(1)).emitAndRecordEvent(any());
 
         verifyNoInteractions(mockUserNotificationService);
@@ -571,7 +566,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
     public void markChargeAsEligibleForCapture_shouldThrowException_WithFeatureFlagEnabledAndUnableToAddChargeToQueue() throws QueueException {
         doThrow(new QueueException()).when(mockCaptureQueue).sendForCapture(any());
 
-        CardCaptureService cardCaptureService = new CardCaptureService(chargeService, mockFeeDao, mockedProviders, mockUserNotificationService,
+        CardCaptureService cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService,
                 mockEnvironment,  GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);
 
         String externalId = "external-id";
@@ -594,7 +589,7 @@ public class CardCaptureServiceTest extends CardServiceTest {
         ChargeEntity chargeEntity = spy(createNewChargeWith("worldpay", 1L, AUTHORISATION_SUCCESS, "gatewayTxId"));
         when(mockedChargeDao.findByExternalId(chargeEntity.getExternalId())).thenReturn(Optional.of(chargeEntity));
 
-        CardCaptureService cardCaptureService = new CardCaptureService(chargeService, mockFeeDao, mockedProviders, mockUserNotificationService,
+        CardCaptureService cardCaptureService = new CardCaptureService(chargeService, mockedProviders, mockUserNotificationService,
                 mockEnvironment,  GREENWICH_MERIDIAN_TIME_OFFSET_CLOCK, mockCaptureQueue, mockEventService);
 
         try {


### PR DESCRIPTION
Description:
- From locally testing it looks like Google Guice @transactional will persist the charge (i.e. flush the EntityManager changes) so no need to explicitly
 call feeDao.persist(...). Adding CascadeType.Persist and then setting the FeeEntity on the charge will ensure it is flushed to the database (tested locally
 and the fees were correctly persisted)
- Previously the CaptureConfirmed event would always emit the fee because only after the code progressed would the fees actually be persisted. This meant that the fee
check on CaptureConfirmed event would always be 0. Refactoring the code and ensuring the fees are added to the ChargeEntity before emitted the event removes the bug
- Added a service integration test to verify that the fees are persisted into the database
- Paired with @SandorArpa and @nlsteers
