### PR TITLE
PP-9333 Serialise agreement on frontend charge response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -26,6 +26,17 @@ public class AgreementService {
         this.clock = clock;
     }
 
+    public Optional<AgreementResponse> findByExternalId(String externalId) {
+        return agreementDao.findByExternalId(externalId)
+                .map(agreementEntity -> new AgreementResponseBuilder()
+                        .withAgreementId(agreementEntity.getExternalId())
+                        .withServiceId(agreementEntity.getServiceId())
+                        .withReference(agreementEntity.getReference())
+                        .withLive(agreementEntity.isLive())
+                        .withCreatedDate(agreementEntity.getCreatedDate())
+                        .build());
+    }
+
     public Optional<AgreementResponse> create(AgreementCreateRequest agreementCreateRequest, long accountId) {
         return gatewayAccountDao.findById(accountId).map(gatewayAccountEntity -> {
             AgreementEntity agreementEntity = anAgreementEntity(clock.instant())

--- a/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/FrontendChargeResponse.java
@@ -2,6 +2,8 @@ package uk.gov.pay.connector.charge.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import uk.gov.pay.connector.agreement.model.AgreementEntity;
+import uk.gov.pay.connector.agreement.model.AgreementResponse;
 import uk.gov.pay.connector.charge.model.builder.AbstractChargeResponseBuilder;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.common.model.api.ExternalChargeState;
@@ -12,6 +14,7 @@ public class FrontendChargeResponse extends ChargeResponse {
     public static class FrontendChargeResponseBuilder extends AbstractChargeResponseBuilder<FrontendChargeResponseBuilder, FrontendChargeResponse> {
         private String status;
         private GatewayAccountEntity gatewayAccount;
+        private AgreementResponse agreement;
 
         public FrontendChargeResponseBuilder withStatus(String status) {
             this.status = status;
@@ -22,6 +25,11 @@ public class FrontendChargeResponse extends ChargeResponse {
 
         public FrontendChargeResponseBuilder withGatewayAccount(GatewayAccountEntity gatewayAccountEntity) {
             this.gatewayAccount = gatewayAccountEntity;
+            return this;
+        }
+
+        public FrontendChargeResponseBuilder withAgreement(AgreementResponse agreement) {
+            this.agreement = agreement;
             return this;
         }
 
@@ -46,10 +54,14 @@ public class FrontendChargeResponse extends ChargeResponse {
     @JsonProperty(value = "gateway_account")
     private GatewayAccountEntity gatewayAccount;
 
+    @JsonProperty
+    private AgreementResponse agreement;
+
     private FrontendChargeResponse(FrontendChargeResponseBuilder builder) {
         super(builder);
         this.status = builder.status;
         this.gatewayAccount = builder.gatewayAccount;
+        this.agreement = builder.agreement;
     }
 
     @Override
@@ -62,6 +74,7 @@ public class FrontendChargeResponse extends ChargeResponse {
 
         if (status != null ? !status.equals(that.status) : that.status != null) return false;
         if (cardDetails != null ? !cardDetails.equals(that.cardDetails) : that.cardDetails != null) return false;
+        if (agreement != null ? !agreement.equals(that.agreement) : that.agreement == null) return false;
         return gatewayAccount != null ? gatewayAccount.equals(that.gatewayAccount) : that.gatewayAccount == null;
 
     }
@@ -72,6 +85,7 @@ public class FrontendChargeResponse extends ChargeResponse {
         result = 31 * result + (status != null ? status.hashCode() : 0);
         result = 31 * result + (cardDetails != null ? cardDetails.hashCode() : 0);
         result = 31 * result + (gatewayAccount != null ? gatewayAccount.hashCode() : 0);
+        result = 31 * result + (agreement != null ? agreement.hashCode() : 0);
         return result;
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResourceTest.java
@@ -4,6 +4,7 @@ import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.pay.connector.agreement.service.AgreementService;
 import uk.gov.pay.connector.cardtype.dao.CardTypeDao;
 import uk.gov.pay.connector.charge.dao.ChargeDao;
 import uk.gov.pay.connector.charge.service.ChargeService;
@@ -27,10 +28,11 @@ class ChargesFrontendResourceTest {
     private static ChargeDao chargeDao = mock(ChargeDao.class);
     private static CardTypeDao cardTypeDao = mock(CardTypeDao.class);
     private static Worldpay3dsFlexJwtService worldpay3dsFlexJwtService = mock(Worldpay3dsFlexJwtService.class);
+    private static AgreementService agreementService = mock(AgreementService.class);
 
     private static final ResourceExtension resources = ResourceTestRuleWithCustomExceptionMappersBuilder
             .getBuilder()
-            .addResource(new ChargesFrontendResource(chargeDao, chargeService, cardTypeDao, worldpay3dsFlexJwtService))
+            .addResource(new ChargesFrontendResource(chargeDao, chargeService, cardTypeDao, worldpay3dsFlexJwtService, agreementService))
             .build();
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -156,8 +156,10 @@ public class ChargesFrontendResourceIT {
 
     @Test
     public void getChargeShouldIncludeAgreementInResponseToFrontEndForRecurringCardPayment() {
-        databaseTestHelper.addAgreement(11l, "service-id", AGREEMENT_ID,
-                "refs", Instant.now(), false, Long.parseLong(accountId));
+        var agreementReference = "refs";
+        var agreementServiceId = "service-id";
+        databaseTestHelper.addAgreement(11l, agreementServiceId, AGREEMENT_ID,
+                agreementReference, Instant.now(), false, Long.parseLong(accountId));
         String chargeExternalId = postToCreateAChargeWithAgreement(expectedAmount);
         String expectedLocation = "https://localhost:" + testContext.getPort() + "/v1/frontend/charges/" + chargeExternalId;
         final Long chargeId = databaseTestHelper.getChargeIdByExternalId(chargeExternalId);
@@ -182,6 +184,9 @@ public class ChargesFrontendResourceIT {
                 .body("total_amount", is(6447))
                 .body("moto", is(false))
                 .body("agreement_id", is(AGREEMENT_ID))
+                .body("agreement.agreement_id", is(AGREEMENT_ID))
+                .body("agreement.reference", is(agreementReference))
+                .body("agreement.service_id", is(agreementServiceId))
                 .body("links", hasSize(3))
                 .body("links", containsLink("self", GET, expectedLocation))
                 .body("links", containsLink("cardAuth", POST, expectedLocation + "/cards"))


### PR DESCRIPTION
Agreements are intentionally loosely coupled to charges to allow the
code that manages agreements to be moved if required. They are joined by
a guaranteed unique external identifier.

If an agreement ID exists on a given charge, lookup the agreement and
include it in the frontend charge response builder.

Note this should be a very small percentage of general "WEB" payments
with the user present as it will only be the case when a user is both
paying and saving their card payment details to be used by a future
agreement.

Use the existing `AgreementResponse` serialiser to avoid including deep
embeds like the agreement gateway account.

* Should pass existing tests ensuring that existing charges without agreements
   behave as expected
* Should assert that new charges that are associated with a valid agreement have
   that agreement correctly serialised