### PR TITLE
BAU: add missing columns to payment instruments table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1858,4 +1858,22 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add card type, address_state_province, first_digits_card_number columns to payment_instruments table" author="">
+        <addColumn tableName="payment_instruments">
+            <column name="card_type" type="varchar(20)">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="payment_instruments">
+            <column name="first_digits_card_number" type="varchar(6)">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+        <addColumn tableName="payment_instruments">
+            <column name="address_state_province" type="varchar(2)">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## WHAT YOU DID
I noticed in manual testing the following exception when trying to make a payment with the save payment instrument flag set to true
```
Internal Exception: org.postgresql.util.PSQLException: ERROR: column "card_type" of relation "payment_instruments" does not exist
```
This adds the migration for the  missing columns.
 
## How to test

Change should make sense. If you want to test end-to-end you can manually set the flag on a test payment e.g.
`update charges set save_payment_instrument_to_agreement=true where external_id='some-external-id';`