### PR TITLE
PP-8945 Add integration test for persisting fees

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeGetPaymentIntentRequest.java
@@ -1,14 +1,11 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
 import uk.gov.pay.connector.app.StripeGatewayConfig;
-import uk.gov.pay.connector.charge.model.domain.Charge;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
 import uk.gov.pay.connector.gateway.model.OrderRequestType;
 import uk.gov.pay.connector.gateway.model.request.GatewayClientRequest;
 import uk.gov.pay.connector.gateway.model.request.RefundGatewayRequest;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountCredentials;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 
 import java.util.Map;
 

--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccount.java
@@ -12,6 +12,7 @@ public class GatewayAccount {
     public static final String CREDENTIALS_PASSWORD = "password";
     public static final String CREDENTIALS_SHA_IN_PASSPHRASE = "sha_in_passphrase";
     public static final String CREDENTIALS_SHA_OUT_PASSPHRASE = "sha_out_passphrase";
+    public static final String CREDENTIALS_STRIPE_ACCOUNT_ID = "stripe_account_id";
     public static final String FIELD_NOTIFY_API_TOKEN = "api_token";
     public static final String FIELD_NOTIFY_PAYMENT_CONFIRMED_TEMPLATE_ID = "template_id";
     public static final String FIELD_NOTIFY_REFUND_ISSUED_TEMPLATE_ID = "refund_issued_template_id";

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
@@ -14,12 +14,13 @@ import uk.gov.pay.connector.util.RandomIdGenerator;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.apache.commons.lang.math.RandomUtils.nextInt;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.pay.connector.charge.model.domain.FeeType.RADAR;
 import static uk.gov.pay.connector.charge.model.domain.FeeType.THREE_D_S;
 import static uk.gov.pay.connector.charge.model.domain.FeeType.TRANSACTION;
@@ -57,12 +58,22 @@ public class CardCaptureServiceIT extends ChargingITestBase {
         testContext.getInstanceFromGuiceContainer(CardCaptureService.class).processGatewayCaptureResponse(externalChargeId, oldChargeStatus, captureResponse);
 
         List<Map<String, Object>> listOfFees = databaseTestHelper.getFeesByChargeId(chargeId);
-        List<String> feeTypeColumnValues = listOfFees.stream().map(map -> map.get("fee_type").toString()).collect(Collectors.toList());
-        List<String> feeAmountColumnValues = listOfFees.stream().map(map -> map.get("amount_collected").toString()).collect(Collectors.toList());
 
-        assertThat(listOfFees.size(), is(3));
-        assertThat(feeTypeColumnValues, containsInAnyOrder("radar", "three_ds", "transaction"));
-        assertThat(feeAmountColumnValues, containsInAnyOrder("10", "20", "480"));
+        assertThat(listOfFees, hasSize(3));
+        assertThat(listOfFees, containsInAnyOrder(
+                allOf(
+                        hasEntry("fee_type", (Object)"radar"),
+                        hasEntry("amount_collected", 10L)
+                ),
+                allOf(
+                        hasEntry("fee_type", (Object)"three_ds"),
+                        hasEntry("amount_collected", 20L)
+                ),
+                allOf(
+                        hasEntry("fee_type", (Object)"transaction"),
+                        hasEntry("amount_collected", 480L)
+                )
+        ));
 
     }
 }

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerIT.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/CollectFeesForFailedPaymentsTaskHandlerIT.java
@@ -1,0 +1,115 @@
+package uk.gov.pay.connector.queue.tasks;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.junit.DropwizardTestContext;
+import uk.gov.pay.connector.junit.TestContext;
+import uk.gov.pay.connector.rules.StripeMockClient;
+import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+import uk.gov.pay.connector.util.RandomIdGenerator;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.commons.lang.math.RandomUtils.nextInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
+import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialState.ACTIVE;
+import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.anAddChargeParams;
+import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
+import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class CollectFeesForFailedPaymentsTaskHandlerIT {
+
+    @DropwizardTestContext
+    private TestContext testContext;
+
+    private DatabaseTestHelper databaseTestHelper;
+
+    private WireMockServer wireMockServer;
+
+    private StripeMockClient stripeMockClient;
+
+    private AddGatewayAccountCredentialsParams accountCredentialsParams;
+
+    private String stripeAccountId = "stripe-account-id";
+    private String accountId = "555";
+    private String paymentIntentId = "stripe-payment-intent-id";
+
+    @Before
+    public void setUp() {
+        wireMockServer = testContext.getWireMockServer();
+        stripeMockClient = new StripeMockClient(wireMockServer);
+
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+
+        accountCredentialsParams = anAddGatewayAccountCredentialsParams()
+                .withPaymentProvider(STRIPE.getName())
+                .withGatewayAccountId(Long.parseLong(accountId))
+                .withState(ACTIVE)
+                .withCredentials(Map.of("stripe_account_id", stripeAccountId))
+                .build();
+
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(accountId)
+                .withPaymentGateway(STRIPE.getName())
+                .withGatewayAccountCredentials(List.of(accountCredentialsParams))
+                .withIntegrationVersion3ds(1)
+                .build());
+    }
+
+    @After
+    public void tearDown() {
+        databaseTestHelper.truncateAllData();
+    }
+
+    @Test
+    public void shouldPersistFees() throws Exception {
+        long chargeId = nextInt();
+        String chargeExternalId = RandomIdGenerator.newId();
+
+        databaseTestHelper.addCharge(anAddChargeParams()
+                .withChargeId(chargeId)
+                .withExternalChargeId(chargeExternalId)
+                .withPaymentProvider(STRIPE.getName())
+                .withGatewayAccountId(accountId)
+                .withAmount(10000)
+                .withStatus(ChargeStatus.AUTHORISATION_REJECTED)
+                .withGatewayCredentialId(accountCredentialsParams.getId())
+                .withTransactionId(paymentIntentId)
+                .build());
+
+        stripeMockClient.mockGet3DSAuthenticatedPaymentIntent(paymentIntentId);
+        stripeMockClient.mockTransferSuccess();
+
+        CollectFeesForFailedPaymentsTaskHandler taskHandler = testContext.getInstanceFromGuiceContainer(CollectFeesForFailedPaymentsTaskHandler.class);
+        taskHandler.collectAndPersistFees(chargeExternalId);
+
+        List<Map<String, Object>> fees = databaseTestHelper.getFeesByChargeId(chargeId);
+        assertThat(fees, hasSize(2));
+        assertThat(fees, containsInAnyOrder(
+                allOf(
+                        hasEntry("fee_type", (Object)"radar"),
+                        hasEntry("amount_collected", 5L)
+                ),
+                allOf(
+                        hasEntry("fee_type", (Object)"three_ds"),
+                        hasEntry("amount_collected", 6L)
+                )
+        ));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
+++ b/src/test/java/uk/gov/pay/connector/rules/StripeMockClient.java
@@ -14,6 +14,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_AUTHORISATION_FAILED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_ERROR_RESPONSE;
+import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CANCEL_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE;
 import static uk.gov.pay.connector.util.TestTemplateResourceLoader.STRIPE_PAYMENT_INTENT_REQUIRES_3DS_RESPONSE;
@@ -77,6 +78,11 @@ public class StripeMockClient {
 
     public void mockGetPaymentIntent(String paymentIntentId) {
         String payload = TestTemplateResourceLoader.load(STRIPE_PAYMENT_INTENT_CAPTURE_SUCCESS_RESPONSE);
+        setupGetResponse(payload, "/v1/payment_intents/" + paymentIntentId, 200);
+    }
+    
+    public void mockGet3DSAuthenticatedPaymentIntent(String paymentIntentId) {
+        String payload = TestTemplateResourceLoader.load(STRIPE_GET_PAYMENT_INTENT_WITH_3DS_AUTHORISED_RESPONSE);
         setupGetResponse(payload, "/v1/payment_intents/" + paymentIntentId, 200);
     }
 

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -78,7 +78,7 @@ stripe:
   notification3dsWaitDelay: ${NOTIFICATION_3DS_WAIT_DELAY:-1000}
   credentials: ['stripe_account_id']
   radarFeeInPence: ${STRIPE_TRANSACTION_RADAR_FEE_IN_PENCE:-5}
-  threeDsFeeInPence: ${STRIPE_TRANSACTION_THREE_DS_FEE_IN_PENCE:-5}
+  threeDsFeeInPence: ${STRIPE_TRANSACTION_THREE_DS_FEE_IN_PENCE:-6}
 
 executorServiceConfig:
   timeoutInSeconds: ${AUTH_READ_TIMEOUT_SECONDS:-2}


### PR DESCRIPTION
Add an integration test for CollectFeesForFailedPaymentsTaskHandler to ensure that fees applicable are successfully persisted to the database.