### PR TITLE
BAU — Make refund email integration test less flaky

### DIFF
--- a/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/SendRefundEmailIT.java
@@ -94,6 +94,8 @@ public class SendRefundEmailIT {
                 .contentType(APPLICATION_FORM_URLENCODED)
                 .post("/v1/api/notifications/epdq");
 
+        Thread.sleep(500L); // Email sent using ExecutorService task: give it some time to complete
+
         verify(notificationClient).sendEmail(anyString(), anyString(), anyMap(), isNull());
     }
 


### PR DESCRIPTION
The refund email integration tests makes an HTTP call to connector’s notification endpoint and then checks it caused an email to be sent. However, we send emails by submitting a task to an `ExecutorService`, which means the email might not have been sent by the time the HTTP call completes (race condition). Fix this in a shameful way (but not unprecedented for our integration tests) by adding a short delay before checking the email is sent to give the task time to do its thing.