### PR TITLE
PP-9331 modify payments endpoint to support setting up payment instruments

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -24,6 +24,7 @@ import io.dropwizard.setup.Environment;
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import uk.gov.pay.connector.agreement.resource.AgreementsApiResource;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
+import uk.gov.pay.connector.charge.exception.AgreementNotFoundExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.exception.TelephonePaymentNotificationsNotAllowedExceptionMapper;
@@ -128,6 +129,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new TelephonePaymentNotificationsNotAllowedExceptionMapper());
         environment.jersey().register(new NoCredentialsExistForProviderExceptionMapper());
         environment.jersey().register(new NoCredentialsInUsableStateExceptionMapper());
+        environment.jersey().register(new AgreementNotFoundExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AgreementNotFoundException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AgreementNotFoundException.java
@@ -1,10 +1,8 @@
 package uk.gov.pay.connector.charge.exception;
-
 import javax.ws.rs.WebApplicationException;
-import static uk.gov.pay.connector.util.ResponseUtil.notFoundResponse;
 
 public class AgreementNotFoundException extends WebApplicationException {
     public AgreementNotFoundException(String message) {
-        super(notFoundResponse(message));
+        super(message);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/exception/AgreementNotFoundExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/AgreementNotFoundExceptionMapper.java
@@ -17,7 +17,7 @@ public class AgreementNotFoundExceptionMapper implements ExceptionMapper<Agreeme
     public Response toResponse(AgreementNotFoundException exception) {
         LOGGER.info(exception.getMessage());
         
-        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.GENERIC, exception.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(ErrorIdentifier.AGREEMENT_NOT_FOUND, exception.getMessage());
 
         return Response.status(Response.Status.NOT_FOUND)
                 .entity(errorResponse)

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -134,6 +134,9 @@ public class ChargeResponse {
     @JsonProperty("moto")
     private boolean moto;
 
+    @JsonProperty("agreement_id")
+    private String agreementId;
+
     ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
         this.dataLinks = builder.getLinks();
         this.chargeId = builder.getChargeId();
@@ -167,6 +170,7 @@ public class ChargeResponse {
         this.walletType = builder.getWalletType();
         this.externalMetadata = builder.getExternalMetadata();
         this.moto = builder.isMoto();
+        this.agreementId = builder.getAgreementId();
     }
 
     public List<Map<String, Object>> getDataLinks() {
@@ -301,6 +305,10 @@ public class ChargeResponse {
         return moto;
     }
 
+    public String getAgreementId() {
+        return agreementId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -373,6 +381,7 @@ public class ChargeResponse {
                 ", totalAmount=" + totalAmount +
                 ", walletType=" + walletType +
                 ", moto=" + moto +
+                ", agreementId=" + agreementId +
                 '}';
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -49,7 +49,8 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected WalletType walletType;
     protected ExternalMetadata externalMetadata;
     protected boolean moto;
-
+    private String agreementId;
+    
     protected abstract T thisObject();
 
     public T withChargeId(String chargeId) {
@@ -222,7 +223,12 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         this.moto = moto;
         return thisObject();
     }
-
+    
+    public T withAgreementId(String agreementId) {
+        this.agreementId = agreementId;
+        return thisObject();
+    }
+    
     public String getChargeId() {
         return chargeId;
     }
@@ -351,5 +357,9 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public boolean isMoto() {
         return moto;
+    }
+
+    public String getAgreementId() {
+        return agreementId;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -49,7 +49,6 @@ import javax.persistence.OrderBy;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.validation.Valid;
-import javax.validation.constraints.Size;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -500,7 +500,8 @@ public class ChargeService {
                 .withLink("self", GET, selfUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeId))
                 .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()))
                 .withWalletType(chargeEntity.getWalletType())
-                .withMoto(chargeEntity.isMoto());
+                .withMoto(chargeEntity.isMoto())
+                .withAgreementId(chargeEntity.getAgreementId());
 
         chargeEntity.getFeeAmount().ifPresent(builderOfResponse::withFee);
         chargeEntity.getExternalMetadata().ifPresent(builderOfResponse::withExternalMetadata);


### PR DESCRIPTION
- Added agreement_id and save_payment_instrument_to_agreement to Resource, Service, ChargeEntity and ChargeResponse.
- Wrote the unit and integration tests
- Disable an old test due to a timezone change issue (Timestamp is 1 hour late the 21st of March 2022)