### PR TITLE
BAU — Make event tests not fail if run on exact millisecond

### DIFF
--- a/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtainedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsExemptionResultObtainedTest.java
@@ -12,6 +12,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
 
 class Gateway3dsExemptionResultObtainedTest {
 
@@ -21,7 +22,7 @@ class Gateway3dsExemptionResultObtainedTest {
         var eventDate = ZonedDateTime.now(UTC);
         String actual = Gateway3dsExemptionResultObtained.from(chargeEntity, eventDate).toJsonString();
 
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(eventDate.toString())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
         assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_3DS_EXEMPTION_RESULT_OBTAINED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
@@ -34,7 +35,7 @@ class Gateway3dsExemptionResultObtainedTest {
         var eventDate = ZonedDateTime.now(UTC);
         String actual = Gateway3dsExemptionResultObtained.from(chargeEntity, eventDate).toJsonString();
 
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(eventDate.toString())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
         assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_3DS_EXEMPTION_RESULT_OBTAINED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtainedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/Gateway3dsInfoObtainedTest.java
@@ -12,6 +12,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasNoJsonPath;
 import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
 
 class Gateway3dsInfoObtainedTest {
 
@@ -23,7 +24,7 @@ class Gateway3dsInfoObtainedTest {
         var eventDate = ZonedDateTime.now(UTC);
         String actual = Gateway3dsInfoObtained.from(chargeEntity, eventDate).toJsonString();
 
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(eventDate.toString())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
         assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_3DS_INFO_OBTAINED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));
@@ -36,7 +37,7 @@ class Gateway3dsInfoObtainedTest {
         var eventDate = ZonedDateTime.now(UTC);
         String actual = Gateway3dsInfoObtained.from(chargeEntity, eventDate).toJsonString();
 
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(eventDate.toString())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
         assertThat(actual, hasJsonPath("$.event_type", equalTo("GATEWAY_3DS_INFO_OBTAINED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));

--- a/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
+++ b/src/test/java/uk/gov/pay/connector/events/model/charge/UserEmailCollectedTest.java
@@ -11,6 +11,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static java.time.ZoneOffset.UTC;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static uk.gov.service.payments.commons.api.json.MicrosecondPrecisionDateTimeSerializer.MICROSECOND_FORMATTER;
 
 public class UserEmailCollectedTest {
 
@@ -20,7 +21,7 @@ public class UserEmailCollectedTest {
         ZonedDateTime eventDate = ZonedDateTime.now(UTC);
         String actual = UserEmailCollected.from(chargeEntity, eventDate).toJsonString();
 
-        assertThat(actual, hasJsonPath("$.timestamp", equalTo(eventDate.toString())));
+        assertThat(actual, hasJsonPath("$.timestamp", equalTo(MICROSECOND_FORMATTER.format(eventDate))));
         assertThat(actual, hasJsonPath("$.event_type", equalTo("USER_EMAIL_COLLECTED")));
         assertThat(actual, hasJsonPath("$.resource_type", equalTo("payment")));
         assertThat(actual, hasJsonPath("$.resource_external_id", equalTo(chargeEntity.getExternalId())));


### PR DESCRIPTION
Some of the event tests check the timestamp in the generated JSON.

They do this by comparing the timestamp in the JSON (formatted using the formatter in `MicrosecondPrecisionDateTimeSerializer`, which outputs an instant with 6 decimal places of second precision) to the stringification of the `ZonedDateTime` that represents the actual timestamp.

This usually works because…

a) the `ZonedDateTime` uses UTC
b) the tests are run on computers that only offer the current time to microsecond precision, meaning when the `ZonedDateTime` is stringified it has at most 6 decimal places for the second
c) it’s unlikely that the test will be run when the current time is an exact millisecond (e.g. 1.123000 seconds) because then the stringification of the `ZonedDateTime` will only have 3 decimal places for the second

However, c) does sometimes happen and it causes the tests to fail. Fix it so that this does not happen.

A better fix would to be use a `Clock` or similar to avoid relying on the current time but that would be more involved.