### PR TITLE
PP-8951 Add reason to metadata for Stripe transfers

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferInRequest.java
@@ -25,9 +25,10 @@ public class StripeTransferInRequest extends StripeTransferRequest {
             StripeGatewayConfig stripeGatewayConfig,
             String govukPayTransactionExternalId,
             Map<String, String> credentials,
-            String transferGroup) {
+            String transferGroup,
+            StripeTransferMetadataReason reason) {
         super(amount, gatewayAccount, stripeChargeId, idempotencyKey, stripeGatewayConfig,
-                govukPayTransactionExternalId, credentials);
+                govukPayTransactionExternalId, credentials, reason);
         this.transferGroup = transferGroup;
     }
 
@@ -41,7 +42,8 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 stripeGatewayConfig,
                 request.getRefundExternalId(),
                 request.getGatewayCredentials(),
-                request.getChargeExternalId()
+                request.getChargeExternalId(),
+                StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT
         );
     }
     
@@ -59,7 +61,8 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 stripeGatewayConfig,
                 chargeExternalId,
                 gatewayAccountCredentials.getCredentials(),
-                chargeExternalId);
+                chargeExternalId,
+                StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT);
     }
 
     @Override
@@ -70,7 +73,7 @@ public class StripeTransferInRequest extends StripeTransferRequest {
                 "transfer_group", transferGroup
         );
         Map<String, String> commonParams = super.params();
-        params.putAll(transferOutParams);
+        params.putAll(transferOutParams); 
         params.putAll(commonParams);
 
         return params;

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
@@ -1,7 +1,6 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
 import java.util.Map;
