### PR TITLE
PP-9495 Agreements includes description and user_identifier in create/ response

### DIFF
--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementCreateRequest.java
@@ -9,22 +9,43 @@ import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AgreementCreateRequest {
+    private static final String DESCRIPTION_FIELD = "description";
+    private static final String USER_IDENTIFIER_FIELD = "user_identifier";
 
     @NotNull(message = "Field [reference] cannot be null")
     @Length(min = 1, max = 255, message = "Field [reference] can have a size between 0 and 255")
     @JsonProperty("reference")
     private String reference;
 
+    @NotNull(message = "Field [" + DESCRIPTION_FIELD + "] cannot be null")
+    @Length(min = 1, max = 255, message = "Field [" + DESCRIPTION_FIELD + "] can have a size between 0 and 255")
+    @JsonProperty(DESCRIPTION_FIELD)
+    private String description;
+
+    @Length(min = 1, max = 255, message = "Field [" + USER_IDENTIFIER_FIELD + "] can have a size between 0 and 255")
+    @JsonProperty(USER_IDENTIFIER_FIELD)
+    private String userIdentifier;
+
     public AgreementCreateRequest() {
         // for Jackson
     }
 
-    public AgreementCreateRequest(String reference) {
+    public AgreementCreateRequest(String reference, String description, String userIdentifier) {
         this.reference = reference;
+        this.description = description;
+        this.userIdentifier = userIdentifier;
     }
 
     public String getReference() {
         return reference;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
     }
 
     @Override
@@ -32,11 +53,13 @@ public class AgreementCreateRequest {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AgreementCreateRequest that = (AgreementCreateRequest) o;
-        return Objects.equals(reference, that.reference);
+        return Objects.equals(reference, that.reference) &&
+                Objects.equals(description, that.description) &&
+                Objects.equals(userIdentifier, that.userIdentifier);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(reference);
+        return Objects.hash(reference, description, userIdentifier);
     }
 }

--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementEntity.java
@@ -46,6 +46,12 @@ public class AgreementEntity {
 
     @Column(name = "reference")
     private String reference;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "user_identifier")
+    private String userIdentifier;
     
     @Column(name = "service_id")
     private String serviceId;
@@ -63,13 +69,15 @@ public class AgreementEntity {
     }
     
     private AgreementEntity(GatewayAccountEntity gatewayAccount, String serviceId, String reference,
-                            boolean live, Instant createdDate) {
+                            String description, String userIdentifier, boolean live, Instant createdDate) {
         this.externalId = RandomIdGenerator.newId();
         this.gatewayAccount = gatewayAccount;
         this.serviceId = serviceId;
         this.reference = reference;
         this.live = live;
         this.createdDate = createdDate;
+        this.description = description;
+        this.userIdentifier = userIdentifier;
     }
 
     public Long getId() {
@@ -128,6 +136,22 @@ public class AgreementEntity {
         this.live = live;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
+    public void setUserIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
+    }
+
     public PaymentInstrumentEntity getPaymentInstrument() {
         return paymentInstrument;
     }
@@ -140,6 +164,8 @@ public class AgreementEntity {
         private GatewayAccountEntity gatewayAccount;
         private Instant createdDate;
         private String reference;
+        private String description;
+        private String userIdentifier;
         private String serviceId;
         private boolean live;
 
@@ -164,6 +190,16 @@ public class AgreementEntity {
             return this;
         }
 
+        public AgreementEntityBuilder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public AgreementEntityBuilder withUserIdentifier(String userIdentifier) {
+            this.userIdentifier = userIdentifier;
+            return this;
+        }
+
         public AgreementEntityBuilder withServiceId(String serviceId) {
             this.serviceId = serviceId;
             return this;
@@ -175,7 +211,7 @@ public class AgreementEntity {
         }
 
         public AgreementEntity build() {
-            return new AgreementEntity(gatewayAccount, serviceId, reference, live, createdDate);
+            return new AgreementEntity(gatewayAccount, serviceId, reference, description, userIdentifier, live, createdDate);
         }
         
     }

--- a/src/main/java/uk/gov/pay/connector/agreement/model/AgreementResponse.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/AgreementResponse.java
@@ -24,6 +24,12 @@ public class AgreementResponse {
     @JsonProperty
     private String reference;
 
+    @JsonProperty
+    private String description;
+
+    @JsonProperty("user_identifier")
+    private String userIdentifier;
+
     @JsonProperty("service_id")
     private String serviceId;
 
@@ -34,6 +40,8 @@ public class AgreementResponse {
         this.agreementId = agreementResponseBuilder.getAgreementId();
         this.createdDate = agreementResponseBuilder.getCreatedDate();
         this.reference = agreementResponseBuilder.getReference();
+        this.description = agreementResponseBuilder.getDescription();
+        this.userIdentifier = agreementResponseBuilder.getUserIdentifier();
         this.serviceId = agreementResponseBuilder.getServiceId();
         this.live = agreementResponseBuilder.isLive();
     }
@@ -58,17 +66,25 @@ public class AgreementResponse {
         return live;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AgreementResponse that = (AgreementResponse) o;
-        return live == that.live && agreementId.equals(that.agreementId) && createdDate.equals(that.createdDate) && reference.equals(that.reference) && serviceId.equals(that.serviceId);
+        return live == that.live && agreementId.equals(that.agreementId) && createdDate.equals(that.createdDate) && reference.equals(that.reference) && serviceId.equals(that.serviceId) && Objects.equals(description, that.description) && Objects.equals(userIdentifier, that.userIdentifier);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(agreementId, createdDate, reference, serviceId, live);
+        return Objects.hash(agreementId, createdDate, reference, serviceId, live, description, userIdentifier);
     }
 
     @Override

--- a/src/main/java/uk/gov/pay/connector/agreement/model/builder/AgreementResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/model/builder/AgreementResponseBuilder.java
@@ -9,6 +9,8 @@ public class AgreementResponseBuilder {
     private String agreementId;
     private Instant createdDate;
     private String reference;
+    private String description;
+    private String userIdentifier;
     private String serviceId;
     private boolean live;
     
@@ -32,6 +34,14 @@ public class AgreementResponseBuilder {
         return live;
     }
 
+    public String getDescription() {
+        return description;
+    }
+
+    public String getUserIdentifier() {
+        return userIdentifier;
+    }
+
     public AgreementResponseBuilder withAgreementId(String agreementId) {
         this.agreementId = agreementId;
         return this;
@@ -44,6 +54,16 @@ public class AgreementResponseBuilder {
 
     public AgreementResponseBuilder withReference(String reference) {
         this.reference = reference;
+        return this;
+    }
+
+    public AgreementResponseBuilder withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    public AgreementResponseBuilder withUserIdentifier(String userIdentifier) {
+        this.userIdentifier = userIdentifier;
         return this;
     }
 

--- a/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
+++ b/src/main/java/uk/gov/pay/connector/agreement/service/AgreementService.java
@@ -34,6 +34,8 @@ public class AgreementService {
                         .withReference(agreementEntity.getReference())
                         .withLive(agreementEntity.isLive())
                         .withCreatedDate(agreementEntity.getCreatedDate())
+                        .withDescription(agreementEntity.getDescription())
+                        .withUserIdentifier(agreementEntity.getUserIdentifier())
                         .build());
     }
 
@@ -41,8 +43,11 @@ public class AgreementService {
         return gatewayAccountDao.findById(accountId).map(gatewayAccountEntity -> {
             AgreementEntity agreementEntity = anAgreementEntity(clock.instant())
                     .withReference(agreementCreateRequest.getReference())
+                    .withDescription(agreementCreateRequest.getDescription())
+                    .withUserIdentifier(agreementCreateRequest.getUserIdentifier())
                     .withServiceId(gatewayAccountEntity.getServiceId())
-                    .withLive(gatewayAccountEntity.isLive()).build();
+                    .withLive(gatewayAccountEntity.isLive())
+                    .build();
             agreementEntity.setGatewayAccount(gatewayAccountEntity);
             
             agreementDao.persist(agreementEntity);
@@ -54,6 +59,8 @@ public class AgreementService {
             agreementResponseBuilder.withReference(agreementEntity.getReference());
             agreementResponseBuilder.withServiceId(agreementEntity.getServiceId());
             agreementResponseBuilder.withLive(agreementEntity.isLive());
+            agreementResponseBuilder.withDescription(agreementEntity.getDescription());
+            agreementResponseBuilder.withUserIdentifier(agreementEntity.getUserIdentifier());
             return agreementResponseBuilder.build();
         });
     }

--- a/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/resource/AgreementsApiResourceTest.java
@@ -35,7 +35,8 @@ class AgreementsApiResourceTest {
     private final static long NOT_VALID_ACCOUNT_ID = 9876l;
 
     private static final String REFERENCE_ID = "1234";
-    
+    private static final String VALID_DESCRIPTION = "a valid description";
+
     private AgreementService agreementService = mock(AgreementService.class);
     
     private final ResourceExtension resources = ResourceTestRuleWithCustomExceptionMappersBuilder
@@ -45,11 +46,11 @@ class AgreementsApiResourceTest {
 
     @Test
     void shouldReturn200_whenPostToAgreement() {
-        AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest("1234");
-        AgreementResponse agreementResponse = new AgreementResponseBuilder().withAgreementId("aid").withReference(REFERENCE_ID).withServiceId("serviceid").withCreatedDate(Instant.parse("2022-03-03T12:00:00Z")).build();
+        AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest("1234", VALID_DESCRIPTION, null);
+        AgreementResponse agreementResponse = new AgreementResponseBuilder().withAgreementId("aid").withReference(REFERENCE_ID).withServiceId("serviceid").withCreatedDate(Instant.parse("2022-03-03T12:00:00Z")).withDescription(VALID_DESCRIPTION).build();
         when(agreementService.create(agreementCreateRequest, VALID_ACCOUNT_ID)).thenReturn(Optional.ofNullable(agreementResponse));
 
-        Map payloadMap = Map.of("reference", REFERENCE_ID);
+        Map payloadMap = Map.of("reference", REFERENCE_ID, "description", VALID_DESCRIPTION);
 
         Response response = resources.client()
                 .target(format(RESOURCE_URL, VALID_ACCOUNT_ID))
@@ -61,7 +62,7 @@ class AgreementsApiResourceTest {
 
     @Test
     void shouldReturn404_whenPostWithUnknownAccountId() {
-        Map payloadMap = Map.of("reference", REFERENCE_ID);
+        Map payloadMap = Map.of("reference", REFERENCE_ID, "description", VALID_DESCRIPTION);
 
         Response response = resources.client()
                 .target(format(RESOURCE_URL, NOT_VALID_ACCOUNT_ID))

--- a/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/agreement/service/AgreementServiceTest.java
@@ -47,15 +47,19 @@ public class AgreementServiceTest {
 
     @Test
     public void shouldCreateAnAgreement() {
+        var description = "a valid description";
+        var userIdentifier = "a-valid-user-reference";
         when(gatewayAccount.getServiceId()).thenReturn(SERVICE_ID);
         when(gatewayAccount.isLive()).thenReturn(false);
         when(mockedGatewayAccountDao.findById(GATEWAY_ACCOUNT_ID)).thenReturn(Optional.of(gatewayAccount));
 
-        AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID);
+        AgreementCreateRequest agreementCreateRequest = new AgreementCreateRequest(REFERENCE_ID, description, userIdentifier);
         Optional<AgreementResponse> response = service.create(agreementCreateRequest, GATEWAY_ACCOUNT_ID);
 
         assertThat(response.isPresent(), is(true));
-        assertThat(REFERENCE_ID, is(response.get().getReference()));
-        assertThat(SERVICE_ID, is(response.get().getServiceId()));
+        assertThat(response.get().getReference(), is(REFERENCE_ID));
+        assertThat(response.get().getServiceId(), is(SERVICE_ID));
+        assertThat(response.get().getDescription(), is(description));
+        assertThat(response.get().getUserIdentifier(), is(userIdentifier));
     }
 }

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -566,6 +566,8 @@ public class DatabaseFixtures {
         Long gatewayAccountId = RandomUtils.nextLong();
         String externalId = "externalIDxxxyz";
         String reference = "AgreementReference";
+        String description = "A valid description";
+        String userIdentifier = "a-valid-user-identifier";
         Instant createdDate = Instant.now();
         boolean live = false;
         String serviceId = "service-id";
@@ -593,7 +595,15 @@ public class DatabaseFixtures {
         public String getServiceId() {
             return serviceId;
         }
-        
+
+        public String getDescription() {
+            return description;
+        }
+
+        public String getUserIdentifier() {
+            return userIdentifier;
+        }
+
         public DatabaseFixtures.TestAgreement withAgreementId(Long agreementId) {
             this.agreementId = agreementId;
             return this;
@@ -605,6 +615,16 @@ public class DatabaseFixtures {
 
         public DatabaseFixtures.TestAgreement withReference(String reference) {
             this.reference = reference;
+            return this;
+        }
+
+        public DatabaseFixtures.TestAgreement withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public DatabaseFixtures.TestAgreement withUserIdentifier(String userIdentifier) {
+            this.userIdentifier = userIdentifier;
             return this;
         }
 
@@ -632,7 +652,7 @@ public class DatabaseFixtures {
             if (gatewayAccountId == null)
                 throw new IllegalStateException("Test Account must be provided.");
 
-            databaseTestHelper.addAgreement(this.getAgreementId(), this.getServiceId(), this.getExternalId(), this.getReference(), this.getCreatedDate() , this.isLive(), gatewayAccountId);
+            databaseTestHelper.addAgreement(this.getAgreementId(), this.getServiceId(), this.getExternalId(), this.getReference(), this.getDescription(), this.getUserIdentifier(), this.getCreatedDate() , this.isLive(), gatewayAccountId);
             return this;
         }
     }

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -1132,7 +1132,7 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
                 .withAccountId(accountId)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
-        databaseTestHelper.addAgreement(11l, "service-id", JSON_TOO_LONG_AGREEMENT_ID_VALUE, "refs", Instant.now(), false, Long.parseLong(accountId));
+        databaseTestHelper.addAgreement(11l, "service-id", JSON_TOO_LONG_AGREEMENT_ID_VALUE, "refs", "description", null, Instant.now(), false, Long.parseLong(accountId));
 
         String postBody = toJson(Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,
@@ -1158,7 +1158,7 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
                 .withAccountId(accountId)
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
-        databaseTestHelper.addAgreement(11l, "service-id", JSON_TOO_SHORT_AGREEMENT_ID_VALUE, "refs", Instant.now(), false, Long.parseLong(accountId));
+        databaseTestHelper.addAgreement(11l, "service-id", JSON_TOO_SHORT_AGREEMENT_ID_VALUE, "refs", "description", null, Instant.now(), false, Long.parseLong(accountId));
 
         String postBody = toJson(Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,
@@ -1185,7 +1185,7 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
                 .build();
         databaseTestHelper.addGatewayAccount(gatewayAccountParams);
         databaseTestHelper.addAgreement(11l, "service-id", JSON_VALID_AGREEMENT_ID_VALUE, 
-                "refs", Instant.now(), false, Long.parseLong(accountId));
+                "refs", "description", null, Instant.now(), false, Long.parseLong(accountId));
 
         String postBody = toJson(Map.of(
                 JSON_AMOUNT_KEY, AMOUNT,

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesFrontendResourceIT.java
@@ -158,8 +158,10 @@ public class ChargesFrontendResourceIT {
     public void getChargeShouldIncludeAgreementInResponseToFrontEndForRecurringCardPayment() {
         var agreementReference = "refs";
         var agreementServiceId = "service-id";
+        var agreementDescription = "a valid description";
+        var agreementUserIdentifier = "a-valid-user-identifier";
         databaseTestHelper.addAgreement(11l, agreementServiceId, AGREEMENT_ID,
-                agreementReference, Instant.now(), false, Long.parseLong(accountId));
+                agreementReference, agreementDescription, agreementUserIdentifier, Instant.now(), false, Long.parseLong(accountId));
         String chargeExternalId = postToCreateAChargeWithAgreement(expectedAmount);
         String expectedLocation = "https://localhost:" + testContext.getPort() + "/v1/frontend/charges/" + chargeExternalId;
         final Long chargeId = databaseTestHelper.getChargeIdByExternalId(chargeExternalId);
@@ -186,6 +188,8 @@ public class ChargesFrontendResourceIT {
                 .body("agreement_id", is(AGREEMENT_ID))
                 .body("agreement.agreement_id", is(AGREEMENT_ID))
                 .body("agreement.reference", is(agreementReference))
+                .body("agreement.description", is(agreementDescription))
+                .body("agreement.user_identifier", is(agreementUserIdentifier))
                 .body("agreement.service_id", is(agreementServiceId))
                 .body("save_payment_instrument_to_agreement", is(true))
                 .body("links", hasSize(3))

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -137,20 +137,22 @@ public class DatabaseTestHelper {
                         .execute());
     }
     
-    public void addAgreement(Long id, String serviceId, String externalId, String reference, Instant createdDate, boolean live, long gatewayAccountId) {
+    public void addAgreement(Long id, String serviceId, String externalId, String reference, String description, String userIdentifier, Instant createdDate, boolean live, long gatewayAccountId) {
         PGobject jsonMetadata = new PGobject();
         jsonMetadata.setType("json");
         
         jdbi.withHandle(h ->
                 h.createUpdate("INSERT INTO agreements(id, external_id, service_id, created_date, " +
-                                "reference, live, gateway_account_id) " +
+                                "reference, description, user_identifier, live, gateway_account_id) " +
                                 "VALUES(:id, :external_id, :service_id, :created_date, " +
-                                ":reference, :live, :gateway_account_id)")
+                                ":reference, :description, :user_identifier, :live, :gateway_account_id)")
                         .bind("id", Long.valueOf(id))
                         .bind("external_id", externalId)
                         .bind("service_id", serviceId)
                         .bind("created_date", LocalDateTime.ofInstant(createdDate, UTC))
                         .bind("reference", reference)
+                        .bind("description", description)
+                        .bind("user_identifier", userIdentifier)
                         .bind("live", live)
                         .bind("gateway_account_id", gatewayAccountId)
                         .execute());


### PR DESCRIPTION
Reflect `description` and `user_identifier` columns on the `AgreementEntity`.

Fields also included in agreement create/ response pattern.

Ensure these values are appropriately validated, passed along and stored with the agreements service/ resource.