### PR TITLE
PP-9115 update credential state on notification

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -271,14 +271,14 @@
         "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java",
         "hashed_secret": "c2baab12724c0f29014dc172042a17ebbd9b60d4",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 114
       },
       {
         "type": "Secret Keyword",
         "filename": "src/test/java/uk/gov/pay/connector/gateway/stripe/StripeNotificationServiceTest.java",
         "hashed_secret": "4991aba1cb28cabc042aa415f2689cf359bb4af2",
         "is_verified": false,
-        "line_number": 107
+        "line_number": 115
       }
     ],
     "src/test/java/uk/gov/pay/connector/gateway/worldpay/WorldpayPaymentProviderTest.java": [
@@ -793,5 +793,5 @@
       }
     ]
   },
-  "generated_at": "2022-01-18T16:44:30Z"
+  "generated_at": "2022-02-03T11:51:23Z"
 }

--- a/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAccountUpdatedHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/stripe/StripeAccountUpdatedHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.pay.connector.gateway.stripe.response.StripeNotification;
+import uk.gov.pay.connector.gatewayaccountcredentials.service.GatewayAccountCredentialsService;
 
 import javax.inject.Inject;
 
@@ -18,15 +19,20 @@ public class StripeAccountUpdatedHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(StripeAccountUpdatedHandler.class);
 
     private final ObjectMapper objectMapper;
+    private final GatewayAccountCredentialsService credentialsService;
 
     @Inject
-    public StripeAccountUpdatedHandler(ObjectMapper objectMapper) {
+    public StripeAccountUpdatedHandler(GatewayAccountCredentialsService credentialsService, ObjectMapper objectMapper) {
+        this.credentialsService = credentialsService;
         this.objectMapper = objectMapper;
     }
 
     public void process(StripeNotification notification) {
         try {
             var dataObject = objectMapper.readValue(notification.getObject(), DataObject.class);
+            if (canBeActivated(dataObject)) {
+                credentialsService.activateCredentialIfNotYetActive(dataObject.getId());
+            }
             LOGGER.info(String.format("Received an account.updated event for stripe account %s", dataObject.getId()),
                     kv("stripe_account_id", dataObject.getId()),
                     kv("payouts_enabled", dataObject.isPayoutsEnabled()),
@@ -37,17 +43,27 @@ public class StripeAccountUpdatedHandler {
         }
     }
 
+    private boolean canBeActivated(DataObject dataObject) {
+        return (!dataObject.getRequirements().hasCurrentlyDue() &&
+                !dataObject.getRequirements().hasPastDue() &&
+                dataObject.isChargesEnabled() &&
+                dataObject.isPayoutsEnabled());
+    }
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     private static class DataObject {
 
         @JsonProperty("id")
         private String id;
 
+        @JsonProperty("charges_enabled")
+        private boolean chargesEnabled;
+
         @JsonProperty("payouts_enabled")
         private boolean payoutsEnabled;
 
         @JsonProperty("requirements")
-        private JsonNode requirements;
+        private Requirements requirements;
 
         private String getId() {
             return id;
@@ -57,8 +73,31 @@ public class StripeAccountUpdatedHandler {
             return payoutsEnabled;
         }
 
-        private String getRequirements() {
-            return requirements.toString();
+        private Requirements getRequirements() {
+            return requirements;
+        }
+
+        public boolean isChargesEnabled() {
+            return chargesEnabled;
+        }
+
+
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class Requirements {
+        @JsonProperty("currently_due")
+        private JsonNode currentlyDue;
+
+        @JsonProperty("past_due")
+        private JsonNode pastDue;
+
+        public boolean hasCurrentlyDue() {
+            return !currentlyDue.isEmpty();
+        }
+
+        public boolean hasPastDue() {
+            return !pastDue.isEmpty();
         }
     }
 }

--- a/src/test/resources/templates/stripe/account_updated.json
+++ b/src/test/resources/templates/stripe/account_updated.json
@@ -80,7 +80,7 @@
       },
       "metadata": {
       },
-      "payouts_enabled": false,
+      "payouts_enabled": true,
       "requirements": {
         "current_deadline": null,
         "currently_due": [


### PR DESCRIPTION
## WHAT YOU DID
- if account doesn’t have any requirements due, then update gateway_account_credential state to `ACTIVE` (if not already active) when receiving an `account.updated` notification.
