### PR TITLE
PP-9388 Add allow_authorisation_api column to gateway_accounts

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1852,4 +1852,10 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add allow_authorisation_api to gateway_accounts table" author="">
+        <addColumn tableName="gateway_accounts">
+            <column name="allow_authorisation_api" type="boolean" defaultValue="false"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Add column for enabling use of the payment authorisation API on a per
gateway account level. Default to false.

Since PostgeSQL 11, a lock is no longer placed on the table when adding
a column with a default value so we can do this in a single operation.

https://www.depesz.com/2018/04/04/waiting-for-postgresql-11-fast-alter-table-add-column-with-a-non-null-default/