### PR TITLE
PP-8945 Simplify fee calculation

### DIFF
--- a/src/main/java/uk/gov/pay/connector/charge/util/StripeFeeCalculator.java
+++ b/src/main/java/uk/gov/pay/connector/charge/util/StripeFeeCalculator.java
@@ -21,23 +21,13 @@ public class StripeFeeCalculator {
         return stripeFee + platformFee.longValue();
     }
 
-    public static Long getTotalAmountForV2(Long stripeFee, CaptureGatewayRequest request, Double feePercentage,
-                                           int radarFeeInPence, int threeDsFeeInPence) {
-        Double platformFee = getPlatformFee(feePercentage, request.getAmount());
-        platformFee += (stripeFee + radarFeeInPence);
-        if (is3dsUsed(request)) {
-            platformFee += threeDsFeeInPence;
-        }
-        return platformFee.longValue();
-    }
-
-    public static List<Fee> getFeeList(Long stripeFee, CaptureGatewayRequest request, Double feePercentage,
-                                       int radarFeeInPence, int threeDsFeeInPence) {
+    public static List<Fee> getFeeListForV2(Long stripeFee, CaptureGatewayRequest request, Double feePercentage,
+                                            int radarFeeInPence, int threeDsFeeInPence) {
         List<Fee> feeList = new ArrayList<>();
         feeList.add(Fee.of(TRANSACTION, getTotalAmountForConnectFee(stripeFee, request, feePercentage)));
-        feeList.add(Fee.of(RADAR, Long.valueOf(radarFeeInPence)));
+        feeList.add(Fee.of(RADAR, (long) radarFeeInPence));
         if (is3dsUsed(request)) {
-            feeList.add(Fee.of(THREE_D_S, Long.valueOf(threeDsFeeInPence)));
+            feeList.add(Fee.of(THREE_D_S, (long) threeDsFeeInPence));
         }
         return feeList;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/CaptureResponse.java
@@ -4,6 +4,7 @@ import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.response.BaseCaptureResponse;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,44 +17,23 @@ public class CaptureResponse {
     private final ChargeState chargeState;
     private final GatewayError gatewayError;
     private final String stringified;
-    private Long feeAmount;
-    private List<Fee> feeList;
-
-    private CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError, String stringified) {
-        this.transactionId = transactionId;
-        this.chargeState = chargeState;
-        this.gatewayError = gatewayError;
-        this.stringified = stringified;
-    }
-
-    private CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError, String stringified, Long feeAmount) {
-        this.transactionId = transactionId;
-        this.chargeState = chargeState;
-        this.gatewayError = gatewayError;
-        this.stringified = stringified;
-        this.feeAmount = feeAmount;
-    }
+    private final List<Fee> feeList;
 
     private CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError,
-                            String stringified, Long feeAmount, List<Fee> feeList) {
+                            String stringified, List<Fee> feeList) {
         this.transactionId = transactionId;
         this.chargeState = chargeState;
         this.gatewayError = gatewayError;
         this.stringified = stringified;
-        this.feeAmount = feeAmount;
         this.feeList = feeList;
     }
 
