### PR TITLE
PP-9013: add search query param to query by stripe_account_id or merchant_id

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
+++ b/src/main/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParams.java
@@ -22,6 +22,7 @@ public class GatewayAccountSearchParams {
     private static final String REQUIRES_3DS_SQL_FIELD = "requires3ds";
     private static final String TYPE_SQL_FIELD = "type";
     private static final String PAYMENT_PROVIDER_SQL_FIELD = "gatewayName";
+    private static final String PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD = "paymentProviderAccountId";
     private static final String PROVIDER_SWITCH_ENABLED_SQL_FIELD = "providerSwitchEnabled";
 
     @QueryParam("accountIds")
@@ -66,6 +67,9 @@ public class GatewayAccountSearchParams {
             message = "Parameter [payment_provider] must be one of 'sandbox', 'worldpay', 'smartpay', 'epdq' or 'stripe'")
     private String paymentProvider;
 
+    @QueryParam("payment_provider_account_id")
+    private String paymentProviderAccountId;
+
     @QueryParam("provider_switch_enabled")
     @Pattern(regexp = "true|false",
             message = "Parameter [provider_switch_enabled] must be true or false")
@@ -97,6 +101,10 @@ public class GatewayAccountSearchParams {
 
     public void setPaymentProvider(String paymentProvider) {
         this.paymentProvider = paymentProvider;
+    }    
+    
+    public void setPaymentProviderAccountId(String paymentProviderAccountId) {
+        this.paymentProviderAccountId = paymentProviderAccountId;
     }
 
     public void setProviderSwitchEnabled(String providerSwitchEnabled) {
@@ -166,6 +174,16 @@ public class GatewayAccountSearchParams {
                     "  and a.payment_provider = #" + PAYMENT_PROVIDER_SQL_FIELD +
                     ")");
         }
+            if (StringUtils.isNotEmpty(paymentProviderAccountId)) {
+            filters.add(" ga.id in ( " +
+                    "  select gateway_account_id " +
+                    "  from ( " +
+                    "    select gateway_account_id " +
+                    "    from gateway_account_credentials gac " +
+                    "    where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD +
+                    "    or gac.credentials->>'merchant_id' = #" + PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD+ ") a" +
+                    ")");
+        }
         if (StringUtils.isNotEmpty(providerSwitchEnabled)) {
             filters.add(" ga.provider_switch_enabled = #" + PROVIDER_SWITCH_ENABLED_SQL_FIELD);
         }
@@ -207,6 +225,9 @@ public class GatewayAccountSearchParams {
         }
         if (StringUtils.isNotEmpty(paymentProvider)) {
             queryMap.put(PAYMENT_PROVIDER_SQL_FIELD, paymentProvider);
+        }        
+        if (StringUtils.isNotEmpty(paymentProviderAccountId)) {
+            queryMap.put(PAYMENT_PROVIDER_ACCOUNT_ID_SQL_FIELD, paymentProviderAccountId);
         }
         if (StringUtils.isNotEmpty(providerSwitchEnabled)) {
             queryMap.put(PROVIDER_SWITCH_ENABLED_SQL_FIELD, Boolean.valueOf(providerSwitchEnabled));
@@ -227,6 +248,7 @@ public class GatewayAccountSearchParams {
                 ", type='" + type + '\'' +
                 ", paymentProvider='" + paymentProvider + '\'' +
                 ", providerSwitchEnabled='" + providerSwitchEnabled + '\'' +
+                ", paymentProviderAccountId='" + paymentProviderAccountId + '\'' +
                 '}';
     }
 }

--- a/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
+++ b/src/test/java/uk/gov/pay/connector/gatewayaccount/model/GatewayAccountSearchParamsTest.java
@@ -26,6 +26,7 @@ public class GatewayAccountSearchParamsTest {
         params.setRequires3ds("true");
         params.setType("live");
         params.setPaymentProvider("stripe");
+        params.setPaymentProviderAccountId("acc123");
         params.setProviderSwitchEnabled("true");
 
         List<String> filterTemplates = params.getFilterTemplates();
@@ -48,7 +49,12 @@ public class GatewayAccountSearchParamsTest {
                         "  ) a " +
                         "  where rn = 1 " +
                         "  and a.payment_provider = #gatewayName" +
-                        ")"));
+                        ")",
+                " ga.id in (   select gateway_account_id   from " +
+                        "(     select gateway_account_id     from gateway_account_credentials gac     " +
+                        "where gac.gateway_account_id = ga.id and gac.credentials->>'stripe_account_id' = #paymentProviderAccountId" +
+                        "    or gac.credentials->>'merchant_id' = #paymentProviderAccountId) a)")
+        );
     }
 
     @Test
@@ -79,10 +85,11 @@ public class GatewayAccountSearchParamsTest {
         params.setRequires3ds("true");
         params.setType("live");
         params.setPaymentProvider("stripe");
+        params.setPaymentProviderAccountId("acc123");
         params.setProviderSwitchEnabled("true");
 
         Map<String, Object> queryMap = params.getQueryMap();
-        assertThat(queryMap, aMapWithSize(12));
+        assertThat(queryMap, aMapWithSize(13));
         assertThat(queryMap, hasEntry("accountIds0", 1L));
         assertThat(queryMap, hasEntry("accountIds1", 22L));
         assertThat(queryMap, hasEntry("serviceId0", "serviceidone"));
@@ -95,6 +102,7 @@ public class GatewayAccountSearchParamsTest {
         assertThat(queryMap, hasEntry("type", "LIVE"));
         assertThat(queryMap, hasEntry("gatewayName", "stripe"));
         assertThat(queryMap, hasEntry("providerSwitchEnabled", true));
+        assertThat(queryMap, hasEntry("paymentProviderAccountId", "acc123"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/GatewayAccountDaoIT.java
@@ -469,6 +469,40 @@ public class GatewayAccountDaoIT extends DaoITestBase {
         List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
         assertThat(gatewayAccounts, hasSize(1));
         assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+    }    
+    
+    @Test
+    public void shouldSearchForAccountsByPaymentProviderAccountId() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withPaymentGateway("sandbox")
+                .withCredentials(Map.of("stripe_account_id", "acc123"))
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setPaymentProviderAccountId("acc123");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
+    }    
+    
+    @Test
+    public void shouldSearchForAccountsByPaymentProviderMerchantId() {
+        long gatewayAccountId_1 = nextLong();
+        databaseTestHelper.addGatewayAccount(anAddGatewayAccountParams()
+                .withAccountId(String.valueOf(gatewayAccountId_1))
+                .withPaymentGateway("sandbox")
+                .withCredentials(Map.of("merchant_id", "acc123"))
+                .build());
+
+        var params = new GatewayAccountSearchParams();
+        params.setPaymentProviderAccountId("acc123");
+
+        List<GatewayAccountEntity> gatewayAccounts = gatewayAccountDao.search(params);
+        assertThat(gatewayAccounts, hasSize(1));
+        assertThat(gatewayAccounts.get(0).getId(), is(gatewayAccountId_1));
     }
 
     @Test


### PR DESCRIPTION
## WHAT YOU DID
add search query param to query for account by stripe_account_id or merchant_id
(this is intended for use by Toolbox as described in the story)

## How to test
Check code and tests make sense. Can be functionally tested alongside https://github.com/alphagov/pay-toolbox/pull/1294

## Code review checklist

### Logging

- [ ] only emit log lines at ERROR level which require immediate attention from a support engineer. These will trigger a zendesk alert.

### Documentation

- [ ] Updated README.md for any of the following ?

* Introduced any new environment variables / removed existing environment variable
* Added new API / updated existing API definition
