### PR TITLE
PP-9315 Support Worldpay 3DS2 non-JS mode

### DIFF
--- a/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/OrderRequestBuilder.java
@@ -18,6 +18,17 @@ public abstract class OrderRequestBuilder {
         private WalletAuthorisationData walletAuthorisationData;
         private String amount;
         private String paymentPlatformReference;
+        private int integrationVersion3ds;
+        private String browserLanguage;
+
+        public String getBrowserLanguage() {
+            return browserLanguage;
+        }
+
+        public void setBrowserLanguage(String browserLanguage) {
+            this.browserLanguage = browserLanguage;
+        }
+
 
         public String getTransactionId() {
             return transactionId;
@@ -74,6 +85,14 @@ public abstract class OrderRequestBuilder {
         public void setWalletAuthorisationData(WalletAuthorisationData walletAuthorisationData) {
             this.walletAuthorisationData = walletAuthorisationData;
         }
+
+        public int getIntegrationVersion3ds() {
+            return integrationVersion3ds;
+        }
+
+        public void setIntegrationVersion3ds(int integrationVersion3ds) {
+            this.integrationVersion3ds = integrationVersion3ds;
+        }
     }
 
     private final TemplateData templateData;
@@ -117,6 +136,16 @@ public abstract class OrderRequestBuilder {
 
     public OrderRequestBuilder withAmount(String amount) {
         templateData.setAmount(amount);
+        return this;
+    }   
+    
+    public OrderRequestBuilder withIntegrationVersion3ds(int integrationVersion3ds) {
+        templateData.setIntegrationVersion3ds(integrationVersion3ds);
+        return this;
+    }    
+    
+    public OrderRequestBuilder withBrowserLanguage(String browserLanguage) {
+        templateData.setBrowserLanguage(browserLanguage);
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/model/AuthCardDetails.java
@@ -31,7 +31,8 @@ public class AuthCardDetails implements AuthorisationDetails {
     private String jsScreenHeight;
     private String jsScreenWidth;
     private String jsTimezoneOffsetMins;
-
+    private String acceptLanguageHeader;
+    
     public static AuthCardDetails anAuthCardDetails() {
         return new AuthCardDetails();
     }
@@ -136,6 +137,11 @@ public class AuthCardDetails implements AuthorisationDetails {
     @JsonProperty("ip_address")
     public void setIpAddress(String ipAddress) {
         this.ipAddress = ipAddress;
+    }    
+    
+    @JsonProperty("accept_language_header")
+    public void setAcceptLanguageHeader(String acceptLanguageHeader) {
+        this.acceptLanguageHeader = acceptLanguageHeader;
     }
 
     public String getCardNo() {
@@ -170,6 +176,10 @@ public class AuthCardDetails implements AuthorisationDetails {
         return acceptHeader;
     }
 
+    public String getAcceptLanguageHeader () {
+        return acceptLanguageHeader;
+    }
+    
     public boolean isCorporateCard() {
         return corporateCard == null ? false : corporateCard;
     }

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayAuthoriseHandler.java
@@ -9,6 +9,7 @@ import uk.gov.pay.connector.gateway.model.GatewayError;
 import uk.gov.pay.connector.gateway.model.request.CardAuthorisationGatewayRequest;
 import uk.gov.pay.connector.gateway.model.response.GatewayResponse;
 import uk.gov.pay.connector.gatewayaccount.model.GatewayAccountEntity;
+import uk.gov.pay.connector.util.AcceptLanguageHeaderParser;
 
 import javax.inject.Inject;
 import java.net.URI;
@@ -28,10 +29,14 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
     
     private final GatewayClient authoriseClient;
     private final Map<String, URI> gatewayUrlMap;
+    private final AcceptLanguageHeaderParser acceptLanguageHeaderParser;
 
     @Inject
     public WorldpayAuthoriseHandler(@Named("WorldpayAuthoriseGatewayClient") GatewayClient authoriseClient,
-                                    @Named("WorldpayGatewayUrlMap") Map<String, URI> gatewayUrlMap) {
+                                    @Named("WorldpayGatewayUrlMap") Map<String, URI> gatewayUrlMap,
+                                    AcceptLanguageHeaderParser acceptLanguageHeaderParser
+    ) {
+        this.acceptLanguageHeaderParser = acceptLanguageHeaderParser;
         this.authoriseClient = authoriseClient;
         this.gatewayUrlMap = gatewayUrlMap;
     }
@@ -54,7 +59,7 @@ public class WorldpayAuthoriseHandler implements WorldpayGatewayResponseGenerato
                     gatewayUrlMap.get(request.getGatewayAccount().getType()),
                     WORLDPAY,
                     request.getGatewayAccount().getType(),
-                    WorldpayOrderBuilder.buildAuthoriseOrderWithExemptionEngine(request, withExemptionEngine),
+                    WorldpayOrderBuilder.buildAuthoriseOrderWithExemptionEngine(request, withExemptionEngine, acceptLanguageHeaderParser),
                     getGatewayAccountCredentialsAsAuthHeader(request.getGatewayCredentials()));
 
             if (response.getEntity().contains("request3DSecure")) {

--- a/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/gateway/worldpay/WorldpayOrderRequestBuilder.java
@@ -33,6 +33,16 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
         private String payerEmail;
         private String state;
         private boolean exemptionEngineEnabled;
+        private int integrationVersion3ds;
+
+        public int getIntegrationVersion3ds() {
+            return integrationVersion3ds;
+        }
+
+        public void setIntegrationVersion3ds(int integrationVersion3ds) {
+            this.integrationVersion3ds = integrationVersion3ds;
+        }
+
 
         public String getReference() {
             return reference;
@@ -232,6 +242,11 @@ public class WorldpayOrderRequestBuilder extends OrderRequestBuilder {
 
     public WorldpayOrderRequestBuilder withPayerEmail(String payerEmail) {
         worldpayTemplateData.setPayerEmail(payerEmail);
+        return this;
+    }    
+    
+    public WorldpayOrderRequestBuilder withIntegrationVersion3ds(int integrationVersion3ds) {
+        worldpayTemplateData.setIntegrationVersion3ds(integrationVersion3ds);
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/connector/util/AcceptLanguageHeaderParser.java
+++ b/src/main/java/uk/gov/pay/connector/util/AcceptLanguageHeaderParser.java
@@ -1,0 +1,34 @@
+package uk.gov.pay.connector.util;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static java.util.function.Predicate.not;
+
+public class AcceptLanguageHeaderParser {
+
+    private final static String DEFAULT_LOCALE = "en-GB";
+
+    public String getPreferredLanguageFromAcceptLanguageHeader(String acceptLanguageHeader) {
+        return parseLanguageRanges(acceptLanguageHeader)
+                .stream()
+                .map(Locale.LanguageRange::getRange)
+                .filter(not(languageRange -> languageRange.equals("*")))
+                .map(Locale::forLanguageTag)
+                .map(Locale::toLanguageTag)
+                .findFirst()
+                .orElse(DEFAULT_LOCALE);
+    }
+
+    private static List<Locale.LanguageRange> parseLanguageRanges(String acceptLanguageHeader) {
+        if (acceptLanguageHeader == null) {
+            return Collections.emptyList();
+        }
+        try {
+            return Locale.LanguageRange.parse(acceptLanguageHeader);
+        } catch (IllegalArgumentException e) {
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
+++ b/src/main/resources/templates/worldpay/WorldpayAuthoriseOrderTemplate.xml
@@ -48,6 +48,9 @@
                 <browser>
                     <acceptHeader>${authCardDetails.acceptHeader?xml}</acceptHeader>
                     <userAgentHeader>${authCardDetails.userAgentHeader?xml}</userAgentHeader>
+                    <#if authCardDetails.worldpay3dsFlexDdcResult.isEmpty() && integrationVersion3ds == 2>
+                    <browserLanguage>${browserLanguage?xml}</browserLanguage>
+                    </#if>
                 </browser>
                 </#if>
             </shopper>
@@ -56,6 +59,13 @@
             <#if authCardDetails.worldpay3dsFlexDdcResult.isPresent()>
             <additional3DSData
                 dfReferenceId="${authCardDetails.worldpay3dsFlexDdcResult.get()?xml}"
+                challengeWindowSize="390x400" challengePreference="noPreference"
+            />
+            </#if>
+            <#if authCardDetails.worldpay3dsFlexDdcResult.isEmpty() && integrationVersion3ds == 2>
+            <additional3DSData
+                dfReferenceId=""
+                javaScriptEnabled="false"
                 challengeWindowSize="390x400" challengePreference="noPreference"
             />
             </#if>

--- a/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
+++ b/src/test/java/uk/gov/pay/connector/model/domain/AuthCardDetailsFixture.java
@@ -21,6 +21,7 @@ public final class AuthCardDetailsFixture {
     private String cardBrand = "visa";
     private String userAgentHeader = "Mozilla/5.0";
     private String acceptHeader = "text/html";
+    private String acceptLanguageHeader = "en-GB,en-US;q=0.9,en;q=0.8";
     private PayersCardType payersCardType = PayersCardType.DEBIT;
     private PayersCardPrepaidStatus payersCardPrepaidStatus = PayersCardPrepaidStatus.UNKNOWN;
     private Boolean corporateCard = Boolean.FALSE;
@@ -127,6 +128,11 @@ public final class AuthCardDetailsFixture {
     public AuthCardDetailsFixture withJsTimezoneOffsetMins(String jsTimezoneOffsetMins) {
         this.jsTimezoneOffsetMins = jsTimezoneOffsetMins;
         return this;
+    }    
+    
+    public AuthCardDetailsFixture withAcceptLanguageHeader(String acceptLanguageHeader) {
+        this.acceptLanguageHeader = acceptLanguageHeader;
+        return this;
     }
     
     public CardDetailsEntity getCardDetailsEntity() {
@@ -164,6 +170,7 @@ public final class AuthCardDetailsFixture {
         authCardDetails.setCardBrand(cardBrand);
         authCardDetails.setUserAgentHeader(userAgentHeader);
         authCardDetails.setAcceptHeader(acceptHeader);
+        authCardDetails.setAcceptLanguageHeader(acceptLanguageHeader);
         authCardDetails.setPayersCardType(payersCardType);
         authCardDetails.setPayersCardPrepaidStatus(payersCardPrepaidStatus);
         authCardDetails.setCorporateCard(corporateCard);

--- a/src/test/java/uk/gov/pay/connector/util/AcceptLanguageHeaderParserTest.java
+++ b/src/test/java/uk/gov/pay/connector/util/AcceptLanguageHeaderParserTest.java
@@ -1,0 +1,21 @@
+package uk.gov.pay.connector.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class AcceptLanguageHeaderParserTest {
+
+    @Test
+    void convertsLocale() {
+        var acceptLanguageHeaderParser = new AcceptLanguageHeaderParser();
+        assertThat(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader("en-GB,en-US;q=0.9,en;q=0.8"), is("en-GB"));
+        assertThat(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader("fr;q=0.9, fr-CH;q=1.0, en;q=0.8, de;q=0.7, *;q=0.5"), is("fr-CH"));
+        assertThat(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader("en-gb,en-us;q=0.9,en;q=0.8"), is("en-GB"));
+        assertThat(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader("*"), is("en-GB"));
+        assertThat(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader(null), is("en-GB"));
+        assertThat(acceptLanguageHeaderParser.getPreferredLanguageFromAcceptLanguageHeader("i like kittens;q=a million"), is("en-GB"));
+    }
+
+}

--- a/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
+++ b/src/test/java/uk/gov/pay/connector/util/TestTemplateResourceLoader.java
@@ -40,6 +40,7 @@ public class TestTemplateResourceLoader {
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITHOUT_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-without-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_IP_ADDRESS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-ip-address.xml";
     public static final String WORLDPAY_VALID_AUTHORISE_WORLDPAY_GOOGLE_PAY_3DS_REQUEST_WITH_EMAIL = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-google-pay-3ds-with-email.xml";
+    public static final String WORLDPAY_VALID_AUTHORISE_REQUEST_3DS_FLEX_NON_JS = WORLDPAY_BASE_NAME + "/valid-authorise-worldpay-request-3ds-flex-non-js.xml";
 
     public static final String WORLDPAY_3DS_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-response.xml";
     public static final String WORLDPAY_3DS_FLEX_RESPONSE = WORLDPAY_BASE_NAME + "/3ds-flex-response.xml";

--- a/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-3ds-flex-non-js.xml
+++ b/src/test/resources/templates/worldpay/valid-authorise-worldpay-request-3ds-flex-non-js.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE paymentService PUBLIC "-//WorldPay//DTD WorldPay PaymentService v1//EN"
+        "http://dtd.worldpay.com/paymentService_v1.dtd">
+<paymentService version="1.4" merchantCode="MERCHANTCODE">
+    <submit>
+        <order orderCode="transaction-id">
+            <description>This is a description</description>
+            <amount currencyCode="GBP" exponent="2" value="500"/>
+            <paymentDetails>
+                <VISA-SSL>
+                    <cardNumber>4111111111111111</cardNumber>
+                    <expiryDate>
+                        <date month="12" year="2015"/>
+                    </expiryDate>
+                    <cardHolderName>Mr. Payment</cardHolderName>
+                    <cvc>123</cvc>
+                    <cardAddress>
+                        <address>
+                            <address1>123 My Street</address1>
+                            <address2>This road</address2>
+                            <postalCode>SW8URR</postalCode>
+                            <city>London</city>
+                            <countryCode>GB</countryCode>
+                        </address>
+                    </cardAddress>
+                </VISA-SSL>
+                <session id="uniqueSessionId"/>
+            </paymentDetails>
+            <shopper>
+                <browser>
+                    <acceptHeader>text/html</acceptHeader>
+                    <userAgentHeader>Mozilla/5.0</userAgentHeader>
+                    <browserLanguage>en-GB</browserLanguage>
+                </browser>
+            </shopper>
+            <additional3DSData
+                    dfReferenceId=""
+                    javaScriptEnabled="false"
+                    challengeWindowSize="390x400" challengePreference="noPreference" 
+            />
+        </order>
+    </submit>
+</paymentService>


### PR DESCRIPTION
## WHAT YOU DID
Implement Worldpay 3DS2 flow as described in https://developer.worldpay.com/docs/wpg/directintegration/3ds2#payment-requests-with-javascript-not-enabled

Note: `dfReferenceId=""` is required for Worldpay to accept the payload even though this is not well documented.

## How to test

Tests should make sense. `WorldpayPaymentProviderTest.java` can be run locally if environment variables are set. 

I will test end-to-end including frontend once this is deployed on Test.