### PR TITLE
BAU: Require unit tests for provider-contract tests

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -53,6 +53,7 @@ jobs:
       pact_broker_password: ${{ secrets.pact_broker_password }}
 
   provider-contract-tests:
+    needs: tests
     uses: alphagov/pay-ci/.github/workflows/_run-provider-contract-tests.yml@master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}


### PR DESCRIPTION
We only want to publish a successful provider pact if the unit tests have passed.