### PR TITLE
PP-9238: Reusable pact provider workflow

### DIFF
--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -34,23 +34,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
-      - name: Run pact tests
+      - name: Run provider pact tests
         run: |
-
           consumer_tag="${{ inputs.consumer_tag }}"
           provider_version="${{ github.sha }}"
-
-#          cat <<'EOF' >settings.xml
-#          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
-#          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-#          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
-#          https://maven.apache.org/xsd/settings-1.0.0.xsd">
-#          <localRepository>${env.MAVEN_REPO}</localRepository>
-#          </settings>
-#          EOF
-
           export MAVEN_REPO="$HOME/.m2"
-
           mvn test \
           -DrunContractTests \
           -DCONSUMER="$consumer" \

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
       - name: pull
       - run: |
-        docker ps
-        docker
-        docker pull postgres:11.1
-        docker pull govukpay/postgres:11.1
+          docker ps
+          docker
+          docker pull postgres:11.1
+          docker pull govukpay/postgres:11.1
 
   run-connector-as-provider-tests:
     name: Run Connector as Provider

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -49,5 +49,5 @@ jobs:
           -Dpact.provider.version="$provider_version" \
           -Dpact.verifier.publishResults=true \
           -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
-          -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \
-          -DPACT_BROKER_PASSWORD="${{ secrets.pact_broker_password }}"
+          -DPACT_BROKER_USERNAME="${{ secrets.PACT_BROKER_USERNAME }}" \
+          -DPACT_BROKER_PASSWORD="${{ secrets.PACT_BROKER_PASSWORD }}"

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -22,18 +22,6 @@ permissions:
 
 
 jobs:
-  test-docker-pull:
-    name: Test docker pull
-    runs-on: ubuntu-18.04
-
-    steps:
-      - name: pull
-        run: |
-          docker ps
-          docker
-          docker pull postgres:11.1
-          docker pull govukpay/postgres:11.1
-
   run-connector-as-provider-tests:
     name: Run Connector as Provider
     runs-on: ubuntu-18.04
@@ -53,6 +41,9 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Pull docker image dependencies
+        run: |
+          docker pull govukpay/postgres:11.1
       - name: Run provider pact tests
         run: |
           consumer_tag="${{ inputs.consumer_tag }}"

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -42,7 +42,7 @@ jobs:
           provider_version="${{ github.sha }}"
           export MAVEN_REPO="$HOME/.m2"
           mvn test \
-          --quiet \
+          --batch-mode \
           -DrunContractTests \
           -DCONSUMER="$consumer" \
           -DPACT_CONSUMER_TAG="$consumer_tag" \

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -22,6 +22,18 @@ permissions:
 
 
 jobs:
+  test-docker-pull:
+    name: Test docker pull
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: pull
+      - run: |
+        docker ps
+        docker
+        docker pull postgres:11.1
+        docker pull govukpay/postgres:11.1
+
   run-connector-as-provider-tests:
     name: Run Connector as Provider
     runs-on: ubuntu-18.04

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -46,5 +46,5 @@ jobs:
           -Dpact.provider.version="$provider_version" \
           -Dpact.verifier.publishResults=true \
           -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
-          -DPACT_BROKER_USERNAME="${{ broker_username }}" \
-          -DPACT_BROKER_PASSWORD="${{ broker_password }}"
+          -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \
+          -DPACT_BROKER_PASSWORD="${{ secrets.pact_broker_password }}"

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -11,6 +11,11 @@ on:
         description: Consumer tag. This could be branch name ('master'), PR number ('1234') or deploy tag ('test-fargate')
         required: true
         type: string
+    secrets:
+      pact_broker_username:
+        required: true
+      pact_broker_password:
+        required: true
 
 permissions:
   contents: read
@@ -49,5 +54,5 @@ jobs:
           -Dpact.provider.version="$provider_version" \
           -Dpact.verifier.publishResults=true \
           -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
-          -DPACT_BROKER_USERNAME="${{ secrets.PACT_BROKER_USERNAME }}" \
-          -DPACT_BROKER_PASSWORD="${{ secrets.PACT_BROKER_PASSWORD }}"
+          -DPACT_BROKER_USERNAME="${{ secrets.pact_broker_username }}" \
+          -DPACT_BROKER_PASSWORD="${{ secrets.pact_broker_password }}"

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        with:
+          repository: alphagov/pay-connector
       - name: Set up JDK 11
         uses: actions/setup-java@f69f00b5e5324696b07f6b1c92f0470a6df00780
         with:

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -42,6 +42,7 @@ jobs:
           provider_version="${{ github.sha }}"
           export MAVEN_REPO="$HOME/.m2"
           mvn test \
+          --quiet \
           -DrunContractTests \
           -DCONSUMER="$consumer" \
           -DPACT_CONSUMER_TAG="$consumer_tag" \

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: pull
-      - run: |
+        run: |
           docker ps
           docker
           docker pull postgres:11.1

--- a/.github/workflows/_run-pact-provider-tests.yml
+++ b/.github/workflows/_run-pact-provider-tests.yml
@@ -1,0 +1,62 @@
+name: Connector As Provider Pact Tests
+
+on:
+  workflow_call:
+    inputs:
+      consumer:
+        description: Name of the consumer app, e.g. frontend
+        required: true
+        type: string
+      consumer_tag:
+        description: Consumer tag. This could be branch name ('master'), PR number ('1234') or deploy tag ('test-fargate')
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+
+jobs:
+  run-connector-as-provider-tests:
+    name: Run Connector as Provider
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Set up JDK 11
+        uses: actions/setup-java@f69f00b5e5324696b07f6b1c92f0470a6df00780
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Maven packages
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run pact tests
+        run: |
+
+          consumer_tag="${{ inputs.consumer_tag }}"
+          provider_version="${{ github.sha }}"
+
+#          cat <<'EOF' >settings.xml
+#          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+#          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+#          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+#          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+#          <localRepository>${env.MAVEN_REPO}</localRepository>
+#          </settings>
+#          EOF
+
+          export MAVEN_REPO="$HOME/.m2"
+
+          mvn test \
+          -DrunContractTests \
+          -DCONSUMER="$consumer" \
+          -DPACT_CONSUMER_TAG="$consumer_tag" \
+          -Dpact.provider.version="$provider_version" \
+          -Dpact.verifier.publishResults=true \
+          -DPACT_BROKER_HOST=pay-pact-broker.cloudapps.digital \
+          -DPACT_BROKER_USERNAME="${{ broker_username }}" \
+          -DPACT_BROKER_PASSWORD="${{ broker_password }}"


### PR DESCRIPTION
## WHAT YOU DID
A reusable workflow to run pact provider tests. 

The workflow takes the consumer (eg `frontend`) and its tag (eg `master`) as parameters, along with the mapped secrets from the repo that's calling it.

For example, a frontend PR or post-merge workflow could call this workflow: https://github.com/alphagov/pay-frontend/runs/5499989312?check_suite_focus=true

The reusable workflow itself uses a postgres docker image and runs the pact tests with maven.