### PR TITLE
PP-9142 Accept authorisation_mode when creating charge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ hs_err_pid*
 *.iml
 *.ipr
 *.iws
+dependency-reduced-pom.xml
 
 #Eclipse
 .project

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.10</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.13.2</jackson.version>
-        <pay-java-commons.version>1.0.20220411103640</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220414105607</pay-java-commons.version>
         <surefire.version>3.0.0-M6</surefire.version>
         <jooq.version>3.16.5</jooq.version>
         <postgresql.version>42.3.3</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeCreateRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.hibernate.validator.constraints.Length;
 import uk.gov.pay.connector.charge.validation.ValidPaymentProvider;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataDeserialiser;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.SupportedLanguageJsonDeserializer;
@@ -77,6 +78,10 @@ public class ChargeCreateRequest {
 
     @JsonProperty("save_payment_instrument_to_agreement")
     private boolean savePaymentInstrumentToAgreement;
+    
+    @JsonProperty("authorisation_mode")
+    @Valid
+    private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
 
     public ChargeCreateRequest() {
     }
@@ -167,6 +172,10 @@ public class ChargeCreateRequest {
         return paymentProvider;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     public String toStringWithoutPersonalIdentifiableInformation() {
         // Don't include:
         // description - some services include PII
@@ -181,6 +190,7 @@ public class ChargeCreateRequest {
                 (paymentProvider != null ? ", payment_provider=" + paymentProvider : "") +
                 (agreementId != null ? ", agreementId=" + agreementId.toString() : "") +
                 ", savePaymentInstrumentToAgreement=" + savePaymentInstrumentToAgreement +
+                ", authorisationMode=" + authorisationMode + 
                 '}';
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/ChargeResponse.java
@@ -15,6 +15,7 @@ import uk.gov.pay.connector.util.DateTimeUtils;
 import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.service.payments.commons.api.json.ApiResponseInstantSerializer;
 import uk.gov.service.payments.commons.api.json.ExternalMetadataSerialiser;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -136,6 +137,9 @@ public class ChargeResponse {
 
     @JsonProperty("agreement_id")
     private String agreementId;
+    
+    @JsonProperty("authorisation_mode")
+    private AuthorisationMode authorisationMode;
 
     ChargeResponse(AbstractChargeResponseBuilder<?, ? extends ChargeResponse> builder) {
         this.dataLinks = builder.getLinks();
@@ -171,6 +175,7 @@ public class ChargeResponse {
         this.externalMetadata = builder.getExternalMetadata();
         this.moto = builder.isMoto();
         this.agreementId = builder.getAgreementId();
+        this.authorisationMode = builder.getAuthorisationMode();
     }
 
     public List<Map<String, Object>> getDataLinks() {
@@ -309,6 +314,10 @@ public class ChargeResponse {
         return agreementId;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -344,7 +353,8 @@ public class ChargeResponse {
                 Objects.equals(totalAmount, that.totalAmount) &&
                 Objects.equals(netAmount, that.netAmount) &&
                 walletType == that.walletType &&
-                Objects.equals(externalMetadata, that.externalMetadata);
+                Objects.equals(externalMetadata, that.externalMetadata) &&
+                authorisationMode == that.authorisationMode;
     }
 
     @Override
@@ -353,7 +363,7 @@ public class ChargeResponse {
                 telephoneNumber, description, reference, providerName, processorId, providerId, createdDate,
                 authorisedDate, paymentOutcome, refundSummary, settlementSummary, authCode, auth3dsData, cardDetails,
                 language, delayedCapture, corporateCardSurcharge, fee, totalAmount, netAmount, walletType,
-                externalMetadata, moto);
+                externalMetadata, moto, authorisationMode);
     }
 
     @Override
@@ -382,6 +392,7 @@ public class ChargeResponse {
                 ", walletType=" + walletType +
                 ", moto=" + moto +
                 ", agreementId=" + agreementId +
+                ", authorisationMode=" + authorisationMode +
                 '}';
     }
 

--- a/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/builder/AbstractChargeResponseBuilder.java
@@ -7,6 +7,7 @@ import uk.gov.pay.connector.charge.model.domain.PersistedCard;
 import uk.gov.pay.connector.charge.model.telephone.PaymentOutcome;
 import uk.gov.pay.connector.common.model.api.ExternalTransactionState;
 import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -50,6 +51,7 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
     protected ExternalMetadata externalMetadata;
     protected boolean moto;
     private String agreementId;
+    private AuthorisationMode authorisationMode;
     
     protected abstract T thisObject();
 
@@ -229,6 +231,11 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
         return thisObject();
     }
     
+    public T withAuthorisationMode(AuthorisationMode authorisationMode) {
+        this.authorisationMode = authorisationMode;
+        return thisObject();
+    }
+    
     public String getChargeId() {
         return chargeId;
     }
@@ -361,5 +368,9 @@ public abstract class AbstractChargeResponseBuilder<T extends AbstractChargeResp
 
     public String getAgreementId() {
         return agreementId;
+    }
+
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
+++ b/src/main/java/uk/gov/pay/connector/charge/model/domain/ChargeEntity.java
@@ -24,6 +24,7 @@ import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
 import uk.gov.service.payments.commons.jpa.InstantToUtcTimestampWithoutTimeZoneConverter;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 import uk.gov.service.payments.commons.model.SupportedLanguageJpaConverter;
@@ -191,6 +192,10 @@ public class ChargeEntity extends AbstractVersionedEntity {
     @OneToOne
     @JoinColumn(name = "payment_instrument_id", nullable = true)
     private PaymentInstrumentEntity paymentInstrument;
+    
+    @Column(name = "authorisation_mode")
+    @Enumerated(EnumType.STRING)
+    private AuthorisationMode authorisationMode;
 
     public ChargeEntity() {
         //for jpa
@@ -217,7 +222,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
             boolean moto,
             String serviceId,
             String agreementId,
-            boolean savePaymentInstrumentToAgreement
+            boolean savePaymentInstrumentToAgreement,
+            AuthorisationMode authorisationMode
     ) {
         this.amount = amount;
         this.status = status.getValue();
@@ -240,6 +246,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         this.serviceId = serviceId;
         this.agreementId = agreementId;
         this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
+        this.authorisationMode = authorisationMode;
     }
 
     public Long getId() {
@@ -543,7 +550,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
     public boolean isSavePaymentInstrumentToAgreement() {
         return savePaymentInstrumentToAgreement;
     }
-    
+
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     public static final class WebChargeEntityBuilder {
         private Long amount;
         private String returnUrl;
@@ -561,8 +572,7 @@ public class ChargeEntity extends AbstractVersionedEntity {
         private String serviceId;
         private String agreementId;
         private boolean savePaymentInstrumentToAgreement;
-
-
+        private AuthorisationMode authorisationMode;
 
         private WebChargeEntityBuilder() {
         }
@@ -651,6 +661,11 @@ public class ChargeEntity extends AbstractVersionedEntity {
             this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
             return this;
         }
+        
+        public WebChargeEntityBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
+            return this;
+        }
 
         public ChargeEntity build() {
             return new ChargeEntity(
@@ -673,7 +688,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     moto,
                     serviceId,
                     agreementId,
-                    savePaymentInstrumentToAgreement);
+                    savePaymentInstrumentToAgreement,
+                    authorisationMode);
         }
     }
 
@@ -786,7 +802,8 @@ public class ChargeEntity extends AbstractVersionedEntity {
                     false,
                     serviceId,
                     agreementId,
-                    savePaymentInstrumentToAgreement);
+                    savePaymentInstrumentToAgreement,
+                    AuthorisationMode.EXTERNAL);
         }
     }
 }

--- a/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
+++ b/src/main/java/uk/gov/pay/connector/charge/resource/ChargesFrontendResource.java
@@ -187,7 +187,8 @@ public class ChargesFrontendResource {
                 .withLink("cardAuth", POST, locationUriFor("/v1/frontend/charges/{chargeId}/cards", uriInfo, chargeId))
                 .withLink("cardCapture", POST, locationUriFor("/v1/frontend/charges/{chargeId}/capture", uriInfo, chargeId))
                 .withWalletType(charge.getWalletType())
-                .withMoto(charge.isMoto());
+                .withMoto(charge.isMoto())
+                .withAuthorisationMode(charge.getAuthorisationMode());
 
         if (charge.getCardDetails() != null) {
             var persistedCard = charge.getCardDetails().toCard();

--- a/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
+++ b/src/main/java/uk/gov/pay/connector/charge/service/ChargeService.java
@@ -281,6 +281,7 @@ public class ChargeService {
                     .withServiceId(gatewayAccount.getServiceId())
                     .withSavePaymentInstrumentToAgreement(chargeRequest.getSavePaymentInstrumentToAgreement())
                     .withAgreementId(chargeRequest.getAgreementId())
+                    .withAuthorisationMode(chargeRequest.getAuthorisationMode())
                     .build();
 
             chargeRequest.getPrefilledCardHolderDetails()
@@ -398,7 +399,8 @@ public class ChargeService {
                 .withProviderId(chargeEntity.getGatewayTransactionId())
                 .withCardDetails(persistedCard)
                 .withEmail(chargeEntity.getEmail())
-                .withChargeId(chargeEntity.getExternalId());
+                .withChargeId(chargeEntity.getExternalId())
+                .withAuthorisationMode(chargeEntity.getAuthorisationMode());
 
         chargeEntity.getExternalMetadata().ifPresent(externalMetadata -> {
 
@@ -502,7 +504,8 @@ public class ChargeService {
                 .withLink("refunds", GET, refundsUriFor(uriInfo, chargeEntity.getGatewayAccount().getId(), chargeEntity.getExternalId()))
                 .withWalletType(chargeEntity.getWalletType())
                 .withMoto(chargeEntity.isMoto())
-                .withAgreementId(chargeEntity.getAgreementId());
+                .withAgreementId(chargeEntity.getAgreementId())
+                .withAuthorisationMode(chargeEntity.getAuthorisationMode());
 
         chargeEntity.getFeeAmount().ifPresent(builderOfResponse::withFee);
         chargeEntity.getExternalMetadata().ifPresent(builderOfResponse::withExternalMetadata);

--- a/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
+++ b/src/test/java/uk/gov/pay/connector/charge/model/domain/ChargeEntityFixture.java
@@ -18,6 +18,7 @@ import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationEntit
 import uk.gov.pay.connector.usernotification.model.domain.EmailNotificationType;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
@@ -68,6 +69,7 @@ public class ChargeEntityFixture {
     private String agreementId = randomUuid().substring(26);
     private boolean savePaymentInstrumentToAgreement = false;
     private PaymentInstrumentEntity paymentInstrument = null;
+    private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
 
     public static ChargeEntityFixture aValidChargeEntity() {
         return new ChargeEntityFixture();
@@ -152,7 +154,8 @@ public class ChargeEntityFixture {
                 moto,
                 serviceId,
                 agreementId,
-                savePaymentInstrumentToAgreement);
+                savePaymentInstrumentToAgreement,
+                authorisationMode);
         chargeEntity.setId(id);
         chargeEntity.setExternalId(externalId);
         chargeEntity.setCorporateSurcharge(corporateSurcharge);
@@ -347,6 +350,11 @@ public class ChargeEntityFixture {
 
     public ChargeEntityFixture withPaymentInstrument(PaymentInstrumentEntity paymentInstrument) {
         this.paymentInstrument = paymentInstrument;
+        return this;
+    }
+
+    public ChargeEntityFixture withAuthorisationMode(AuthorisationMode authorisationMode) {
+        this.authorisationMode = authorisationMode;
         return this;
     }
 

--- a/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
+++ b/src/test/java/uk/gov/pay/connector/charge/service/ChargeServiceTest.java
@@ -411,7 +411,8 @@ public class ChargeServiceTest {
                 .withSettlement(settlement)
                 .withReturnUrl(chargeEntity.getReturnUrl())
                 .withLanguage(chargeEntity.getLanguage())
-                .withMoto(chargeEntity.isMoto());
+                .withMoto(chargeEntity.isMoto())
+                .withAuthorisationMode(chargeEntity.getAuthorisationMode());
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/ChargeDaoIT.java
@@ -17,6 +17,7 @@ import uk.gov.pay.connector.gatewayaccountcredentials.model.GatewayAccountCreden
 import uk.gov.pay.connector.it.dao.DatabaseFixtures.TestCharge;
 import uk.gov.pay.connector.paymentprocessor.model.Exemption3ds;
 import uk.gov.pay.connector.util.RandomIdGenerator;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.Source;
 import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
@@ -134,6 +135,7 @@ public class ChargeDaoIT extends DaoITestBase {
                 .withId(null)
                 .withGatewayAccountEntity(gatewayAccount)
                 .withGatewayAccountCredentialsEntity(gatewayAccountCredentialsEntity)
+                .withAuthorisationMode(AuthorisationMode.MOTO_API)
                 .build();
 
         assertThat(chargeEntity.getId(), is(nullValue()));
@@ -141,6 +143,9 @@ public class ChargeDaoIT extends DaoITestBase {
         chargeDao.persist(chargeEntity);
 
         assertThat(chargeEntity.getId(), is(notNullValue()));
+
+        Optional<ChargeEntity> charge = chargeDao.findById(chargeEntity.getId());
+        assertThat(charge.get().getAuthorisationMode(), is(AuthorisationMode.MOTO_API));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceCreateIT.java
@@ -162,6 +162,7 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
                 .body("settlement_summary.captured_time", nullValue())
                 .body("created_date", matchesPattern("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(.\\d{1,3})?Z"))
                 .body("created_date", isWithin(10, SECONDS))
+                .body("authorisation_mode", is("web"))
                 .contentType(JSON);
 
         String externalChargeId = response.extract().path(JSON_CHARGE_KEY);
@@ -252,6 +253,34 @@ public class ChargesApiResourceCreateIT extends ChargingITestBase {
                 .statusCode(OK.getStatusCode())
                 .contentType(JSON)
                 .body(JSON_LANGUAGE_KEY, is("en"));
+    }
+
+    @Test
+    public void makeChargeWithAuthorisationModeMotoApi() {
+        String postBody = toJson(Map.of(
+                JSON_AMOUNT_KEY, AMOUNT,
+                JSON_REFERENCE_KEY, JSON_REFERENCE_VALUE,
+                JSON_DESCRIPTION_KEY, JSON_DESCRIPTION_VALUE,
+                JSON_RETURN_URL_KEY, RETURN_URL,
+                JSON_EMAIL_KEY, EMAIL,
+                "authorisation_mode", "moto_api"
+        ));
+
+        ValidatableResponse response = connectorRestApiClient
+                .postCreateCharge(postBody)
+                .statusCode(Status.CREATED.getStatusCode())
+                .body(JSON_LANGUAGE_KEY, is("en"))
+                .contentType(JSON);
+
+        String externalChargeId = response.extract().path(JSON_CHARGE_KEY);
+
+        connectorRestApiClient
+                .withAccountId(accountId)
+                .withChargeId(externalChargeId)
+                .getCharge()
+                .statusCode(OK.getStatusCode())
+                .contentType(JSON)
+                .body("authorisation_mode", is("moto_api"));
     }
 
     @Test

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTelephonePaymentsIT.java
@@ -90,7 +90,8 @@ public class ChargesApiResourceTelephonePaymentsIT extends ChargingITestBase {
                 .body("charge_id.length()", is(26))
                 .body("state.status", is("success"))
                 .body("state.finished", is(true))
-                .body("charge_id", is(notNullValue()));
+                .body("charge_id", is(notNullValue()))
+                .body("authorisation_mode", is("external"));
 
         String chargeExternalId = response.extract().path("charge_id").toString();
         String actualGatewayAccountCredentialId = databaseTestHelper.getChargeByExternalId(chargeExternalId).get("gateway_account_credential_id").toString();

--- a/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTest.java
+++ b/src/test/java/uk/gov/pay/connector/it/resources/ChargesApiResourceTest.java
@@ -8,8 +8,10 @@ import uk.gov.pay.connector.charge.resource.ChargesApiResource;
 import uk.gov.pay.connector.charge.service.ChargeExpiryService;
 import uk.gov.pay.connector.charge.service.ChargeService;
 import uk.gov.pay.connector.common.exception.ConstraintViolationExceptionMapper;
+import uk.gov.pay.connector.common.exception.ValidationExceptionMapper;
 import uk.gov.pay.connector.common.model.api.ErrorResponse;
 import uk.gov.pay.connector.gatewayaccount.service.GatewayAccountService;
+import uk.gov.pay.connector.util.JsonMappingExceptionMapper;
 import uk.gov.service.payments.commons.model.ErrorIdentifier;
 
 import javax.ws.rs.client.Entity;
@@ -19,9 +21,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static io.netty.util.internal.SystemPropertyUtil.contains;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -36,6 +40,8 @@ public class ChargesApiResourceTest {
             .addResource(new ChargesApiResource(chargeService, chargeExpiryService, gatewayAccountService))
             .setRegisterDefaultExceptionMappers(false)
             .addProvider(ConstraintViolationExceptionMapper.class)
+            .addProvider(JsonMappingExceptionMapper.class)
+            .addProvider(ValidationExceptionMapper.class)
             .build();
 
     @Test
@@ -58,5 +64,25 @@ public class ChargesApiResourceTest {
         assertThat(errorResponse.getMessages(), hasItem("Field [payment_provider] must be one of [epdq, sandbox, smartpay, stripe, worldpay]"));
         assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
     }
-    
+
+    @Test
+    void createCharge_invalidAuthorisationMode_shouldReturn400() {
+        var payload = Map.of(
+                "amount", 100,
+                "reference", "ref",
+                "description", "desc",
+                "return_url", "http://service.url/success-page/",
+                "authorisation_mode", "foo"
+        );
+
+        Response response = resources
+                .target("/v1/api/accounts/1/charges")
+                .request()
+                .post(Entity.json(payload));
+
+        assertThat(response.getStatus(), is(400));
+        ErrorResponse errorResponse = response.readEntity(ErrorResponse.class);
+        assertThat(errorResponse.getMessages().get(0), startsWith("Cannot deserialize value of type `uk.gov.service.payments.commons.model.AuthorisationMode`"));
+        assertThat(errorResponse.getIdentifier(), is(ErrorIdentifier.GENERIC));
+    }
 }

--- a/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
+++ b/src/test/java/uk/gov/pay/connector/util/AddChargeParams.java
@@ -1,11 +1,12 @@
 package uk.gov.pay.connector.util;
 
-import uk.gov.service.payments.commons.model.SupportedLanguage;
-import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 import uk.gov.pay.connector.cardtype.model.domain.CardType;
 import uk.gov.pay.connector.charge.model.ServicePaymentReference;
 import uk.gov.pay.connector.charge.model.domain.ChargeStatus;
 import uk.gov.pay.connector.charge.model.domain.ParityCheckStatus;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
+import uk.gov.service.payments.commons.model.SupportedLanguage;
+import uk.gov.service.payments.commons.model.charge.ExternalMetadata;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -40,6 +41,7 @@ public class AddChargeParams {
     private final String issuerUrl;
     private final String agreementId;
     private final boolean savePaymentInstrumentToAgreement;
+    private final AuthorisationMode authorisationMode;
 
     private AddChargeParams(AddChargeParamsBuilder builder) {
         chargeId = builder.chargeId;
@@ -68,6 +70,7 @@ public class AddChargeParams {
         issuerUrl = builder.issuerUrl;
         agreementId = builder.agreementId;
         savePaymentInstrumentToAgreement = builder.savePaymentInstrumentToAgreement;
+        authorisationMode = builder.authorisationMode;
     }
 
     public Long getChargeId() {
@@ -174,6 +177,10 @@ public class AddChargeParams {
         return agreementId;
     }
 
+    public AuthorisationMode getAuthorisationMode() {
+        return authorisationMode;
+    }
+
     public static final class AddChargeParamsBuilder {
         private Long chargeId = new Random().nextLong();
         private String externalChargeId = "anExternalChargeId";
@@ -201,6 +208,7 @@ public class AddChargeParams {
         private String issuerUrl;
         private String agreementId;
         private boolean savePaymentInstrumentToAgreement;
+        private AuthorisationMode authorisationMode = AuthorisationMode.WEB;
 
         private AddChargeParamsBuilder() {
         }
@@ -337,6 +345,11 @@ public class AddChargeParams {
 
         public AddChargeParamsBuilder withSavePaymentInstrumentToAgreement(boolean savePaymentInstrumentToAgreement) {
             this.savePaymentInstrumentToAgreement = savePaymentInstrumentToAgreement;
+            return this;
+        }
+        
+        public AddChargeParamsBuilder withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/util/DatabaseTestHelper.java
@@ -102,13 +102,13 @@ public class DatabaseTestHelper {
                         "description, created_date, reference, version, email, language, " +
                         "delayed_capture, corporate_surcharge, parity_check_status, parity_check_date, " +
                         "external_metadata, card_type, payment_provider, gateway_account_credential_id, service_id, " +
-                        "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement) " +
+                        "issuer_url_3ds, agreement_id, save_payment_instrument_to_agreement, authorisation_mode) " +
                         "VALUES(:id, :external_id, :amount, " +
                         ":status, :gateway_account_id, :return_url, :gateway_transaction_id, " +
                         ":description, :created_date, :reference, :version, :email, :language, " +
                         ":delayed_capture, :corporate_surcharge, :parity_check_status, :parity_check_date, " +
                         ":external_metadata, :card_type, :payment_provider, :gateway_account_credential_id, :service_id, " +
-                        ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement)")
+                        ":issuer_url_3ds, :agreementId, :savePaymentInstrumentToAgreement, :authorisationMode)")
                         .bind("id", addChargeParams.getChargeId())
                         .bind("external_id", addChargeParams.getExternalChargeId())
                         .bind("amount", addChargeParams.getAmount())
@@ -134,6 +134,7 @@ public class DatabaseTestHelper {
                         .bind("issuer_url_3ds", addChargeParams.getIssuerUrl())
                         .bind("agreementId", addChargeParams.getAgreementId())
                         .bind("savePaymentInstrumentToAgreement", addChargeParams.getSavePaymentInstrumentToAgreement())
+                        .bind("authorisationMode", addChargeParams.getAuthorisationMode())
                         .execute());
     }
     


### PR DESCRIPTION
Accept the field `authorisation_mode` in the POST request body to create
a charge. This can be any values for the AuthorisationMode enum in
pay-java-commons - `web`, `moto_api` or `external`. Save this on the
charge, and return in charge responses.

We only ever want the `external` authorisation_mode to be set internally
for payments created by the telephone payment notification API.
Validation to prevent this mode being used when creating a standard
payment through the API will be added in public API.