### PR TITLE
PP-9495 Require agreements description column

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1906,4 +1906,8 @@
             </column>
         </addColumn>
     </changeSet>
+
+    <changeSet id="update description on agreeements to not nullable" author="">
+        <addNotNullConstraint tableName="agreements" columnName="description" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Depends on https://github.com/alphagov/pay-connector/pull/3602

The `description` column is required for agreements, now that entitles
and tests populate this field, update the column to required.