### PR TITLE
PP-9093 Remove explicit dependency on log4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,18 +33,6 @@
         <PACT_CONSUMER_TAG/>
     </properties>
     <dependencies>
-        <!-- We do not use log4j-core or log4j-api but some dependencies do
-             and versions before 2.15.0 are vulnerable to CVE-2021-44228 -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.17.1</version>
-        </dependency>
         <dependency>
             <groupId>uk.gov.service.payments</groupId>
             <artifactId>logging</artifactId>

--- a/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
+++ b/src/main/java/uk/gov/pay/connector/expunge/service/ChargeExpungeService.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static net.logstash.logback.argument.StructuredArguments.kv;
-import static org.apache.logging.log4j.util.Strings.isNotBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_ERROR;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_TIMEOUT;
 import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.AUTHORISATION_UNEXPECTED_ERROR;


### PR DESCRIPTION
We don't bring in log4j transitively so can safely remove the explicit dependency.