### PR TITLE
PP-8950 Skip expunging test Stripe payments without fees

### DIFF
--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -123,7 +123,8 @@ public class ChargeExpungeService {
     }
 
     private boolean isStripePaymentMissingFees(ChargeEntity chargeEntity) {
-        if (chargeEntity.getCreatedDate().isBefore(stripeGatewayConfig.getCollectFeeForStripeFailedPaymentsFromDate())) {
+        if (chargeEntity.getGatewayAccount().isLive() &&
+                chargeEntity.getCreatedDate().isBefore(stripeGatewayConfig.getCollectFeeForStripeFailedPaymentsFromDate())) {
             return false;
         }
         // We collect fees asynchronously for failed Stripe payments that we have attempted to authorise with Stripe -


### PR DESCRIPTION
Stripe V2 pricing for test accounts, including fees for failed payments, has been enabled on all environments.

If a payment is for a test account, skip expunging it if there are no fees collected when we expect fees to have been collected.