### PR TITLE
PP-9327 Log dispute event details

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.10</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.13.2</jackson.version>
-        <pay-java-commons.version>1.0.20220318142022</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220322120555</pay-java-commons.version>
         <surefire.version>3.0.0-M5</surefire.version>
         <jooq.version>3.16.5</jooq.version>
         <postgresql.version>42.3.3</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
+++ b/src/main/java/uk/gov/pay/connector/queue/tasks/handlers/StripeWebhookTaskHandler.java
@@ -17,8 +17,11 @@ import javax.inject.Inject;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static net.logstash.logback.argument.StructuredArguments.kv;
 import static uk.gov.pay.connector.gateway.PaymentGatewayName.STRIPE;
 import static uk.gov.pay.connector.gateway.stripe.StripeNotificationType.DISPUTE_CREATED;
+import static uk.gov.service.payments.logging.LoggingKeys.GATEWAY_DISPUTE_ID;
+import static uk.gov.service.payments.logging.LoggingKeys.LEDGER_EVENT_TYPE;
 
 public class StripeWebhookTaskHandler {
     
@@ -57,7 +60,9 @@ public class StripeWebhookTaskHandler {
 
     private void emitEvent(Event event) {
         eventService.emitEvent(event);
-        logger.info("Emitted event for Stripe Webhook Task: " + event.getResourceExternalId());
+        logger.info("Event sent to payment event queue: {}", event.getResourceExternalId(),
+                kv(LEDGER_EVENT_TYPE, event.getEventType()),
+                kv(GATEWAY_DISPUTE_ID, event.getResourceExternalId()));
     }
 
     private DisputeCreated createDisputeCreatedEvent(StripeDisputeData stripeDisputeData,


### PR DESCRIPTION
## WHAT YOU DID
- Updated log to include 'ledger event type' & 'gateway payout id' when a dispute event is emitted to ledger.

