### PR TITLE
PP-9144 Replace 'annotated' validation methods with a single validation method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <eclipselink.version>2.7.10</eclipselink.version>
         <guice.version>5.1.0</guice.version>
         <jackson.version>2.13.2</jackson.version>
-        <pay-java-commons.version>1.0.20220414105607</pay-java-commons.version>
+        <pay-java-commons.version>1.0.20220420114302</pay-java-commons.version>
         <surefire.version>3.0.0-M6</surefire.version>
         <jooq.version>3.16.6</jooq.version>
         <postgresql.version>42.3.4</postgresql.version>

--- a/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
+++ b/src/main/java/uk/gov/pay/connector/app/ConnectorApp.java
@@ -26,6 +26,7 @@ import uk.gov.pay.connector.agreement.resource.AgreementsApiResource;
 import uk.gov.pay.connector.cardtype.resource.CardTypesResource;
 import uk.gov.pay.connector.charge.exception.AgreementNotFoundExceptionMapper;
 import uk.gov.pay.connector.charge.exception.ConflictWebApplicationExceptionMapper;
+import uk.gov.pay.connector.charge.exception.InvalidAttributeValueExceptionMapper;
 import uk.gov.pay.connector.charge.exception.MotoPaymentNotAllowedForGatewayAccountExceptionMapper;
 import uk.gov.pay.connector.charge.exception.OneTimeTokenAlreadyUsedExceptionMapper;
 import uk.gov.pay.connector.charge.exception.OneTimeTokenInvalidExceptionMapper;
@@ -136,6 +137,7 @@ public class ConnectorApp extends Application<ConnectorConfiguration> {
         environment.jersey().register(new OneTimeTokenInvalidExceptionMapper());
         environment.jersey().register(new OneTimeTokenAlreadyUsedExceptionMapper());
         environment.jersey().register(new OneTimeTokenUsageInvalidForMotoApiExceptionMapper());
+        environment.jersey().register(new InvalidAttributeValueExceptionMapper());
 
         environment.jersey().register(injector.getInstance(GatewayAccountResource.class));
         environment.jersey().register(injector.getInstance(StripeAccountSetupResource.class));

--- a/src/main/java/uk/gov/pay/connector/charge/exception/InvalidAttributeValueException.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/InvalidAttributeValueException.java
@@ -1,0 +1,11 @@
+package uk.gov.pay.connector.charge.exception;
+
+import javax.ws.rs.BadRequestException;
+
+import static java.lang.String.format;
+
+public class InvalidAttributeValueException extends BadRequestException {
+    public InvalidAttributeValueException(String fieldName, String message) {
+        super(format("Invalid attribute value: %s. %s", fieldName, message));
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/charge/exception/InvalidAttributeValueExceptionMapper.java
+++ b/src/main/java/uk/gov/pay/connector/charge/exception/InvalidAttributeValueExceptionMapper.java
@@ -1,0 +1,29 @@
+package uk.gov.pay.connector.charge.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.pay.connector.common.model.api.ErrorResponse;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import java.util.List;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.service.payments.commons.model.ErrorIdentifier.INVALID_ATTRIBUTE_VALUE;
+
+public class InvalidAttributeValueExceptionMapper implements ExceptionMapper<InvalidAttributeValueException> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InvalidAttributeValueExceptionMapper.class);
+
+    @Override
+    public Response toResponse(InvalidAttributeValueException exception) {
+        LOGGER.info(exception.getMessage());
+
+        ErrorResponse errorResponse = new ErrorResponse(INVALID_ATTRIBUTE_VALUE, List.of(exception.getMessage()));
+
+        return Response.status(422)
+                .entity(errorResponse)
+                .type(APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
+++ b/src/main/java/uk/gov/pay/connector/paymentprocessor/resource/CardResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.core.UriInfo;
 import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static uk.gov.pay.connector.common.validator.AuthCardDetailsValidator.isValidCardNumberLength;
 import static uk.gov.pay.connector.util.ResponseUtil.badRequestResponse;
 import static uk.gov.pay.connector.util.ResponseUtil.serviceErrorResponse;
 
@@ -167,6 +168,7 @@ public class CardResource {
     @Produces(APPLICATION_JSON)
     public Response authorise(@Valid @NotNull AuthoriseRequest authoriseRequest) {
         tokenService.validateTokenForMotoApi(authoriseRequest.getOneTimeToken());
+        authoriseRequest.validate();
 
         return Response.noContent().build();
     }


### PR DESCRIPTION
## WHAT YOU DID
- Use a separate validation method so error responses with `INVALID_ATTRIBUTE_VALUE` identifier can be returned to publicapi.
  Validation exceptions (ValidationExceptionMapper) thrown by using @ValidaitonMethod are currently mapped to GENERIC error identifier and changing this would impact other endpoints.
