### PR TITLE
PP-8945 Store fees and send event for failed payments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/FeeEntity.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.charge.model.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import uk.gov.pay.connector.common.model.domain.UTCDateTimeConverter;
+import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
 
@@ -37,6 +38,10 @@ public class FeeEntity {
         this.amountCollected = amount;
         this.createdDate = createdDate;
         this.feeType = feeType;
+    }
+
+    public FeeEntity(ChargeEntity chargeEntity, Instant createdDate, Fee fee) {
+        this(chargeEntity, createdDate, fee.getAmount(), fee.getFeeType());
     }
 
     @Id

--- a/src/main/java/uk/gov/pay/connector/charge/util/StripeFeeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/StripeFeeCalculator.java
@@ -41,6 +41,10 @@ public class StripeFeeCalculator {
         }
         return feeList;
     }
+    
+    public static Long getTotalFeeAmount(List<Fee> feeList) {
+        return feeList.stream().map(Fee::getAmount).reduce(0L, Long::sum);
+    }
 
     private static Double getPlatformFee(Double feePercentage, Long grossChargeAmount) {
         return Math.ceil((feePercentage / 100) * grossChargeAmount);

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProvider.java
@@ -8,6 +8,7 @@ import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.common.model.api.ExternalChargeRefundAvailability;
+import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.CaptureResponse;
 import uk.gov.pay.connector.gateway.ChargeQueryGatewayRequest;
 import uk.gov.pay.connector.gateway.ChargeQueryResponse;
@@ -36,8 +37,6 @@ import uk.gov.pay.connector.gateway.stripe.handler.StripeRefundHandler;
 import uk.gov.pay.connector.gateway.stripe.response.Stripe3dsRequiredParams;
 import uk.gov.pay.connector.gateway.util.DefaultExternalRefundAvailabilityCalculator;
 import uk.gov.pay.connector.gateway.util.ExternalRefundAvailabilityCalculator;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.refund.model.domain.Refund;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.pay.connector.wallets.WalletAuthorisationGatewayRequest;
@@ -157,9 +156,8 @@ public class StripePaymentProvider implements PaymentProvider {
         return new StripeAuthorisationRequestSummary(authCardDetails);
     }
     
-    public void transferFeesForFailedPayments(Charge charge, GatewayAccountEntity gatewayAccount, GatewayAccountCredentialsEntity gatewayAccountCredentials) 
-            throws GatewayException {
-        stripeFailedPaymentFeeCollectionHandler.calculateAndTransferFees(charge, gatewayAccount, gatewayAccountCredentials);
+    public List<Fee> calculateAndTransferFeesForFailedPayments(ChargeEntity charge) throws GatewayException {
+        return stripeFailedPaymentFeeCollectionHandler.calculateAndTransferFees(charge);
     }
 
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
@@ -3,7 +3,10 @@ package uk.gov.pay.connector.gateway.stripe.handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.FeeType;
+import uk.gov.pay.connector.charge.util.StripeFeeCalculator;
+import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
@@ -12,42 +15,46 @@ import uk.gov.pay.connector.gateway.stripe.json.StripePaymentIntent;
 import uk.gov.pay.connector.gateway.stripe.json.StripeTransferResponse;
 import uk.gov.pay.connector.gateway.stripe.request.StripeGetPaymentIntentRequest;
 import uk.gov.pay.connector.gateway.stripe.request.StripeTransferInRequest;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 public class StripeFailedPaymentFeeCollectionHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StripeFailedPaymentFeeCollectionHandler.class);
-    
+
     private final GatewayClient client;
     private final StripeGatewayConfig stripeGatewayConfig;
     private final JsonObjectMapper jsonObjectMapper;
-
+    
     public StripeFailedPaymentFeeCollectionHandler(
-            GatewayClient gatewayClient,
+            GatewayClient client,
             StripeGatewayConfig stripeGatewayConfig,
             JsonObjectMapper jsonObjectMapper) {
-        this.client = gatewayClient;
+        this.client = client;
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.jsonObjectMapper = jsonObjectMapper;
     }
-
-    public void calculateAndTransferFees(Charge charge, GatewayAccountEntity gatewayAccount, GatewayAccountCredentialsEntity gatewayAccountCredentials)
-            throws GatewayException {
+    
+    public List<Fee> calculateAndTransferFees(ChargeEntity charge) throws GatewayException {
         // TODO: no Stripe charge exists if the 3DS attempt is failed, so this method of determining whether a payment has been through 3DS will need to change
-        boolean threeDsFeeApplicable = getStripeCharge(charge, gatewayAccount, gatewayAccountCredentials)
+        boolean threeDsFeeApplicable = getStripeCharge(charge)
                 .map(this::isThreeDsFeeApplicable)
                 .orElse(false);
-        int fee = stripeGatewayConfig.getRadarFeeInPence();
-        if (threeDsFeeApplicable) {
-            fee += stripeGatewayConfig.getThreeDsFeeInPence();
-        }
 
-        transferFeeFromConnectAccount(fee, charge, gatewayAccount, gatewayAccountCredentials);
+        List<Fee> fees = new ArrayList<>();
+        fees.add(Fee.of(FeeType.RADAR, (long) stripeGatewayConfig.getRadarFeeInPence()));
+        if (threeDsFeeApplicable) {
+            fees.add(Fee.of(FeeType.THREE_D_S, (long) stripeGatewayConfig.getThreeDsFeeInPence()));
+        }
+        Long feeAmount = StripeFeeCalculator.getTotalFeeAmount(fees);
+
+        transferFeeFromConnectAccount(feeAmount, charge);
+
+        return fees;
+
     }
 
     private boolean isThreeDsFeeApplicable(StripeCharge stripeCharge) {
@@ -57,8 +64,8 @@ public class StripeFailedPaymentFeeCollectionHandler {
                 stripeCharge.getPaymentMethodDetails().getCard().getThreeDSecure().getAuthenticated();
     }
 
-    private Optional<StripeCharge> getStripeCharge(Charge charge, GatewayAccountEntity gatewayAccount, GatewayAccountCredentialsEntity gatewayAccountCredentials) throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
-        StripePaymentIntent paymentIntent = getPaymentIntent(charge, gatewayAccount, gatewayAccountCredentials);
+    private Optional<StripeCharge> getStripeCharge(ChargeEntity charge) throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
+        StripePaymentIntent paymentIntent = getPaymentIntent(charge);
         List<StripeCharge> charges = paymentIntent.getChargesCollection().getCharges();
         if (charges.size() > 1) {
             throw new RuntimeException("Expected at most 1 Charge for PaymentIntent, found " + charges.size());
@@ -66,21 +73,23 @@ public class StripeFailedPaymentFeeCollectionHandler {
         return charges.stream().findFirst();
     }
 
-    private StripePaymentIntent getPaymentIntent(Charge charge,
-                                                 GatewayAccountEntity gatewayAccount,
-                                                 GatewayAccountCredentialsEntity gatewayAccountCredentials)
+    private StripePaymentIntent getPaymentIntent(ChargeEntity charge)
             throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
-        GatewayClientRequest request = StripeGetPaymentIntentRequest.of(charge, gatewayAccount, gatewayAccountCredentials, stripeGatewayConfig);
+        GatewayClientRequest request = StripeGetPaymentIntentRequest.of(charge, stripeGatewayConfig);
         String rawResponse = client.getRequestFor(request).getEntity();
         return jsonObjectMapper.getObject(rawResponse, StripePaymentIntent.class);
     }
 
-    private void transferFeeFromConnectAccount(int feeAmount,
-                                               Charge charge,
-                                               GatewayAccountEntity gatewayAccount,
-                                               GatewayAccountCredentialsEntity gatewayAccountCredentials)
+    private void transferFeeFromConnectAccount(long feeAmount,
+                                               ChargeEntity charge)
             throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
-        StripeTransferInRequest transferInRequest = StripeTransferInRequest.of(String.valueOf(feeAmount), gatewayAccount, gatewayAccountCredentials, charge.getGatewayTransactionId(), charge.getExternalId(), stripeGatewayConfig);
+        StripeTransferInRequest transferInRequest = StripeTransferInRequest.of(
+                String.valueOf(feeAmount),
+                charge.getGatewayAccount(),
+                charge.getGatewayAccountCredentialsEntity(),
+                charge.getGatewayTransactionId(),
+                charge.getExternalId(),
+                stripeGatewayConfig);
         String rawResponse = client.postRequestFor(transferInRequest).getEntity();
         StripeTransferResponse stripeTransferResponse = jsonObjectMapper.getObject(rawResponse, StripeTransferResponse.class);
 

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
@@ -2,6 +2,7 @@ package uk.gov.pay.connector.gateway.stripe.request;
 
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.Charge;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
@@ -32,14 +33,12 @@ public class StripeGetPaymentIntentRequest extends StripeRequest {
         );
     }
     
-    public static GatewayClientRequest of(Charge charge, 
-                                          GatewayAccountEntity gatewayAccountEntity,
-                                          GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity, 
+    public static GatewayClientRequest of(ChargeEntity charge,
                                           StripeGatewayConfig stripeGatewayConfig) {
         return new StripeGetPaymentIntentRequest(
-                gatewayAccountEntity,
+                charge.getGatewayAccount(),
                 stripeGatewayConfig,
-                gatewayAccountCredentialsEntity.getCredentials(),
+                charge.getGatewayAccountCredentialsEntity().getCredentials(),
                 charge.getGatewayTransactionId()
         );
     }

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureService.java
@@ -125,12 +125,12 @@ public class CardCaptureService {
         ChargeEntity charge = chargeService.findChargeByExternalId(chargeId);
 
         captureResponse.getFeeList().ifPresent(feeList -> {
-            feeList.stream().map(fee -> new FeeEntity(charge, clock.instant(), fee.getAmount(), fee.getFeeType())).forEach(charge::addFee);
+                    feeList.stream().map(fee -> new FeeEntity(charge, clock.instant(), fee)).forEach(charge::addFee);
                     if (feeList.size() > 1) {
                         try {
                             sendToEventQueue(FeeIncurredEvent.from(charge));
                         } catch (EventCreationException e) {
-                            LOG.info(format("Failed to create fee incurred event [%s], exception: [%s]", charge.getExternalId(), e.getMessage()));
+                            LOG.warn(format("Failed to create fee incurred event [%s], exception: [%s]", charge.getExternalId(), e.getMessage()));
                         }
                     }
                 }

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandler.java
@@ -1,0 +1,68 @@
+package uk.gov.pay.connector.queue.tasks;
+
+import com.google.inject.persist.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.FeeEntity;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.exception.EventCreationException;
+import uk.gov.pay.connector.events.model.charge.FeeIncurredEvent;
+import uk.gov.pay.connector.fee.model.Fee;
+import uk.gov.pay.connector.gateway.GatewayException;
+import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
+
+import javax.inject.Inject;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+
+import static java.lang.String.format;
+import static net.logstash.logback.argument.StructuredArguments.kv;
+import static uk.gov.service.payments.logging.LoggingKeys.LEDGER_EVENT_TYPE;
+import static uk.gov.service.payments.logging.LoggingKeys.PAYMENT_EXTERNAL_ID;
+
+public class CollectFeesForFailedPaymentsTaskHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CollectFeesForFailedPaymentsTaskHandler.class);
+
+    private final StripePaymentProvider stripePaymentProvider;
+    private final ChargeService chargeService;
+    private final EventService eventService;
+    private final Clock clock;
+
+    @Inject
+    public CollectFeesForFailedPaymentsTaskHandler(StripePaymentProvider stripePaymentProvider,
+                                                   ChargeService chargeService,
+                                                   EventService eventService,
+                                                   Clock clock) {
+        this.stripePaymentProvider = stripePaymentProvider;
+        this.chargeService = chargeService;
+        this.eventService = eventService;
+        this.clock = clock;
+    }
+    
+    @Transactional
+    public void collectAndPersistFees(String chargeExternalId) throws GatewayException {
+        ChargeEntity charge = chargeService.findChargeByExternalId(chargeExternalId);
+        List<Fee> fees = stripePaymentProvider.calculateAndTransferFeesForFailedPayments(charge);
+
+        Instant now = clock.instant();
+        fees.stream().map(fee -> new FeeEntity(charge, now, fee)).forEach(charge::addFee);
+
+        emitFeeEvent(charge);
+    }
+
+    private void emitFeeEvent(ChargeEntity charge) {
+        try {
+            FeeIncurredEvent event = FeeIncurredEvent.from(charge);
+            eventService.emitAndRecordEvent(event);
+            LOGGER.info("Fee incurred event sent to event queue",
+                    kv(LEDGER_EVENT_TYPE, event.getEventType()),
+                    kv(PAYMENT_EXTERNAL_ID, event.getResourceExternalId()));
+        } catch (EventCreationException e) {
+            LOGGER.warn(format("Failed to create fee incurred event [%s], exception: [%s]", charge.getExternalId(), e.getMessage()));
+        }
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -161,7 +161,7 @@ public class ChargeEntityFixture {
 
         if (this.fees != null) {
             fees.stream().forEach(partialFee -> {
-                FeeEntity fee = new FeeEntity(chargeEntity, Instant.now(), partialFee.getAmount(), partialFee.getFeeType());
+                FeeEntity fee = new FeeEntity(chargeEntity, Instant.now(), partialFee);
                 chargeEntity.addFee(fee);
             });
         }

--- a/src/test/java/uk/gov/pay/connector/charge/util/StripeFeeCalculatorTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/util/StripeFeeCalculatorTest.java
@@ -74,4 +74,17 @@ class StripeFeeCalculatorTest {
         assertThat(feeList.get(2).getFeeType(), Is.is(FeeType.THREE_D_S));
         assertThat(feeList.get(2).getAmount(), Is.is(10L));
     }
+
+    @Test
+    void shouldReturnTotalAmountForListOfFees() {
+        List<Fee> feeList = List.of(
+                Fee.of(FeeType.TRANSACTION, 100L),
+                Fee.of(FeeType.RADAR, 50L),
+                Fee.of(FeeType.THREE_D_S, 25L)
+        );
+
+        Long totalFeeAmount = StripeFeeCalculator.getTotalFeeAmount(feeList);
+        
+        assertThat(totalFeeAmount, is(175L));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -13,6 +13,7 @@ import uk.gov.pay.connector.charge.model.domain.Auth3dsRequiredEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.domain.Address;
+import uk.gov.pay.connector.events.EventService;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayClientFactory;
 import uk.gov.pay.connector.gateway.GatewayException.GatewayConnectionTimeoutException;
@@ -32,6 +33,7 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -76,6 +78,8 @@ public class StripePaymentProviderTest {
     private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
     private GatewayClient.Response paymentMethodResponse = mock(GatewayClient.Response.class);
     private GatewayClient.Response paymentIntentsResponse = mock(GatewayClient.Response.class);
+    private Clock clock = mock(Clock.class);
+    private EventService eventService = mock(EventService.class);
     
     private static final String issuerUrl = "http://stripe.url/3ds";
     private static final String threeDsVersion = "2.0.1";

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerTest.java
@@ -1,0 +1,97 @@
+package uk.gov.pay.connector.queue.tasks;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.charge.service.ChargeService;
+import uk.gov.pay.connector.events.EventService;
+import uk.gov.pay.connector.events.eventdetails.charge.FeeIncurredEventDetails;
+import uk.gov.pay.connector.events.model.charge.FeeIncurredEvent;
+import uk.gov.pay.connector.fee.model.Fee;
+import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.RADAR;
+import static uk.gov.pay.connector.charge.model.domain.FeeType.THREE_D_S;
+
+@ExtendWith(MockitoExtension.class)
+class CollectFeesForFailedPaymentsTaskHandlerTest {
+
+    @Mock
+    private ChargeService chargeService;
+
+    @Mock
+    private StripePaymentProvider stripePaymentProvider;
+
+    @Mock
+    private EventService eventService;
+
+    @Captor
+    private ArgumentCaptor<FeeIncurredEvent> feeIncurredEventArgumentCaptor;
+
+    private static final Clock clock = Clock.fixed(Instant.parse("2020-01-01T10:10:10.100Z"), ZoneOffset.UTC);
+
+    private final String chargeExternalId = "a-charge-external-id";
+
+    private final ChargeEntity charge = aValidChargeEntity()
+            .withExternalId(chargeExternalId)
+            .withStatus(ChargeStatus.EXPIRED)
+            .build();
+    
+    private CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler;
+
+    @BeforeEach
+    void setUp() {
+        collectFeesForFailedPaymentsTaskHandler = new CollectFeesForFailedPaymentsTaskHandler(stripePaymentProvider, chargeService, eventService, clock);
+        when(chargeService.findChargeByExternalId(chargeExternalId)).thenReturn(charge);
+    }
+
+    @Test
+    void shouldPersistFeesAndEmitEvent() throws Exception {
+        List<Fee> fees = List.of(
+                Fee.of(RADAR, 6L),
+                Fee.of(THREE_D_S, 7L)
+        );
+        when(stripePaymentProvider.calculateAndTransferFeesForFailedPayments(charge)).thenReturn(fees);
+        
+        collectFeesForFailedPaymentsTaskHandler.collectAndPersistFees(chargeExternalId);
+        
+        assertThat(charge.getFees(), hasSize(2));
+        assertThat(charge.getFees(), containsInAnyOrder(
+                allOf(
+                        hasProperty("amountCollected", is(6L)),
+                        hasProperty("feeType", is(RADAR)),
+                        hasProperty("createdDate", is(clock.instant()))
+                ),
+                allOf(
+                        hasProperty("amountCollected", is(7L)),
+                        hasProperty("feeType", is(THREE_D_S)),
+                        hasProperty("createdDate", is(clock.instant()))
+                )
+        ));
+
+        verify(eventService).emitAndRecordEvent(feeIncurredEventArgumentCaptor.capture());
+        FeeIncurredEventDetails eventDetails = (FeeIncurredEventDetails) feeIncurredEventArgumentCaptor.getValue().getEventDetails();
+        assertThat(eventDetails.getFee(), is(13L));
+        assertThat(eventDetails.getFeeBreakdown(), is(fees));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -14,20 +14,15 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.gateway.stripe.StripePaymentProvider;
-import uk.gov.pay.connector.gatewayaccount.dao.GatewayAccountDao;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
-import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -49,13 +44,7 @@ class TaskQueueMessageHandlerTest {
     private ChargeService chargeService;
     
     @Mock
-    private GatewayAccountDao gatewayAccountDao;
-    
-    @Mock
-    private GatewayAccountCredentialsService gatewayAccountCredentialsService;
-    
-    @Mock
-    private StripePaymentProvider stripePaymentProvider;
+    private CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler;
     
     @Mock
     private Appender<ILoggingEvent> logAppender;
@@ -74,21 +63,18 @@ class TaskQueueMessageHandlerTest {
     private final GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
             .withGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity))
             .build();
-    private final ChargeEntity chargeEntity = aValidChargeEntity()
+    private final ChargeEntity charge = aValidChargeEntity()
             .withExternalId(chargeExternalId)
             .withGatewayAccountEntity(gatewayAccountEntity)
             .withStatus(ChargeStatus.EXPIRED)
             .build();
-    private final Charge charge = Charge.from(chargeEntity);
 
     @BeforeEach
     public void setup() {
         taskQueueMessageHandler = new TaskQueueMessageHandler(
                 taskQueue,
                 chargeService,
-                gatewayAccountDao,
-                gatewayAccountCredentialsService,
-                stripePaymentProvider);
+                collectFeesForFailedPaymentsTaskHandler);
         
         Logger errorLogger = (Logger) LoggerFactory.getLogger(TaskQueueMessageHandler.class);
         errorLogger.setLevel(Level.ERROR);
@@ -98,13 +84,10 @@ class TaskQueueMessageHandlerTest {
     @Test
     public void shouldProcessCollectFeeTask() throws Exception {
         PaymentTaskMessage paymentTaskMessage = setupQueueMessage(chargeExternalId, COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME);
-        when(chargeService.findCharge(chargeExternalId)).thenReturn(Optional.of(charge));
-        when(gatewayAccountDao.findById(gatewayAccountEntity.getId())).thenReturn(Optional.of(gatewayAccountEntity));
-        when(gatewayAccountCredentialsService.findCredentialFromCharge(charge, gatewayAccountEntity)).thenReturn(Optional.of(gatewayAccountCredentialsEntity));
 
         taskQueueMessageHandler.processMessages();
 
-        verify(stripePaymentProvider).transferFeesForFailedPayments(charge, gatewayAccountEntity, gatewayAccountCredentialsEntity);
+        verify(collectFeesForFailedPaymentsTaskHandler).collectAndPersistFees(chargeExternalId);
         verify(taskQueue).markMessageAsProcessed(paymentTaskMessage.getQueueMessage());
     }
 


### PR DESCRIPTION
When processing Stripe failed payments, after transferring the applicable amount for Stripe fees from the Stripe connect account, store entries in the `fees` table for each of the fee types that were applied. Send a FEE_INCURRED event to ledger containing the fee breakdown.

Always expect that the charge exists in the connector database, and throw an exception if it has been expunged. We will separately add a check that will stop Stripe charges from being expunged if they have not had the applicable fees taken.

Stop using StripePaymentProvider and call StripeFailedPaymentFeeCollectionHandler directly from
TaskQueueMessageHandler to simplify the code. To allow for this, added a new GatewayOperation enum entry so a separate Stripe client can be created in StripeFailedPaymentFeeCollectionHandler.