### PR TITLE
PP-9332: db changes for save payment instrument to agreement and agreement_id

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1764,4 +1764,17 @@
         </createTable>
     </changeSet>
 
+    <changeSet id="save_payment_instrument_to_agreement_agreement_id_charges" author="">
+        <addColumn tableName="charges">
+            <column name="save_payment_instrument_to_agreement" type="boolean"  defaultValue="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="charges">
+            <column name="agreement_id" type="varchar(26)" />
+        </addColumn>
+
+    </changeSet>
+
+
 </databaseChangeLog>


### PR DESCRIPTION
Add `save_payment_instrument_to_agreement BOOLEAN NOT NULL` and `agreement_id VARCHAR(26)` (default value false) to `charges` table.

with @jbz149, @kundanscorpio