### PR TITLE
PP-9142 Change default value for authorisation_mode

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -1894,4 +1894,16 @@
             </column>
         </addColumn>
     </changeSet>
+
+    <changeSet id="drop column authorisation_mode from charges table" author="">
+        <dropColumn tableName="charges" columnName="authorisation_mode"/>
+    </changeSet>
+
+    <changeSet id="add authorisation_mode to charges table with default value" author="">
+        <addColumn tableName="charges">
+            <column name="authorisation_mode" type="varchar(30)" defaultValue="WEB">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
To be consistent with other enum values, and to make serialization
and deserialization of the enum easier, the `authorisation_mode` should
be stored in the databased capitalized.

Drop the column and re-add with the correct default of "WEB". This is
possible as there are no charges currently in the database that have
been created with a different value.
