### PR TITLE
PP-9265 Force shutdown payout queue receiver on shutdown

### DIFF
--- a/src/main/java/uk/gov/pay/connector/queue/managed/PayoutReconcileMessageReceiver.java
+++ b/src/main/java/uk/gov/pay/connector/queue/managed/PayoutReconcileMessageReceiver.java
@@ -55,32 +55,15 @@ public class PayoutReconcileMessageReceiver implements Managed {
     @Override
     public void stop() {
         LOGGER.info("Shutting down payout reconciliation service");
-        payoutReconcileMessageExecutorService.shutdown();
-        try {
-            // Wait for existing payouts to finish being captured
-            if (payoutReconcileMessageExecutorService.awaitTermination(15, TimeUnit.SECONDS)) {
-                LOGGER.info("payout reconciliation service shut down cleanly");
-            } else {
-                // If the existing payouts being captured didn't terminate within the allowed time then force them to.
-                LOGGER.error("Payouts still being captured after shutdown wait time will now be forcefully stopped");
-                payoutReconcileMessageExecutorService.shutdownNow();
-                if (!payoutReconcileMessageExecutorService.awaitTermination(12, TimeUnit.SECONDS)){
-                    LOGGER.error("Payout reconciliation service could not be forced stopped");
-                }
-            }
-        } catch (InterruptedException ex) {
-            LOGGER.error("Failed to shutdown payout reconciliation service cleanly as the wait was interrupted.");
-            payoutReconcileMessageExecutorService.shutdownNow();
-            // Preserve interrupt status
-            Thread.currentThread().interrupt();
-        }
+        payoutReconcileMessageExecutorService.shutdownNow();
+        LOGGER.info("Payout reconciliation service shut down");
     }
 
     private void processPayouts() {
         try {
             payoutReconcileProcess.processPayouts();
         } catch (Exception e) {
-            LOGGER.error("Queue message payoutReconcileMessageReceiver thread exception [message={}]", e.getMessage());
+            LOGGER.warn("Queue message payoutReconcileMessageReceiver thread exception [class={} message={}]", e.getClass(), e.getMessage());
         }
     }
 }


### PR DESCRIPTION
It is fine to kill threads running tasks to process payout
reconciliation immediately, as this just sends events to ledger for the
associated payments and is retry-able with no adverse effects.

It is desirable to do this, as the thread running the task can be
waiting for up to 20s for messages on the SQS queue to become available
as we use long polling, and so block the connector shutdown.

For most of the day there are no payouts to process, so the task will
usually be waiting for the entire 20s for messages to become available.