### PR TITLE
PP-9265 Increase timeout for queue message receiver shutdown

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/CaptureProcessConfig.java
@@ -17,6 +17,7 @@ public class CaptureProcessConfig extends Configuration {
     private int failedCaptureRetryDelayInSeconds;
     private int queueSchedulerThreadDelayInSeconds;
     private int queueSchedulerNumberOfThreads;
+    private int queueSchedulerShutdownTimeoutInSeconds;
 
     public int getChargesConsideredOverdueForCaptureAfter() {
         return chargesConsideredOverdueForCaptureAfter;
@@ -38,5 +39,9 @@ public class CaptureProcessConfig extends Configuration {
 
     public int getQueueSchedulerNumberOfThreads() {
         return queueSchedulerNumberOfThreads;
+    }
+
+    public int getQueueSchedulerShutdownTimeoutInSeconds() {
+        return queueSchedulerShutdownTimeoutInSeconds;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/app/config/TaskQueueConfig.java
+++ b/src/main/java/uk/gov/pay/connector/app/config/TaskQueueConfig.java
@@ -8,6 +8,7 @@ public class TaskQueueConfig extends Configuration {
     private int queueSchedulerNumberOfThreads;
     private int queueSchedulerThreadDelayInSeconds;
     private int failedMessageRetryDelayInSeconds;
+    private int queueSchedulerShutdownTimeoutInSeconds;
 
     public Boolean getTaskQueueEnabled() {
         return taskQueueEnabled;
@@ -23,5 +24,9 @@ public class TaskQueueConfig extends Configuration {
 
     public int getFailedMessageRetryDelayInSeconds() {
         return failedMessageRetryDelayInSeconds;
+    }
+
+    public int getQueueSchedulerShutdownTimeoutInSeconds() {
+        return queueSchedulerShutdownTimeoutInSeconds;
     }
 }

--- a/src/main/resources/config/config.yaml
+++ b/src/main/resources/config/config.yaml
@@ -140,6 +140,7 @@ captureProcessConfig:
 
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
+  queueSchedulerShutdownTimeoutInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
 
 sqsConfig:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-false}
@@ -169,6 +170,7 @@ taskQueue:
   failedMessageRetryDelayInSeconds: ${TASK_QUEUE_MESSAGE_RETRY_FAILED_IN_SECONDS:-3600}
   queueSchedulerNumberOfThreads: ${TASKS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
   queueSchedulerThreadDelayInSeconds: ${TASKS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
+  queueSchedulerShutdownTimeoutInSeconds: ${TASKS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
 
 jerseyClient:
   # Defines the socket timeout (SO_TIMEOUT), which is the

--- a/src/test/resources/config/test-config.yaml
+++ b/src/test/resources/config/test-config.yaml
@@ -94,6 +94,7 @@ captureProcessConfig:
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
+  queueSchedulerShutdownTimeoutInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
 
 sqsConfig:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}
@@ -123,6 +124,7 @@ taskQueue:
   failedMessageRetryDelayInSeconds: ${TASK_QUEUE_MESSAGE_RETRY_FAILED_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${TASKS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
   queueSchedulerThreadDelayInSeconds: ${TASKS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
+  queueSchedulerShutdownTimeoutInSeconds: ${TASKS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
 
 jerseyClient:
   timeout: 500ms

--- a/src/test/resources/config/test-it-config.yaml
+++ b/src/test/resources/config/test-it-config.yaml
@@ -94,6 +94,7 @@ captureProcessConfig:
   failedCaptureRetryDelayInSeconds: ${CAPTURE_PROCESS_FAILED_CAPTURE_RETRY_DELAY_IN_SECONDS:-3600}
   queueSchedulerThreadDelayInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
+  queueSchedulerShutdownTimeoutInSeconds: ${CAPTURE_PROCESS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
 
 eventQueue:
   eventQueueEnabled: ${EVENT_QUEUE_ENABLED:-false}
@@ -110,6 +111,7 @@ taskQueue:
   failedMessageRetryDelayInSeconds: ${TASK_QUEUE_MESSAGE_RETRY_FAILED_IN_SECONDS:-1}
   queueSchedulerNumberOfThreads: ${TASKS_QUEUE_SCHEDULER_NUMBER_OF_THREADS:-1}
   queueSchedulerThreadDelayInSeconds: ${TASKS_QUEUE_SCHEDULER_THREAD_DELAY_IN_SECONDS:-1}
+  queueSchedulerShutdownTimeoutInSeconds: ${TASKS_QUEUE_SCHEDULER_SHUTDOWN_TIMEOUT_IN_SECONDS:-40}
 
 sqsConfig:
   nonStandardServiceEndpoint: ${AWS_SQS_NON_STANDARD_SERVICE_ENDPOINT:-true}


### PR DESCRIPTION
Increase the timeout for waiting for scheduled tasks to finish for the
SQS queue message receivers for the capture queue and the tasks queue.

This is required because the tasks run by these message receivers poll
SQS using long polling with a maximum wait time of 20s before processing
up to a batch of 10 messages.

Increase the timeout to 40s for both queue receivers to decrease the
chance that we have to force-stop the schedulers.

Make the timeout more easily configurable by reading from an
environment variable for each queue receiver.