### PR TITLE
PP-9144 Additional validation for one_time_token and ITest

### DIFF
--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -29,6 +29,7 @@ import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapp
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.exception.OneTimeTokenAlreadyUsedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.OneTimeTokenInvalidExceptionMapper;
+import uk.gov.pay.connector.charge.exception.OneTimeTokenUsageInvalidForMotoApiExceptionMapper;
 import uk.gov.pay.connector.charge.exception.TelephonePaymentNotificationsNotAllowedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ZeroAmountNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.resource.ChargesApiResource;
@@ -58,10 +59,10 @@ import uk.gov.pay.connector.healthcheck.SQSHealthCheck;
 import uk.gov.pay.connector.healthcheck.resource.HealthCheckResource;
 import uk.gov.pay.connector.paymentprocessor.resource.CardResource;
 import uk.gov.pay.connector.paymentprocessor.resource.DiscrepancyResource;
-import uk.gov.pay.connector.queue.managed.TaskQueueMessageReceiver;
 import uk.gov.pay.connector.queue.managed.CaptureMessageReceiver;
 import uk.gov.pay.connector.queue.managed.PayoutReconcileMessageReceiver;
 import uk.gov.pay.connector.queue.managed.StateTransitionMessageReceiver;
+import uk.gov.pay.connector.queue.managed.TaskQueueMessageReceiver;
 import uk.gov.pay.connector.refund.resource.RefundsResource;
 import uk.gov.pay.connector.report.resource.ParityCheckerResource;
 import uk.gov.pay.connector.report.resource.PerformanceReportResource;
@@ -134,6 +135,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new AgreementNotFoundExceptionMapper());
         environment.jersey().register(new OneTimeTokenInvalidExceptionMapper());
         environment.jersey().register(new OneTimeTokenAlreadyUsedExceptionMapper());
