### PR TITLE
PP-8951 amend payout processing for fee collection balance tx

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -417,7 +417,7 @@
         "filename": "src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java",
         "hashed_secret": "f182dd26dca3b13579d94c83c1d8cccba160ff77",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 101
       }
     ],
     "src/test/java/uk/gov/pay/connector/resources/AuthCardDetailsValidatorTest.java": [
@@ -793,5 +793,5 @@
       }
     ]
   },
-  "generated_at": "2022-01-14T14:10:21Z"
+  "generated_at": "2022-01-14T16:48:42Z"
 }

--- a/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
+++ b/src/test/java/uk/gov/pay/connector/payout/PayoutReconcileProcessTest.java
@@ -32,7 +32,6 @@ import uk.gov.pay.connector.gateway.stripe.json.StripePayout;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountType;
 import uk.gov.pay.connector.gatewayaccount.model.StripeCredentials;
-import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCredentialsEntity;
 import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 import uk.gov.pay.connector.queue.QueueException;
 import uk.gov.pay.connector.queue.QueueMessage;
@@ -49,14 +48,17 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadata.GOVUK_PAY_TRANSACTION_EXTERNAL_ID;
+import static uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadata.REASON_KEY;
+import static uk.gov.pay.connector.gateway.stripe.request.StripeTransferMetadataReason.TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT;
 import static uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntityFixture.aGatewayAccountEntity;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -94,20 +96,18 @@ public class PayoutReconcileProcessTest {
 
     @Captor
     private ArgumentCaptor<LoggingEvent> loggingEventArgumentCaptor;
-
-    private GatewayAccountEntity gatewayAccountEntity;
-    private GatewayAccountCredentialsEntity gatewayAccountCredentialsEntity;
-
+    
     private final String stripeAccountId = "acct_2RDpWRLXEC2XwBWp";
     private final String stripeApiKey = "a-fake-api-key";
     private final String payoutId = "po_123dv3RPEC2XwBWpqiQfnJGQ";
     private final ZonedDateTime payoutCreatedDate = ZonedDateTime.parse("2020-05-01T10:30:00.000Z");
     private final String paymentExternalId = "payment-id";
     private final String refundExternalId = "refund-id";
+    private final String failedPaymentWithFeeExternalId = "failed-payment-with-fee-id";
 
     @Before
     public void setUp() throws Exception {
-        gatewayAccountEntity = aGatewayAccountEntity()
+        GatewayAccountEntity gatewayAccountEntity = aGatewayAccountEntity()
                 .withType(GatewayAccountType.TEST)
                 .build();
 
@@ -125,34 +125,34 @@ public class PayoutReconcileProcessTest {
 
     @Test
     public void shouldEmitEventsForMessageAndMarkAsProcessed() throws Exception {
-        when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
-
-        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
-
-        payoutReconcileProcess.processPayouts();
-
         var paymentEvent = new PaymentIncludedInPayout(paymentExternalId, payoutId, payoutCreatedDate);
         var refundEvent = new RefundIncludedInPayout(refundExternalId, payoutId, payoutCreatedDate);
-        StripePayout stripePayout = new StripePayout("po_123", 1213L, 1589395533L,
+        var feeCollectionEvent = new PaymentIncludedInPayout(failedPaymentWithFeeExternalId, payoutId, payoutCreatedDate);
+        var stripePayout = new StripePayout("po_123", 1213L, 1589395533L,
                 1589395500L, "pending", "card", "statement_desc");
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
+        when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
+        
+        payoutReconcileProcess.processPayouts();
 
-        verify(eventService).emitEvent(eq(paymentEvent), eq(false));
-        verify(eventService).emitEvent(eq(refundEvent), eq(false));
-        verify(payoutEmitterService).emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated(),
+        verify(eventService, atMost(1)).emitEvent(paymentEvent, false);
+        verify(eventService, atMost(1)).emitEvent(refundEvent, false);
+        verify(eventService, atMost(1)).emitEvent(feeCollectionEvent, false);
+        verifyNoMoreInteractions(eventService);
+        verify(payoutEmitterService, atMost(1)).emitPayoutEvent(PayoutCreated.class, stripePayout.getCreated(),
                 stripeAccountId, stripePayout);
-
-        verify(payoutReconcileQueue).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
+        verify(payoutReconcileQueue, atMost(1)).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
 
     @Test
     public void shouldEmitAdditionalPayoutPaidEventIfPayoutStatusIsPaid() throws Exception {
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
+        ArgumentCaptor<Class<? extends PayoutEvent>> captor = ArgumentCaptor.forClass(Class.class);
         setupMockBalanceTransactions("paid");
         when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
 
-        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
         payoutReconcileProcess.processPayouts();
 
-        ArgumentCaptor<Class<? extends PayoutEvent>> captor = ArgumentCaptor.forClass(Class.class);
         verify(payoutEmitterService, times(2)).emitPayoutEvent(
                 captor.capture(), any(), any(), any());
 
@@ -164,21 +164,22 @@ public class PayoutReconcileProcessTest {
 
     @Test
     public void shouldEmitAdditionalPayoutFailedEventIfPayoutStatusIsFailed() throws Exception {
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
+        ArgumentCaptor<Class<? extends PayoutEvent>> captor = ArgumentCaptor.forClass(Class.class);
+        ArgumentCaptor<StripePayout> captorForStripePayout = ArgumentCaptor.forClass(StripePayout.class);
         setupMockBalanceTransactions("failed");
         when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
 
-        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
         payoutReconcileProcess.processPayouts();
-
-        ArgumentCaptor<Class<? extends PayoutEvent>> captor = ArgumentCaptor.forClass(Class.class);
-        ArgumentCaptor<StripePayout> captorForStripePayout = ArgumentCaptor.forClass(StripePayout.class);
+        
         verify(payoutEmitterService, times(2)).emitPayoutEvent(
                 captor.capture(), any(), any(), captorForStripePayout.capture());
+
+        StripePayout stripePayoutForFailedEvent = captorForStripePayout.getAllValues().get(1);
 
         assertThat(captor.getAllValues().get(0), is(PayoutCreated.class));
         assertThat(captor.getAllValues().get(1), is(PayoutFailed.class));
 
-        StripePayout stripePayoutForFailedEvent = captorForStripePayout.getAllValues().get(1);
         assertThat(stripePayoutForFailedEvent.getFailureCode(), is("account_closed"));
         assertThat(stripePayoutForFailedEvent.getFailureMessage(), is("The bank account has been closed"));
         assertThat(stripePayoutForFailedEvent.getFailureBalanceTransaction(), is("ba_1GkZtqDv3CZEaFO2CQhLrluk"));
@@ -188,9 +189,8 @@ public class PayoutReconcileProcessTest {
 
     @Test
     public void shouldNotEmitEventsIfConnectorConfigurationDisabled() throws Exception {
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
         when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(false);
-
-        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
 
         payoutReconcileProcess.processPayouts();
 
@@ -200,9 +200,8 @@ public class PayoutReconcileProcessTest {
 
     @Test
     public void shouldNotMarkMessageAsSuccessfullyProcessedIfNoPaymentsOrRefundsFound() throws Exception {
-        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
-
-        when(stripeClientWrapper.getBalanceTransactionsForPayout(eq(payoutId), eq(stripeAccountId), eq(stripeApiKey)))
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
+        when(stripeClientWrapper.getBalanceTransactionsForPayout(payoutId, stripeAccountId, stripeApiKey))
                 .thenReturn(List.of());
 
         payoutReconcileProcess.processPayouts();
@@ -212,42 +211,37 @@ public class PayoutReconcileProcessTest {
 
     @Test
     public void shouldNotMarkMessageAsSuccessfullyProcessedIfEventEmissionFails() throws Exception {
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
         when(connectorConfiguration.getEmitPayoutEvents()).thenReturn(true);
-
-        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
-
+        
         doThrow(new QueueException()).when(eventService).emitEvent(any(), anyBoolean());
 
         payoutReconcileProcess.processPayouts();
 
         verify(logAppender).doAppend(loggingEventArgumentCaptor.capture());
         assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("Error sending PAYMENT_INCLUDED_IN_PAYOUT event"));
-
         verify(payoutReconcileQueue, never()).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
 
     @Test
     public void shouldNotMarkMessageAsSuccessfullyProcessedIfStripeTransferMetadataMissing() throws Exception {
-        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage(stripeAccountId);
-
+        PayoutReconcileMessage payoutReconcileMessage = setupQueueMessage();
         BalanceTransaction refundBalanceTransaction = mock(BalanceTransaction.class);
         Transfer refundTransferSource = mock(Transfer.class);
         when(refundBalanceTransaction.getType()).thenReturn("transfer");
         when(refundBalanceTransaction.getSourceObject()).thenReturn(refundTransferSource);
         when(refundTransferSource.getMetadata()).thenReturn(Map.of());
-
-        when(stripeClientWrapper.getBalanceTransactionsForPayout(eq(payoutId), eq(stripeAccountId), eq(stripeApiKey)))
+        when(stripeClientWrapper.getBalanceTransactionsForPayout(payoutId, stripeAccountId, stripeApiKey))
                 .thenReturn(List.of(refundBalanceTransaction));
 
         payoutReconcileProcess.processPayouts();
 
         verify(logAppender).doAppend(loggingEventArgumentCaptor.capture());
         assertThat(loggingEventArgumentCaptor.getValue().getFormattedMessage(), containsString("Transaction external ID missing in metadata"));
-
         verify(payoutReconcileQueue, never()).markMessageAsProcessed(payoutReconcileMessage.getQueueMessage());
     }
 
-    private PayoutReconcileMessage setupQueueMessage(String stripeAccountId) throws QueueException {
+    private PayoutReconcileMessage setupQueueMessage() throws QueueException {
         Payout payout = new Payout(payoutId, stripeAccountId, payoutCreatedDate);
         QueueMessage mockQueueMessage = mock(QueueMessage.class);
         PayoutReconcileMessage payoutReconcileMessage = PayoutReconcileMessage.of(payout, mockQueueMessage);
@@ -270,6 +264,15 @@ public class PayoutReconcileProcessTest {
         when(refundBalanceTransaction.getSourceObject()).thenReturn(refundTransferSource);
         when(refundTransferSource.getMetadata()).thenReturn(Map.of(GOVUK_PAY_TRANSACTION_EXTERNAL_ID, refundExternalId));
 
+        BalanceTransaction feeBalanceTransaction = mock(BalanceTransaction.class);
+        Transfer feeTransferSource = mock(Transfer.class);
+        when(feeBalanceTransaction.getType()).thenReturn("transfer");
+        when(feeBalanceTransaction.getSourceObject()).thenReturn(feeTransferSource);
+        when(feeTransferSource.getMetadata()).thenReturn(Map.of(
+                GOVUK_PAY_TRANSACTION_EXTERNAL_ID, failedPaymentWithFeeExternalId,
+                REASON_KEY, TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT.toString()
+        ));
+
         BalanceTransaction payoutBalanceTransaction = mock(BalanceTransaction.class);
         com.stripe.model.Payout payoutSource = mock(com.stripe.model.Payout.class);
         when(payoutSource.getId()).thenReturn("po_123");
@@ -289,7 +292,12 @@ public class PayoutReconcileProcessTest {
         when(payoutBalanceTransaction.getType()).thenReturn("payout");
         when(payoutBalanceTransaction.getSourceObject()).thenReturn(payoutSource);
 
-        when(stripeClientWrapper.getBalanceTransactionsForPayout(eq(payoutId), eq(stripeAccountId), eq(stripeApiKey)))
-                .thenReturn(List.of(paymentBalanceTransaction, refundBalanceTransaction, payoutBalanceTransaction));
+        List<BalanceTransaction> balanceTransactions = List.of(
+                paymentBalanceTransaction,
+                refundBalanceTransaction,
+                feeBalanceTransaction,
+                payoutBalanceTransaction);
+        when(stripeClientWrapper.getBalanceTransactionsForPayout(payoutId, stripeAccountId, stripeApiKey))
+                .thenReturn(balanceTransactions);
     }
 }


### PR DESCRIPTION
## WHAT YOU DID
Updated the payouts process to emit `PAYMENT_INCLUDED_IN_PAYOUT` events when transfers are tagged with a `TRANSFER_FEE_AMOUNT_FOR_FAILED_PAYMENT` reason.

Previously, the processing loop would incorrectly assume that all transfers were refunds. Now, we check the `reason` to determine if the transfer is a payout for fee collection on failed payments.
