### PR TITLE
PP-9260 Bump AWS SDK version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
   - govuk-pay
   - java
   ignore:
-  - dependency-name: com.amazonaws:aws-java-sdk-sqs
-    versions:
-    - "> 1.11.598"
-    - "< 1.12"
   - dependency-name: org.liquibase:liquibase-core
     versions:
     - ">= 4.3.a"

--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sqs</artifactId>
-            <version>1.11.598</version>
+            <version>1.12.160</version>
         </dependency>
         <dependency>
             <groupId>org.dhatim</groupId>


### PR DESCRIPTION
Not sure why dependabot was not bumping this, as there are versions > 1.12. Bump and remove that ignore from the dependabot file.