+        environment.jersey().register(new OneTimeTokenUsageInvalidForMotoApiExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/OneTimeTokenUsageInvalidForMotoApiException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/OneTimeTokenUsageInvalidForMotoApiException.java
@@ -1,0 +1,9 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.BadRequestException;
+
+public class OneTimeTokenUsageInvalidForMotoApiException extends BadRequestException {
+    public OneTimeTokenUsageInvalidForMotoApiException() {
+        super("The one_time_token is not a valid moto api token");
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/OneTimeTokenUsageInvalidForMotoApiExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/OneTimeTokenUsageInvalidForMotoApiExceptionMapper.java
@@ -1,0 +1,30 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.GENERIC;
+
+public class OneTimeTokenUsageInvalidForMotoApiExceptionMapper implements ExceptionMapper<OneTimeTokenUsageInvalidForMotoApiException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OneTimeTokenUsageInvalidForMotoApiExceptionMapper.class);
+
+    @Override
+    public Response toResponse(OneTimeTokenUsageInvalidForMotoApiException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(GENERIC, List.of(exception.getMessage()));
+
+        return Response.status(BAD_REQUEST)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -166,7 +166,7 @@ public class CardResource {
     @Path("/v1/api/charges/authorise")
     @Produces(APPLICATION_JSON)
     public Response authorise(@Valid @NotNull AuthoriseRequest authoriseRequest) {
-        tokenService.validateToken(authoriseRequest.getOneTimeToken());
+        tokenService.validateTokenForMotoApi(authoriseRequest.getOneTimeToken());
 
         return Response.noContent().build();
     }

--- a/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
+++ b/src/test/java/uk/gov/pay/connector/it/JsonRequestHelper.java
@@ -168,6 +168,22 @@ public class JsonRequestHelper {
         payload.add("encrypted_payment_data", encryptedPaymentData);
         return toJson(payload);
     }
+
+    public static String buildJsonForMotoApiPaymentAuthorisation(String cardHolderName,
+                                                                 String cardNumber,
+                                                                 String expiryDate,
+                                                                 String cvc,
+                                                                 String oneTimeToken) {
+        JsonObject payload = new JsonObject();
+        payload.addProperty("cardholder_name", cardHolderName);
+        payload.addProperty("card_number", cardNumber);
+        payload.addProperty("expiry_date", expiryDate);
+        payload.addProperty("cvc", cvc);
+        payload.addProperty("one_time_token", oneTimeToken);
+
+        return toJson(payload);
+    }
+
     private static JsonObject buildJsonAuthorisationDetailsWithoutAddress(String cardHolderName,
                                                                           String cardNumber,
                                                                           String cvc,

--- a/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
+++ b/src/test/java/uk/gov/pay/connector/it/base/ChargingITestBase.java
@@ -289,6 +289,10 @@ public class ChargingITestBase {
         return "/v1/api/accounts/{accountId}/charges/{chargeId}/cancel".replace("{accountId}", accountId).replace("{chargeId}", chargeId);
     }
 
+    public static String authoriseMotoApiChargeUrlFor() {
+        return "/v1/api/charges/authorise";
+    }
+
     protected Matcher<? super List<Map<String, Object>>> hasEvent(ChargeStatus chargeStatus) {
         return new TypeSafeMatcher<>() {
             @Override

--- a/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
+++ b/src/test/java/uk/gov/pay/connector/it/dao/DatabaseFixtures.java
@@ -18,6 +18,7 @@ import uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams;
 import uk.gov.pay.connector.util.DatabaseTestHelper;
 import uk.gov.pay.connector.util.RandomIdGenerator;
 import uk.gov.pay.connector.wallets.WalletType;
+import uk.gov.service.payments.commons.model.AuthorisationMode;
 import uk.gov.service.payments.commons.model.CardExpiryDate;
 import uk.gov.service.payments.commons.model.SupportedLanguage;
 
@@ -39,6 +40,7 @@ import static uk.gov.pay.connector.util.AddChargeParams.AddChargeParamsBuilder.a
 import static uk.gov.pay.connector.util.AddGatewayAccountCredentialsParams.AddGatewayAccountCredentialsParamsBuilder.anAddGatewayAccountCredentialsParams;
 import static uk.gov.pay.connector.util.AddGatewayAccountParams.AddGatewayAccountParamsBuilder.anAddGatewayAccountParams;
 import static uk.gov.pay.connector.util.RandomIdGenerator.randomUuid;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.WEB;
 
 public class DatabaseFixtures {
 
@@ -678,6 +680,7 @@ public class DatabaseFixtures {
         private String description = "Test description";
         private ZonedDateTime parityCheckDate;
         Long gatewayCredentialId;
+        private AuthorisationMode authorisationMode = WEB;
 
         public TestCardDetails getCardDetails() {
             return cardDetails;
@@ -797,6 +800,7 @@ public class DatabaseFixtures {
                     .withParityCheckStatus(parityCheckStatus)
                     .withParityCheckDate(parityCheckDate)
                     .withGatewayCredentialId(gatewayCredentialId)
+                    .withAuthorisationMode(authorisationMode)
                     .build());
 
             if (cardDetails != null) {
@@ -807,6 +811,11 @@ public class DatabaseFixtures {
 
         public TestCharge withCorporateCardSurcharge(Long corporateCardSurcharge) {
             this.corporateCardSurcharge = corporateCardSurcharge;
+            return this;
+        }
+
+        public TestCharge withAuthorisationMode(AuthorisationMode authorisationMode) {
+            this.authorisationMode = authorisationMode;
             return this;
         }
 

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceAuthoriseMotoApiPaymentIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceAuthoriseMotoApiPaymentIT.java
@@ -1,4 +1,95 @@
-import static org.junit.jupiter.api.Assertions.*;
-class CardResourceAuthoriseMotoApiPaymentIT {
-  
+package uk.gov.pay.connector.paymentprocessor.resource;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.pay.connector.app.ConnectorApp;
+import uk.gov.pay.connector.it.base.ChargingITestBase;
+import uk.gov.pay.connector.it.dao.DatabaseFixtures;
+import uk.gov.pay.connector.junit.DropwizardConfig;
+import uk.gov.pay.connector.junit.DropwizardJUnitRunner;
+import uk.gov.pay.connector.util.DatabaseTestHelper;
+
+import static io.restassured.http.ContentType.JSON;
+import static org.hamcrest.Matchers.hasItems;
+import static uk.gov.pay.connector.charge.model.domain.ChargeStatus.CREATED;
+import static uk.gov.pay.connector.it.JsonRequestHelper.buildJsonForMotoApiPaymentAuthorisation;
+import static uk.gov.service.payments.commons.model.AuthorisationMode.MOTO_API;
+
+@RunWith(DropwizardJUnitRunner.class)
+@DropwizardConfig(app = ConnectorApp.class, config = "config/test-it-config.yaml")
+public class CardResourceAuthoriseMotoApiPaymentIT extends ChargingITestBase {
+
+    public CardResourceAuthoriseMotoApiPaymentIT() {
+        super("sandbox");
+    }
+
+    private DatabaseFixtures.TestToken token;
+    private DatabaseTestHelper databaseTestHelper;
+
+    @Before
+    public void setup() {
+        databaseTestHelper = testContext.getDatabaseTestHelper();
+
+        DatabaseFixtures.TestAccount gatewayAccount = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestAccount()
+                .insert();
+
+        DatabaseFixtures.TestCharge charge = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestCharge()
+                .withChargeStatus(CREATED)
+                .withAuthorisationMode(MOTO_API)
+                .withTestAccount(gatewayAccount)
+                .insert();
+
+        token = DatabaseFixtures
+                .withDatabaseTestHelper(databaseTestHelper)
+                .aTestToken()
+                .withCharge(charge)
+                .withUsed(false)
+                .insert();
+    }
+
+    @After
+    public void tearDown() {
+        databaseTestHelper.truncateAllData();
+    }
+
+    @Test
+    public void authoriseMotoApiPayment_shouldReturn204ResponseForValidPayload() {
+        String validPayload = buildJsonForMotoApiPaymentAuthorisation("Joe Bogs ", "4242424242424242", "11/99", "123",
+                token.getSecureRedirectToken());
+        shouldAuthoriseChargeFor(validPayload);
+    }
+
+    @Test
+    public void shouldReturnError_ForInvalidPayload() {
+        String invalidPayload = buildJsonForMotoApiPaymentAuthorisation("", "", "", "",
+                token.getSecureRedirectToken());
+
+        givenSetup()
+                .body(invalidPayload)
+                .post(authoriseMotoApiChargeUrlFor())
+                .then()
+                .statusCode(422)
+                .contentType(JSON)
+                .body("message", hasItems(
+                        "Missing mandatory attribute: cardholder_name",
+                        "Missing mandatory attribute: card_number",
+                        "Missing mandatory attribute: expiry_date",
+                        "Missing mandatory attribute: cvc"
+                ));
+    }
+
+    private void shouldAuthoriseChargeFor(String payload) {
+        givenSetup()
+                .body(payload)
+                .post(authoriseMotoApiChargeUrlFor())
+                .then()
+                .statusCode(204);
+    }
+
 }

--- a/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceAuthoriseMotoApiPaymentIT.java
+++ b/src/test/java/uk/gov/pay/connector/paymentprocessor/resource/CardResourceAuthoriseMotoApiPaymentIT.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class CardResourceAuthoriseMotoApiPaymentIT {
+  
+}


### PR DESCRIPTION
## WHAT YOU DID
- Added validation to make sure one_time_token (for authorise API) is associated with the charge created with authorisation_mode=MOTO_API only.
- Added basic integration tests for authorise moto payment api
