### PR TITLE
PP-8945 Handle Stripe charge not existing

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/handler/StripeFailedPaymentFeeCollectionHandler.java
@@ -4,8 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.app.StripeGatewayConfig;
 import uk.gov.pay.connector.charge.model.domain.ChargeEntity;
+import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.FeeType;
 import uk.gov.pay.connector.charge.util.StripeFeeCalculator;
+import uk.gov.pay.connector.chargeevent.model.domain.ChargeEventEntity;
 import uk.gov.pay.connector.fee.model.Fee;
 import uk.gov.pay.connector.gateway.GatewayClient;
 import uk.gov.pay.connector.gateway.GatewayException;
@@ -20,6 +22,7 @@ import uk.gov.pay.connector.util.JsonObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class StripeFailedPaymentFeeCollectionHandler {
 
@@ -28,7 +31,7 @@ public class StripeFailedPaymentFeeCollectionHandler {
     private final GatewayClient client;
     private final StripeGatewayConfig stripeGatewayConfig;
     private final JsonObjectMapper jsonObjectMapper;
-    
+
     public StripeFailedPaymentFeeCollectionHandler(
             GatewayClient client,
             StripeGatewayConfig stripeGatewayConfig,
@@ -37,12 +40,15 @@ public class StripeFailedPaymentFeeCollectionHandler {
         this.stripeGatewayConfig = stripeGatewayConfig;
         this.jsonObjectMapper = jsonObjectMapper;
     }
-    
+
     public List<Fee> calculateAndTransferFees(ChargeEntity charge) throws GatewayException {
-        // TODO: no Stripe charge exists if the 3DS attempt is failed, so this method of determining whether a payment has been through 3DS will need to change
+        // It is possible for no Stripe charge to exist for the payment intent if the 3DS attempt is failed. For now, we
+        // are falling back on checking our internal charge events if there is no Stripe charge. This will however miss
+        // cases where 3DS has been initiated but not completed, for which we might still be charged a fee. Ideally
+        // we need a way to tell whether a 3DS attempt has been started from the Stripe API.
         boolean threeDsFeeApplicable = getStripeCharge(charge)
-                .map(this::isThreeDsFeeApplicable)
-                .orElse(false);
+                .map(this::stripeChargeHas3dsAttempt)
+                .orElseGet(() -> chargeHasEventsIndicating3dsWasCompleted(charge));
 
         List<Fee> fees = new ArrayList<>();
         fees.add(Fee.of(FeeType.RADAR, (long) stripeGatewayConfig.getRadarFeeInPence()));
@@ -57,15 +63,22 @@ public class StripeFailedPaymentFeeCollectionHandler {
 
     }
 
-    private boolean isThreeDsFeeApplicable(StripeCharge stripeCharge) {
+    private boolean stripeChargeHas3dsAttempt(StripeCharge stripeCharge) {
         return stripeCharge.getPaymentMethodDetails() != null &&
                 stripeCharge.getPaymentMethodDetails().getCard() != null &&
                 stripeCharge.getPaymentMethodDetails().getCard().getThreeDSecure() != null &&
                 stripeCharge.getPaymentMethodDetails().getCard().getThreeDSecure().getAuthenticated();
     }
 
+    private boolean chargeHasEventsIndicating3dsWasCompleted(ChargeEntity chargeEntity) {
+        List<ChargeStatus> eventStatuses = chargeEntity.getEvents().stream().map(ChargeEventEntity::getStatus).collect(Collectors.toList());
+        return eventStatuses.contains(ChargeStatus.AUTHORISATION_3DS_REQUIRED) &&
+                (eventStatuses.contains(ChargeStatus.AUTHORISATION_REJECTED) || eventStatuses.contains(ChargeStatus.AUTHORISATION_SUCCESS));
+    }
+
     private Optional<StripeCharge> getStripeCharge(ChargeEntity charge) throws GatewayException.GatewayErrorException, GatewayException.GenericGatewayException, GatewayException.GatewayConnectionTimeoutException {
         StripePaymentIntent paymentIntent = getPaymentIntent(charge);
+
         List<StripeCharge> charges = paymentIntent.getChargesCollection().getCharges();
         if (charges.size() > 1) {
             throw new RuntimeException("Expected at most 1 Charge for PaymentIntent, found " + charges.size());


### PR DESCRIPTION
For some payments that fail 3DS, no charge is created for the payment intent in Stripe. This means that we cannot determine from the Stripe API whether or not the payment has been through 3DS, and so whether to apply a 3DS fee.

Implement a (possibly) temporary solution, where if there is no Stripe charge, look at the charge events in connector to determine whether 3DS was completed. We are only able to determine that 3DS was used if there is an AUTHORISATION_REJECTED event or AUTHORISATION_SUCCESS event. This means we cannot account for payments where 3DS is initiated but not completed, which we may still be charged a fee for.