-import java.util.Optional;
 
 public class StripeTransferMetadata {
     public static final String STRIPE_CHARGE_ID_KEY = "stripe_charge_id";

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadata.java
@@ -1,30 +1,38 @@
 package uk.gov.pay.connector.gateway.stripe.request;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class StripeTransferMetadata {
     public static final String STRIPE_CHARGE_ID_KEY = "stripe_charge_id";
     public static final String GOVUK_PAY_TRANSACTION_EXTERNAL_ID = "govuk_pay_transaction_external_id";
+    public static final String REASON_KEY = "reason";
 
     private final String stripeChargeId;
     private final String govukPayTransactionExternalId;
+    private final StripeTransferMetadataReason reason;
 
-    public StripeTransferMetadata(String stripeChargeId, String reconciliationTransactionId) {
+    public StripeTransferMetadata(String stripeChargeId, String reconciliationTransactionId, StripeTransferMetadataReason reason) {
         this.stripeChargeId = stripeChargeId;
         this.govukPayTransactionExternalId = reconciliationTransactionId;
+        this.reason = reason;
     }
 
     public static StripeTransferMetadata from(Map<String, String> metadata) {
-        return new StripeTransferMetadata(metadata.get(STRIPE_CHARGE_ID_KEY), metadata.get(GOVUK_PAY_TRANSACTION_EXTERNAL_ID));
+        return new StripeTransferMetadata(
+                metadata.get(STRIPE_CHARGE_ID_KEY),
+                metadata.get(GOVUK_PAY_TRANSACTION_EXTERNAL_ID),
+                StripeTransferMetadataReason.fromString(metadata.get(REASON_KEY)));
     }
 
     public Map<String, String> getParams() {
         return Map.of(
                 formatMetadataRequestKey(STRIPE_CHARGE_ID_KEY), this.stripeChargeId,
-                formatMetadataRequestKey(GOVUK_PAY_TRANSACTION_EXTERNAL_ID), this.govukPayTransactionExternalId
+                formatMetadataRequestKey(GOVUK_PAY_TRANSACTION_EXTERNAL_ID), this.govukPayTransactionExternalId,
+                formatMetadataRequestKey(REASON_KEY), this.reason.toString()
         );
     }
-    
+
     private String formatMetadataRequestKey(String key) {
         return String.format("metadata[%s]", key);
     }
@@ -35,5 +43,9 @@ public class StripeTransferMetadata {
 
     public String getGovukPayTransactionExternalId() {
         return govukPayTransactionExternalId;
+    }
+
+    public StripeTransferMetadataReason getReason() {
+        return reason;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
@@ -1,0 +1,23 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+public enum StripeTransferMetadataReason {
+    NOT_DEFINED,
+    TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT,
+    TRANSFER_REFUND_AMOUNT,
+    TRANSFER_PAYMENT_AMOUNT;
+    
+    public static StripeTransferMetadataReason fromString(String value) {
+        if (value == null) {
+            return NOT_DEFINED;
+        }
+        return Arrays.stream(StripeTransferMetadataReason.values())
+                .filter(stripeTransferMetadataReason -> StringUtils.equals(stripeTransferMetadataReason.name(), value.toUpperCase(Locale.ENGLISH)))
+                .findFirst()
+                .orElse(StripeTransferMetadataReason.NOT_DEFINED);
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReason.java
@@ -11,13 +11,18 @@ public enum StripeTransferMetadataReason {
     TRANSFER_REFUND_AMOUNT,
     TRANSFER_PAYMENT_AMOUNT;
     
+    @Override
+    public String toString() {
+        return name().toLowerCase((Locale.ENGLISH));
+    }
+    
     public static StripeTransferMetadataReason fromString(String value) {
         if (value == null) {
             return NOT_DEFINED;
         }
         return Arrays.stream(StripeTransferMetadataReason.values())
-                .filter(stripeTransferMetadataReason -> StringUtils.equals(stripeTransferMetadataReason.name(), value.toUpperCase(Locale.ENGLISH)))
+                .filter(stripeTransferMetadataReason -> StringUtils.equalsIgnoreCase(stripeTransferMetadataReason.name(), value))
                 .findFirst()
-                .orElse(StripeTransferMetadataReason.NOT_DEFINED);
+                .orElse(NOT_DEFINED);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequest.java
@@ -18,7 +18,7 @@ public class StripeTransferOutRequest extends StripeTransferRequest {
                                      String govukPayTransactionExternalId,
                                      Map<String, String> credentials) {
         super(amount, gatewayAccount, sourceTransactionId, idempotencyKey, stripeGatewayConfig,
-                govukPayTransactionExternalId, credentials);
+                govukPayTransactionExternalId, credentials, StripeTransferMetadataReason.TRANSFER_PAYMENT_AMOUNT);
     }
 
     public static StripeTransferOutRequest of(String amount, String stripeChargeId, CaptureGatewayRequest request, StripeGatewayConfig stripeGatewayConfig) {

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferRequest.java
@@ -11,6 +11,7 @@ public abstract class StripeTransferRequest extends StripeRequest {
     protected String amount;
     protected String stripeChargeId;
     protected String govukPayTransactionExternalId;
+    protected StripeTransferMetadataReason reason;
 
     protected StripeTransferRequest(
             String amount,
@@ -19,11 +20,13 @@ public abstract class StripeTransferRequest extends StripeRequest {
             String idempotencyKey,
             StripeGatewayConfig stripeGatewayConfig,
             String govukPayTransactionExternalId,
-            Map<String, String> credentials) {
+            Map<String, String> credentials,
+            StripeTransferMetadataReason reason) {
         super(gatewayAccount, idempotencyKey, stripeGatewayConfig, credentials);
         this.stripeChargeId = stripeChargeId;
         this.amount = amount;
         this.govukPayTransactionExternalId = govukPayTransactionExternalId;
+        this.reason = reason;
     }
 
     public String urlPath() {
@@ -32,7 +35,7 @@ public abstract class StripeTransferRequest extends StripeRequest {
 
     @Override
     protected Map<String, String> params() {
-        StripeTransferMetadata stripeTransferMetadata = new StripeTransferMetadata(this.stripeChargeId, this.govukPayTransactionExternalId);
+        StripeTransferMetadata stripeTransferMetadata = new StripeTransferMetadata(stripeChargeId, govukPayTransactionExternalId, reason);
         Map<String, String> baseParams = new HashMap<>();
         baseParams.put("amount", amount);
         baseParams.put("currency", "GBP");

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReasonTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReasonTest.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.gateway.stripe.request;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+class StripeTransferMetadataReasonTest {
+    
+    @Test
+    void shouldResolveEnumValueWhenExists() {
+        assertThat(StripeTransferMetadataReason.fromString("TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT"), is(StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT));
+    }
+
+    @Test
+    void shouldResolveEnumValueWhenExists_ignoresCase() {
+        assertThat(StripeTransferMetadataReason.fromString("transfer_fee_amount_for_failed_payment"), is(StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT));
+    }
+
+    @Test
+    void shouldResolveDefaultValueWhenNotExists() {
+        assertThat(StripeTransferMetadataReason.fromString("BLAH"), is(StripeTransferMetadataReason.NOT_DEFINED));
+    }
+
+    @Test
+    void shouldResolveDefaultValueForNullValue() {
+        assertThat(StripeTransferMetadataReason.fromString(null), is(StripeTransferMetadataReason.NOT_DEFINED));
+    }
+}

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReasonTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataReasonTest.java
@@ -2,19 +2,23 @@ package uk.gov.pay.connector.gateway.stripe.request;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+
 
 class StripeTransferMetadataReasonTest {
     
     @Test
     void shouldResolveEnumValueWhenExists() {
-        assertThat(StripeTransferMetadataReason.fromString("TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT"), is(StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT));
+        assertThat(StripeTransferMetadataReason.fromString("transfer_fee_amount_for_failed_payment"), is(StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT));
     }
 
     @Test
     void shouldResolveEnumValueWhenExists_ignoresCase() {
-        assertThat(StripeTransferMetadataReason.fromString("transfer_fee_amount_for_failed_payment"), is(StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT));
+        assertThat(StripeTransferMetadataReason.fromString("TRANSFER_PAYMENT_AMOUNT"), is(StripeTransferMetadataReason.TRANSFER_PAYMENT_AMOUNT));
     }
 
     @Test
@@ -25,5 +29,11 @@ class StripeTransferMetadataReasonTest {
     @Test
     void shouldResolveDefaultValueForNullValue() {
         assertThat(StripeTransferMetadataReason.fromString(null), is(StripeTransferMetadataReason.NOT_DEFINED));
+    }
+    
+    @Test
+    void shouldBeLowerCaseWhenConvertedToString() {
+        assertThat(StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT.toString(), is(not(StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT.name())));
+        assertThat(StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT.toString(), is(StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT.name().toLowerCase(Locale.ENGLISH)));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
@@ -8,6 +8,9 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadataReason.NOT_DEFINED;
+import static uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadataReason.TRANSFER_PAYMENT_AMOUNT;
+import static uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StripeTransferMetadataTest {
@@ -17,12 +20,12 @@ public class StripeTransferMetadataTest {
         Map<String, String> stripeObjectMetadata = Map.of(
                 "stripe_charge_id", "some-charge-id",
                 "govuk_pay_transaction_external_id", "some-reconciliation-transaction-id",
-                "reason", "TRANSFER_REFUND_AMOUNT"
+                "reason", "transfer_payment_amount"
         );
         var stripeTransferMetadata = StripeTransferMetadata.from(stripeObjectMetadata);
         assertThat(stripeTransferMetadata.getStripeChargeId(), is("some-charge-id"));
         assertThat(stripeTransferMetadata.getGovukPayTransactionExternalId(), is("some-reconciliation-transaction-id"));
-        assertThat(stripeTransferMetadata.getReason(), is(StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT));
+        assertThat(stripeTransferMetadata.getReason(), is(TRANSFER_PAYMENT_AMOUNT));
     }
 
     @Test
@@ -34,17 +37,17 @@ public class StripeTransferMetadataTest {
         var stripeTransferMetadata = StripeTransferMetadata.from(stripeObjectMetadata);
         assertThat(stripeTransferMetadata.getStripeChargeId(), is("some-charge-id"));
         assertThat(stripeTransferMetadata.getGovukPayTransactionExternalId(), is("some-reconciliation-transaction-id"));
-        assertThat(stripeTransferMetadata.getReason(), is(StripeTransferMetadataReason.NOT_DEFINED));
+        assertThat(stripeTransferMetadata.getReason(), is(NOT_DEFINED));
     }
 
     @Test
     public void shouldSerialiseToMetadata() {
         var stripeTransferMetadata = new StripeTransferMetadata("some-charge-id",
                 "some-reconciliation-transaction-id",
-                StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT);
+                TRANSFER_REFUND_AMOUNT);
         var requestMap = stripeTransferMetadata.getParams();
         assertThat(requestMap.get("metadata[stripe_charge_id]"), is("some-charge-id"));
         assertThat(requestMap.get("metadata[govuk_pay_transaction_external_id]"), is("some-reconciliation-transaction-id"));
-        assertThat(requestMap.get("metadata[reason]"), is("TRANSFER_REFUND_AMOUNT"));
+        assertThat(requestMap.get("metadata[reason]"), is("transfer_refund_amount"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferMetadataTest.java
@@ -16,18 +16,35 @@ public class StripeTransferMetadataTest {
     public void shouldDeserialiseFromMetadata() {
         Map<String, String> stripeObjectMetadata = Map.of(
                 "stripe_charge_id", "some-charge-id",
+                "govuk_pay_transaction_external_id", "some-reconciliation-transaction-id",
+                "reason", "TRANSFER_REFUND_AMOUNT"
+        );
+        var stripeTransferMetadata = StripeTransferMetadata.from(stripeObjectMetadata);
+        assertThat(stripeTransferMetadata.getStripeChargeId(), is("some-charge-id"));
+        assertThat(stripeTransferMetadata.getGovukPayTransactionExternalId(), is("some-reconciliation-transaction-id"));
+        assertThat(stripeTransferMetadata.getReason(), is(StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT));
+    }
+
+    @Test
+    public void shouldDeserialiseFromMetadata_whenMetadataDoesNotIncludeReason() {
+        Map<String, String> stripeObjectMetadata = Map.of(
+                "stripe_charge_id", "some-charge-id",
                 "govuk_pay_transaction_external_id", "some-reconciliation-transaction-id"
         );
         var stripeTransferMetadata = StripeTransferMetadata.from(stripeObjectMetadata);
         assertThat(stripeTransferMetadata.getStripeChargeId(), is("some-charge-id"));
-        assertThat(stripeTransferMetadata.getGovukPayTransactionExternalId(),is("some-reconciliation-transaction-id"));
+        assertThat(stripeTransferMetadata.getGovukPayTransactionExternalId(), is("some-reconciliation-transaction-id"));
+        assertThat(stripeTransferMetadata.getReason(), is(StripeTransferMetadataReason.NOT_DEFINED));
     }
 
     @Test
-    public void shouldSeraliseToMetadata() {
-        var stripeTransferMetadata = new StripeTransferMetadata("some-charge-id", "some-reconciliation-transaction-id");
+    public void shouldSerialiseToMetadata() {
+        var stripeTransferMetadata = new StripeTransferMetadata("some-charge-id",
+                "some-reconciliation-transaction-id",
+                StripeTransferMetadataReason.TRANSFER_REFUND_AMOUNT);
         var requestMap = stripeTransferMetadata.getParams();
         assertThat(requestMap.get("metadata[stripe_charge_id]"), is("some-charge-id"));
         assertThat(requestMap.get("metadata[govuk_pay_transaction_external_id]"), is("some-reconciliation-transaction-id"));
+        assertThat(requestMap.get("metadata[reason]"), is("TRANSFER_REFUND_AMOUNT"));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
+++ b/src/test/java/uk/gov/pay/connector/gateway/stripe/request/StripeTransferOutRequestTest.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
@@ -86,6 +86,7 @@ public class StripeTransferOutRequestTest {
         assertThat(payload, containsString("expand%5B%5D=balance_transaction"));
         assertThat(payload, containsString("expand%5B%5D=destination_payment"));
         assertThat(payload, containsString("metadata%5Bgovuk_pay_transaction_external_id%5D=" + chargeExternalId));
+        assertThat(payload, containsString("metadata%5Breason%5D=" + StripeTransferMetadataReason.TRANSFER_PAYMENT_AMOUNT));
     }
 
     @Test


### PR DESCRIPTION
Add a "reason" field to the metadata we attach to a Stripe transfer when
it is created. This will allow us to later determine the purpose of the
transfer, as we need to be able to differentiate between transfers made
for refunds and transfers made to collect fees for failed payments when
reconciling payouts.

We also attach a reason to transfers made for payments when they are
captured, but we will not use this for anything other than information
purposes when viewing in the Stripe dashboard.

Co-authored-by: Nathaniel Steers <nathaniel.steers@digital.cabinet-office.gov.uk>