### PR TITLE
PP-9495 Add description and user_identifier to agreements table

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1884,4 +1884,14 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add description, user_identifier to agreements table" author="">
+        <addColumn tableName="agreements">
+            <column name="description" type="varchar(255)">
+                <constraints nullable="true" unique="false"/>
+            </column>
+            <column name="user_identifier" type="varchar(255)">
+                <constraints nullable="true" unique="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Adds `description` and `user_reference` columns to the existing
agreements
table.

Note the `description` column will eventually have the constraint
`nullable=false` however this will come in a follow-up migration once
the existing resources and DAOs correctly validate and guarantee this
data is available.