### PR TITLE
pp-8945 provide payment intent information on stripe authorisation fa…

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeAuthorisationFailedResponse.java
@@ -1,7 +1,10 @@
 package uk.gov.pay.connector.gateway.stripe.json;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.model.Gateway3dsRequiredParams;
 import uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse;
+import uk.gov.pay.connector.gateway.stripe.handler.StripeAuthoriseHandler;
 
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -11,7 +14,9 @@ import static uk.gov.pay.connector.gateway.model.response.BaseAuthoriseResponse.
 
 public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse {
 
-    private StripeErrorResponse errorResponse;
+    private static final Logger logger = LoggerFactory.getLogger(StripeAuthorisationFailedResponse.class);
+
+    private final StripeErrorResponse errorResponse;
 
     private StripeAuthorisationFailedResponse(StripeErrorResponse errorResponse) {
         this.errorResponse = errorResponse;
@@ -23,7 +28,13 @@ public class StripeAuthorisationFailedResponse implements BaseAuthoriseResponse 
 
     @Override
     public String getTransactionId() {
-        return errorResponse.getError().getCharge();
+        if (errorResponse != null && errorResponse.getError() != null
+                && errorResponse.getError().getStripePaymentIntent() != null) {
+            return errorResponse.getError().getStripePaymentIntent().getId();
+        } else {
+            logger.error("Payment intent not found on Stripe error response");
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/json/StripeErrorResponse.java
@@ -28,7 +28,7 @@ public class StripeErrorResponse {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class Error {
+    public static class Error {
 
         @JsonProperty("charge")
         private String charge;
@@ -38,6 +38,8 @@ public class StripeErrorResponse {
         private String code;
         @JsonProperty("message")
         private String message;
+        @JsonProperty("payment_intent")
+        private StripePaymentIntent stripePaymentIntent;
 
         public String getType() {
             return type;
@@ -53,6 +55,10 @@ public class StripeErrorResponse {
 
         public String getCharge() {
             return charge;
+        }
+        
+        public StripePaymentIntent getStripePaymentIntent() {
+            return stripePaymentIntent;
         }
 
         @Override
@@ -70,7 +76,9 @@ public class StripeErrorResponse {
             if (StringUtils.isNotBlank(message)) {
                 joiner.add("message: " + getMessage());
             }
-
+            if (stripePaymentIntent != null) {
+                joiner.add("payment intent: " + stripePaymentIntent.getId());
+            }
             return joiner.toString();
         }
     }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/StripePaymentProviderTest.java
@@ -33,13 +33,13 @@ import uk.gov.pay.connector.model.domain.AuthCardDetailsFixture;
 import uk.gov.pay.connector.util.JsonObjectMapper;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 
-import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -68,19 +68,17 @@ import static uk.gov.pay.connector.util.TestTemplateResourceLoader.load;
 public class StripePaymentProviderTest {
 
     private StripePaymentProvider provider;
-    private GatewayClient gatewayClient = mock(GatewayClient.class);
-    private GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
-    private Environment environment = mock(Environment.class);
-    private MetricRegistry metricRegistry = mock(MetricRegistry.class);
-    private ConnectorConfiguration configuration = mock(ConnectorConfiguration.class);
-    private StripeGatewayConfig gatewayConfig = mock(StripeGatewayConfig.class);
-    private LinksConfig linksConfig = mock(LinksConfig.class);
-    private JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
-    private GatewayClient.Response paymentMethodResponse = mock(GatewayClient.Response.class);
-    private GatewayClient.Response paymentIntentsResponse = mock(GatewayClient.Response.class);
-    private Clock clock = mock(Clock.class);
-    private EventService eventService = mock(EventService.class);
-    
+    private final GatewayClient gatewayClient = mock(GatewayClient.class);
+    private final GatewayClientFactory gatewayClientFactory = mock(GatewayClientFactory.class);
+    private final Environment environment = mock(Environment.class);
+    private final MetricRegistry metricRegistry = mock(MetricRegistry.class);
+    private final ConnectorConfiguration configuration = mock(ConnectorConfiguration.class);
+    private final StripeGatewayConfig gatewayConfig = mock(StripeGatewayConfig.class);
+    private final LinksConfig linksConfig = mock(LinksConfig.class);
+    private final JsonObjectMapper objectMapper = new JsonObjectMapper(new ObjectMapper());
+    private final GatewayClient.Response paymentMethodResponse = mock(GatewayClient.Response.class);
+    private final GatewayClient.Response paymentIntentsResponse = mock(GatewayClient.Response.class);
+
     private static final String issuerUrl = "http://stripe.url/3ds";
     private static final String threeDsVersion = "2.0.1";
 
@@ -188,9 +186,10 @@ public class StripePaymentProviderTest {
 
         BaseAuthoriseResponse baseAuthoriseResponse = authoriseResponse.getBaseResponse().get();
         assertThat(baseAuthoriseResponse.authoriseStatus().getMappedChargeStatus(), is(AUTHORISATION_REJECTED));
+        assertThat(baseAuthoriseResponse.getTransactionId(), equalTo("pi_aaaaaaaaaaaaaaaaaaaaaaaa"));
         assertThat(baseAuthoriseResponse.toString(), containsString("type: card_error"));
-        assertThat(baseAuthoriseResponse.toString(), containsString("code: resource_missing"));
         assertThat(baseAuthoriseResponse.toString(), containsString("message: No such charge: ch_123456 or something similar"));
+        assertThat(baseAuthoriseResponse.toString(), containsString("code: resource_missing"));
     }
 
     @Test

--- a/src/test/resources/templates/stripe/error_response.json
+++ b/src/test/resources/templates/stripe/error_response.json
@@ -1,8 +1,116 @@
 {
   "error": {
-    "charge": "ch_1DX3j5C6H5MjhE5YhPcLhENF",
+    "charge": "ch_aaaaaaaaaaaaaaaaaaaaaaaa",
     "code": "resource_missing",
+    "decline_code": "generic_decline",
+    "doc_url": "https://stripe.com/docs/error-codes/card-declined",
     "message": "No such charge: ch_123456 or something similar",
-    "type": "{{type}}"
+    "type": "{{type}}",
+    "payment_intent": {
+      "id": "pi_aaaaaaaaaaaaaaaaaaaaaaaa",
+      "object": "payment_intent",
+      "amount": 12000,
+      "amount_capturable": 0,
+      "charges": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ch_aaaaaaaaaaaaaaaaaaaaaaaa",
+            "object": "charge",
+            "amount": 12000,
+            "amount_captured": 0,
+            "amount_refunded": 0,
+            "application": null,
+            "application_fee": null,
+            "application_fee_amount": null,
+            "balance_transaction": null,
+            "billing_details": {
+              "address": {
+                "city": "Manchester",
+                "country": "GB",
+                "line1": "Floor 1A City Tower",
+                "line2": "Piccadilly Plaza",
+                "postal_code": "M1 4BT",
+                "state": null
+              },
+              "email": null,
+              "name": "J. Bogs",
+              "phone": null
+            },
+            "calculated_statement_descriptor": "Stripe",
+            "captured": false,
+            "created": 1641912339,
+            "currency": "gbp",
+            "customer": null,
+            "description": "New passport application",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_code": "card_declined",
+            "failure_message": "Your card was declined.",
+            "fraud_details": {
+            },
+            "invoice": null,
+            "livemode": false,
+            "metadata": {
+            },
+            "on_behalf_of": "acct_aaaaaaaaaaaaaaaa",
+            "order": null,
+            "outcome": {
+              "network_status": "declined_by_network",
+              "reason": "generic_decline",
+              "risk_level": "normal",
+              "risk_score": 24,
+              "seller_message": "The bank did not return any further details with this decline.",
+              "type": "issuer_declined"
+            },
+            "paid": false,
+            "payment_intent": "pi_aaaaaaaaaaaaaaaaaaaaaaaa",
+            "payment_method": "pm_aaaaaaaaaaaaaaaaaaaaaaaa",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": "pass",
+                  "address_postal_code_check": "pass",
+                  "cvc_check": "pass"
+                },
+                "country": "US",
+                "exp_month": 2,
+                "exp_year": 2023,
+                "fingerprint": "0CFI1ogMdJ3zM4Ey",
+                "funding": "credit",
+                "installments": null,
+                "last4": "0002",
+                "network": "visa",
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": null,
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [
+              ],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/charges/ch_aaaaaaaaaaaaaaaaaaaaaaaa/refunds"
+            },
+            "review": null,
+            "shipping": null,
+            "source": null,
+            "source_transfer": null,
+            "statement_descriptor": null,
+            "statement_descriptor_suffix": null,
+            "status": "failed",
+            "transfer_data": null
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
…ilures

## WHAT YOU DID
Previously, payments that failed authorisation were storing the stripe charge id for the gateway_transaction_id. This was left over from when our stripe payment integration was not using payment intent.

To be consistent with successful payments, this has been updated to return the payment intent id.

Co-authored-by: @stephencdaly 