-    public CaptureResponse(String transactionId, ChargeState chargeState, Long feeAmount, List<Fee> feeList) {
-        this(transactionId, chargeState, null, null, feeAmount, feeList);
+    private CaptureResponse(String transactionId, ChargeState chargeState, GatewayError gatewayError, String stringified) {
+        this(transactionId, chargeState, gatewayError, stringified, Collections.emptyList());
     }
-
-    public CaptureResponse(String transactionId, ChargeState chargeState, Long feeAmount) {
-        this(transactionId, chargeState, null, null, feeAmount);
-    }
-
-    public CaptureResponse(GatewayError gatewayError, String stringified) {
-        this(null, null, gatewayError, stringified, null);
+    
+    public CaptureResponse(String transactionId, ChargeState chargeState, List<Fee> feeList) {
+        this(transactionId, chargeState, null, null, feeList);
     }
 
     public static CaptureResponse fromGatewayError(GatewayError gatewayError) {
@@ -67,11 +47,11 @@ public class CaptureResponse {
             return new CaptureResponse(captureResponse.getTransactionId(), chargeState,null, captureResponse.stringify());
     }
 
-    public static CaptureResponse fromBaseCaptureResponse(BaseCaptureResponse captureResponse, ChargeState chargeState, Long feeAmount, List<Fee> feeList) {
+    public static CaptureResponse fromBaseCaptureResponse(BaseCaptureResponse captureResponse, ChargeState chargeState, List<Fee> feeList) {
         if (isNotBlank(captureResponse.getErrorCode())) {
             return new CaptureResponse(captureResponse.getTransactionId(), chargeState, genericGatewayError(captureResponse.stringify()), captureResponse.stringify());
         } else
-            return new CaptureResponse(captureResponse.getTransactionId(), chargeState,null, captureResponse.stringify(), feeAmount, feeList);
+            return new CaptureResponse(captureResponse.getTransactionId(), chargeState,null, captureResponse.stringify(), feeList);
     }
 
     public Optional<GatewayError> getError() {
@@ -97,12 +77,8 @@ public class CaptureResponse {
         return gatewayError == null;
     }
 
-    public Optional<Long> getFee() {
-        return Optional.ofNullable(feeAmount);
-    }
-
-    public Optional<List<Fee>> getFeeList() {
-        return Optional.ofNullable(feeList);
+    public List<Fee> getFeeList() {
+        return feeList;
     }
 
     public enum ChargeState {

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandler.java
@@ -2,7 +2,6 @@ package uk.gov.pay.connector.queue.tasks;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.queue.QueueException;
 
 import javax.inject.Inject;
@@ -17,15 +16,12 @@ public class TaskQueueMessageHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TaskQueueMessageHandler.class);
     private final TaskQueue taskQueue;
-    private final ChargeService chargeService;
     private final CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler;
 
     @Inject
     public TaskQueueMessageHandler(TaskQueue taskQueue,
-                                   ChargeService chargeService,
                                    CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler) {
         this.taskQueue = taskQueue;
-        this.chargeService = chargeService;
         this.collectFeesForFailedPaymentsTaskHandler = collectFeesForFailedPaymentsTaskHandler;
     }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceIT.java
@@ -51,7 +51,7 @@ public class CardCaptureServiceIT extends ChargingITestBase {
         String oldChargeStatus = ChargeStatus.CAPTURE_READY.getValue();
         String transactionId = "transactionId";
         List<Fee> feeList = List.of(Fee.of(RADAR, 10L), Fee.of(THREE_D_S, 20L), Fee.of(TRANSACTION, 480L));
-        CaptureResponse captureResponse = new CaptureResponse(transactionId, CaptureResponse.ChargeState.COMPLETE, 100L, feeList);
+        CaptureResponse captureResponse = new CaptureResponse(transactionId, CaptureResponse.ChargeState.COMPLETE, feeList);
 
         // Trigger the post gateway capture response programmatically which normally would be invoked by the scheduler.
         testContext.getInstanceFromGuiceContainer(CardCaptureService.class).processGatewayCaptureResponse(externalChargeId, oldChargeStatus, captureResponse);

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/service/CardCaptureServiceTest.java
@@ -151,13 +151,13 @@ public class CardCaptureServiceTest extends CardServiceTest {
 
     private void stripeWillRespondWithSuccess() {
         when(mockedPaymentProvider.capture(any())).thenReturn(
-                fromBaseCaptureResponse(BaseCaptureResponse.fromTransactionId(randomUUID().toString(), STRIPE), PENDING, 50L,
+                fromBaseCaptureResponse(BaseCaptureResponse.fromTransactionId(randomUUID().toString(), STRIPE), PENDING,
                         List.of(Fee.of(FeeType.TRANSACTION, 50L))));
     }
 
     private void stripeWillRespondWithSuccessAndAdditionalFees() {
         when(mockedPaymentProvider.capture(any())).thenReturn(
-                fromBaseCaptureResponse(BaseCaptureResponse.fromTransactionId(randomUUID().toString(), STRIPE), PENDING, 50L,
+                fromBaseCaptureResponse(BaseCaptureResponse.fromTransactionId(randomUUID().toString(), STRIPE), PENDING,
                         List.of(Fee.of(FeeType.TRANSACTION, 50L), Fee.of(FeeType.RADAR, 40L), Fee.of(FeeType.THREE_D_S, 30L))));
     }
 

--- a/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
+++ b/src/test/java/uk/gov/pay/connector/queue/tasks/TaskQueueMessageHandlerTest.java
@@ -14,11 +14,6 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
-import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
-import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
-import uk.gov.pay.connector.charge.service.ChargeService;
-import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
 
@@ -29,9 +24,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.pay.connector.charge.model.domain.ChargeEntityFixture.aValidChargeEntity;
-import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
-import static uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntityFixture.aGatewayAccountCredentialsEntity;
 import static uk.gov.pay.connector.queue.tasks.TaskQueueService.COLLECT_FEE_FOR_STRIPE_FAILED_PAYMENT_TASK_NAME;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,9 +31,6 @@ class TaskQueueMessageHandlerTest {
     
     @Mock
     private TaskQueue taskQueue;
-    
-    @Mock
-    private ChargeService chargeService;
     
     @Mock
     private CollectFeesForFailedPaymentsTaskHandler collectFeesForFailedPaymentsTaskHandler;
@@ -56,24 +45,11 @@ class TaskQueueMessageHandlerTest {
     
     
     private final String chargeExternalId = "a-charge-external-id";
-    
-    private final GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity = aGatewayAccountCredentialsEntity()
-            .withPaymentProvider("stripe")
-            .build();
-    private final GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
-            .withGatewayAccountCredentials(List.of(gatewayAccountCredentialsEntity))
-            .build();
-    private final ChargeEntity charge = aValidChargeEntity()
-            .withExternalId(chargeExternalId)
-            .withGatewayAccountEntity(gatewayAccountEntity)
-            .withStatus(ChargeStatus.EXPIRED)
-            .build();
 
     @BeforeEach
     public void setup() {
         taskQueueMessageHandler = new TaskQueueMessageHandler(
                 taskQueue,
-                chargeService,
                 collectFeesForFailedPaymentsTaskHandler);
         
         Logger errorLogger = (Logger) LoggerFactory.getLogger(TaskQueueMessageHandler.class);


### PR DESCRIPTION
Simplify the fee calculation for the fees for successful payments to only determine in one place which fees apply. Before we were doing this in two places - when getting the fee list and getting the total fee, which carries the risk of the code getting out of sync in the two places.

To get the total fee, we now sum the amounts of all the fees in the fee list returned from the calculator.

In addition, remove the total fee amount from the CaptureResponse, as this was unused other than in tests.

Also, make CaptureResponse.getFeeList return a `List<Fee>` rather than an `Optional<List<Fee>>`, as in some cases it was returning an empty Optional, and in other cases, an Optional containing an empty List. It is simpler to just always return an empty List in cases where there are no fees.